### PR TITLE
Add Qwen3-TTS non-streaming mode override

### DIFF
--- a/TTS/qwen3_tts_handler.py
+++ b/TTS/qwen3_tts_handler.py
@@ -10,7 +10,6 @@ from pathlib import Path
 from sys import platform
 import tempfile
 from time import perf_counter
-import types
 
 import numpy as np
 from rich.console import Console
@@ -127,7 +126,6 @@ class Qwen3TTSHandler(BaseHandler):
                 dtype=dtype,
                 attn_implementation=attn_implementation,
             )
-            self._install_faster_non_streaming_mode_override()
 
         logger.info(
             "Using Qwen3-TTS streaming chunk size %d (~%.0fms audio per chunk) on %s",
@@ -256,68 +254,6 @@ class Qwen3TTSHandler(BaseHandler):
         if self.backend == "mlx":
             return DEFAULT_MLX_STREAMING_CHUNK_SIZE
         return DEFAULT_FASTER_STREAMING_CHUNK_SIZE
-
-    def _install_faster_non_streaming_mode_override(self):
-        if self.backend != "faster_qwen3_tts" or self.non_streaming_mode is None:
-            return
-
-        override = bool(self.non_streaming_mode)
-        original = getattr(self.model, "_prepare_generation_custom", None)
-        if original is None:
-            logger.warning(
-                "Unable to apply qwen3_tts_non_streaming_mode override: "
-                "faster-qwen3-tts is missing _prepare_generation_custom."
-            )
-            return
-        if getattr(self.model, "_speech_to_speech_non_streaming_mode_override", None) == override:
-            return
-
-        def _prepare_generation_custom_with_override(model_self, text, language, speaker, instruct=None):
-            input_texts = [model_self.model._build_assistant_text(text)]
-            input_ids = model_self.model._tokenize_texts(input_texts)
-
-            instruct_ids = []
-            if instruct is None or instruct == "":
-                instruct_ids.append(None)
-            else:
-                instruct_ids.append(
-                    model_self.model._tokenize_texts(
-                        [model_self.model._build_instruct_text(instruct)]
-                    )[0]
-                )
-
-            m = model_self.model.model
-            tie, tam, tth, tpe = model_self._build_talker_inputs_local(
-                m=m,
-                input_ids=input_ids,
-                ref_ids=[None],
-                voice_clone_prompt=None,
-                languages=[language] if language is not None else ["Auto"],
-                speakers=[speaker],
-                non_streaming_mode=override,
-                instruct_ids=instruct_ids,
-            )
-
-            if not model_self._warmed_up:
-                model_self._warmup(tie.shape[1])
-
-            talker = m.talker
-            config = m.config.talker_config
-            talker.rope_deltas = None
-
-            return m, talker, config, tie, tam, tth, tpe
-
-        self.model._prepare_generation_custom = types.MethodType(
-            _prepare_generation_custom_with_override,
-            self.model,
-        )
-        self.model._speech_to_speech_original_prepare_generation_custom = original
-        self.model._speech_to_speech_non_streaming_mode_override = override
-
-    def _maybe_add_non_streaming_mode(self, kwargs):
-        if self.non_streaming_mode is not None:
-            kwargs["non_streaming_mode"] = self.non_streaming_mode
-        return kwargs
 
     def _infer_model_type_from_name(self):
         name = (self.model_name or "").lower()
@@ -704,22 +640,17 @@ class Qwen3TTSHandler(BaseHandler):
             )
             return
 
-        faster_kwargs = self._maybe_add_non_streaming_mode(
-            {
-                "text": text,
-                "language": self.language,
-                "ref_audio": self.ref_audio,
-                "ref_text": self.ref_text,
-                "xvec_only": self.xvec_only,
-                "chunk_size": self.streaming_chunk_size,
-                "max_new_tokens": self.max_new_tokens,
-                "parity_mode": self.parity_mode,
-            }
-        )
-
         yield from self._stream(
             self.model.generate_voice_clone_streaming(
-                **faster_kwargs,
+                text=text,
+                language=self.language,
+                ref_audio=self.ref_audio,
+                ref_text=self.ref_text,
+                xvec_only=self.xvec_only,
+                chunk_size=self.streaming_chunk_size,
+                max_new_tokens=self.max_new_tokens,
+                parity_mode=self.parity_mode,
+                non_streaming_mode=self.non_streaming_mode,
             ),
             label="voice_clone_parity" if self.parity_mode else "voice_clone",
         )
@@ -751,6 +682,7 @@ class Qwen3TTSHandler(BaseHandler):
                 instruct=self.instruct,
                 chunk_size=self.streaming_chunk_size,
                 max_new_tokens=self.max_new_tokens,
+                non_streaming_mode=self.non_streaming_mode,
             ),
             label="custom_voice",
         )
@@ -773,6 +705,7 @@ class Qwen3TTSHandler(BaseHandler):
                 language=self.language,
                 chunk_size=self.streaming_chunk_size,
                 max_new_tokens=self.max_new_tokens,
+                non_streaming_mode=self.non_streaming_mode,
             ),
             label="voice_design",
         )

--- a/TTS/qwen3_tts_handler.py
+++ b/TTS/qwen3_tts_handler.py
@@ -314,6 +314,11 @@ class Qwen3TTSHandler(BaseHandler):
         self.model._speech_to_speech_original_prepare_generation_custom = original
         self.model._speech_to_speech_non_streaming_mode_override = override
 
+    def _maybe_add_non_streaming_mode(self, kwargs):
+        if self.non_streaming_mode is not None:
+            kwargs["non_streaming_mode"] = self.non_streaming_mode
+        return kwargs
+
     def _infer_model_type_from_name(self):
         name = (self.model_name or "").lower()
         if "voicedesign" in name:
@@ -699,19 +704,22 @@ class Qwen3TTSHandler(BaseHandler):
             )
             return
 
+        faster_kwargs = self._maybe_add_non_streaming_mode(
+            {
+                "text": text,
+                "language": self.language,
+                "ref_audio": self.ref_audio,
+                "ref_text": self.ref_text,
+                "xvec_only": self.xvec_only,
+                "chunk_size": self.streaming_chunk_size,
+                "max_new_tokens": self.max_new_tokens,
+                "parity_mode": self.parity_mode,
+            }
+        )
+
         yield from self._stream(
             self.model.generate_voice_clone_streaming(
-                text=text,
-                language=self.language,
-                ref_audio=self.ref_audio,
-                ref_text=self.ref_text,
-                xvec_only=self.xvec_only,
-                chunk_size=self.streaming_chunk_size,
-                max_new_tokens=self.max_new_tokens,
-                non_streaming_mode=self.non_streaming_mode
-                if self.non_streaming_mode is not None
-                else True,
-                parity_mode=self.parity_mode,
+                **faster_kwargs,
             ),
             label="voice_clone_parity" if self.parity_mode else "voice_clone",
         )

--- a/TTS/qwen3_tts_handler.py
+++ b/TTS/qwen3_tts_handler.py
@@ -10,6 +10,7 @@ from pathlib import Path
 from sys import platform
 import tempfile
 from time import perf_counter
+import types
 
 import numpy as np
 from rich.console import Console
@@ -62,6 +63,7 @@ class Qwen3TTSHandler(BaseHandler):
         instruct=None,
         xvec_only=False,
         parity_mode=False,
+        non_streaming_mode=None,
         mlx_quantization=None,
         streaming_chunk_size=None,
         max_new_tokens=360,
@@ -81,6 +83,7 @@ class Qwen3TTSHandler(BaseHandler):
         self.instruct = instruct
         self.xvec_only = xvec_only
         self.parity_mode = parity_mode
+        self.non_streaming_mode = non_streaming_mode
         self.mlx_quantization = self._normalize_mlx_quantization(mlx_quantization)
         self.max_new_tokens = max_new_tokens
         self.blocksize = blocksize
@@ -100,6 +103,12 @@ class Qwen3TTSHandler(BaseHandler):
             logger.info(
                 f"Loading Qwen3-TTS model: {self.model_name} via mlx-audio on Apple Silicon"
             )
+            if self.non_streaming_mode is not None:
+                logger.warning(
+                    "qwen3_tts_non_streaming_mode=%s is ignored on Apple Silicon because "
+                    "mlx-audio does not expose non_streaming_mode yet.",
+                    self.non_streaming_mode,
+                )
             model_quantization = self._model_name_quantization_suffix(self.model_name)
             if model_quantization and model_quantization != "bf16":
                 logger.info(
@@ -118,6 +127,7 @@ class Qwen3TTSHandler(BaseHandler):
                 dtype=dtype,
                 attn_implementation=attn_implementation,
             )
+            self._install_faster_non_streaming_mode_override()
 
         logger.info(
             "Using Qwen3-TTS streaming chunk size %d (~%.0fms audio per chunk) on %s",
@@ -246,6 +256,63 @@ class Qwen3TTSHandler(BaseHandler):
         if self.backend == "mlx":
             return DEFAULT_MLX_STREAMING_CHUNK_SIZE
         return DEFAULT_FASTER_STREAMING_CHUNK_SIZE
+
+    def _install_faster_non_streaming_mode_override(self):
+        if self.backend != "faster_qwen3_tts" or self.non_streaming_mode is None:
+            return
+
+        override = bool(self.non_streaming_mode)
+        original = getattr(self.model, "_prepare_generation_custom", None)
+        if original is None:
+            logger.warning(
+                "Unable to apply qwen3_tts_non_streaming_mode override: "
+                "faster-qwen3-tts is missing _prepare_generation_custom."
+            )
+            return
+        if getattr(self.model, "_speech_to_speech_non_streaming_mode_override", None) == override:
+            return
+
+        def _prepare_generation_custom_with_override(model_self, text, language, speaker, instruct=None):
+            input_texts = [model_self.model._build_assistant_text(text)]
+            input_ids = model_self.model._tokenize_texts(input_texts)
+
+            instruct_ids = []
+            if instruct is None or instruct == "":
+                instruct_ids.append(None)
+            else:
+                instruct_ids.append(
+                    model_self.model._tokenize_texts(
+                        [model_self.model._build_instruct_text(instruct)]
+                    )[0]
+                )
+
+            m = model_self.model.model
+            tie, tam, tth, tpe = model_self._build_talker_inputs_local(
+                m=m,
+                input_ids=input_ids,
+                ref_ids=[None],
+                voice_clone_prompt=None,
+                languages=[language] if language is not None else ["Auto"],
+                speakers=[speaker],
+                non_streaming_mode=override,
+                instruct_ids=instruct_ids,
+            )
+
+            if not model_self._warmed_up:
+                model_self._warmup(tie.shape[1])
+
+            talker = m.talker
+            config = m.config.talker_config
+            talker.rope_deltas = None
+
+            return m, talker, config, tie, tam, tth, tpe
+
+        self.model._prepare_generation_custom = types.MethodType(
+            _prepare_generation_custom_with_override,
+            self.model,
+        )
+        self.model._speech_to_speech_original_prepare_generation_custom = original
+        self.model._speech_to_speech_non_streaming_mode_override = override
 
     def _infer_model_type_from_name(self):
         name = (self.model_name or "").lower()
@@ -641,6 +708,9 @@ class Qwen3TTSHandler(BaseHandler):
                 xvec_only=self.xvec_only,
                 chunk_size=self.streaming_chunk_size,
                 max_new_tokens=self.max_new_tokens,
+                non_streaming_mode=self.non_streaming_mode
+                if self.non_streaming_mode is not None
+                else True,
                 parity_mode=self.parity_mode,
             ),
             label="voice_clone_parity" if self.parity_mode else "voice_clone",

--- a/arguments_classes/qwen3_tts_arguments.py
+++ b/arguments_classes/qwen3_tts_arguments.py
@@ -64,6 +64,12 @@ class Qwen3TTSHandlerArguments:
             "help": "Disable CUDA-graph streaming path and use parity mode for stability. Default is False."
         },
     )
+    qwen3_tts_non_streaming_mode: Optional[bool] = field(
+        default=None,
+        metadata={
+            "help": "Optional override for Qwen3-TTS text prefill behavior. Leave unset to keep each backend/mode default. Set to true to prefill the full target text before decode, or false to feed trailing text token-by-token during decode. Currently ignored on Apple Silicon because mlx-audio does not expose this yet."
+        },
+    )
     qwen3_tts_mlx_quantization: Optional[str] = field(
         default=None,
         metadata={

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -34,7 +34,7 @@ dependencies = [
     "phonemizer-fork>=3.3.2; platform_system == 'Darwin'",
     "nano-parakeet>=0.2.0; platform_system != 'Darwin'",
     "kokoro>=0.9.2; platform_system != 'Darwin'",
-    "faster-qwen3-tts>=0.2.5; platform_system != 'Darwin'",
+    "faster-qwen3-tts>=0.2.6; platform_system != 'Darwin'",
 ]
 
 [dependency-groups]

--- a/tests/test_qwen3_tts_handler_backend.py
+++ b/tests/test_qwen3_tts_handler_backend.py
@@ -379,3 +379,38 @@ def test_process_voice_clone_passes_non_streaming_mode_to_faster_backend(monkeyp
 
     assert len(outputs) == 1
     assert captured["non_streaming_mode"] is False
+
+
+def test_process_voice_clone_omits_non_streaming_mode_when_unset(monkeypatch):
+    captured = {}
+    handler = object.__new__(Qwen3TTSHandler)
+    handler.should_listen = Event()
+    handler.runtime_config = None
+    handler.cancel_scope = None
+    handler.ref_audio = "TTS/ref_audio.wav"
+    handler.ref_text = "Reference text."
+    handler.speaker = None
+    handler.instruct = None
+    handler.language = "English"
+    handler.xvec_only = False
+    handler.parity_mode = False
+    handler.non_streaming_mode = None
+    handler.streaming_chunk_size = 8
+    handler.max_new_tokens = 360
+    handler.blocksize = 512
+    handler.backend = "faster_qwen3_tts"
+    handler.queue_in = Queue()
+    handler.model = SimpleNamespace(
+        model=SimpleNamespace(model=SimpleNamespace(tts_model_type="base")),
+        generate_voice_clone_streaming=lambda **kwargs: (
+            captured.update(kwargs),
+            iter([(np.zeros(512, dtype=np.float32), 16000, {})]),
+        )[1],
+    )
+
+    monkeypatch.setattr(qwen3_tts_module.console, "print", lambda *args, **kwargs: None)
+
+    outputs = list(handler.process("Hello there."))
+
+    assert len(outputs) == 1
+    assert "non_streaming_mode" not in captured

--- a/tests/test_qwen3_tts_handler_backend.py
+++ b/tests/test_qwen3_tts_handler_backend.py
@@ -145,6 +145,26 @@ def test_setup_preserves_explicit_chunk_size_on_darwin(monkeypatch):
     assert handler.streaming_chunk_size == 4
 
 
+def test_setup_warns_when_non_streaming_mode_set_on_darwin(monkeypatch, caplog):
+    def _setup_mlx(self, model_name):
+        return None
+
+    monkeypatch.setattr(qwen3_tts_module, "platform", "darwin")
+    monkeypatch.setattr(Qwen3TTSHandler, "_setup_mlx", _setup_mlx)
+    monkeypatch.setattr(Qwen3TTSHandler, "warmup", lambda self: None)
+
+    handler = object.__new__(Qwen3TTSHandler)
+
+    with caplog.at_level("WARNING"):
+        handler.setup(
+            Event(),
+            model_name="Qwen/Qwen3-TTS-12Hz-0.6B-Base",
+            non_streaming_mode=True,
+        )
+
+    assert "mlx-audio does not expose non_streaming_mode yet" in caplog.text
+
+
 def test_setup_rejects_invalid_mlx_quantization(monkeypatch):
     def _setup_mlx(self, model_name):
         return None
@@ -177,6 +197,45 @@ def test_mlx_helper_methods_use_model_config_and_streaming_conversion():
     assert handler._model_type() == "custom_voice"
     assert handler._resolve_speaker() == "Vivian"
     assert handler._mlx_streaming_interval() == pytest.approx(0.64)
+
+
+@pytest.mark.parametrize("override", [True, False])
+def test_install_faster_non_streaming_mode_override_patches_custom_prepare(override):
+    recorded = {}
+    fake_model = SimpleNamespace(
+        _warmed_up=True,
+        model=SimpleNamespace(
+            _build_assistant_text=lambda text: f"assistant:{text}",
+            _tokenize_texts=lambda texts: [texts[0]],
+            _build_instruct_text=lambda text: f"instruct:{text}",
+            model=SimpleNamespace(
+                talker=SimpleNamespace(rope_deltas=None),
+                config=SimpleNamespace(talker_config=SimpleNamespace()),
+            ),
+        ),
+        _prepare_generation_custom=lambda *args, **kwargs: None,
+        _build_talker_inputs_local=lambda **kwargs: (
+            recorded.update(kwargs),
+            ("tie", "tam", "tth", "tpe"),
+        )[1],
+    )
+
+    handler = object.__new__(Qwen3TTSHandler)
+    handler.backend = "faster_qwen3_tts"
+    handler.non_streaming_mode = override
+    handler.model = fake_model
+
+    handler._install_faster_non_streaming_mode_override()
+    handler.model._prepare_generation_custom(
+        text="Hello there.",
+        language="English",
+        speaker="Vivian",
+        instruct="calm",
+    )
+
+    assert recorded["non_streaming_mode"] is override
+    assert recorded["languages"] == ["English"]
+    assert recorded["speakers"] == ["Vivian"]
 
 
 def test_prepare_mlx_ref_audio_normalizes_file_and_caches_result(monkeypatch, tmp_path):
@@ -285,3 +344,38 @@ def test_process_reenables_listening_when_generation_fails_outside_realtime(monk
 
     assert outputs == []
     assert handler.should_listen.is_set() is True
+
+
+def test_process_voice_clone_passes_non_streaming_mode_to_faster_backend(monkeypatch):
+    captured = {}
+    handler = object.__new__(Qwen3TTSHandler)
+    handler.should_listen = Event()
+    handler.runtime_config = None
+    handler.cancel_scope = None
+    handler.ref_audio = "TTS/ref_audio.wav"
+    handler.ref_text = "Reference text."
+    handler.speaker = None
+    handler.instruct = None
+    handler.language = "English"
+    handler.xvec_only = False
+    handler.parity_mode = False
+    handler.non_streaming_mode = False
+    handler.streaming_chunk_size = 8
+    handler.max_new_tokens = 360
+    handler.blocksize = 512
+    handler.backend = "faster_qwen3_tts"
+    handler.queue_in = Queue()
+    handler.model = SimpleNamespace(
+        model=SimpleNamespace(model=SimpleNamespace(tts_model_type="base")),
+        generate_voice_clone_streaming=lambda **kwargs: (
+            captured.update(kwargs),
+            iter([(np.zeros(512, dtype=np.float32), 16000, {})]),
+        )[1],
+    )
+
+    monkeypatch.setattr(qwen3_tts_module.console, "print", lambda *args, **kwargs: None)
+
+    outputs = list(handler.process("Hello there."))
+
+    assert len(outputs) == 1
+    assert captured["non_streaming_mode"] is False

--- a/tests/test_qwen3_tts_handler_backend.py
+++ b/tests/test_qwen3_tts_handler_backend.py
@@ -14,6 +14,10 @@ from pipeline_messages import MessageTag
 from TTS.qwen3_tts_handler import Qwen3TTSHandler
 
 
+def _audible_stream_chunk():
+    return np.full(512, 0.1, dtype=np.float32)
+
+
 def test_setup_uses_mlx_backend_on_darwin_and_maps_qwen_repo_ids(monkeypatch):
     recorded = {}
 
@@ -199,45 +203,6 @@ def test_mlx_helper_methods_use_model_config_and_streaming_conversion():
     assert handler._mlx_streaming_interval() == pytest.approx(0.64)
 
 
-@pytest.mark.parametrize("override", [True, False])
-def test_install_faster_non_streaming_mode_override_patches_custom_prepare(override):
-    recorded = {}
-    fake_model = SimpleNamespace(
-        _warmed_up=True,
-        model=SimpleNamespace(
-            _build_assistant_text=lambda text: f"assistant:{text}",
-            _tokenize_texts=lambda texts: [texts[0]],
-            _build_instruct_text=lambda text: f"instruct:{text}",
-            model=SimpleNamespace(
-                talker=SimpleNamespace(rope_deltas=None),
-                config=SimpleNamespace(talker_config=SimpleNamespace()),
-            ),
-        ),
-        _prepare_generation_custom=lambda *args, **kwargs: None,
-        _build_talker_inputs_local=lambda **kwargs: (
-            recorded.update(kwargs),
-            ("tie", "tam", "tth", "tpe"),
-        )[1],
-    )
-
-    handler = object.__new__(Qwen3TTSHandler)
-    handler.backend = "faster_qwen3_tts"
-    handler.non_streaming_mode = override
-    handler.model = fake_model
-
-    handler._install_faster_non_streaming_mode_override()
-    handler.model._prepare_generation_custom(
-        text="Hello there.",
-        language="English",
-        speaker="Vivian",
-        instruct="calm",
-    )
-
-    assert recorded["non_streaming_mode"] is override
-    assert recorded["languages"] == ["English"]
-    assert recorded["speakers"] == ["Vivian"]
-
-
 def test_prepare_mlx_ref_audio_normalizes_file_and_caches_result(monkeypatch, tmp_path):
     source = tmp_path / "source.wav"
     source.write_bytes(b"fake")
@@ -369,7 +334,7 @@ def test_process_voice_clone_passes_non_streaming_mode_to_faster_backend(monkeyp
         model=SimpleNamespace(model=SimpleNamespace(tts_model_type="base")),
         generate_voice_clone_streaming=lambda **kwargs: (
             captured.update(kwargs),
-            iter([(np.zeros(512, dtype=np.float32), 16000, {})]),
+            iter([(_audible_stream_chunk(), 16000, {})]),
         )[1],
     )
 
@@ -381,7 +346,7 @@ def test_process_voice_clone_passes_non_streaming_mode_to_faster_backend(monkeyp
     assert captured["non_streaming_mode"] is False
 
 
-def test_process_voice_clone_omits_non_streaming_mode_when_unset(monkeypatch):
+def test_process_voice_clone_passes_none_non_streaming_mode_when_unset(monkeypatch):
     captured = {}
     handler = object.__new__(Qwen3TTSHandler)
     handler.should_listen = Event()
@@ -404,7 +369,7 @@ def test_process_voice_clone_omits_non_streaming_mode_when_unset(monkeypatch):
         model=SimpleNamespace(model=SimpleNamespace(tts_model_type="base")),
         generate_voice_clone_streaming=lambda **kwargs: (
             captured.update(kwargs),
-            iter([(np.zeros(512, dtype=np.float32), 16000, {})]),
+            iter([(_audible_stream_chunk(), 16000, {})]),
         )[1],
     )
 
@@ -413,4 +378,76 @@ def test_process_voice_clone_omits_non_streaming_mode_when_unset(monkeypatch):
     outputs = list(handler.process("Hello there."))
 
     assert len(outputs) == 1
-    assert "non_streaming_mode" not in captured
+    assert captured["non_streaming_mode"] is None
+
+
+@pytest.mark.parametrize("override", [None, False, True])
+def test_process_custom_voice_passes_non_streaming_mode_to_faster_backend(monkeypatch, override):
+    captured = {}
+    handler = object.__new__(Qwen3TTSHandler)
+    handler.should_listen = Event()
+    handler.runtime_config = None
+    handler.cancel_scope = None
+    handler.ref_audio = None
+    handler.ref_text = "Reference text."
+    handler.speaker = "Vivian"
+    handler.instruct = "calm"
+    handler.language = "English"
+    handler.xvec_only = False
+    handler.parity_mode = False
+    handler.non_streaming_mode = override
+    handler.streaming_chunk_size = 8
+    handler.max_new_tokens = 360
+    handler.blocksize = 512
+    handler.backend = "faster_qwen3_tts"
+    handler.queue_in = Queue()
+    handler.model = SimpleNamespace(
+        model=SimpleNamespace(model=SimpleNamespace(tts_model_type="custom_voice")),
+        generate_custom_voice_streaming=lambda **kwargs: (
+            captured.update(kwargs),
+            iter([(_audible_stream_chunk(), 16000, {})]),
+        )[1],
+    )
+
+    monkeypatch.setattr(qwen3_tts_module.console, "print", lambda *args, **kwargs: None)
+
+    outputs = list(handler.process("Hello there."))
+
+    assert len(outputs) == 1
+    assert captured["non_streaming_mode"] is override
+
+
+@pytest.mark.parametrize("override", [None, False, True])
+def test_process_voice_design_passes_non_streaming_mode_to_faster_backend(monkeypatch, override):
+    captured = {}
+    handler = object.__new__(Qwen3TTSHandler)
+    handler.should_listen = Event()
+    handler.runtime_config = None
+    handler.cancel_scope = None
+    handler.ref_audio = None
+    handler.ref_text = "Reference text."
+    handler.speaker = None
+    handler.instruct = "bright radio voice"
+    handler.language = "English"
+    handler.xvec_only = False
+    handler.parity_mode = False
+    handler.non_streaming_mode = override
+    handler.streaming_chunk_size = 8
+    handler.max_new_tokens = 360
+    handler.blocksize = 512
+    handler.backend = "faster_qwen3_tts"
+    handler.queue_in = Queue()
+    handler.model = SimpleNamespace(
+        model=SimpleNamespace(model=SimpleNamespace(tts_model_type="voice_design")),
+        generate_voice_design_streaming=lambda **kwargs: (
+            captured.update(kwargs),
+            iter([(_audible_stream_chunk(), 16000, {})]),
+        )[1],
+    )
+
+    monkeypatch.setattr(qwen3_tts_module.console, "print", lambda *args, **kwargs: None)
+
+    outputs = list(handler.process("Hello there."))
+
+    assert len(outputs) == 1
+    assert captured["non_streaming_mode"] is override


### PR DESCRIPTION
## What changed

This adds a `qwen3_tts_non_streaming_mode` override to the speech-to-speech Qwen3-TTS integration.

- Adds a tri-state CLI/config flag so unset preserves each backend's existing default behavior.
- Applies explicit `true` / `false` overrides to the faster-qwen3-tts backend.
- Passes the override through the faster voice-clone path.
- Patches faster custom-voice and voice-design setup so they can use the same override without changing the upstream package.
- Warns and ignores the override on Apple Silicon because `mlx-audio` does not expose `non_streaming_mode` yet.
- Adds backend-focused tests for the new flag behavior.

## Why

The faster-qwen3-tts backend has different effective defaults across voice-clone and custom-voice flows. This makes it hard to compare output quality and latency across modes.

This change makes the text-prefill behavior explicit and user-configurable while keeping the existing defaults intact when the flag is not set.

## Impact

Users can now run:

```bash
--qwen3_tts_non_streaming_mode true
```

or:

```bash
--qwen3_tts_non_streaming_mode false
```

to force full-text prefill or token-by-token trailing-text feeding on the faster backend.

On Apple Silicon, the flag is accepted but logged as ignored until `mlx-audio` supports the same control.

## Validation

- `python -m py_compile TTS/qwen3_tts_handler.py arguments_classes/qwen3_tts_arguments.py tests/test_qwen3_tts_handler_backend.py`
- direct parser check for `None` / `true` / `false`
- direct smoke check that the faster custom-voice override patches `_prepare_generation_custom`
- direct smoke check that the faster voice-clone path forwards the explicit override

`pytest` was not run because the current `.venv` does not have `pytest` installed.
