### PR TITLE
Fix hanging client on KeyboardInterrupt

### DIFF
--- a/listen_and_play.py
+++ b/listen_and_play.py
@@ -113,6 +113,8 @@ def listen_and_play(
 
     finally:
         stop_event.set()
+        # Given that socket::recv is blocking in receive_data_chunk, shut it down to allow the thread to continue.
+        recv_socket.shutdown(socket.SHUT_RDWR)
         recv_thread.join()
         send_thread.join()
         send_socket.close()


### PR DESCRIPTION
Given that `socket.recv()` is blocking in `receive_data_chunk()`, shut it down to allow the thread to continue. Client hangs because `recv_thread.join()` is waiting forever. Worth noting that shutdown is about closing off the connection, and `close()` is about closing the file descriptor and discarding any data that may be in the file description's buffer. Fixes https://github.com/huggingface/speech-to-speech/issues/122 .
