### PR TITLE
Normalize Responses API assistant history

### DIFF
--- a/LLM/openai_api_language_model.py
+++ b/LLM/openai_api_language_model.py
@@ -96,6 +96,49 @@ class OpenApiModelHandler(BaseHandler):
         logger.info(
             f"{self.__class__.__name__}:  warmed up! time: {(end - start):.3f} s"
         )
+
+    def _normalize_responses_message_content(self, content):
+        """Convert Responses API output content back into request-safe input parts.
+
+        The Responses API returns assistant message parts like ``output_text``.
+        When we place those assistant turns back into ``input=...`` on the next
+        request, they need to be converted to ``input_text`` content items.
+        """
+        if content is None:
+            return []
+
+        if isinstance(content, str):
+            return [{"type": "input_text", "text": content}]
+
+        if not isinstance(content, list):
+            return [{"type": "input_text", "text": str(content)}]
+
+        normalized = []
+        for part in content:
+            if isinstance(part, dict):
+                part_type = part.get("type")
+                text = part.get("text")
+                image_url = part.get("image_url")
+            else:
+                part_type = getattr(part, "type", None)
+                text = getattr(part, "text", None)
+                image_url = getattr(part, "image_url", None)
+
+            if part_type in ("input_text", "output_text") and text:
+                normalized.append({"type": "input_text", "text": text})
+            elif part_type == "input_image" and image_url:
+                normalized.append({"type": "input_image", "image_url": image_url})
+
+        return normalized
+
+    def _append_assistant_message(self, role, content):
+        normalized_content = self._normalize_responses_message_content(content)
+        self.chat.append({
+            "type": "message",
+            "role": role,
+            "content": normalized_content,
+        })
+
     def _apply_runtime_config(self, override_tool_choice=None):
         if not self.runtime_config:
             return
@@ -201,11 +244,10 @@ class OpenApiModelHandler(BaseHandler):
                         if event.item.type == "function_call":
                             tools.append(event.item.model_dump())
                         elif event.item.type == "message":
-                            self.chat.append({
-                                "type": "message",
-                                "role": event.item.role,
-                                "content": event.item.content,
-                            })
+                            self._append_assistant_message(
+                                event.item.role,
+                                event.item.content,
+                            )
                     elif event.type == "response.completed":
                         usage = getattr(event.response, "usage", None)
                         if usage:
@@ -228,11 +270,10 @@ class OpenApiModelHandler(BaseHandler):
                         if message.type == "function_call":
                             tools.append(message.model_dump())
                         elif message.type == "message":
-                            self.chat.append({
-                                "type": "message",
-                                "role": message.role,
-                                "content": message.content,
-                            })
+                            self._append_assistant_message(
+                                message.role,
+                                message.content,
+                            )
                             for chunk in message.content:
                                 if chunk.type == "output_text":
                                     clean_text += remove_unspeechable(chunk.text)

--- a/tests/test_openai_api_language_model.py
+++ b/tests/test_openai_api_language_model.py
@@ -202,6 +202,46 @@ def test_second_turn_flattens_assistant_history_for_responses():
         {
             "type": "message",
             "role": "assistant",
-            "content": [SimpleNamespace(type="output_text", text="Hello.")],
+            "content": [{"type": "input_text", "text": "Hello."}],
+        }
+    ]
+
+
+def test_streaming_history_normalizes_output_text_for_next_turn():
+    handler = _make_handler(stream=True)
+    captured = {}
+    call_count = 0
+
+    first_stream = iter([
+        _make_text_delta_event("Hello."),
+        _make_output_item_done_event(
+            content=[SimpleNamespace(type="output_text", text="Hello.")]
+        ),
+    ])
+
+    def fake_create(**kwargs):
+        nonlocal call_count
+        call_count += 1
+        if call_count == 1:
+            return first_stream
+        captured.update(kwargs)
+        return iter([])
+
+    handler.client = SimpleNamespace(
+        responses=SimpleNamespace(create=fake_create)
+    )
+
+    list(handler.process("Hi"))
+    list(handler.process("Again"))
+
+    assistant_items = [
+        item for item in captured["input"]
+        if item.get("role") == "assistant"
+    ]
+    assert assistant_items == [
+        {
+            "type": "message",
+            "role": "assistant",
+            "content": [{"type": "input_text", "text": "Hello."}],
         }
     ]


### PR DESCRIPTION
## Summary
This fixes malformed assistant history being replayed into the OpenAI-compatible Responses API on later turns.

## Root Cause
The `open_api` handler was storing assistant messages exactly as returned by the Responses API. Those messages contain `output_text` content items, but follow-up `responses.create(input=...)` calls expect request-safe input parts like `input_text`.

That mismatch caused large schema-validation errors on subsequent turns, with logs showing the API trying and failing to coerce an assistant `message` payload into many other response item variants.

## What Changed
- normalize assistant message content before appending it back into chat history
- convert `output_text` items into request-safe `input_text` items
- keep the same behavior for both streaming and non-streaming response handling
- add regression coverage for both code paths

## Validation
- `pytest tests/test_openai_api_language_model.py`

## Impact
This is separate from the Qwen3-TTS work. It fixes the `open_api` LLM path for any backend using the Responses API compatibility layer.