### PR TITLE
bug: use `whisper-mlx` instead of `moonshine` as the STT model for macos

### DIFF
--- a/s2s_pipeline.py
+++ b/s2s_pipeline.py
@@ -120,7 +120,7 @@ def optimal_mac_settings(mac_optimal_settings: Optional[str], *handler_kwargs):
             if hasattr(kwargs, "mode"):
                 kwargs.mode = "local"
             if hasattr(kwargs, "stt"):
-                kwargs.stt = "moonshine"
+                kwargs.stt = "whisper-mlx"
             if hasattr(kwargs, "llm"):
                 kwargs.llm = "mlx-lm"
             if hasattr(kwargs, "tts"):


### PR DESCRIPTION
## Description

The README section in the below image already claims it uses `whisper-mlx` but this is not reflected in the code, so this PR fixes that.

<img width="719" height="488" alt="image" src="https://github.com/user-attachments/assets/9b03587b-820b-49a5-8bd4-7c5b257d4457" />
