### PR TITLE
fix: Changed [True] to [False] in help text for audio_enhancement to align with actual default

### DIFF
--- a/arguments_classes/vad_arguments.py
+++ b/arguments_classes/vad_arguments.py
@@ -42,6 +42,6 @@ class VADHandlerArguments:
     audio_enhancement: bool = field(
         default=False,
         metadata={
-            "help": "improves sound quality by applying techniques like noise reduction, equalization, and echo cancellation. Default is True."
+            "help": "improves sound quality by applying techniques like noise reduction, equalization, and echo cancellation. Default is False."
         },
     )


### PR DESCRIPTION
Fixed help comment mismatch with actual default value.

Introduced in this commit: https://github.com/huggingface/speech-to-speech/commit/5e667f94a43152fec53d561213c630d0fbc40721