### PR TITLE
add Facebook MMS TTS with expanded language support

### DIFF
--- a/LLM/language_model.py
+++ b/LLM/language_model.py
@@ -25,6 +25,7 @@ WHISPER_LANGUAGE_TO_LLM_LANGUAGE = {
     "zh": "chinese",
     "ja": "japanese",
     "ko": "korean",
+    "hi": "hindi",
 }
 
 class LanguageModelHandler(BaseHandler):

--- a/STT/whisper_stt_handler.py
+++ b/STT/whisper_stt_handler.py
@@ -19,6 +19,7 @@ SUPPORTED_LANGUAGES = [
     "zh",
     "ja",
     "ko",
+    "hi"
 ]
 
 

--- a/TTS/facebookmms_handler.py
+++ b/TTS/facebookmms_handler.py
@@ -15,11 +15,45 @@ logger = logging.getLogger(__name__)
 console = Console()
 
 WHISPER_LANGUAGE_TO_FACEBOOK_LANGUAGE = {
-    "en": "eng",
-    "fr": "fra",
-    "es": "spa",
-    "ko": "kor",
-    "hi": "hin",
+    "en": "eng", # English
+    "fr": "fra", # French
+    "es": "spa", # Spanish
+    "ko": "kor", # Korean
+    "hi": "hin", # Hindi
+    "ar": "ara", # Arabic
+    "ar": "hyw", # Armenian
+    "az": "azb", # Azerbaijani
+    "bu": "bul", # Bulgarian
+    "ca": "cat", # Catalan
+    "nl": "nld", # Dutch
+    "fi": "fin", # Finnish
+    "fr": "fra", # French
+    "de": "deu", # German
+    "el": "ell", # Greek
+    "he": "heb", # Hebrew
+    "hu": "hun", # Hungarian
+    "is": "isl", # Icelandic
+    "id": "ind", # Indonesian
+    "ka": "kan", # Kannada
+    "kk": "kaz", # Kazakh
+    "lv": "lav", # Latvian
+    "zl": "zlm", # Malay
+    "ma": "mar", # Marathi
+    "fa": "fas", # Persian
+    "po": "pol", # Polish
+    "pt": "por", # Portuguese
+    "ro": "ron", # Romanian
+    "ru": "rus", # Russian
+    "sw": "swh", # Swahili
+    "sv": "swe", # Swedish
+    "tg": "tgl", # Tagalog
+    "ta": "tam", # Tamil
+    "th": "tha", # Thai
+    "tu": "tur", # Turkish
+    "uk": "ukr", # Ukrainian
+    "ur": "urd", # Urdu
+    "vi": "vie", # Vietnamese
+    "cy": "cym", # Welsh
 }
 
 class FacebookMMSTTSHandler(BaseHandler):

--- a/TTS/facebookmms_handler.py
+++ b/TTS/facebookmms_handler.py
@@ -29,7 +29,6 @@ class FacebookMMSTTSHandler(BaseHandler):
         facebook_mms_device="cuda",
         facebook_mms_torch_dtype="float32",
         language="en",
-        speaker_to_id="en",  # Added for consistency with MeloTTSHandler
         stream=True,
         chunk_size=512,
         **kwargs

--- a/TTS/facebookmms_handler.py
+++ b/TTS/facebookmms_handler.py
@@ -15,11 +15,11 @@ logger = logging.getLogger(__name__)
 console = Console()
 
 WHISPER_LANGUAGE_TO_FACEBOOK_LANGUAGE = {
-    "<|en|>": "eng",
-    "<|fr|>": "fra",
-    "<|es|>": "spa",
-    "<|ko|>": "kor",
-    "<|hi|>": "hin",
+    "en": "eng",
+    "fr": "fra",
+    "es": "spa",
+    "ko": "kor",
+    "hi": "hin",
 }
 
 class FacebookMMSTTSHandler(BaseHandler):
@@ -29,7 +29,7 @@ class FacebookMMSTTSHandler(BaseHandler):
         facebook_mms_device="cuda",
         facebook_mms_torch_dtype="float32",
         language="en",
-        tts_language=None,  # Added tts_language flag
+        speaker_to_id="en",  # Added for consistency with MeloTTSHandler
         stream=True,
         chunk_size=512,
         **kwargs
@@ -39,16 +39,20 @@ class FacebookMMSTTSHandler(BaseHandler):
         self.torch_dtype = getattr(torch, facebook_mms_torch_dtype)
         self.stream = stream
         self.chunk_size = chunk_size
-        self.language = "<|" + (tts_language if tts_language else language) + "|>"  # Use tts_language if provided
+        self.language = language
 
         self.load_model(self.language)
 
-    def load_model(self, language_id):
-        model_name = f"facebook/mms-tts-{WHISPER_LANGUAGE_TO_FACEBOOK_LANGUAGE[language_id]}"
-        logger.info(f"Loading model: {model_name}")
-        self.model = VitsModel.from_pretrained(model_name).to(self.device)
-        self.tokenizer = AutoTokenizer.from_pretrained(model_name)
-        self.language = language_id
+    def load_model(self, language_code):
+        try:
+            model_name = f"facebook/mms-tts-{WHISPER_LANGUAGE_TO_FACEBOOK_LANGUAGE[language_code]}"
+            logger.info(f"Loading model: {model_name}")
+            self.model = VitsModel.from_pretrained(model_name).to(self.device)
+            self.tokenizer = AutoTokenizer.from_pretrained(model_name)
+            self.language = language_code
+        except KeyError:
+            logger.warning(f"Unsupported language: {language_code}. Falling back to English.")
+            self.load_model("en")
 
     def generate_audio(self, text):
         if not text:
@@ -82,22 +86,22 @@ class FacebookMMSTTSHandler(BaseHandler):
             return None
 
     def process(self, llm_sentence):
-        language_id = None
+        language_code = None
 
         if isinstance(llm_sentence, tuple):
-            llm_sentence, language_id = llm_sentence
+            llm_sentence, language_code = llm_sentence
 
         console.print(f"[green]ASSISTANT: {llm_sentence}")
         logger.debug(f"Processing text: {llm_sentence}")
-        logger.debug(f"Language ID: {language_id}")
+        logger.debug(f"Language code: {language_code}")
 
-        if language_id is not None and self.language != language_id:
+        if language_code is not None and self.language != language_code:
             try:
-                logger.info(f"Switching language from {self.language} to {language_id}")
-                self.load_model(language_id)
+                logger.info(f"Switching language from {self.language} to {language_code}")
+                self.load_model(language_code)
             except KeyError:
-                console.print(f"[red]Language {language_id} not supported by Facebook MMS. Using {self.language} instead.")
-                logger.warning(f"Unsupported language: {language_id}")
+                console.print(f"[red]Language {language_code} not supported by Facebook MMS. Using {self.language} instead.")
+                logger.warning(f"Unsupported language: {language_code}")
 
         audio_output = self.generate_audio(llm_sentence)
         

--- a/arguments_classes/facebookmms_tts_arguments.py
+++ b/arguments_classes/facebookmms_tts_arguments.py
@@ -1,0 +1,17 @@
+from dataclasses import field, dataclass
+
+@dataclass
+class FacebookMMSTTSHandlerArguments:
+    model_name: str = field(
+        default="facebook/mms-tts-hin",
+        metadata={
+            "help": "The model name to use. Default is 'facebook/mms-tts-hin'."
+        },
+    )
+    tts_language: str = field(  # Renamed to avoid conflict
+        default="en",
+        metadata={
+            "help": "The language code for the TTS model. Default is 'en' for English."
+        },
+    )
+    

--- a/arguments_classes/facebookmms_tts_arguments.py
+++ b/arguments_classes/facebookmms_tts_arguments.py
@@ -3,12 +3,12 @@ from dataclasses import field, dataclass
 @dataclass
 class FacebookMMSTTSHandlerArguments:
     model_name: str = field(
-        default="facebook/mms-tts-hin",
+        default="facebook/mms-tts-eng",
         metadata={
             "help": "The model name to use. Default is 'facebook/mms-tts-hin'."
         },
     )
-    tts_language: str = field(  # Renamed to avoid conflict
+    tts_language: str = field(
         default="en",
         metadata={
             "help": "The language code for the TTS model. Default is 'en' for English."

--- a/arguments_classes/facebookmms_tts_arguments.py
+++ b/arguments_classes/facebookmms_tts_arguments.py
@@ -5,7 +5,7 @@ class FacebookMMSTTSHandlerArguments:
     model_name: str = field(
         default="facebook/mms-tts-eng",
         metadata={
-            "help": "The model name to use. Default is 'facebook/mms-tts-hin'."
+            "help": "The model name to use. Default is 'facebook/mms-tts-eng'."
         },
     )
     tts_language: str = field(

--- a/arguments_classes/module_arguments.py
+++ b/arguments_classes/module_arguments.py
@@ -35,7 +35,7 @@ class ModuleArguments:
     tts: Optional[str] = field(
         default="parler",
         metadata={
-            "help": "The TTS to use. Either 'parler', 'melo', or 'chatTTS'. Default is 'parler'"
+            "help": "The TTS to use. Either 'parler', 'melo', 'chatTTS' or 'facebookmms'. Default is 'parler'"
         },
     )
     log_level: str = field(

--- a/arguments_classes/whisper_stt_arguments.py
+++ b/arguments_classes/whisper_stt_arguments.py
@@ -57,7 +57,7 @@ class WhisperSTTHandlerArguments:
         metadata={
             "help": """The language for the conversation. 
             Choose between 'en' (english), 'fr' (french), 'es' (spanish), 
-            'zh' (chinese), 'ko' (korean), 'ja' (japanese), or 'None'.
+            'zh' (chinese), 'ko' (korean), 'ja' (japanese), 'hi' (hindi) or 'None'.
             If using 'auto', the language is automatically detected and can
             change during the conversation. Default is 'en'."""
         },

--- a/s2s_pipeline.py
+++ b/s2s_pipeline.py
@@ -21,6 +21,7 @@ from arguments_classes.socket_sender_arguments import SocketSenderArguments
 from arguments_classes.vad_arguments import VADHandlerArguments
 from arguments_classes.whisper_stt_arguments import WhisperSTTHandlerArguments
 from arguments_classes.melo_tts_arguments import MeloTTSHandlerArguments
+from arguments_classes.facebookmms_tts_arguments import FacebookMMSTTSHandlerArguments
 import torch
 import nltk
 from rich.console import Console
@@ -81,6 +82,7 @@ def main():
             ParlerTTSHandlerArguments,
             MeloTTSHandlerArguments,
             ChatTTSHandlerArguments,
+            FacebookMMSTTSHandlerArguments,
         )
     )
 
@@ -99,6 +101,7 @@ def main():
             parler_tts_handler_kwargs,
             melo_tts_handler_kwargs,
             chat_tts_handler_kwargs,
+            facebook_mms_tts_handler_kwargs,
         ) = parser.parse_json_file(json_file=os.path.abspath(sys.argv[1]))
     else:
         # Parse arguments from command line if no JSON file is provided
@@ -114,6 +117,7 @@ def main():
             parler_tts_handler_kwargs,
             melo_tts_handler_kwargs,
             chat_tts_handler_kwargs,
+            facebook_mms_tts_handler_kwargs,
         ) = parser.parse_args_into_dataclasses()
 
     # 1. Handle logger
@@ -191,6 +195,7 @@ def main():
     prepare_args(parler_tts_handler_kwargs, "tts")
     prepare_args(melo_tts_handler_kwargs, "melo")
     prepare_args(chat_tts_handler_kwargs, "chat_tts")
+    prepare_args(facebook_mms_tts_handler_kwargs, "facebook_mms_tts")
 
     # 3. Build the pipeline
     stop_event = Event()
@@ -327,6 +332,15 @@ def main():
             queue_out=send_audio_chunks_queue,
             setup_args=(should_listen,),
             setup_kwargs=vars(chat_tts_handler_kwargs),
+        )
+    elif module_kwargs.tts == "facebookmms":
+        from TTS.facebookmms_handler import FacebookMMSTTSHandler
+        tts = FacebookMMSTTSHandler(
+            stop_event,
+            queue_in=lm_response_queue,
+            queue_out=send_audio_chunks_queue,
+            setup_args=(should_listen,),
+            setup_kwargs=vars(facebook_mms_tts_handler_kwargs),
         )
     else:
         raise ValueError("The TTS should be either parler, melo or chatTTS")


### PR DESCRIPTION
This PR introduces support for multiple languages in the speech-to-speech pipeline by integrating Facebook's MMS TTS model.

### Key Changes:
- Added Facebook mms handler and arguments file
- Added a new option to specify the language for TTS with the `--tts_language` flag.
- Support for Hindi (and other languages) using the `facebookmms` TTS model.
- Extended the pipeline to handle multilingual speech synthesis.

### Example usage with Hindi:

```bash
python s2s_pipeline.py --recv_host 0.0.0.0 --send_host 0.0.0.0 --stt_model_name openai/whisper-medium --tts_language hi --language hi --tts facebookmms --lm_model_name meta-llama/Meta-Llama-3.1-8B-Instruct