### PR TITLE
feat[stt]: add faster-whisper

### DIFF
--- a/STT/faster_whisper_handler.py
+++ b/STT/faster_whisper_handler.py
@@ -51,6 +51,8 @@ class FasterWhisperSTTHandler(BaseHandler):
             console.print(f"[yellow]USER: {pred_text}")
 
             yield pred_text
+        else:
+            logger.debug("no text detected. skipping...")
 
     def cleanup(self):
         print("Stopping FasterWhisperSTTHandler")

--- a/STT/faster_whisper_handler.py
+++ b/STT/faster_whisper_handler.py
@@ -1,0 +1,62 @@
+import logging
+import os
+from time import perf_counter
+
+from faster_whisper import WhisperModel
+from rich.console import Console
+
+from baseHandler import BaseHandler
+
+console = Console()
+
+logger = logging.getLogger(__name__)
+
+
+class FasterWhisperSTTHandler(BaseHandler):
+    """
+    Handles the Speech To Text generation using a Whisper model.
+    """
+
+    def setup(
+        self,
+        model_name: str = "tiny.en",
+        device: str = "auto",
+        compute_type: str = "auto",
+        gen_kwargs={},
+    ):
+        self.gen_kwargs = self.adapt_gen_kwargs(gen_kwargs)
+
+        os.environ["KMP_DUPLICATE_LIB_OK"] = "TRUE"
+        self.model = WhisperModel(model_name, device=device, compute_type=compute_type)
+
+    def process(self, audio):
+        logger.debug("infering faster whisper...")
+
+        global pipeline_start
+        pipeline_start = perf_counter()
+
+        segments, info = self.model.transcribe(audio, **self.gen_kwargs)
+        output_text = []
+
+        for segment in segments:
+            logger.debug(
+                "[%.2fs -> %.2fs] %s" % (segment.start, segment.end, segment.text)
+            )
+            output_text.append(segment.text)
+
+        pred_text = " ".join(output_text).strip()
+
+        logger.debug("finished whisper inference")
+        if pred_text:
+            console.print(f"[yellow]USER: {pred_text}")
+
+            yield pred_text
+
+    def cleanup(self):
+        print("Stopping FasterWhisperSTTHandler")
+        del self.model
+
+    def adapt_gen_kwargs(self, gen_kwargs: dict):
+        gen_kwargs["without_timestamps"] = not gen_kwargs.pop("return_timestamps", True)
+
+        return gen_kwargs

--- a/arguments_classes/faster_whisper_stt_arguments.py
+++ b/arguments_classes/faster_whisper_stt_arguments.py
@@ -1,0 +1,60 @@
+from dataclasses import dataclass, field
+
+
+@dataclass
+class FasterWhisperSTTHandlerArguments:
+    stt_model_name: str = field(
+        default="tiny.en",
+        metadata={
+            "help": """The pretrained Faster Whisper model to use.
+            One of ('tiny', 'tiny.en', 'base', 'base.en', 'small', 'small.en', 'distil-small.en', 'medium', 'medium.en', 'distil-medium.en', 'large-v1', 'large-v2', 'large-v3', 'large', 'distil-large-v2', 'distil-large-v3').
+            Default is 'small'."""
+        },
+    )
+    stt_device: str = field(
+        default="auto",
+        metadata={
+            "help": """The device type on which the model will run.
+            One of ('cpu', 'cuda', 'auto').
+            Default is 'auto'."""
+        },
+    )
+    stt_compute_type: str = field(
+        default="auto",
+        metadata={
+            "help": """The data type to use for computation.
+            One of ('default', 'auto', 'int8', 'int8_float32', 'int8_float16', 'int8_bfloat16', 'int16', 'float16', 'float32', 'bfloat16')
+            Default is 'auto'.
+            Refer to 'https://opennmt.net/CTranslate2/quantization.html#quantize-on-model-loading'"""
+        },
+    )
+    stt_gen_max_new_tokens: int = field(
+        default=128,
+        metadata={
+            "help": "The maximum number of new tokens to generate. Default is 128."
+        },
+    )
+    stt_gen_beam_size: int = field(
+        default=1,
+        metadata={
+            "help": "The number of beams for beam search. Default is 1, implying greedy decoding."
+        },
+    )
+    stt_gen_return_timestamps: bool = field(
+        default=False,
+        metadata={
+            "help": "Whether to return timestamps with transcriptions. Default is False."
+        },
+    )
+    stt_gen_task: str = field(
+        default="transcribe",
+        metadata={
+            "help": "The task to perform, typically 'transcribe' for transcription. Default is 'transcribe'."
+        },
+    )
+    stt_gen_language: str = field(
+        default="en",
+        metadata={
+            "help": "The language of the speech to transcribe. Default is 'en' for English."
+        },
+    )

--- a/arguments_classes/faster_whisper_stt_arguments.py
+++ b/arguments_classes/faster_whisper_stt_arguments.py
@@ -3,7 +3,7 @@ from dataclasses import dataclass, field
 
 @dataclass
 class FasterWhisperSTTHandlerArguments:
-    stt_model_name: str = field(
+    faster_whisper_stt_model_name: str = field(
         default="tiny.en",
         metadata={
             "help": """The pretrained Faster Whisper model to use.
@@ -11,7 +11,7 @@ class FasterWhisperSTTHandlerArguments:
             Default is 'small'."""
         },
     )
-    stt_device: str = field(
+    faster_whisper_stt_device: str = field(
         default="auto",
         metadata={
             "help": """The device type on which the model will run.
@@ -19,7 +19,7 @@ class FasterWhisperSTTHandlerArguments:
             Default is 'auto'."""
         },
     )
-    stt_compute_type: str = field(
+    faster_whisper_stt_compute_type: str = field(
         default="auto",
         metadata={
             "help": """The data type to use for computation.
@@ -28,31 +28,31 @@ class FasterWhisperSTTHandlerArguments:
             Refer to 'https://opennmt.net/CTranslate2/quantization.html#quantize-on-model-loading'"""
         },
     )
-    stt_gen_max_new_tokens: int = field(
+    faster_whisper_stt_gen_max_new_tokens: int = field(
         default=128,
         metadata={
             "help": "The maximum number of new tokens to generate. Default is 128."
         },
     )
-    stt_gen_beam_size: int = field(
+    faster_whisper_stt_gen_beam_size: int = field(
         default=1,
         metadata={
             "help": "The number of beams for beam search. Default is 1, implying greedy decoding."
         },
     )
-    stt_gen_return_timestamps: bool = field(
+    faster_whisper_stt_gen_return_timestamps: bool = field(
         default=False,
         metadata={
             "help": "Whether to return timestamps with transcriptions. Default is False."
         },
     )
-    stt_gen_task: str = field(
+    faster_whisper_stt_gen_task: str = field(
         default="transcribe",
         metadata={
             "help": "The task to perform, typically 'transcribe' for transcription. Default is 'transcribe'."
         },
     )
-    stt_gen_language: str = field(
+    faster_whisper_stt_gen_language: str = field(
         default="en",
         metadata={
             "help": "The language of the speech to transcribe. Default is 'en' for English."

--- a/arguments_classes/module_arguments.py
+++ b/arguments_classes/module_arguments.py
@@ -41,6 +41,6 @@ class ModuleArguments:
     log_level: str = field(
         default="info",
         metadata={
-            "help": "Provide logging level. Example --log_level debug, default=warning."
+            "help": "Provide logging level. Example --log_level debug, default=info."
         },
     )

--- a/arguments_classes/module_arguments.py
+++ b/arguments_classes/module_arguments.py
@@ -23,7 +23,7 @@ class ModuleArguments:
     stt: Optional[str] = field(
         default="whisper",
         metadata={
-            "help": "The STT to use. Either 'whisper', 'whisper-mlx', and 'paraformer'. Default is 'whisper'."
+            "help": "The STT to use. Either 'whisper', 'whisper-mlx', 'faster-whisper', and 'paraformer'. Default is 'whisper'."
         },
     )
     llm: Optional[str] = field(

--- a/requirements.txt
+++ b/requirements.txt
@@ -5,5 +5,6 @@ torch==2.4.0
 sounddevice==0.5.0
 ChatTTS>=0.1.1
 funasr>=1.1.6
+faster-whisper>=1.0.3
 modelscope>=1.17.1
 deepfilternet>=0.5.6

--- a/requirements_mac.txt
+++ b/requirements_mac.txt
@@ -7,6 +7,7 @@ lightning-whisper-mlx>=0.0.10
 mlx-lm>=0.14.0
 ChatTTS>=0.1.1
 funasr>=1.1.6
+faster-whisper>=1.0.3
 modelscope>=1.17.1
 deepfilternet>=0.5.6
 

--- a/s2s_pipeline.py
+++ b/s2s_pipeline.py
@@ -20,6 +20,9 @@ from arguments_classes.socket_receiver_arguments import SocketReceiverArguments
 from arguments_classes.socket_sender_arguments import SocketSenderArguments
 from arguments_classes.vad_arguments import VADHandlerArguments
 from arguments_classes.whisper_stt_arguments import WhisperSTTHandlerArguments
+from arguments_classes.faster_whisper_stt_arguments import (
+    FasterWhisperSTTHandlerArguments,
+)
 from arguments_classes.melo_tts_arguments import MeloTTSHandlerArguments
 import torch
 import nltk
@@ -76,6 +79,7 @@ def main():
             VADHandlerArguments,
             WhisperSTTHandlerArguments,
             ParaformerSTTHandlerArguments,
+            FasterWhisperSTTHandlerArguments,
             LanguageModelHandlerArguments,
             MLXLanguageModelHandlerArguments,
             ParlerTTSHandlerArguments,
@@ -94,6 +98,7 @@ def main():
             vad_handler_kwargs,
             whisper_stt_handler_kwargs,
             paraformer_stt_handler_kwargs,
+            faster_whisper_stt_handler_kwargs,
             language_model_handler_kwargs,
             mlx_language_model_handler_kwargs,
             parler_tts_handler_kwargs,
@@ -109,6 +114,7 @@ def main():
             vad_handler_kwargs,
             whisper_stt_handler_kwargs,
             paraformer_stt_handler_kwargs,
+            faster_whisper_stt_handler_kwargs,
             language_model_handler_kwargs,
             mlx_language_model_handler_kwargs,
             parler_tts_handler_kwargs,
@@ -182,10 +188,12 @@ def main():
         parler_tts_handler_kwargs,
         whisper_stt_handler_kwargs,
         paraformer_stt_handler_kwargs,
+        faster_whisper_stt_handler_kwargs,
     )
 
     prepare_args(whisper_stt_handler_kwargs, "stt")
     prepare_args(paraformer_stt_handler_kwargs, "paraformer_stt")
+    prepare_args(faster_whisper_stt_handler_kwargs, "faster_whisper_stt")
     prepare_args(language_model_handler_kwargs, "lm")
     prepare_args(mlx_language_model_handler_kwargs, "mlx_lm")
     prepare_args(parler_tts_handler_kwargs, "tts")
@@ -264,6 +272,15 @@ def main():
             queue_in=spoken_prompt_queue,
             queue_out=text_prompt_queue,
             setup_kwargs=vars(paraformer_stt_handler_kwargs),
+        )
+    elif module_kwargs.stt == "faster-whisper":
+        from STT.faster_whisper_handler import FasterWhisperSTTHandler
+
+        stt = FasterWhisperSTTHandler(
+            stop_event,
+            queue_in=spoken_prompt_queue,
+            queue_out=text_prompt_queue,
+            setup_kwargs=vars(faster_whisper_stt_handler_kwargs),
         )
     else:
         raise ValueError(


### PR DESCRIPTION
#4 

`return_timestamps` in whisper gen_kwargs is adopted here (instead of `without_timestamps` in actual faster-whisper kwargs) because I think it could be more natural and straightforward