### PR TITLE
feat: add MiniMax as first-class LLM provider (M3 default)

### DIFF
--- a/LLM/minimax_language_model.py
+++ b/LLM/minimax_language_model.py
@@ -1,0 +1,66 @@
+import logging
+import os
+import re
+
+from LLM.openai_api_language_model import OpenApiModelHandler
+
+logger = logging.getLogger(__name__)
+
+# Pattern to strip thinking tags from MiniMax M2.5/M2.7 responses
+THINK_TAG_PATTERN = re.compile(r"<think>.*?</think>\s*", re.DOTALL)
+
+
+class MiniMaxModelHandler(OpenApiModelHandler):
+    """
+    MiniMax LLM handler built on top of the OpenAI-compatible API handler.
+
+    Adds MiniMax-specific defaults (base URL, model, API key auto-detection)
+    and temperature clamping to stay within MiniMax's accepted range.
+    """
+
+    def setup(
+        self,
+        model_name="MiniMax-M2.7",
+        device="cuda",
+        gen_kwargs={},
+        base_url="https://api.minimax.io/v1",
+        api_key=None,
+        stream=False,
+        user_role="user",
+        chat_size=1,
+        init_chat_role="system",
+        init_chat_prompt="You are a helpful AI assistant.",
+    ):
+        if api_key is None:
+            api_key = os.environ.get("MINIMAX_API_KEY")
+            if not api_key:
+                raise ValueError(
+                    "MiniMax API key is required. Set it via --minimax_api_key or "
+                    "the MINIMAX_API_KEY environment variable."
+                )
+
+        # Clamp temperature to MiniMax's accepted range [0.0, 1.0]
+        gen_kwargs = dict(gen_kwargs)
+        if "temperature" in gen_kwargs:
+            gen_kwargs["temperature"] = max(0.0, min(1.0, gen_kwargs["temperature"]))
+
+        super().setup(
+            model_name=model_name,
+            device=device,
+            gen_kwargs=gen_kwargs,
+            base_url=base_url,
+            api_key=api_key,
+            stream=stream,
+            user_role=user_role,
+            chat_size=chat_size,
+            init_chat_role=init_chat_role,
+            init_chat_prompt=init_chat_prompt,
+            disable_thinking=False,
+        )
+
+    def process(self, prompt):
+        for text, language_code, tools in super().process(prompt):
+            # Strip thinking tags that MiniMax models may include
+            if text:
+                text = THINK_TAG_PATTERN.sub("", text).strip()
+            yield text, language_code, tools

--- a/LLM/minimax_language_model.py
+++ b/LLM/minimax_language_model.py
@@ -6,7 +6,7 @@ from LLM.openai_api_language_model import OpenApiModelHandler
 
 logger = logging.getLogger(__name__)
 
-# Pattern to strip thinking tags from MiniMax M2.5/M2.7 responses
+# Pattern to strip thinking tags from MiniMax M3/M2.7 responses
 THINK_TAG_PATTERN = re.compile(r"<think>.*?</think>\s*", re.DOTALL)
 
 
@@ -20,7 +20,7 @@ class MiniMaxModelHandler(OpenApiModelHandler):
 
     def setup(
         self,
-        model_name="MiniMax-M2.7",
+        model_name="MiniMax-M3",
         device="cuda",
         gen_kwargs={},
         base_url="https://api.minimax.io/v1",

--- a/README.md
+++ b/README.md
@@ -45,6 +45,7 @@ The pipeline provides a fully open and modular approach, with a focus on leverag
 - Any instruction-following model on the [Hugging Face Hub](https://huggingface.co/models?pipeline_tag=text-generation&sort=trending) via Transformers 🤗
 - [mlx-lm](https://github.com/ml-explore/mlx-examples/blob/main/llms/README.md)
 - [OpenAI API](https://platform.openai.com/docs/quickstart)
+- [MiniMax API](https://platform.minimaxi.com/) — MiniMax-M2.7, MiniMax-M2.5, MiniMax-M2.5-highspeed
 
 **TTS**
 - [MeloTTS](https://github.com/myshell-ai/MeloTTS)
@@ -229,6 +230,24 @@ python s2s_pipeline.py \
 ```
 
 Available voice presets: `alba`, `marius`, `javert`, `jean`, `fantine`, `cosette`, `eponine`, `azelma`. You can also use custom voice files or HuggingFace paths.
+
+### Using MiniMax LLM
+
+You can use [MiniMax](https://platform.minimaxi.com/) cloud models as the language model backend. Set your API key and select the `minimax` LLM:
+
+```bash
+export MINIMAX_API_KEY="your-api-key"
+
+python s2s_pipeline.py \
+    --llm minimax \
+    --minimax_model_name MiniMax-M2.7 \
+    --minimax_stream \
+    --tts pocket \
+    --recv_host 0.0.0.0 \
+    --send_host 0.0.0.0
+```
+
+Available models: `MiniMax-M2.7` (default), `MiniMax-M2.5`, `MiniMax-M2.5-highspeed` (204K context).
 
 ## Command-line Usage
 

--- a/README.md
+++ b/README.md
@@ -45,7 +45,7 @@ The pipeline provides a fully open and modular approach, with a focus on leverag
 - Any instruction-following model on the [Hugging Face Hub](https://huggingface.co/models?pipeline_tag=text-generation&sort=trending) via Transformers 🤗
 - [mlx-lm](https://github.com/ml-explore/mlx-examples/blob/main/llms/README.md)
 - [OpenAI API](https://platform.openai.com/docs/quickstart)
-- [MiniMax API](https://platform.minimaxi.com/) — MiniMax-M2.7, MiniMax-M2.5, MiniMax-M2.5-highspeed
+- [MiniMax API](https://platform.minimaxi.com/) — MiniMax-M3, MiniMax-M2.7, MiniMax-M2.7-highspeed
 
 **TTS**
 - [MeloTTS](https://github.com/myshell-ai/MeloTTS)
@@ -240,14 +240,14 @@ export MINIMAX_API_KEY="your-api-key"
 
 python s2s_pipeline.py \
     --llm minimax \
-    --minimax_model_name MiniMax-M2.7 \
+    --minimax_model_name MiniMax-M3 \
     --minimax_stream \
     --tts pocket \
     --recv_host 0.0.0.0 \
     --send_host 0.0.0.0
 ```
 
-Available models: `MiniMax-M2.7` (default), `MiniMax-M2.5`, `MiniMax-M2.5-highspeed` (204K context).
+Available models: `MiniMax-M3` (default, 512K context, up to 128K output, image input), `MiniMax-M2.7`, `MiniMax-M2.7-highspeed`.
 
 ## Command-line Usage
 

--- a/arguments_classes/minimax_language_model_arguments.py
+++ b/arguments_classes/minimax_language_model_arguments.py
@@ -1,0 +1,54 @@
+from dataclasses import dataclass, field
+
+
+@dataclass
+class MiniMaxLanguageModelHandlerArguments:
+    minimax_model_name: str = field(
+        default="MiniMax-M2.7",
+        metadata={
+            "help": "The MiniMax model to use. Default is 'MiniMax-M2.7'. "
+            "Also available: 'MiniMax-M2.5', 'MiniMax-M2.5-highspeed'."
+        },
+    )
+    minimax_user_role: str = field(
+        default="user",
+        metadata={
+            "help": "Role assigned to the user in the chat context. Default is 'user'."
+        },
+    )
+    minimax_init_chat_role: str = field(
+        default="system",
+        metadata={
+            "help": "Initial role for setting up the chat context. Default is 'system'."
+        },
+    )
+    minimax_init_chat_prompt: str = field(
+        default="You are a helpful and friendly AI assistant. You are polite, respectful, and aim to provide concise responses of less than 20 words.",
+        metadata={
+            "help": "The initial chat prompt to establish context for the language model."
+        },
+    )
+    minimax_chat_size: int = field(
+        default=5,
+        metadata={
+            "help": "Number of interactions assistant-user to keep for the chat. None for no limitations."
+        },
+    )
+    minimax_api_key: str = field(
+        default=None,
+        metadata={
+            "help": "MiniMax API key. If not set, falls back to MINIMAX_API_KEY environment variable."
+        },
+    )
+    minimax_base_url: str = field(
+        default="https://api.minimax.io/v1",
+        metadata={
+            "help": "MiniMax API base URL. Default is 'https://api.minimax.io/v1'."
+        },
+    )
+    minimax_stream: bool = field(
+        default=False,
+        metadata={
+            "help": "Whether to use streaming mode for MiniMax API responses. Default is False."
+        },
+    )

--- a/arguments_classes/minimax_language_model_arguments.py
+++ b/arguments_classes/minimax_language_model_arguments.py
@@ -4,10 +4,10 @@ from dataclasses import dataclass, field
 @dataclass
 class MiniMaxLanguageModelHandlerArguments:
     minimax_model_name: str = field(
-        default="MiniMax-M2.7",
+        default="MiniMax-M3",
         metadata={
-            "help": "The MiniMax model to use. Default is 'MiniMax-M2.7'. "
-            "Also available: 'MiniMax-M2.5', 'MiniMax-M2.5-highspeed'."
+            "help": "The MiniMax model to use. Default is 'MiniMax-M3'. "
+            "Also available: 'MiniMax-M2.7', 'MiniMax-M2.7-highspeed'."
         },
     )
     minimax_user_role: str = field(

--- a/arguments_classes/module_arguments.py
+++ b/arguments_classes/module_arguments.py
@@ -29,7 +29,7 @@ class ModuleArguments:
     llm: Optional[str] = field(
         default="transformers",
         metadata={
-            "help": "The LLM to use. Either 'transformers' or 'mlx-lm'. Default is 'transformers'"
+            "help": "The LLM to use. Either 'transformers', 'open_api', 'minimax', or 'mlx-lm'. Default is 'transformers'"
         },
     )
     tts: Optional[str] = field(

--- a/s2s_pipeline.py
+++ b/s2s_pipeline.py
@@ -32,6 +32,7 @@ from arguments_classes.parakeet_tdt_arguments import (
 )
 from arguments_classes.melo_tts_arguments import MeloTTSHandlerArguments
 from arguments_classes.open_api_language_model_arguments import OpenApiLanguageModelHandlerArguments
+from arguments_classes.minimax_language_model_arguments import MiniMaxLanguageModelHandlerArguments
 from arguments_classes.facebookmms_tts_arguments import FacebookMMSTTSHandlerArguments
 from arguments_classes.pocket_tts_arguments import PocketTTSHandlerArguments
 from arguments_classes.kokoro_tts_arguments import KokoroTTSHandlerArguments
@@ -96,6 +97,7 @@ def parse_arguments():
             ParakeetTDTSTTHandlerArguments,
             LanguageModelHandlerArguments,
             OpenApiLanguageModelHandlerArguments,
+            MiniMaxLanguageModelHandlerArguments,
             MLXLanguageModelHandlerArguments,
             MeloTTSHandlerArguments,
             ChatTTSHandlerArguments,
@@ -191,6 +193,7 @@ def prepare_all_args(
     parakeet_tdt_stt_handler_kwargs,
     language_model_handler_kwargs,
     open_api_language_model_handler_kwargs,
+    minimax_language_model_handler_kwargs,
     mlx_language_model_handler_kwargs,
     melo_tts_handler_kwargs,
     chat_tts_handler_kwargs,
@@ -208,6 +211,7 @@ def prepare_all_args(
         parakeet_tdt_stt_handler_kwargs,
         language_model_handler_kwargs,
         open_api_language_model_handler_kwargs,
+        minimax_language_model_handler_kwargs,
         mlx_language_model_handler_kwargs,
         melo_tts_handler_kwargs,
         chat_tts_handler_kwargs,
@@ -225,6 +229,7 @@ def prepare_all_args(
     rename_args(language_model_handler_kwargs, "lm")
     rename_args(mlx_language_model_handler_kwargs, "mlx_lm")
     rename_args(open_api_language_model_handler_kwargs, "open_api")
+    rename_args(minimax_language_model_handler_kwargs, "minimax")
     rename_args(melo_tts_handler_kwargs, "melo")
     rename_args(chat_tts_handler_kwargs, "chat_tts")
     rename_args(facebook_mms_tts_handler_kwargs, "facebook_mms")
@@ -260,6 +265,7 @@ def build_pipeline(
     parakeet_tdt_stt_handler_kwargs,
     language_model_handler_kwargs,
     open_api_language_model_handler_kwargs,
+    minimax_language_model_handler_kwargs,
     mlx_language_model_handler_kwargs,
     melo_tts_handler_kwargs,
     chat_tts_handler_kwargs,
@@ -339,7 +345,7 @@ def build_pipeline(
     )
 
     stt = get_stt_handler(module_kwargs, stop_event, spoken_prompt_queue, text_prompt_queue, whisper_stt_handler_kwargs, faster_whisper_stt_handler_kwargs, paraformer_stt_handler_kwargs, mlx_audio_whisper_stt_handler_kwargs, parakeet_tdt_stt_handler_kwargs)
-    lm = get_llm_handler(module_kwargs, stop_event, text_prompt_queue, lm_response_queue, language_model_handler_kwargs, open_api_language_model_handler_kwargs, mlx_language_model_handler_kwargs)
+    lm = get_llm_handler(module_kwargs, stop_event, text_prompt_queue, lm_response_queue, language_model_handler_kwargs, open_api_language_model_handler_kwargs, minimax_language_model_handler_kwargs, mlx_language_model_handler_kwargs)
 
     # Add LM output processor to extract tools and forward clean text to TTS
     from LLM.lm_output_processor import LMOutputProcessor
@@ -420,12 +426,13 @@ def get_stt_handler(module_kwargs, stop_event, spoken_prompt_queue, text_prompt_
 
 
 def get_llm_handler(
-    module_kwargs, 
-    stop_event, 
-    text_prompt_queue, 
-    lm_response_queue, 
+    module_kwargs,
+    stop_event,
+    text_prompt_queue,
+    lm_response_queue,
     language_model_handler_kwargs,
     open_api_language_model_handler_kwargs,
+    minimax_language_model_handler_kwargs,
     mlx_language_model_handler_kwargs
 ):
     if module_kwargs.llm == "transformers":
@@ -444,7 +451,14 @@ def get_llm_handler(
             queue_out=lm_response_queue,
             setup_kwargs=vars(open_api_language_model_handler_kwargs),
         )
-
+    elif module_kwargs.llm == "minimax":
+        from LLM.minimax_language_model import MiniMaxModelHandler
+        return MiniMaxModelHandler(
+            stop_event,
+            queue_in=text_prompt_queue,
+            queue_out=lm_response_queue,
+            setup_kwargs=vars(minimax_language_model_handler_kwargs),
+        )
     elif module_kwargs.llm == "mlx-lm":
         from LLM.mlx_language_model import MLXLanguageModelHandler
         return MLXLanguageModelHandler(
@@ -455,7 +469,7 @@ def get_llm_handler(
         )
 
     else:
-        raise ValueError("The LLM should be either transformers or mlx-lm")
+        raise ValueError("The LLM should be either transformers, open_api, minimax, or mlx-lm")
 
 
 def get_tts_handler(module_kwargs, stop_event, lm_response_queue, send_audio_chunks_queue, should_listen, melo_tts_handler_kwargs, chat_tts_handler_kwargs, facebook_mms_tts_handler_kwargs, pocket_tts_handler_kwargs, kokoro_tts_handler_kwargs, qwen3_tts_handler_kwargs):
@@ -541,6 +555,7 @@ def main():
         parakeet_tdt_stt_handler_kwargs,
         language_model_handler_kwargs,
         open_api_language_model_handler_kwargs,
+        minimax_language_model_handler_kwargs,
         mlx_language_model_handler_kwargs,
         melo_tts_handler_kwargs,
         chat_tts_handler_kwargs,
@@ -561,6 +576,7 @@ def main():
         parakeet_tdt_stt_handler_kwargs,
         language_model_handler_kwargs,
         open_api_language_model_handler_kwargs,
+        minimax_language_model_handler_kwargs,
         mlx_language_model_handler_kwargs,
         melo_tts_handler_kwargs,
         chat_tts_handler_kwargs,
@@ -585,6 +601,7 @@ def main():
         parakeet_tdt_stt_handler_kwargs,
         language_model_handler_kwargs,
         open_api_language_model_handler_kwargs,
+        minimax_language_model_handler_kwargs,
         mlx_language_model_handler_kwargs,
         melo_tts_handler_kwargs,
         chat_tts_handler_kwargs,

--- a/tests/test_minimax_language_model.py
+++ b/tests/test_minimax_language_model.py
@@ -1,0 +1,421 @@
+"""Tests for MiniMax language model handler."""
+
+import os
+from pathlib import Path
+from types import SimpleNamespace
+import sys
+
+import pytest
+
+sys.path.insert(0, str(Path(__file__).resolve().parents[1]))
+
+from LLM.chat import Chat
+from LLM.minimax_language_model import MiniMaxModelHandler, THINK_TAG_PATTERN
+
+
+# ---------------------------------------------------------------------------
+# Unit tests
+# ---------------------------------------------------------------------------
+
+class TestThinkTagStripping:
+    """Test that MiniMax thinking tags are properly stripped."""
+
+    def test_strips_think_tags(self):
+        text = "<think>Let me think about this...</think>Hello!"
+        result = THINK_TAG_PATTERN.sub("", text).strip()
+        assert result == "Hello!"
+
+    def test_strips_multiline_think_tags(self):
+        text = "<think>\nStep 1: analyze\nStep 2: respond\n</think>\nThe answer is 42."
+        result = THINK_TAG_PATTERN.sub("", text).strip()
+        assert result == "The answer is 42."
+
+    def test_no_think_tags(self):
+        text = "Just a normal response."
+        result = THINK_TAG_PATTERN.sub("", text).strip()
+        assert result == "Just a normal response."
+
+    def test_empty_think_tags(self):
+        text = "<think></think>Response."
+        result = THINK_TAG_PATTERN.sub("", text).strip()
+        assert result == "Response."
+
+
+class TestTemperatureClamping:
+    """Test that temperature is clamped to MiniMax's [0.0, 1.0] range."""
+
+    def _make_handler(self, gen_kwargs, api_key="test-key"):
+        handler = object.__new__(MiniMaxModelHandler)
+        # Patch os.environ for auto-detection
+        os.environ["MINIMAX_API_KEY"] = api_key
+        try:
+            handler.setup(gen_kwargs=gen_kwargs)
+        finally:
+            os.environ.pop("MINIMAX_API_KEY", None)
+        return handler
+
+    def test_temperature_above_max_clamped(self, monkeypatch):
+        monkeypatch.setattr(
+            "LLM.minimax_language_model.OpenApiModelHandler.setup",
+            lambda self, **kw: _capture_setup(self, **kw),
+        )
+        handler = object.__new__(MiniMaxModelHandler)
+        os.environ["MINIMAX_API_KEY"] = "test-key"
+        try:
+            handler.setup(gen_kwargs={"temperature": 1.5})
+        finally:
+            os.environ.pop("MINIMAX_API_KEY", None)
+        assert handler._captured_kwargs["gen_kwargs"]["temperature"] == 1.0
+
+    def test_temperature_below_min_clamped(self, monkeypatch):
+        monkeypatch.setattr(
+            "LLM.minimax_language_model.OpenApiModelHandler.setup",
+            lambda self, **kw: _capture_setup(self, **kw),
+        )
+        handler = object.__new__(MiniMaxModelHandler)
+        os.environ["MINIMAX_API_KEY"] = "test-key"
+        try:
+            handler.setup(gen_kwargs={"temperature": -0.5})
+        finally:
+            os.environ.pop("MINIMAX_API_KEY", None)
+        assert handler._captured_kwargs["gen_kwargs"]["temperature"] == 0.0
+
+    def test_temperature_in_range_unchanged(self, monkeypatch):
+        monkeypatch.setattr(
+            "LLM.minimax_language_model.OpenApiModelHandler.setup",
+            lambda self, **kw: _capture_setup(self, **kw),
+        )
+        handler = object.__new__(MiniMaxModelHandler)
+        os.environ["MINIMAX_API_KEY"] = "test-key"
+        try:
+            handler.setup(gen_kwargs={"temperature": 0.7})
+        finally:
+            os.environ.pop("MINIMAX_API_KEY", None)
+        assert handler._captured_kwargs["gen_kwargs"]["temperature"] == 0.7
+
+    def test_no_temperature_no_error(self, monkeypatch):
+        monkeypatch.setattr(
+            "LLM.minimax_language_model.OpenApiModelHandler.setup",
+            lambda self, **kw: _capture_setup(self, **kw),
+        )
+        handler = object.__new__(MiniMaxModelHandler)
+        os.environ["MINIMAX_API_KEY"] = "test-key"
+        try:
+            handler.setup(gen_kwargs={})
+        finally:
+            os.environ.pop("MINIMAX_API_KEY", None)
+        assert "temperature" not in handler._captured_kwargs["gen_kwargs"]
+
+
+def _capture_setup(self, **kwargs):
+    """Helper to capture kwargs passed to parent setup."""
+    self._captured_kwargs = kwargs
+
+
+class TestApiKeyDetection:
+    """Test MiniMax API key auto-detection from environment."""
+
+    def test_raises_without_api_key(self, monkeypatch):
+        monkeypatch.delenv("MINIMAX_API_KEY", raising=False)
+        handler = object.__new__(MiniMaxModelHandler)
+        with pytest.raises(ValueError, match="MiniMax API key is required"):
+            handler.setup(api_key=None)
+
+    def test_uses_env_var(self, monkeypatch):
+        monkeypatch.setenv("MINIMAX_API_KEY", "env-key-123")
+        monkeypatch.setattr(
+            "LLM.minimax_language_model.OpenApiModelHandler.setup",
+            lambda self, **kw: _capture_setup(self, **kw),
+        )
+        handler = object.__new__(MiniMaxModelHandler)
+        handler.setup()
+        assert handler._captured_kwargs["api_key"] == "env-key-123"
+
+    def test_explicit_key_overrides_env(self, monkeypatch):
+        monkeypatch.setenv("MINIMAX_API_KEY", "env-key")
+        monkeypatch.setattr(
+            "LLM.minimax_language_model.OpenApiModelHandler.setup",
+            lambda self, **kw: _capture_setup(self, **kw),
+        )
+        handler = object.__new__(MiniMaxModelHandler)
+        handler.setup(api_key="explicit-key")
+        assert handler._captured_kwargs["api_key"] == "explicit-key"
+
+
+class TestDefaultValues:
+    """Test MiniMax handler default configuration."""
+
+    def test_default_base_url(self, monkeypatch):
+        monkeypatch.setattr(
+            "LLM.minimax_language_model.OpenApiModelHandler.setup",
+            lambda self, **kw: _capture_setup(self, **kw),
+        )
+        handler = object.__new__(MiniMaxModelHandler)
+        os.environ["MINIMAX_API_KEY"] = "test-key"
+        try:
+            handler.setup()
+        finally:
+            os.environ.pop("MINIMAX_API_KEY", None)
+        assert handler._captured_kwargs["base_url"] == "https://api.minimax.io/v1"
+
+    def test_default_model(self, monkeypatch):
+        monkeypatch.setattr(
+            "LLM.minimax_language_model.OpenApiModelHandler.setup",
+            lambda self, **kw: _capture_setup(self, **kw),
+        )
+        handler = object.__new__(MiniMaxModelHandler)
+        os.environ["MINIMAX_API_KEY"] = "test-key"
+        try:
+            handler.setup()
+        finally:
+            os.environ.pop("MINIMAX_API_KEY", None)
+        assert handler._captured_kwargs["model_name"] == "MiniMax-M2.7"
+
+    def test_disable_thinking_off(self, monkeypatch):
+        monkeypatch.setattr(
+            "LLM.minimax_language_model.OpenApiModelHandler.setup",
+            lambda self, **kw: _capture_setup(self, **kw),
+        )
+        handler = object.__new__(MiniMaxModelHandler)
+        os.environ["MINIMAX_API_KEY"] = "test-key"
+        try:
+            handler.setup()
+        finally:
+            os.environ.pop("MINIMAX_API_KEY", None)
+        assert handler._captured_kwargs["disable_thinking"] is False
+
+
+class TestProcessThinkTagStripping:
+    """Test that process() strips think tags from generated output."""
+
+    def test_strips_think_tags_in_process(self, monkeypatch):
+        from LLM import openai_api_language_model
+
+        monkeypatch.setattr(
+            openai_api_language_model,
+            "sent_tokenize",
+            lambda text: [text] if text else [],
+        )
+
+        handler = object.__new__(MiniMaxModelHandler)
+        handler.model_name = "MiniMax-M2.7"
+        handler.stream = False
+        handler.gen_kwargs = {}
+        handler.disable_thinking = False
+        handler.user_role = "user"
+        handler.chat = Chat(1)
+
+        response = SimpleNamespace(
+            choices=[
+                SimpleNamespace(
+                    message=SimpleNamespace(
+                        content="<think>reasoning here</think>The answer is 42."
+                    )
+                )
+            ]
+        )
+        handler.client = SimpleNamespace(
+            chat=SimpleNamespace(
+                completions=SimpleNamespace(
+                    create=lambda **kwargs: response,
+                )
+            )
+        )
+
+        outputs = list(handler.process("What is the meaning of life?"))
+        assert len(outputs) == 1
+        text, lang, tools = outputs[0]
+        assert text == "The answer is 42."
+        assert "<think>" not in text
+
+    def test_no_think_tags_passthrough(self, monkeypatch):
+        from LLM import openai_api_language_model
+
+        monkeypatch.setattr(
+            openai_api_language_model,
+            "sent_tokenize",
+            lambda text: [text] if text else [],
+        )
+
+        handler = object.__new__(MiniMaxModelHandler)
+        handler.model_name = "MiniMax-M2.7"
+        handler.stream = False
+        handler.gen_kwargs = {}
+        handler.disable_thinking = False
+        handler.user_role = "user"
+        handler.chat = Chat(1)
+
+        response = SimpleNamespace(
+            choices=[
+                SimpleNamespace(
+                    message=SimpleNamespace(content="Normal response.")
+                )
+            ]
+        )
+        handler.client = SimpleNamespace(
+            chat=SimpleNamespace(
+                completions=SimpleNamespace(
+                    create=lambda **kwargs: response,
+                )
+            )
+        )
+
+        outputs = list(handler.process("Hello"))
+        assert outputs[0][0] == "Normal response."
+
+
+class TestStreamingWithThinkTags:
+    """Test streaming mode strips think tags correctly."""
+
+    def test_streaming_strips_think_tags(self, monkeypatch):
+        from LLM import openai_api_language_model
+
+        monkeypatch.setattr(
+            openai_api_language_model,
+            "sent_tokenize",
+            lambda text: [s for s in text.split(". ") if s],
+        )
+
+        def _chunk(content):
+            return SimpleNamespace(
+                choices=[SimpleNamespace(delta=SimpleNamespace(content=content))]
+            )
+
+        chunks = [
+            _chunk("<think>thinking</think>Hello. "),
+            _chunk("World."),
+        ]
+
+        handler = object.__new__(MiniMaxModelHandler)
+        handler.model_name = "MiniMax-M2.7"
+        handler.stream = True
+        handler.gen_kwargs = {}
+        handler.disable_thinking = False
+        handler.user_role = "user"
+        handler.chat = Chat(1)
+        handler.client = SimpleNamespace(
+            chat=SimpleNamespace(
+                completions=SimpleNamespace(
+                    create=lambda **kwargs: iter(chunks),
+                )
+            )
+        )
+
+        outputs = list(handler.process("Hi"))
+        # All outputs should have think tags stripped
+        for text, _, _ in outputs:
+            assert "<think>" not in text
+
+
+class TestArgumentsDataclass:
+    """Test MiniMax arguments dataclass."""
+
+    def test_default_values(self):
+        from arguments_classes.minimax_language_model_arguments import (
+            MiniMaxLanguageModelHandlerArguments,
+        )
+
+        args = MiniMaxLanguageModelHandlerArguments()
+        assert args.minimax_model_name == "MiniMax-M2.7"
+        assert args.minimax_base_url == "https://api.minimax.io/v1"
+        assert args.minimax_api_key is None
+        assert args.minimax_stream is False
+        assert args.minimax_user_role == "user"
+        assert args.minimax_init_chat_role == "system"
+        assert args.minimax_chat_size == 5
+
+
+class TestPipelineIntegration:
+    """Test that MiniMax is properly registered in the pipeline."""
+
+    def test_minimax_handler_is_subclass_of_openapi(self):
+        """MiniMaxModelHandler extends OpenApiModelHandler."""
+        from LLM.openai_api_language_model import OpenApiModelHandler
+
+        assert issubclass(MiniMaxModelHandler, OpenApiModelHandler)
+
+    def test_minimax_arguments_rename(self):
+        """Test that argument renaming works for minimax prefix."""
+        from arguments_classes.minimax_language_model_arguments import (
+            MiniMaxLanguageModelHandlerArguments,
+        )
+        from copy import copy
+
+        args = MiniMaxLanguageModelHandlerArguments()
+
+        # Simulate rename_args logic
+        gen_kwargs = {}
+        for key in copy(args.__dict__):
+            if key.startswith("minimax"):
+                value = args.__dict__.pop(key)
+                new_key = key[len("minimax") + 1:]
+                if new_key.startswith("gen_"):
+                    gen_kwargs[new_key[4:]] = value
+                else:
+                    args.__dict__[new_key] = value
+        args.__dict__["gen_kwargs"] = gen_kwargs
+
+        assert args.model_name == "MiniMax-M2.7"
+        assert args.base_url == "https://api.minimax.io/v1"
+        assert args.api_key is None
+        assert args.stream is False
+
+    def test_minimax_handler_inherits_process(self):
+        """MiniMaxModelHandler has its own process method that wraps parent."""
+        assert hasattr(MiniMaxModelHandler, "process")
+        # It should override process (not just inherit it)
+        from LLM.openai_api_language_model import OpenApiModelHandler
+        assert MiniMaxModelHandler.process is not OpenApiModelHandler.process
+
+
+# ---------------------------------------------------------------------------
+# Integration tests (require MINIMAX_API_KEY)
+# ---------------------------------------------------------------------------
+
+@pytest.mark.skipif(
+    not os.environ.get("MINIMAX_API_KEY"),
+    reason="MINIMAX_API_KEY not set",
+)
+class TestMiniMaxIntegration:
+    """Integration tests that call the real MiniMax API."""
+
+    def test_non_streaming_response(self):
+        handler = object.__new__(MiniMaxModelHandler)
+        handler.setup(
+            model_name="MiniMax-M2.7",
+            api_key=os.environ["MINIMAX_API_KEY"],
+            stream=False,
+        )
+
+        outputs = list(handler.process("Say hello in one word."))
+        assert len(outputs) >= 1
+        text, _, _ = outputs[0]
+        assert isinstance(text, str)
+        assert len(text) > 0
+
+    def test_streaming_response(self):
+        handler = object.__new__(MiniMaxModelHandler)
+        handler.setup(
+            model_name="MiniMax-M2.7",
+            api_key=os.environ["MINIMAX_API_KEY"],
+            stream=True,
+        )
+
+        outputs = list(handler.process("Say hello in one word."))
+        assert len(outputs) >= 1
+        full_text = "".join(t for t, _, _ in outputs)
+        assert len(full_text) > 0
+
+    def test_session_reset(self):
+        handler = object.__new__(MiniMaxModelHandler)
+        handler.setup(
+            model_name="MiniMax-M2.7",
+            api_key=os.environ["MINIMAX_API_KEY"],
+            stream=False,
+        )
+
+        list(handler.process("Hello"))
+        assert len(handler.chat.buffer) > 0
+
+        handler.on_session_end()
+        assert len(handler.chat.buffer) == 0

--- a/tests/test_minimax_language_model.py
+++ b/tests/test_minimax_language_model.py
@@ -169,7 +169,7 @@ class TestDefaultValues:
             handler.setup()
         finally:
             os.environ.pop("MINIMAX_API_KEY", None)
-        assert handler._captured_kwargs["model_name"] == "MiniMax-M2.7"
+        assert handler._captured_kwargs["model_name"] == "MiniMax-M3"
 
     def test_disable_thinking_off(self, monkeypatch):
         monkeypatch.setattr(
@@ -198,7 +198,7 @@ class TestProcessThinkTagStripping:
         )
 
         handler = object.__new__(MiniMaxModelHandler)
-        handler.model_name = "MiniMax-M2.7"
+        handler.model_name = "MiniMax-M3"
         handler.stream = False
         handler.gen_kwargs = {}
         handler.disable_thinking = False
@@ -238,7 +238,7 @@ class TestProcessThinkTagStripping:
         )
 
         handler = object.__new__(MiniMaxModelHandler)
-        handler.model_name = "MiniMax-M2.7"
+        handler.model_name = "MiniMax-M3"
         handler.stream = False
         handler.gen_kwargs = {}
         handler.disable_thinking = False
@@ -287,7 +287,7 @@ class TestStreamingWithThinkTags:
         ]
 
         handler = object.__new__(MiniMaxModelHandler)
-        handler.model_name = "MiniMax-M2.7"
+        handler.model_name = "MiniMax-M3"
         handler.stream = True
         handler.gen_kwargs = {}
         handler.disable_thinking = False
@@ -316,7 +316,7 @@ class TestArgumentsDataclass:
         )
 
         args = MiniMaxLanguageModelHandlerArguments()
-        assert args.minimax_model_name == "MiniMax-M2.7"
+        assert args.minimax_model_name == "MiniMax-M3"
         assert args.minimax_base_url == "https://api.minimax.io/v1"
         assert args.minimax_api_key is None
         assert args.minimax_stream is False
@@ -355,7 +355,7 @@ class TestPipelineIntegration:
                     args.__dict__[new_key] = value
         args.__dict__["gen_kwargs"] = gen_kwargs
 
-        assert args.model_name == "MiniMax-M2.7"
+        assert args.model_name == "MiniMax-M3"
         assert args.base_url == "https://api.minimax.io/v1"
         assert args.api_key is None
         assert args.stream is False
@@ -382,7 +382,7 @@ class TestMiniMaxIntegration:
     def test_non_streaming_response(self):
         handler = object.__new__(MiniMaxModelHandler)
         handler.setup(
-            model_name="MiniMax-M2.7",
+            model_name="MiniMax-M3",
             api_key=os.environ["MINIMAX_API_KEY"],
             stream=False,
         )
@@ -396,7 +396,7 @@ class TestMiniMaxIntegration:
     def test_streaming_response(self):
         handler = object.__new__(MiniMaxModelHandler)
         handler.setup(
-            model_name="MiniMax-M2.7",
+            model_name="MiniMax-M3",
             api_key=os.environ["MINIMAX_API_KEY"],
             stream=True,
         )
@@ -409,7 +409,7 @@ class TestMiniMaxIntegration:
     def test_session_reset(self):
         handler = object.__new__(MiniMaxModelHandler)
         handler.setup(
-            model_name="MiniMax-M2.7",
+            model_name="MiniMax-M3",
             api_key=os.environ["MINIMAX_API_KEY"],
             stream=False,
         )


### PR DESCRIPTION
## Summary

- Add [MiniMax](https://platform.minimaxi.com/) cloud models (MiniMax-M3, MiniMax-M2.7, MiniMax-M2.7-highspeed) as a dedicated LLM backend via `--llm minimax`
- **MiniMax-M3 is the default** — 512K context window, up to 128K output, image input support
- Auto-detects `MINIMAX_API_KEY` from environment, clamps temperature to [0.0, 1.0], strips `<think>` reasoning tags from M3/M2.7 responses
- Adds `MiniMaxModelHandler` extending `OpenApiModelHandler`, dedicated arguments dataclass, pipeline registration, README docs

## Changes

| File | Description |
|------|-------------|
| `LLM/minimax_language_model.py` | MiniMax handler with temp clamping and think-tag stripping (default M3) |
| `arguments_classes/minimax_language_model_arguments.py` | Dedicated arguments dataclass with MiniMax defaults |
| `s2s_pipeline.py` | Register `minimax` as LLM option in pipeline |
| `arguments_classes/module_arguments.py` | Update `--llm` help text |
| `README.md` | Add MiniMax to LLM list and usage section (M3 / M2.7 / M2.7-highspeed) |
| `tests/test_minimax_language_model.py` | 21 unit + 3 integration tests |

## Available models

- `MiniMax-M3` (default) — 512K context, up to 128K output, image input
- `MiniMax-M2.7` — previous generation
- `MiniMax-M2.7-highspeed` — previous generation low-latency variant

## Usage

```bash
export MINIMAX_API_KEY="your-api-key"

python s2s_pipeline.py \
    --llm minimax \
    --minimax_model_name MiniMax-M3 \
    --minimax_stream \
    --tts pocket \
    --recv_host 0.0.0.0 \
    --send_host 0.0.0.0
```

## Test plan

- [x] 18 unit tests pass (think-tag stripping, temperature clamping, API key detection, defaults, argument renaming)
- [x] 3 pipeline integration tests pass (subclass check, argument renaming, process override)
- [x] 3 integration tests with real MiniMax API (non-streaming, streaming, session reset)
- [x] Existing `test_openai_api_language_model.py` tests still pass (no regressions)
