### PR TITLE
Add new STT and TTS models to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,6 +38,8 @@ The pipeline provides a fully open and modular approach, with a focus on leverag
 **STT**
 - Any [Whisper](https://huggingface.co/docs/transformers/en/model_doc/whisper) model checkpoint on the Hugging Face Hub through Transformers 🤗, including [whisper-large-v3](https://huggingface.co/openai/whisper-large-v3) and [distil-large-v3](https://huggingface.co/distil-whisper/distil-large-v3)
 - [Lightning Whisper MLX](https://github.com/mustafaaljadery/lightning-whisper-mlx?tab=readme-ov-file#lightning-whisper-mlx)
+- [MLX Audio Whisper](https://github.com/huggingface/mlx-audio) - Fast Whisper inference on Apple Silicon
+- [Parakeet TDT](https://huggingface.co/nvidia/parakeet-tdt-1.1b) - Real-time streaming STT with sub-100ms latency on Apple Silicon
 - [Paraformer - FunASR](https://github.com/modelscope/FunASR)
 
 **LLM**
@@ -49,6 +51,7 @@ The pipeline provides a fully open and modular approach, with a focus on leverag
 - [Parler-TTS](https://github.com/huggingface/parler-tts) 🤗
 - [MeloTTS](https://github.com/myshell-ai/MeloTTS)
 - [ChatTTS](https://github.com/2noise/ChatTTS?tab=readme-ov-file)
+- [Kokoro-82M](https://huggingface.co/hexgrad/Kokoro-82M) - Fast and high-quality TTS optimized for Apple Silicon
 
 ## Setup
 


### PR DESCRIPTION
## Summary
- Add Parakeet TDT to STT section - real-time streaming STT with sub-100ms latency on Apple Silicon
- Add MLX Audio Whisper to STT section - fast Whisper inference optimized for Apple Silicon
- Add Kokoro-82M to TTS section - fast and high-quality TTS optimized for Apple Silicon

These models were recently added to the repository and represent significant performance improvements, especially for Apple Silicon users.

## Test plan
- [x] README renders correctly
- [x] All links are valid
- [x] Model descriptions are accurate

🤖 Generated with [Claude Code](https://claude.com/claude-code)