### PR TITLE
feat: add MiniMax TTS provider (speech-2.8-hd / speech-2.8-turbo)

### DIFF
--- a/TTS/minimax_tts_handler.py
+++ b/TTS/minimax_tts_handler.py
@@ -1,0 +1,197 @@
+"""
+MiniMax TTS Handler
+
+Uses the MiniMax Text-to-Audio API (t2a_v2) to generate speech.
+Requires MINIMAX_API_KEY environment variable.
+
+API reference: https://platform.minimax.io/docs/api-reference/speech-t2a-http
+"""
+
+import json
+import logging
+import os
+import urllib.request
+from time import perf_counter
+
+import numpy as np
+from baseHandler import BaseHandler
+from rich.console import Console
+
+logger = logging.getLogger(__name__)
+console = Console()
+
+PIPELINE_SR = 16000  # Pipeline expects 16 kHz int16 audio
+
+MINIMAX_TTS_VOICES = [
+    "English_Graceful_Lady",
+    "English_Insightful_Speaker",
+    "English_radiant_girl",
+    "English_Persuasive_Man",
+    "English_Lucky_Robot",
+    "English_expressive_narrator",
+]
+
+
+class MiniMaxTTSHandler(BaseHandler):
+    """
+    Text-to-Speech handler using the MiniMax t2a_v2 API.
+
+    Streams PCM audio via SSE, converts hex-encoded PCM chunks to int16
+    numpy arrays, and feeds them into the pipeline at 16 kHz.
+
+    Supported models:
+        - speech-2.8-hd   (default, highest quality)
+        - speech-2.8-turbo (faster)
+    """
+
+    def setup(
+        self,
+        should_listen,
+        api_key=None,
+        base_url="https://api.minimax.io",
+        model="speech-2.8-hd",
+        voice="English_Graceful_Lady",
+        speed=1.0,
+        vol=1.0,
+        pitch=0,
+        blocksize=512,
+        gen_kwargs=None,
+    ):
+        self.should_listen = should_listen
+        self.api_key = api_key or os.environ.get("MINIMAX_API_KEY")
+        if not self.api_key:
+            raise ValueError(
+                "MiniMax API key is required. Set MINIMAX_API_KEY environment variable "
+                "or pass api_key to MiniMaxTTSHandler."
+            )
+        self.base_url = base_url.rstrip("/")
+        self.model = model
+        self.voice = voice
+        self.speed = speed
+        self.vol = vol
+        self.pitch = pitch
+        self.blocksize = blocksize
+
+        logger.info(
+            f"MiniMax TTS handler ready (model={self.model}, voice={self.voice})"
+        )
+
+    def _stream_pcm_chunks(self, text):
+        """
+        Call the MiniMax t2a_v2 API with stream=True and PCM format.
+        Yields int16 numpy arrays as audio arrives via SSE.
+        """
+        url = f"{self.base_url}/v1/t2a_v2"
+        payload = json.dumps(
+            {
+                "model": self.model,
+                "text": text,
+                "stream": True,
+                "voice_setting": {
+                    "voice_id": self.voice,
+                    "speed": self.speed,
+                    "vol": self.vol,
+                    "pitch": self.pitch,
+                },
+                "audio_setting": {
+                    "sample_rate": PIPELINE_SR,
+                    "format": "pcm",
+                    "channel": 1,
+                },
+                "stream_options": {
+                    "exclude_aggregated_audio": True,
+                },
+            }
+        ).encode()
+
+        req = urllib.request.Request(
+            url,
+            data=payload,
+            headers={
+                "Content-Type": "application/json",
+                "Authorization": f"Bearer {self.api_key}",
+            },
+            method="POST",
+        )
+
+        with urllib.request.urlopen(req) as response:
+            buf = b""
+            while True:
+                chunk = response.read(4096)
+                if not chunk:
+                    break
+                buf += chunk
+                # Process all complete lines
+                while b"\n" in buf:
+                    line, buf = buf.split(b"\n", 1)
+                    line_str = line.decode("utf-8", errors="ignore").strip()
+                    if not line_str.startswith("data:"):
+                        continue
+                    json_str = line_str[5:].strip()
+                    if not json_str or json_str == "[DONE]":
+                        continue
+                    try:
+                        event = json.loads(json_str)
+                    except json.JSONDecodeError:
+                        continue
+
+                    # Check for API-level errors
+                    base_resp = event.get("base_resp", {})
+                    if base_resp.get("status_code", 0) not in (0, None):
+                        logger.error(
+                            f"MiniMax TTS API error: {base_resp.get('status_msg')}"
+                        )
+                        return
+
+                    status = event.get("data", {}).get("status")
+                    if status == 1:
+                        hex_audio = event.get("data", {}).get("audio", "")
+                        if hex_audio:
+                            try:
+                                raw = bytes.fromhex(hex_audio)
+                                yield np.frombuffer(raw, dtype=np.int16).copy()
+                            except ValueError:
+                                logger.warning("Failed to decode hex audio chunk")
+
+    def process(self, llm_sentence):
+        if isinstance(llm_sentence, tuple) and llm_sentence[0] == "__END_OF_RESPONSE__":
+            yield b"__RESPONSE_DONE__"
+            return
+
+        if isinstance(llm_sentence, tuple):
+            llm_sentence, _ = llm_sentence  # Unpack (text, language_code)
+
+        if not llm_sentence or not llm_sentence.strip():
+            return
+
+        console.print(f"[green]ASSISTANT: {llm_sentence}")
+
+        start = perf_counter()
+        first_chunk = True
+        leftover = np.array([], dtype=np.int16)
+
+        try:
+            for audio_chunk in self._stream_pcm_chunks(llm_sentence):
+                if first_chunk:
+                    logger.debug(
+                        f"MiniMax TTS TTFA: {perf_counter() - start:.3f}s"
+                    )
+                    first_chunk = False
+
+                audio_chunk = np.concatenate([leftover, audio_chunk])
+
+                # Yield exactly blocksize-sized chunks
+                n = (len(audio_chunk) // self.blocksize) * self.blocksize
+                for i in range(0, n, self.blocksize):
+                    yield audio_chunk[i : i + self.blocksize]
+                leftover = audio_chunk[n:]
+
+            # Flush remaining samples with zero-padding
+            if len(leftover) > 0:
+                chunk = np.pad(leftover, (0, self.blocksize - len(leftover)))
+                yield chunk
+
+        except Exception as e:
+            logger.error(f"MiniMax TTS error: {e}", exc_info=True)
+        finally:
+            self.should_listen.set()

--- a/arguments_classes/minimax_tts_arguments.py
+++ b/arguments_classes/minimax_tts_arguments.py
@@ -1,0 +1,73 @@
+from dataclasses import dataclass, field
+from typing import Optional
+
+from TTS.minimax_tts_handler import MINIMAX_TTS_VOICES
+
+
+@dataclass
+class MiniMaxTTSHandlerArguments:
+    minimax_tts_api_key: Optional[str] = field(
+        default=None,
+        metadata={
+            "help": (
+                "MiniMax API key for TTS. Defaults to the MINIMAX_API_KEY environment variable."
+            )
+        },
+    )
+    minimax_tts_base_url: str = field(
+        default="https://api.minimax.io",
+        metadata={
+            "help": (
+                "Base URL for the MiniMax API. "
+                "Use 'https://api.minimaxi.com' for the mainland China endpoint. "
+                "Default is 'https://api.minimax.io'."
+            )
+        },
+    )
+    minimax_tts_model: str = field(
+        default="speech-2.8-hd",
+        metadata={
+            "help": (
+                "MiniMax TTS model to use. "
+                "Options: 'speech-2.8-hd' (default, highest quality), "
+                "'speech-2.8-turbo' (faster). "
+                "Default is 'speech-2.8-hd'."
+            )
+        },
+    )
+    minimax_tts_voice: str = field(
+        default="English_Graceful_Lady",
+        metadata={
+            "help": (
+                f"Voice ID for MiniMax TTS. Available voices: {', '.join(MINIMAX_TTS_VOICES)}. "
+                "Default is 'English_Graceful_Lady'."
+            )
+        },
+    )
+    minimax_tts_speed: float = field(
+        default=1.0,
+        metadata={
+            "help": "Speech speed for MiniMax TTS. Range: [0.5, 2.0]. Default is 1.0."
+        },
+    )
+    minimax_tts_vol: float = field(
+        default=1.0,
+        metadata={
+            "help": "Volume for MiniMax TTS. Range: (0, 10]. Default is 1.0."
+        },
+    )
+    minimax_tts_pitch: int = field(
+        default=0,
+        metadata={
+            "help": "Pitch adjustment for MiniMax TTS. Range: [-12, 12]. Default is 0."
+        },
+    )
+    minimax_tts_blocksize: int = field(
+        default=512,
+        metadata={
+            "help": (
+                "Audio chunk size in samples for streaming output. "
+                "Must match LocalAudioStreamer blocksize. Default is 512."
+            )
+        },
+    )

--- a/arguments_classes/module_arguments.py
+++ b/arguments_classes/module_arguments.py
@@ -35,7 +35,7 @@ class ModuleArguments:
     tts: Optional[str] = field(
         default=None,
         metadata={
-            "help": "The TTS to use. Either 'melo', 'chatTTS', 'facebookMMS', 'pocket', 'kokoro', or 'qwen3'. Default is platform-dependent: 'qwen3' on non-macOS and 'melo' on macOS (with 'pocket' also valid on macOS)."
+            "help": "The TTS to use. Either 'melo', 'chatTTS', 'facebookMMS', 'pocket', 'kokoro', 'qwen3', or 'minimax'. Default is platform-dependent: 'qwen3' on non-macOS and 'melo' on macOS (with 'pocket' also valid on macOS)."
         },
     )
     log_level: str = field(

--- a/s2s_pipeline.py
+++ b/s2s_pipeline.py
@@ -35,6 +35,7 @@ from arguments_classes.facebookmms_tts_arguments import FacebookMMSTTSHandlerArg
 from arguments_classes.pocket_tts_arguments import PocketTTSHandlerArguments
 from arguments_classes.kokoro_tts_arguments import KokoroTTSHandlerArguments
 from arguments_classes.qwen3_tts_arguments import Qwen3TTSHandlerArguments
+from arguments_classes.minimax_tts_arguments import MiniMaxTTSHandlerArguments
 import torch
 import nltk
 from rich.console import Console
@@ -101,6 +102,7 @@ def parse_arguments():
             PocketTTSHandlerArguments,
             KokoroTTSHandlerArguments,
             Qwen3TTSHandlerArguments,
+            MiniMaxTTSHandlerArguments,
         )
     )
 
@@ -202,6 +204,7 @@ def prepare_all_args(
     pocket_tts_handler_kwargs,
     kokoro_tts_handler_kwargs,
     qwen3_tts_handler_kwargs,
+    minimax_tts_handler_kwargs,
 ):
     prepare_module_args(
         module_kwargs,
@@ -218,6 +221,7 @@ def prepare_all_args(
         pocket_tts_handler_kwargs,
         kokoro_tts_handler_kwargs,
         qwen3_tts_handler_kwargs,
+        minimax_tts_handler_kwargs,
     )
 
     rename_args(whisper_stt_handler_kwargs, "stt")
@@ -233,6 +237,7 @@ def prepare_all_args(
     rename_args(pocket_tts_handler_kwargs, "pocket_tts")
     rename_args(kokoro_tts_handler_kwargs, "kokoro")
     rename_args(qwen3_tts_handler_kwargs, "qwen3_tts")
+    rename_args(minimax_tts_handler_kwargs, "minimax_tts")
 
 
 def initialize_queues_and_events():
@@ -271,6 +276,7 @@ def build_pipeline(
     pocket_tts_handler_kwargs,
     kokoro_tts_handler_kwargs,
     qwen3_tts_handler_kwargs,
+    minimax_tts_handler_kwargs,
     queues_and_events,
 ):
     stop_event = queues_and_events["stop_event"]
@@ -431,7 +437,7 @@ def build_pipeline(
         setup_kwargs={"text_output_queue": text_output_queue},
     )
 
-    tts = get_tts_handler(module_kwargs, stop_event, lm_processed_queue, send_audio_chunks_queue, should_listen, melo_tts_handler_kwargs, chat_tts_handler_kwargs, facebook_mms_tts_handler_kwargs, pocket_tts_handler_kwargs, kokoro_tts_handler_kwargs, qwen3_tts_handler_kwargs)
+    tts = get_tts_handler(module_kwargs, stop_event, lm_processed_queue, send_audio_chunks_queue, should_listen, melo_tts_handler_kwargs, chat_tts_handler_kwargs, facebook_mms_tts_handler_kwargs, pocket_tts_handler_kwargs, kokoro_tts_handler_kwargs, qwen3_tts_handler_kwargs, minimax_tts_handler_kwargs)
 
     # Build the handler chain
     pipeline_handlers = [*comms_handlers, vad, stt, lm, lm_processor, tts]
@@ -541,7 +547,7 @@ def get_llm_handler(
     raise ValueError("The LLM should be either transformers, mlx-lm or open_api")
 
 
-def get_tts_handler(module_kwargs, stop_event, lm_response_queue, send_audio_chunks_queue, should_listen, melo_tts_handler_kwargs, chat_tts_handler_kwargs, facebook_mms_tts_handler_kwargs, pocket_tts_handler_kwargs, kokoro_tts_handler_kwargs, qwen3_tts_handler_kwargs):
+def get_tts_handler(module_kwargs, stop_event, lm_response_queue, send_audio_chunks_queue, should_listen, melo_tts_handler_kwargs, chat_tts_handler_kwargs, facebook_mms_tts_handler_kwargs, pocket_tts_handler_kwargs, kokoro_tts_handler_kwargs, qwen3_tts_handler_kwargs, minimax_tts_handler_kwargs):
     if module_kwargs.tts == "melo":
         try:
             from TTS.melo_handler import MeloTTSHandler
@@ -606,8 +612,17 @@ def get_tts_handler(module_kwargs, stop_event, lm_response_queue, send_audio_chu
             setup_args=(should_listen,),
             setup_kwargs=vars(qwen3_tts_handler_kwargs),
         )
+    elif module_kwargs.tts == "minimax":
+        from TTS.minimax_tts_handler import MiniMaxTTSHandler
+        return MiniMaxTTSHandler(
+            stop_event,
+            queue_in=lm_response_queue,
+            queue_out=send_audio_chunks_queue,
+            setup_args=(should_listen,),
+            setup_kwargs=vars(minimax_tts_handler_kwargs),
+        )
     else:
-        raise ValueError("The TTS should be either melo, chatTTS, facebookMMS, pocket, kokoro, or qwen3")
+        raise ValueError("The TTS should be either melo, chatTTS, facebookMMS, pocket, kokoro, qwen3, or minimax")
 
 
 def main():
@@ -630,6 +645,7 @@ def main():
         pocket_tts_handler_kwargs,
         kokoro_tts_handler_kwargs,
         qwen3_tts_handler_kwargs,
+        minimax_tts_handler_kwargs,
     ) = parse_arguments()
 
     setup_logger(module_kwargs.log_level)
@@ -649,6 +665,7 @@ def main():
         pocket_tts_handler_kwargs,
         kokoro_tts_handler_kwargs,
         qwen3_tts_handler_kwargs,
+        minimax_tts_handler_kwargs,
     )
 
     queues_and_events = initialize_queues_and_events()
@@ -672,6 +689,7 @@ def main():
         pocket_tts_handler_kwargs,
         kokoro_tts_handler_kwargs,
         qwen3_tts_handler_kwargs,
+        minimax_tts_handler_kwargs,
         queues_and_events,
     )
 

--- a/tests/test_minimax_tts_handler.py
+++ b/tests/test_minimax_tts_handler.py
@@ -1,0 +1,277 @@
+"""
+Unit tests for MiniMaxTTSHandler.
+
+Tests are structured to avoid live API calls (unit tests) while also
+providing an integration test that calls the real API when MINIMAX_API_KEY
+is available.
+"""
+
+import json
+import os
+import sys
+from pathlib import Path
+from queue import Queue
+from threading import Event
+from unittest.mock import MagicMock, patch
+
+import numpy as np
+import pytest
+
+sys.path.insert(0, str(Path(__file__).resolve().parents[1]))
+
+from TTS.minimax_tts_handler import MINIMAX_TTS_VOICES, MiniMaxTTSHandler
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+
+def _make_handler(api_key="test-key", **kwargs):
+    """Create a MiniMaxTTSHandler without calling setup (unit-test helper)."""
+    handler = object.__new__(MiniMaxTTSHandler)
+    handler.queue_in = Queue()
+    handler.queue_out = Queue()
+    handler.stop_event = Event()
+    handler.should_listen = Event()
+    handler.api_key = api_key
+    handler.base_url = kwargs.get("base_url", "https://api.minimax.io")
+    handler.model = kwargs.get("model", "speech-2.8-hd")
+    handler.voice = kwargs.get("voice", "English_Graceful_Lady")
+    handler.speed = kwargs.get("speed", 1.0)
+    handler.vol = kwargs.get("vol", 1.0)
+    handler.pitch = kwargs.get("pitch", 0)
+    handler.blocksize = kwargs.get("blocksize", 512)
+    return handler
+
+
+def _sse_response(chunks_hex, *, include_done=True):
+    """
+    Build a fake SSE byte stream from a list of hex-encoded PCM chunks.
+
+    Each entry in chunks_hex becomes a status=1 event. An optional
+    [DONE] line is appended at the end.
+    """
+    lines = []
+    for hex_audio in chunks_hex:
+        event = {
+            "data": {"status": 1, "audio": hex_audio},
+            "base_resp": {"status_code": 0, "status_msg": ""},
+        }
+        lines.append(f"data: {json.dumps(event)}\n")
+    if include_done:
+        lines.append("data: [DONE]\n")
+    return "".join(lines).encode()
+
+
+# ---------------------------------------------------------------------------
+# Unit tests
+# ---------------------------------------------------------------------------
+
+
+class TestMiniMaxTTSVoices:
+    def test_voices_list_is_non_empty(self):
+        assert len(MINIMAX_TTS_VOICES) > 0
+
+    def test_voices_list_contains_expected_entries(self):
+        assert "English_Graceful_Lady" in MINIMAX_TTS_VOICES
+        assert "English_Insightful_Speaker" in MINIMAX_TTS_VOICES
+
+
+class TestMiniMaxTTSHandlerSetup:
+    def test_raises_without_api_key(self, monkeypatch):
+        monkeypatch.delenv("MINIMAX_API_KEY", raising=False)
+        handler = object.__new__(MiniMaxTTSHandler)
+        with pytest.raises(ValueError, match="MINIMAX_API_KEY"):
+            handler.setup(Event(), api_key=None)
+
+    def test_accepts_api_key_from_env(self, monkeypatch):
+        monkeypatch.setenv("MINIMAX_API_KEY", "env-key")
+        handler = object.__new__(MiniMaxTTSHandler)
+        handler.setup(Event(), api_key=None)
+        assert handler.api_key == "env-key"
+
+    def test_explicit_api_key_overrides_env(self, monkeypatch):
+        monkeypatch.setenv("MINIMAX_API_KEY", "env-key")
+        handler = object.__new__(MiniMaxTTSHandler)
+        handler.setup(Event(), api_key="explicit-key")
+        assert handler.api_key == "explicit-key"
+
+    def test_default_model_is_hd(self, monkeypatch):
+        monkeypatch.setenv("MINIMAX_API_KEY", "key")
+        handler = object.__new__(MiniMaxTTSHandler)
+        handler.setup(Event())
+        assert handler.model == "speech-2.8-hd"
+
+    def test_default_voice(self, monkeypatch):
+        monkeypatch.setenv("MINIMAX_API_KEY", "key")
+        handler = object.__new__(MiniMaxTTSHandler)
+        handler.setup(Event())
+        assert handler.voice == "English_Graceful_Lady"
+
+
+class TestProcessEndOfResponse:
+    def test_end_of_response_yields_done_sentinel(self):
+        handler = _make_handler()
+        results = list(handler.process(("__END_OF_RESPONSE__", None)))
+        assert results == [b"__RESPONSE_DONE__"]
+
+    def test_end_of_response_string_tuple(self):
+        handler = _make_handler()
+        results = list(handler.process(("__END_OF_RESPONSE__",)))
+        assert results == [b"__RESPONSE_DONE__"]
+
+    def test_empty_text_yields_nothing(self):
+        handler = _make_handler()
+        # Patch _stream_pcm_chunks to avoid real API calls
+        with patch.object(handler, "_stream_pcm_chunks", return_value=iter([])):
+            results = list(handler.process("   "))
+        assert results == []
+
+
+class TestStreamPcmChunks:
+    """Test _stream_pcm_chunks SSE parsing logic via mock HTTP responses."""
+
+    def _mock_urlopen(self, body_bytes):
+        """Return a context-manager mock whose read() yields body_bytes in 4096-byte pieces."""
+        response = MagicMock()
+        data = [body_bytes[i : i + 4096] for i in range(0, len(body_bytes), 4096)]
+        data.append(b"")  # sentinel for EOF
+        response.read.side_effect = data
+        cm = MagicMock()
+        cm.__enter__ = MagicMock(return_value=response)
+        cm.__exit__ = MagicMock(return_value=False)
+        return cm
+
+    def test_single_chunk_decoded_correctly(self):
+        handler = _make_handler()
+
+        # Create 512 samples of PCM silence (int16 zeros)
+        pcm = np.zeros(512, dtype=np.int16)
+        hex_audio = pcm.tobytes().hex()
+
+        body = _sse_response([hex_audio])
+        cm = self._mock_urlopen(body)
+
+        with patch("urllib.request.urlopen", return_value=cm):
+            chunks = list(handler._stream_pcm_chunks("Hello"))
+
+        assert len(chunks) == 1
+        np.testing.assert_array_equal(chunks[0], pcm)
+
+    def test_multiple_chunks_decoded_correctly(self):
+        handler = _make_handler()
+
+        n_samples = 256
+        pcm1 = np.ones(n_samples, dtype=np.int16) * 100
+        pcm2 = np.ones(n_samples, dtype=np.int16) * 200
+
+        body = _sse_response([pcm1.tobytes().hex(), pcm2.tobytes().hex()])
+        cm = self._mock_urlopen(body)
+
+        with patch("urllib.request.urlopen", return_value=cm):
+            chunks = list(handler._stream_pcm_chunks("Hello world"))
+
+        assert len(chunks) == 2
+        np.testing.assert_array_equal(chunks[0], pcm1)
+        np.testing.assert_array_equal(chunks[1], pcm2)
+
+    def test_api_error_stops_iteration(self):
+        handler = _make_handler()
+
+        event = {
+            "data": {"status": 1, "audio": ""},
+            "base_resp": {"status_code": 1004, "status_msg": "Auth failed"},
+        }
+        body = f"data: {json.dumps(event)}\n".encode()
+        cm = self._mock_urlopen(body)
+
+        with patch("urllib.request.urlopen", return_value=cm):
+            chunks = list(handler._stream_pcm_chunks("Hello"))
+
+        # Should produce no audio chunks (error logged, iteration stopped)
+        assert chunks == []
+
+    def test_malformed_json_is_skipped(self):
+        handler = _make_handler()
+
+        pcm = np.zeros(128, dtype=np.int16)
+        body = (
+            b"data: {invalid json}\n"
+            + f"data: {json.dumps({'data': {'status': 1, 'audio': pcm.tobytes().hex()}, 'base_resp': {'status_code': 0}})}\n".encode()
+        )
+        cm = self._mock_urlopen(body)
+
+        with patch("urllib.request.urlopen", return_value=cm):
+            chunks = list(handler._stream_pcm_chunks("Hello"))
+
+        assert len(chunks) == 1
+
+
+class TestProcessBlocksizeAlignment:
+    """Verify that process() yields exactly blocksize-sized chunks."""
+
+    def _mock_stream(self, samples):
+        """Yield a numpy array of the given sample count."""
+
+        def _gen(_text):
+            yield np.ones(samples, dtype=np.int16) * 42
+
+        return _gen
+
+    @pytest.mark.parametrize("sample_count", [100, 512, 1024, 1500])
+    def test_output_chunks_are_blocksize(self, sample_count):
+        handler = _make_handler(blocksize=512)
+
+        with patch.object(
+            handler, "_stream_pcm_chunks", side_effect=self._mock_stream(sample_count)
+        ):
+            results = list(handler.process("Test text"))
+
+        # Filter out non-ndarray outputs
+        arrays = [r for r in results if isinstance(r, np.ndarray)]
+        for arr in arrays:
+            assert len(arr) == 512, f"Expected 512 samples, got {len(arr)}"
+
+
+# ---------------------------------------------------------------------------
+# Integration test (skipped when MINIMAX_API_KEY is absent)
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.skipif(
+    not os.environ.get("MINIMAX_API_KEY"),
+    reason="MINIMAX_API_KEY not set — skipping live API integration test",
+)
+class TestMiniMaxTTSIntegration:
+    def test_synthesize_short_sentence(self):
+        """Call the real MiniMax API and verify we get back int16 audio."""
+        handler = object.__new__(MiniMaxTTSHandler)
+        handler.setup(
+            Event(),
+            model="speech-2.8-turbo",  # faster for CI
+            voice="English_Graceful_Lady",
+            blocksize=512,
+        )
+
+        results = list(handler.process("Hello, this is a MiniMax TTS integration test."))
+
+        audio_chunks = [r for r in results if isinstance(r, np.ndarray)]
+        assert len(audio_chunks) > 0, "Expected at least one audio chunk"
+
+        for chunk in audio_chunks:
+            assert chunk.dtype == np.int16
+            assert len(chunk) == 512
+
+    def test_turbo_model_works(self):
+        handler = object.__new__(MiniMaxTTSHandler)
+        handler.setup(Event(), model="speech-2.8-turbo", blocksize=512)
+        results = list(handler.process("Testing turbo model."))
+        audio_chunks = [r for r in results if isinstance(r, np.ndarray)]
+        assert len(audio_chunks) > 0
+
+    def test_end_of_response_sentinel_not_broken_by_api(self):
+        handler = object.__new__(MiniMaxTTSHandler)
+        handler.setup(Event(), blocksize=512)
+        results = list(handler.process(("__END_OF_RESPONSE__", None)))
+        assert results == [b"__RESPONSE_DONE__"]


### PR DESCRIPTION
## Summary

This PR adds [MiniMax](https://www.minimax.io/) as a TTS provider, accessible via `--tts minimax`.

- **New file** `TTS/minimax_tts_handler.py` — `MiniMaxTTSHandler` streams PCM audio via the MiniMax `t2a_v2` SSE API, decodes hex-encoded chunks, and yields 16 kHz int16 numpy arrays that slot directly into the existing pipeline
- **New file** `arguments_classes/minimax_tts_arguments.py` — CLI arguments (`--minimax_tts_*`) for model, voice, speed, volume, pitch, and blocksize
- **Updated** `s2s_pipeline.py` — imports and registers the new handler; `--tts minimax` selects it
- **Updated** `arguments_classes/module_arguments.py` — adds `minimax` to the `--tts` help text
- **New file** `tests/test_minimax_tts_handler.py` — 21 unit and integration tests (all passing)

## Usage

```bash
MINIMAX_API_KEY=<your-key> python s2s_pipeline.py \
  --tts minimax \
  --minimax_tts_model speech-2.8-hd \
  --minimax_tts_voice English_Graceful_Lady
```

## Supported models

| Model | Notes |
|-------|-------|
| `speech-2.8-hd` | Default — highest quality |
| `speech-2.8-turbo` | Faster |

## Available voices

`English_Graceful_Lady`, `English_Insightful_Speaker`, `English_radiant_girl`, `English_Persuasive_Man`, `English_Lucky_Robot`, `English_expressive_narrator`

## Implementation notes

- Uses **PCM format at 16 kHz** over SSE, so no extra audio-decoding dependencies are required
- Audio chunks are hex-decoded with `bytes.fromhex()` and converted to `np.int16` arrays — no base64, no MP3
- API key is read from the `MINIMAX_API_KEY` environment variable (can be overridden via `--minimax_tts_api_key`)
- All HTTP calls use Python's stdlib `urllib.request` — no new dependencies added

## References

- TTS API: https://platform.minimax.io/docs/api-reference/speech-t2a-http