### PR TITLE
Assigning min new tokens to a compiled whisper graph on a thread brea…

### DIFF
--- a/STT/whisper_stt_handler.py
+++ b/STT/whisper_stt_handler.py
@@ -66,6 +66,7 @@ class WhisperSTTHandler(BaseHandler):
         if self.compile_mode not in (None, "default"):
             # generating more tokens than previously will trigger CUDA graphs capture
             # one should warmup with a number of generated tokens above max tokens targeted for subsequent generation
+            # hence, having min_new_tokens < max_new_tokens in the future doesn't make sense
             warmup_gen_kwargs = {
                 "min_new_tokens": self.gen_kwargs["max_new_tokens"],  # Yes, assign max_new_tokens to min_new_tokens
                 "max_new_tokens": self.gen_kwargs["max_new_tokens"],

--- a/STT/whisper_stt_handler.py
+++ b/STT/whisper_stt_handler.py
@@ -67,7 +67,7 @@ class WhisperSTTHandler(BaseHandler):
             # generating more tokens than previously will trigger CUDA graphs capture
             # one should warmup with a number of generated tokens above max tokens targeted for subsequent generation
             warmup_gen_kwargs = {
-                "min_new_tokens": self.gen_kwargs["min_new_tokens"],
+                "min_new_tokens": self.gen_kwargs["max_new_tokens"],  # Yes, assign max_new_tokens to min_new_tokens
                 "max_new_tokens": self.gen_kwargs["max_new_tokens"],
                 **self.gen_kwargs,
             }

--- a/arguments_classes/whisper_stt_arguments.py
+++ b/arguments_classes/whisper_stt_arguments.py
@@ -33,12 +33,6 @@ class WhisperSTTHandlerArguments:
             "help": "The maximum number of new tokens to generate. Default is 128."
         },
     )
-    stt_gen_min_new_tokens: int = field(
-        default=0,
-        metadata={
-            "help": "The minimum number of new tokens to generate. Default is 0."
-        },
-    )
     stt_gen_num_beams: int = field(
         default=1,
         metadata={


### PR DESCRIPTION
…ks it

Someone reported that we were assigning min_new_tokens to max_new_tokens in a few parts of the code. For the LLM, that was a bug, but for whisper, it was intended. I "fixed" it without realizing that I would break things. @RodriMora reported that it now breaks the compiled graphs for whisper. After some investigation, I realized why this was done originally like this. I now removed the 'min_new_tokens' for the whisper arguments, and improved the comment to avoid me or someone else breaking it again in the future. 

Here is the issue where this was raised: https://github.com/huggingface/speech-to-speech/issues/56