### PR TITLE
[codex] Default macOS Qwen3-TTS to 6bit

### DIFF
--- a/README.md
+++ b/README.md
@@ -141,7 +141,7 @@ This setting:
    - Sets MLX LM for the language model (uses `--lm_model_name` to specify the model)
    - Sets Qwen3-TTS for TTS
    - `--tts melo`, `--tts pocket`, and `--tts kokoro` are also valid TTS options on macOS.
-   - Qwen3 on Apple Silicon uses `mlx-audio` and supports `--qwen3_tts_mlx_quantization 4bit|6bit|8bit` for faster MLX variants.
+   - Qwen3 on Apple Silicon uses `mlx-audio` and defaults to the `6bit` MLX variant unless you explicitly select a different quantization or model suffix.
    - To compare the MLX variants locally, run:
      ```bash
      .venv/bin/python benchmark_tts.py \

--- a/TTS/README.md
+++ b/TTS/README.md
@@ -102,21 +102,20 @@ python s2s_pipeline.py \
 
 Behavior:
 - Uses `faster-qwen3-tts` on non-macOS platforms.
-- Uses `mlx-audio` on Apple Silicon and auto-maps `Qwen/...` model IDs to `mlx-community/...-bf16` when possible.
-- Supports opt-in MLX quantized models on Apple Silicon via `--qwen3_tts_mlx_quantization 4bit`, `6bit`, or `8bit`.
+- Uses `mlx-audio` on Apple Silicon and auto-maps `Qwen/...` model IDs to `mlx-community/...`, defaulting to the `6bit` MLX variant unless the model name already pins a suffix.
+- Supports MLX quantization overrides on Apple Silicon via `--qwen3_tts_mlx_quantization bf16|4bit|6bit|8bit`.
 - Keeps the existing voice-clone/custom-voice/voice-design handler flow intact.
 
-Example for Apple Silicon with the 6-bit MLX variant:
+Example for Apple Silicon using the default 6-bit MLX variant:
 
 ```bash
 python s2s_pipeline.py \
   --tts qwen3 \
   --qwen3_tts_model_name Qwen/Qwen3-TTS-12Hz-0.6B-Base \
-  --qwen3_tts_mlx_quantization 6bit \
   --qwen3_tts_ref_audio TTS/ref_audio.wav
 ```
 
-You can also select `4bit` or `8bit` the same way:
+You can override the default and select `bf16`, `4bit`, or `8bit` explicitly:
 
 ```bash
 python s2s_pipeline.py \

--- a/TTS/qwen3_tts_handler.py
+++ b/TTS/qwen3_tts_handler.py
@@ -25,8 +25,7 @@ logger = logging.getLogger(__name__)
 console = Console()
 
 DEFAULT_MODEL = "Qwen/Qwen3-TTS-12Hz-0.6B-Base"
-DEFAULT_MLX_MODEL = "mlx-community/Qwen3-TTS-12Hz-0.6B-Base-bf16"
-DEFAULT_MLX_QUANTIZATION = "6bit"
+DEFAULT_MLX_MODEL = "mlx-community/Qwen3-TTS-12Hz-0.6B-Base-6bit"
 DEFAULT_REF_TEXT = "I'm confused why some people have super short timelines, yet at the same time are bullish on scaling up reinforcement learning atop LLMs. If we're actually close to a human-like learner, then this whole approach of training on verifiable outcomes."
 DEFAULT_FASTER_STREAMING_CHUNK_SIZE = 8
 DEFAULT_MLX_STREAMING_CHUNK_SIZE = 4
@@ -86,7 +85,6 @@ class Qwen3TTSHandler(BaseHandler):
         self.max_new_tokens = max_new_tokens
         self.blocksize = blocksize
         self.dtype = None
-        self.effective_mlx_quantization = None
         self.gen_kwargs = gen_kwargs or {}
         self._mlx_ref_audio_cache = {}
         self._mlx_temp_ref_audio_files = set()
@@ -98,17 +96,15 @@ class Qwen3TTSHandler(BaseHandler):
 
         if self.backend == "mlx":
             self.device = "mps"
-            self.effective_mlx_quantization = self._effective_mlx_quantization(
-                model_name
-            )
             self.model_name = self._resolve_mlx_model_name(model_name)
             logger.info(
                 f"Loading Qwen3-TTS model: {self.model_name} via mlx-audio on Apple Silicon"
             )
-            if self.effective_mlx_quantization and self.effective_mlx_quantization != "bf16":
+            model_quantization = self._model_name_quantization_suffix(self.model_name)
+            if model_quantization and model_quantization != "bf16":
                 logger.info(
                     "Using MLX quantized Qwen3-TTS variant: %s",
-                    self.effective_mlx_quantization,
+                    model_quantization,
                 )
             self._setup_mlx(self.model_name)
         else:
@@ -204,11 +200,10 @@ class Qwen3TTSHandler(BaseHandler):
         return value
 
     def _apply_mlx_quantization_suffix(self, model_name):
-        quantization = self.effective_mlx_quantization
-        if quantization is None:
+        if self.mlx_quantization is None:
             return model_name
 
-        desired_suffix = f"-{quantization}"
+        desired_suffix = f"-{self.mlx_quantization}"
         for suffix in VALID_MLX_QUANTIZATION_SUFFIXES:
             current_suffix = f"-{suffix}"
             if model_name.endswith(current_suffix):
@@ -226,23 +221,21 @@ class Qwen3TTSHandler(BaseHandler):
 
         return None
 
-    def _effective_mlx_quantization(self, model_name):
-        if self.mlx_quantization is not None:
-            return self.mlx_quantization
-
-        if self._model_name_quantization_suffix(model_name) is not None:
-            return None
-
-        return DEFAULT_MLX_QUANTIZATION
-
     def _resolve_mlx_model_name(self, model_name):
         if not model_name:
             return self._apply_mlx_quantization_suffix(DEFAULT_MLX_MODEL)
         if model_name.startswith("mlx-community/"):
+            if (
+                self.mlx_quantization is None
+                and self._model_name_quantization_suffix(model_name) is None
+            ):
+                return f"{model_name}-6bit"
             return self._apply_mlx_quantization_suffix(model_name)
         if model_name.startswith("Qwen/"):
             mapped = model_name.replace("Qwen/", "mlx-community/", 1)
-            if not mapped.endswith(tuple(f"-{suffix}" for suffix in VALID_MLX_QUANTIZATION_SUFFIXES)):
+            if self._model_name_quantization_suffix(mapped) is None:
+                if self.mlx_quantization is None:
+                    return f"{mapped}-6bit"
                 mapped = f"{mapped}-bf16"
             return self._apply_mlx_quantization_suffix(mapped)
         return model_name

--- a/TTS/qwen3_tts_handler.py
+++ b/TTS/qwen3_tts_handler.py
@@ -26,6 +26,7 @@ console = Console()
 
 DEFAULT_MODEL = "Qwen/Qwen3-TTS-12Hz-0.6B-Base"
 DEFAULT_MLX_MODEL = "mlx-community/Qwen3-TTS-12Hz-0.6B-Base-bf16"
+DEFAULT_MLX_QUANTIZATION = "6bit"
 DEFAULT_REF_TEXT = "I'm confused why some people have super short timelines, yet at the same time are bullish on scaling up reinforcement learning atop LLMs. If we're actually close to a human-like learner, then this whole approach of training on verifiable outcomes."
 DEFAULT_FASTER_STREAMING_CHUNK_SIZE = 8
 DEFAULT_MLX_STREAMING_CHUNK_SIZE = 4
@@ -85,6 +86,7 @@ class Qwen3TTSHandler(BaseHandler):
         self.max_new_tokens = max_new_tokens
         self.blocksize = blocksize
         self.dtype = None
+        self.effective_mlx_quantization = None
         self.gen_kwargs = gen_kwargs or {}
         self._mlx_ref_audio_cache = {}
         self._mlx_temp_ref_audio_files = set()
@@ -96,13 +98,17 @@ class Qwen3TTSHandler(BaseHandler):
 
         if self.backend == "mlx":
             self.device = "mps"
+            self.effective_mlx_quantization = self._effective_mlx_quantization(
+                model_name
+            )
             self.model_name = self._resolve_mlx_model_name(model_name)
             logger.info(
                 f"Loading Qwen3-TTS model: {self.model_name} via mlx-audio on Apple Silicon"
             )
-            if self.mlx_quantization:
+            if self.effective_mlx_quantization and self.effective_mlx_quantization != "bf16":
                 logger.info(
-                    "Using MLX quantized Qwen3-TTS variant: %s", self.mlx_quantization
+                    "Using MLX quantized Qwen3-TTS variant: %s",
+                    self.effective_mlx_quantization,
                 )
             self._setup_mlx(self.model_name)
         else:
@@ -198,16 +204,36 @@ class Qwen3TTSHandler(BaseHandler):
         return value
 
     def _apply_mlx_quantization_suffix(self, model_name):
-        if self.mlx_quantization is None:
+        quantization = self.effective_mlx_quantization
+        if quantization is None:
             return model_name
 
-        desired_suffix = f"-{self.mlx_quantization}"
+        desired_suffix = f"-{quantization}"
         for suffix in VALID_MLX_QUANTIZATION_SUFFIXES:
             current_suffix = f"-{suffix}"
             if model_name.endswith(current_suffix):
                 return model_name[: -len(current_suffix)] + desired_suffix
 
         return f"{model_name}{desired_suffix}"
+
+    def _model_name_quantization_suffix(self, model_name):
+        if not model_name:
+            return None
+
+        for suffix in VALID_MLX_QUANTIZATION_SUFFIXES:
+            if model_name.endswith(f"-{suffix}"):
+                return suffix
+
+        return None
+
+    def _effective_mlx_quantization(self, model_name):
+        if self.mlx_quantization is not None:
+            return self.mlx_quantization
+
+        if self._model_name_quantization_suffix(model_name) is not None:
+            return None
+
+        return DEFAULT_MLX_QUANTIZATION
 
     def _resolve_mlx_model_name(self, model_name):
         if not model_name:

--- a/arguments_classes/qwen3_tts_arguments.py
+++ b/arguments_classes/qwen3_tts_arguments.py
@@ -7,7 +7,7 @@ class Qwen3TTSHandlerArguments:
     qwen3_tts_model_name: str = field(
         default="Qwen/Qwen3-TTS-12Hz-0.6B-Base",
         metadata={
-            "help": "The Qwen3-TTS model to use (HuggingFace Hub ID or local path). On Apple Silicon, Qwen/* model IDs are auto-mapped to the corresponding mlx-community/*-bf16 model when possible."
+            "help": "The Qwen3-TTS model to use (HuggingFace Hub ID or local path). On Apple Silicon, Qwen/* model IDs are auto-mapped to the corresponding mlx-community/* model when possible, defaulting to the 6bit MLX variant unless the model name already pins a specific suffix."
         },
     )
     qwen3_tts_device: str = field(
@@ -67,7 +67,7 @@ class Qwen3TTSHandlerArguments:
     qwen3_tts_mlx_quantization: Optional[str] = field(
         default=None,
         metadata={
-            "help": "Optional MLX quantization override on Apple Silicon. Supported values: 'bf16', '4bit', '6bit', '8bit'. Leave unset for the default bf16 models."
+            "help": "Optional MLX quantization override on Apple Silicon. Supported values: 'bf16', '4bit', '6bit', '8bit'. Leave unset to use the default 6bit MLX variant unless the model name already includes a quantization suffix."
         },
     )
     qwen3_tts_language: str = field(

--- a/tests/test_qwen3_tts_handler_backend.py
+++ b/tests/test_qwen3_tts_handler_backend.py
@@ -38,10 +38,11 @@ def test_setup_uses_mlx_backend_on_darwin_and_maps_qwen_repo_ids(monkeypatch):
     assert handler.backend == "mlx"
     assert handler.device == "mps"
     assert handler.dtype is None
+    assert handler.effective_mlx_quantization == "6bit"
     assert handler.streaming_chunk_size == 4
     assert (
         recorded["model_name"]
-        == "mlx-community/Qwen3-TTS-12Hz-1.7B-CustomVoice-bf16"
+        == "mlx-community/Qwen3-TTS-12Hz-1.7B-CustomVoice-6bit"
     )
 
 
@@ -65,10 +66,33 @@ def test_setup_supports_quantized_mlx_mapping_on_darwin(monkeypatch, quantizatio
 
     assert handler.backend == "mlx"
     assert handler.mlx_quantization == quantization
+    assert handler.effective_mlx_quantization == quantization
     assert (
         recorded["model_name"]
         == f"mlx-community/Qwen3-TTS-12Hz-0.6B-Base-{quantization}"
     )
+
+
+def test_setup_preserves_explicit_mlx_model_suffix_when_quantization_unset(monkeypatch):
+    recorded = {}
+
+    def _setup_mlx(self, model_name):
+        recorded["model_name"] = model_name
+
+    monkeypatch.setattr(qwen3_tts_module, "platform", "darwin")
+    monkeypatch.setattr(Qwen3TTSHandler, "_setup_mlx", _setup_mlx)
+    monkeypatch.setattr(Qwen3TTSHandler, "warmup", lambda self: None)
+
+    handler = object.__new__(Qwen3TTSHandler)
+    handler.setup(
+        Event(),
+        model_name="mlx-community/Qwen3-TTS-12Hz-0.6B-Base-bf16",
+    )
+
+    assert handler.backend == "mlx"
+    assert handler.mlx_quantization is None
+    assert handler.effective_mlx_quantization is None
+    assert recorded["model_name"] == "mlx-community/Qwen3-TTS-12Hz-0.6B-Base-bf16"
 
 
 def test_setup_preserves_faster_backend_off_darwin(monkeypatch):

--- a/tests/test_qwen3_tts_handler_backend.py
+++ b/tests/test_qwen3_tts_handler_backend.py
@@ -38,7 +38,6 @@ def test_setup_uses_mlx_backend_on_darwin_and_maps_qwen_repo_ids(monkeypatch):
     assert handler.backend == "mlx"
     assert handler.device == "mps"
     assert handler.dtype is None
-    assert handler.effective_mlx_quantization == "6bit"
     assert handler.streaming_chunk_size == 4
     assert (
         recorded["model_name"]
@@ -66,7 +65,6 @@ def test_setup_supports_quantized_mlx_mapping_on_darwin(monkeypatch, quantizatio
 
     assert handler.backend == "mlx"
     assert handler.mlx_quantization == quantization
-    assert handler.effective_mlx_quantization == quantization
     assert (
         recorded["model_name"]
         == f"mlx-community/Qwen3-TTS-12Hz-0.6B-Base-{quantization}"
@@ -91,7 +89,6 @@ def test_setup_preserves_explicit_mlx_model_suffix_when_quantization_unset(monke
 
     assert handler.backend == "mlx"
     assert handler.mlx_quantization is None
-    assert handler.effective_mlx_quantization is None
     assert recorded["model_name"] == "mlx-community/Qwen3-TTS-12Hz-0.6B-Base-bf16"
 
 


### PR DESCRIPTION
## What changed
- default Apple Silicon Qwen3-TTS model resolution to the `6bit` MLX variant when no quantization override is provided
- preserve explicitly pinned MLX model suffixes such as `-bf16`, `-4bit`, `-6bit`, and `-8bit`
- update the Qwen3 TTS argument help text and README docs to match the new default behavior
- add a regression test covering the explicit-suffix preservation case

## Why
The previous Qwen3-TTS macOS integration supported `6bit`, but leaving `--qwen3_tts_mlx_quantization` unset still resolved through the bf16 path. This follow-up makes the default match the intended Apple Silicon recommendation without overriding users who already pin a specific MLX variant.

## User impact
- macOS users get the faster `6bit` Qwen3-TTS MLX path by default
- users can still force `bf16`, `4bit`, `6bit`, or `8bit` explicitly
- explicit `mlx-community/...-bf16` style model names continue to work as written

## Validation
- `python -m py_compile TTS/qwen3_tts_handler.py arguments_classes/qwen3_tts_arguments.py tests/test_qwen3_tts_handler_backend.py`
- `pytest tests/test_qwen3_tts_handler_backend.py`
