### PR TITLE
set keras backend to torch.

### DIFF
--- a/STT/moonshine_handler.py
+++ b/STT/moonshine_handler.py
@@ -1,3 +1,6 @@
+import os
+os.environ['KERAS_BACKEND'] = 'torch'
+
 from time import perf_counter
 import moonshine
 import torch


### PR DESCRIPTION
small bug with moonshine, I need to set the backend to torch since this project doesn't have tensorflow