### PR TITLE
Fix missing sounddevice module

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,4 @@
 nltk==3.8.2
 parler_tts @ git+https://github.com/huggingface/parler-tts.git
 torch==2.4.0
+sounddevice

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,4 @@
 nltk==3.8.2
 parler_tts @ git+https://github.com/huggingface/parler-tts.git
 torch==2.4.0
-sounddevice
+sounddevice==0.5.0


### PR DESCRIPTION
Without this I get the following after installation of pip packages:

```
$ python listen_and_play.py --host localhost

Traceback (most recent call last):
  File "/Users/alex.hayton/funtime/speech-to-speech/listen_and_play.py", line 6, in <module>
    import sounddevice as sd
ModuleNotFoundError: No module named 'sounddevice'
```