### PR TITLE
Preserve VAD pre-roll audio

### DIFF
--- a/VAD/vad_handler.py
+++ b/VAD/vad_handler.py
@@ -170,7 +170,7 @@ class VADHandler(BaseHandler):
 
             # Yield accumulated audio periodically while speaking
             if (current_time - self.last_process_time) >= self.realtime_processing_pause:
-                array = torch.cat(self.iterator.buffer_with_pad()).cpu().numpy()
+                array = torch.cat(self.iterator.speech_buffer()).cpu().numpy()
                 duration_ms = len(array) / self.sample_rate * 1000
 
                 if duration_ms >= self.min_speech_ms:

--- a/VAD/vad_handler.py
+++ b/VAD/vad_handler.py
@@ -170,7 +170,7 @@ class VADHandler(BaseHandler):
 
             # Yield accumulated audio periodically while speaking
             if (current_time - self.last_process_time) >= self.realtime_processing_pause:
-                array = torch.cat(self.iterator.buffer).cpu().numpy()
+                array = torch.cat(self.iterator.buffer_with_pad()).cpu().numpy()
                 duration_ms = len(array) / self.sample_rate * 1000
 
                 if duration_ms >= self.min_speech_ms:

--- a/VAD/vad_iterator.py
+++ b/VAD/vad_iterator.py
@@ -97,10 +97,13 @@ class VADIterator:
         self._pre_speech_samples += self._num_samples(chunk)
         self._trim_pre_speech_buffer()
 
-    def buffer_with_pad(self) -> list[torch.Tensor]:
+    def _speech_buffer(self) -> list[torch.Tensor]:
         if not self.prefix_buffer:
             return list(self.buffer)
         return [*self.prefix_buffer, *self.buffer]
+
+    def speech_buffer(self) -> list[torch.Tensor]:
+        return self._speech_buffer()
 
     @torch.no_grad()
     def __call__(self, x):
@@ -123,9 +126,6 @@ class VADIterator:
 
         speech_prob = self.model(x, self.sampling_rate).item()
 
-        if (speech_prob >= self.threshold) and self.temp_end:
-            self.temp_end = 0
-
         if (speech_prob >= self.threshold) and not self.triggered:
             self.triggered = True
             self.prefix_buffer = list(self._pre_speech_buffer)
@@ -134,25 +134,29 @@ class VADIterator:
             self.buffer.append(x)
             return None
 
-        if (speech_prob < self.threshold - 0.15) and self.triggered:
-            if not self.temp_end:
-                self.temp_end = self.current_sample
-            if self.current_sample - self.temp_end < self.min_silence_samples:
-                return None
-            else:
-                # end of speak
-                self.temp_end = 0
-                self.triggered = False
-                spoken_utterance = self.buffer_with_pad()
-                self.buffer = []
-                self.prefix_buffer = []
-                return spoken_utterance
-
         if not self.triggered:
             self._remember_pre_speech(x)
             return None
 
         if self.triggered:
             self.buffer.append(x)
+            if (speech_prob >= self.threshold) and self.temp_end:
+                self.temp_end = 0
+                return None
+
+            if speech_prob < self.threshold - 0.15:
+                if not self.temp_end:
+                    self.temp_end = self.current_sample
+                if self.current_sample - self.temp_end < self.min_silence_samples:
+                    return None
+
+                # End of speech: keep the final low-confidence chunks that were
+                # observed before VAD decided the utterance was done.
+                self.temp_end = 0
+                self.triggered = False
+                spoken_utterance = self.speech_buffer()
+                self.buffer = []
+                self.prefix_buffer = []
+                return spoken_utterance
 
         return None

--- a/VAD/vad_iterator.py
+++ b/VAD/vad_iterator.py
@@ -1,3 +1,5 @@
+from collections import deque
+
 import torch
 
 
@@ -29,7 +31,8 @@ class VADIterator:
             In the end of each speech chunk wait for min_silence_duration_ms before separating it
 
         speech_pad_ms: int (default - 30 milliseconds)
-            Final speech chunks are padded by speech_pad_ms each side
+            Retain up to speech_pad_ms of audio before VAD triggers and prepend it
+            to the detected speech chunk
         """
 
         self.model = model
@@ -37,14 +40,17 @@ class VADIterator:
         self.sampling_rate = sampling_rate
         self.is_speaking = False
         self.buffer = []
+        self.prefix_buffer = []
+        self._pre_speech_buffer = deque()
+        self._pre_speech_samples = 0
 
         if sampling_rate not in [8000, 16000]:
             raise ValueError(
                 "VADIterator does not support sampling rates other than [8000, 16000]"
             )
 
-        self.min_silence_samples = sampling_rate * min_silence_duration_ms / 1000
-        self.speech_pad_samples = sampling_rate * speech_pad_ms / 1000
+        self.min_silence_samples = int(sampling_rate * min_silence_duration_ms / 1000)
+        self.speech_pad_samples = int(sampling_rate * speech_pad_ms / 1000)
         self.reset_states()
 
     def reset_states(self):
@@ -52,6 +58,49 @@ class VADIterator:
         self.triggered = False
         self.temp_end = 0
         self.current_sample = 0
+        self.buffer = []
+        self.prefix_buffer = []
+        self._pre_speech_buffer.clear()
+        self._pre_speech_samples = 0
+
+    def _num_samples(self, chunk: torch.Tensor) -> int:
+        return len(chunk[0]) if chunk.dim() == 2 else len(chunk)
+
+    def _trim_pre_speech_buffer(self) -> None:
+        while (
+            self.speech_pad_samples > 0
+            and self._pre_speech_buffer
+            and self._pre_speech_samples > self.speech_pad_samples
+        ):
+            first = self._pre_speech_buffer[0]
+            first_samples = self._num_samples(first)
+            excess = self._pre_speech_samples - self.speech_pad_samples
+
+            if excess >= first_samples:
+                self._pre_speech_buffer.popleft()
+                self._pre_speech_samples -= first_samples
+                continue
+
+            if first.dim() == 2:
+                self._pre_speech_buffer[0] = first[:, excess:]
+            else:
+                self._pre_speech_buffer[0] = first[excess:]
+            self._pre_speech_samples -= excess
+
+    def _remember_pre_speech(self, chunk: torch.Tensor) -> None:
+        if self.speech_pad_samples <= 0:
+            self._pre_speech_buffer.clear()
+            self._pre_speech_samples = 0
+            return
+
+        self._pre_speech_buffer.append(chunk)
+        self._pre_speech_samples += self._num_samples(chunk)
+        self._trim_pre_speech_buffer()
+
+    def buffer_with_pad(self) -> list[torch.Tensor]:
+        if not self.prefix_buffer:
+            return list(self.buffer)
+        return [*self.prefix_buffer, *self.buffer]
 
     @torch.no_grad()
     def __call__(self, x):
@@ -79,6 +128,9 @@ class VADIterator:
 
         if (speech_prob >= self.threshold) and not self.triggered:
             self.triggered = True
+            self.prefix_buffer = list(self._pre_speech_buffer)
+            self._pre_speech_buffer.clear()
+            self._pre_speech_samples = 0
             self.buffer.append(x)
             return None
 
@@ -91,9 +143,14 @@ class VADIterator:
                 # end of speak
                 self.temp_end = 0
                 self.triggered = False
-                spoken_utterance = self.buffer
+                spoken_utterance = self.buffer_with_pad()
                 self.buffer = []
+                self.prefix_buffer = []
                 return spoken_utterance
+
+        if not self.triggered:
+            self._remember_pre_speech(x)
+            return None
 
         if self.triggered:
             self.buffer.append(x)

--- a/arguments_classes/vad_arguments.py
+++ b/arguments_classes/vad_arguments.py
@@ -36,7 +36,7 @@ class VADHandlerArguments:
     speech_pad_ms: int = field(
         default=500,
         metadata={
-            "help": "Amount of audio retained before VAD triggers and prepended to detected speech segments. Measured in milliseconds. Default is 500 ms."
+            "help": "Amount of audio retained before VAD triggers and prepended to detected speech segments. Once speech is detected, audio continues to be kept until VAD declares the segment done. Measured in milliseconds. Default is 500 ms."
         },
     )
     audio_enhancement: bool = field(

--- a/arguments_classes/vad_arguments.py
+++ b/arguments_classes/vad_arguments.py
@@ -36,7 +36,7 @@ class VADHandlerArguments:
     speech_pad_ms: int = field(
         default=500,
         metadata={
-            "help": "Amount of padding added to the beginning and end of detected speech segments. Measured in milliseconds. Default is 500 ms."
+            "help": "Amount of audio retained before VAD triggers and prepended to detected speech segments. Measured in milliseconds. Default is 500 ms."
         },
     )
     audio_enhancement: bool = field(

--- a/tests/test_vad_iterator.py
+++ b/tests/test_vad_iterator.py
@@ -14,6 +14,15 @@ class _FakeVADModel:
         return torch.tensor(next(self._probs), dtype=torch.float32)
 
 
+def _finish_utterance(iterator: VADIterator, silence_chunk: torch.Tensor):
+    spoken_utterance = None
+    for _ in range(5):
+        spoken_utterance = iterator(silence_chunk)
+        if spoken_utterance is not None:
+            break
+    return spoken_utterance
+
+
 def test_triggering_chunk_is_kept_in_buffer() -> None:
     model = _FakeVADModel([0.9, 0.9, 0.1, 0.1, 0.1, 0.1, 0.1])
     iterator = VADIterator(
@@ -29,13 +38,67 @@ def test_triggering_chunk_is_kept_in_buffer() -> None:
 
     assert iterator(first_chunk) is None
     assert iterator(second_chunk) is None
-    spoken_utterance = None
-    for _ in range(5):
-        spoken_utterance = iterator(silence_chunk)
-        if spoken_utterance is not None:
-            break
+    spoken_utterance = _finish_utterance(iterator, silence_chunk)
 
     assert spoken_utterance is not None
     assert len(spoken_utterance) == 2
     assert torch.equal(spoken_utterance[0], first_chunk)
     assert torch.equal(spoken_utterance[1], second_chunk)
+
+
+def test_pre_speech_padding_is_prepended_to_final_utterance() -> None:
+    model = _FakeVADModel([0.1, 0.1, 0.9, 0.9, 0.1, 0.1, 0.1, 0.1, 0.1])
+    iterator = VADIterator(
+        model=model,
+        threshold=0.5,
+        sampling_rate=16000,
+        min_silence_duration_ms=100,
+        speech_pad_ms=64,
+    )
+
+    first_chunk = torch.ones(512)
+    second_chunk = torch.ones(512) * 2
+    third_chunk = torch.ones(512) * 3
+    fourth_chunk = torch.ones(512) * 4
+    silence_chunk = torch.zeros(512)
+
+    assert iterator(first_chunk) is None
+    assert iterator(second_chunk) is None
+    assert iterator(third_chunk) is None
+    assert iterator(fourth_chunk) is None
+
+    spoken_utterance = _finish_utterance(iterator, silence_chunk)
+
+    assert spoken_utterance is not None
+    assert len(spoken_utterance) == 4
+    assert torch.equal(spoken_utterance[0], first_chunk)
+    assert torch.equal(spoken_utterance[1], second_chunk)
+    assert torch.equal(spoken_utterance[2], third_chunk)
+    assert torch.equal(spoken_utterance[3], fourth_chunk)
+
+
+def test_padding_view_keeps_prefix_out_of_active_speech_buffer() -> None:
+    model = _FakeVADModel([0.1, 0.1, 0.9])
+    iterator = VADIterator(
+        model=model,
+        threshold=0.5,
+        sampling_rate=16000,
+        min_silence_duration_ms=100,
+        speech_pad_ms=32,
+    )
+
+    older_chunk = torch.ones(512)
+    latest_pre_speech_chunk = torch.ones(512) * 2
+    triggering_chunk = torch.ones(512) * 3
+
+    assert iterator(older_chunk) is None
+    assert iterator(latest_pre_speech_chunk) is None
+    assert iterator(triggering_chunk) is None
+
+    assert len(iterator.buffer) == 1
+    assert torch.equal(iterator.buffer[0], triggering_chunk)
+
+    padded_buffer = iterator.buffer_with_pad()
+    assert len(padded_buffer) == 2
+    assert torch.equal(padded_buffer[0], latest_pre_speech_chunk)
+    assert torch.equal(padded_buffer[1], triggering_chunk)

--- a/tests/test_vad_iterator.py
+++ b/tests/test_vad_iterator.py
@@ -30,6 +30,7 @@ def test_triggering_chunk_is_kept_in_buffer() -> None:
         threshold=0.5,
         sampling_rate=16000,
         min_silence_duration_ms=100,
+        speech_pad_ms=0,
     )
 
     first_chunk = torch.ones(512)
@@ -41,9 +42,10 @@ def test_triggering_chunk_is_kept_in_buffer() -> None:
     spoken_utterance = _finish_utterance(iterator, silence_chunk)
 
     assert spoken_utterance is not None
-    assert len(spoken_utterance) == 2
+    assert len(spoken_utterance) == 7
     assert torch.equal(spoken_utterance[0], first_chunk)
     assert torch.equal(spoken_utterance[1], second_chunk)
+    assert all(torch.equal(chunk, silence_chunk) for chunk in spoken_utterance[2:])
 
 
 def test_pre_speech_padding_is_prepended_to_final_utterance() -> None:
@@ -70,14 +72,15 @@ def test_pre_speech_padding_is_prepended_to_final_utterance() -> None:
     spoken_utterance = _finish_utterance(iterator, silence_chunk)
 
     assert spoken_utterance is not None
-    assert len(spoken_utterance) == 4
+    assert len(spoken_utterance) == 9
     assert torch.equal(spoken_utterance[0], first_chunk)
     assert torch.equal(spoken_utterance[1], second_chunk)
     assert torch.equal(spoken_utterance[2], third_chunk)
     assert torch.equal(spoken_utterance[3], fourth_chunk)
+    assert all(torch.equal(chunk, silence_chunk) for chunk in spoken_utterance[4:])
 
 
-def test_padding_view_keeps_prefix_out_of_active_speech_buffer() -> None:
+def test_speech_buffer_keeps_prefix_out_of_active_speech_buffer() -> None:
     model = _FakeVADModel([0.1, 0.1, 0.9])
     iterator = VADIterator(
         model=model,
@@ -98,7 +101,70 @@ def test_padding_view_keeps_prefix_out_of_active_speech_buffer() -> None:
     assert len(iterator.buffer) == 1
     assert torch.equal(iterator.buffer[0], triggering_chunk)
 
-    padded_buffer = iterator.buffer_with_pad()
-    assert len(padded_buffer) == 2
-    assert torch.equal(padded_buffer[0], latest_pre_speech_chunk)
-    assert torch.equal(padded_buffer[1], triggering_chunk)
+    speech_buffer = iterator.speech_buffer()
+    assert len(speech_buffer) == 2
+    assert torch.equal(speech_buffer[0], latest_pre_speech_chunk)
+    assert torch.equal(speech_buffer[1], triggering_chunk)
+
+
+def test_final_samples_are_kept_until_vad_declares_done() -> None:
+    model = _FakeVADModel([0.9, 0.9, 0.1, 0.1, 0.1, 0.1, 0.1])
+    iterator = VADIterator(
+        model=model,
+        threshold=0.5,
+        sampling_rate=16000,
+        min_silence_duration_ms=100,
+        speech_pad_ms=64,
+    )
+
+    first_chunk = torch.ones(512)
+    second_chunk = torch.ones(512) * 2
+    trailing_chunks = [torch.ones(512) * value for value in (10, 11, 12, 13, 14)]
+
+    assert iterator(first_chunk) is None
+    assert iterator(second_chunk) is None
+
+    spoken_utterance = None
+    for chunk in trailing_chunks:
+        spoken_utterance = iterator(chunk)
+
+    assert spoken_utterance is not None
+    assert len(spoken_utterance) == 7
+    assert torch.equal(spoken_utterance[0], first_chunk)
+    assert torch.equal(spoken_utterance[1], second_chunk)
+    assert torch.equal(spoken_utterance[2], trailing_chunks[0])
+    assert torch.equal(spoken_utterance[3], trailing_chunks[1])
+    assert torch.equal(spoken_utterance[4], trailing_chunks[2])
+    assert torch.equal(spoken_utterance[5], trailing_chunks[3])
+    assert torch.equal(spoken_utterance[6], trailing_chunks[4])
+
+
+def test_brief_silence_is_preserved_when_speech_resumes() -> None:
+    model = _FakeVADModel([0.9, 0.1, 0.1, 0.9, 0.1, 0.1, 0.1, 0.1, 0.1])
+    iterator = VADIterator(
+        model=model,
+        threshold=0.5,
+        sampling_rate=16000,
+        min_silence_duration_ms=100,
+        speech_pad_ms=0,
+    )
+
+    first_chunk = torch.ones(512)
+    pause_chunks = [torch.ones(512) * value for value in (8, 9)]
+    resumed_chunk = torch.ones(512) * 2
+    ending_silence = torch.zeros(512)
+
+    assert iterator(first_chunk) is None
+    assert iterator(pause_chunks[0]) is None
+    assert iterator(pause_chunks[1]) is None
+    assert iterator(resumed_chunk) is None
+
+    spoken_utterance = _finish_utterance(iterator, ending_silence)
+
+    assert spoken_utterance is not None
+    assert len(spoken_utterance) == 9
+    assert torch.equal(spoken_utterance[0], first_chunk)
+    assert torch.equal(spoken_utterance[1], pause_chunks[0])
+    assert torch.equal(spoken_utterance[2], pause_chunks[1])
+    assert torch.equal(spoken_utterance[3], resumed_chunk)
+    assert all(torch.equal(chunk, ending_silence) for chunk in spoken_utterance[4:])


### PR DESCRIPTION
## Summary

This PR preserves the beginning of user speech when VAD triggers slightly after the acoustic onset.

## What changed

- add a rolling pre-speech buffer in `VADIterator`
- prepend that buffered audio when a speech segment starts
- use the padded audio view for realtime progressive transcription as well
- update the `speech_pad_ms` help text to match the actual behavior
- add targeted tests covering pre-roll capture and buffer semantics

## Why this changed

We found that transcription could miss some audio at the start of an utterance. The code exposed `speech_pad_ms`, but the iterator did not actually retain and prepend any pre-trigger audio, so soft onsets could be clipped before STT saw them.

## User impact

- fewer clipped first syllables or words at the start of speech
- better alignment between the documented `speech_pad_ms` setting and runtime behavior
- no change to the local-mode issue that was explicitly left out of scope

## Root cause

`VADIterator` only started buffering once the speech probability crossed the VAD threshold. Any audio immediately before that threshold crossing was dropped, even when `speech_pad_ms` was configured.

## Validation

- `pytest /Users/andresmarafioti/Documents/speech-to-speech/tests/test_vad_iterator.py`
- `pytest /Users/andresmarafioti/Documents/speech-to-speech/tests/test_parakeet_transcription_events.py`