### PR TITLE
Bugfix: can not concatenate str + GenerationResponse

### DIFF
--- a/LLM/mlx_language_model.py
+++ b/LLM/mlx_language_model.py
@@ -98,8 +98,8 @@ class MLXLanguageModelHandler(BaseHandler):
             prompt,
             max_tokens=self.gen_kwargs["max_new_tokens"],
         ):
-            output += t
-            curr_output += t
+            output += t.text
+            curr_output += t.text
             if curr_output.endswith((".", "?", "!", "<|end|>")):
                 yield (curr_output.replace("<|end|>", ""), language_code)
                 curr_output = ""


### PR DESCRIPTION
I installed the project locally on a Mac following the instructions (commit `fbe9a43`). Upon the first run I got:
```
Exception in thread Thread-5 (run):
Traceback (most recent call last):
  File ".../lib/python3.11/threading.py", line 1045, in _bootstrap_inner
    self.run()
  File ".../lib/python3.11/threading.py", line 982, in run
    self._target(*self._args, **self._kwargs)
  File ".../speech-to-speech/baseHandler.py", line 37, in run
    for output in self.process(input):
  File ".../speech-to-speech/LLM/mlx_language_model.py", line 101, in process
    output += t
TypeError: can only concatenate str (not "GenerationResponse") to str
```

Looks like `stream_generate` returns instances of `GenerationResponse` and not strings. Getting the `.text` attribute from the generation response fixes the issue and I confirm that I can run the model correctly.