### PR TITLE
Scale Qwen3 TTS token budgets to utterance length

### DIFF
--- a/TTS/qwen3_tts_handler.py
+++ b/TTS/qwen3_tts_handler.py
@@ -6,10 +6,13 @@ Qwen3 TTS Handler
 """
 
 import logging
+import math
 from pathlib import Path
+import re
 from sys import platform
 import tempfile
 from time import perf_counter
+import unicodedata
 
 import numpy as np
 from rich.console import Console
@@ -29,9 +32,16 @@ DEFAULT_MLX_MODEL = "mlx-community/Qwen3-TTS-12Hz-0.6B-Base-6bit"
 DEFAULT_REF_TEXT = "I'm confused why some people have super short timelines, yet at the same time are bullish on scaling up reinforcement learning atop LLMs. If we're actually close to a human-like learner, then this whole approach of training on verifiable outcomes."
 DEFAULT_FASTER_STREAMING_CHUNK_SIZE = 8
 DEFAULT_MLX_STREAMING_CHUNK_SIZE = 4
+DEFAULT_QWEN3_TTS_MAX_NEW_TOKENS = 1536
+MIN_QWEN3_TTS_UTTERANCE_TOKENS = 360
 VALID_MLX_QUANTIZATION_SUFFIXES = ("bf16", "4bit", "6bit", "8bit")
 MLX_STREAMING_TOKENS_PER_SECOND = 12.5
 PIPELINE_SR = 16000
+ESTIMATED_QWEN3_WORDS_PER_SECOND = 2.6
+ESTIMATED_QWEN3_CHARS_PER_SECOND = 14.0
+QWEN3_TOKEN_SAFETY_MARGIN = 1.35
+QWEN3_BASE_PROMPT_SECONDS = 1.0
+QWEN3_PUNCTUATION_PAUSE_SECONDS = 0.5
 
 
 class Qwen3TTSHandler(BaseHandler):
@@ -65,7 +75,7 @@ class Qwen3TTSHandler(BaseHandler):
         non_streaming_mode=None,
         mlx_quantization=None,
         streaming_chunk_size=None,
-        max_new_tokens=360,
+        max_new_tokens=DEFAULT_QWEN3_TTS_MAX_NEW_TOKENS,
         blocksize=512,
         gen_kwargs=None,
         runtime_config: RuntimeConfig | None = None,
@@ -417,6 +427,56 @@ class Qwen3TTSHandler(BaseHandler):
     def _to_int16(self, audio):
         return np.clip(audio * 32768, -32768, 32767).astype(np.int16)
 
+    def _estimate_max_new_tokens(self, text):
+        text = (text or "").strip()
+        chunk_size = max(1, int(getattr(self, "streaming_chunk_size", 1)))
+        configured_cap = max(1, int(getattr(self, "max_new_tokens", DEFAULT_QWEN3_TTS_MAX_NEW_TOKENS)))
+
+        if not text:
+            return min(configured_cap, MIN_QWEN3_TTS_UTTERANCE_TOKENS)
+
+        word_count = len(re.findall(r"\w+", text, flags=re.UNICODE))
+        char_count = len(re.sub(r"\s+", "", text))
+        word_seconds = (
+            word_count / ESTIMATED_QWEN3_WORDS_PER_SECOND if word_count else 0.0
+        )
+        char_seconds = (
+            char_count / ESTIMATED_QWEN3_CHARS_PER_SECOND if char_count else 0.0
+        )
+        punctuation_count = sum(
+            unicodedata.category(ch).startswith("P") for ch in text
+        )
+        punctuation_seconds = punctuation_count * QWEN3_PUNCTUATION_PAUSE_SECONDS
+        estimated_seconds = max(word_seconds, char_seconds) + punctuation_seconds + QWEN3_BASE_PROMPT_SECONDS
+        estimated_tokens = math.ceil(
+            estimated_seconds
+            * MLX_STREAMING_TOKENS_PER_SECOND
+            * QWEN3_TOKEN_SAFETY_MARGIN
+        )
+        aligned_tokens = max(
+            chunk_size,
+            math.ceil(estimated_tokens / chunk_size) * chunk_size,
+        )
+        requested_tokens = max(MIN_QWEN3_TTS_UTTERANCE_TOKENS, aligned_tokens)
+        resolved_tokens = min(configured_cap, requested_tokens)
+
+        if resolved_tokens < requested_tokens:
+            logger.warning(
+                "Qwen3-TTS estimated %d codec tokens for a %d-character utterance, "
+                "but max_new_tokens is capped at %d; output may still truncate.",
+                requested_tokens,
+                len(text),
+                configured_cap,
+            )
+
+        logger.debug(
+            "Qwen3-TTS using max_new_tokens=%d for utterance with %d words and %d chars",
+            resolved_tokens,
+            word_count,
+            char_count,
+        )
+        return resolved_tokens
+
     def _warmup_process(self, llm_sentence):
         model_type = self._model_type()
         if self.ref_audio:
@@ -602,28 +662,29 @@ class Qwen3TTSHandler(BaseHandler):
     def _mlx_streaming_interval(self):
         return max(1, self.streaming_chunk_size) / MLX_STREAMING_TOKENS_PER_SECOND
 
-    def _mlx_stream_kwargs(self):
+    def _mlx_stream_kwargs(self, max_tokens):
         return {
-            "max_tokens": self.max_new_tokens,
+            "max_tokens": max_tokens,
             "verbose": False,
             "stream": True,
             "streaming_interval": self._mlx_streaming_interval(),
             **self.gen_kwargs,
         }
 
-    def _stream_mlx_generation(self, generation_fn, label, **generation_kwargs):
+    def _stream_mlx_generation(self, generation_fn, label, max_tokens, **generation_kwargs):
         with MLXLockContext(handler_name="Qwen3TTS", timeout=10.0) as acquired:
             if not acquired:
                 raise TimeoutError("Timed out waiting for MLX lock")
             yield from self._stream(
                 generation_fn(
-                    **self._mlx_stream_kwargs(),
+                    **self._mlx_stream_kwargs(max_tokens=max_tokens),
                     **generation_kwargs,
                 ),
                 label=label,
             )
 
     def _process_voice_clone(self, text):
+        utterance_max_new_tokens = self._estimate_max_new_tokens(text)
         if self.backend == "mlx":
             if self.xvec_only:
                 logger.warning("mlx-audio Qwen3-TTS does not support xvec_only; ignoring it")
@@ -633,6 +694,7 @@ class Qwen3TTSHandler(BaseHandler):
             yield from self._stream_mlx_generation(
                 self.model.generate,
                 label="voice_clone_mlx",
+                max_tokens=utterance_max_new_tokens,
                 text=text,
                 ref_audio=self._prepare_mlx_ref_audio(self.ref_audio),
                 ref_text=self.ref_text,
@@ -648,7 +710,7 @@ class Qwen3TTSHandler(BaseHandler):
                 ref_text=self.ref_text,
                 xvec_only=self.xvec_only,
                 chunk_size=self.streaming_chunk_size,
-                max_new_tokens=self.max_new_tokens,
+                max_new_tokens=utterance_max_new_tokens,
                 parity_mode=self.parity_mode,
                 non_streaming_mode=self.non_streaming_mode,
             ),
@@ -656,6 +718,7 @@ class Qwen3TTSHandler(BaseHandler):
         )
 
     def _process_custom_voice(self, text):
+        utterance_max_new_tokens = self._estimate_max_new_tokens(text)
         speaker = self._resolve_speaker()
         if not speaker:
             raise ValueError(
@@ -667,6 +730,7 @@ class Qwen3TTSHandler(BaseHandler):
             yield from self._stream_mlx_generation(
                 self.model.generate_custom_voice,
                 label="custom_voice_mlx",
+                max_tokens=utterance_max_new_tokens,
                 text=text,
                 speaker=speaker,
                 language=self.language,
@@ -681,17 +745,19 @@ class Qwen3TTSHandler(BaseHandler):
                 language=self.language,
                 instruct=self.instruct,
                 chunk_size=self.streaming_chunk_size,
-                max_new_tokens=self.max_new_tokens,
+                max_new_tokens=utterance_max_new_tokens,
                 non_streaming_mode=self.non_streaming_mode,
             ),
             label="custom_voice",
         )
 
     def _process_voice_design(self, text):
+        utterance_max_new_tokens = self._estimate_max_new_tokens(text)
         if self.backend == "mlx":
             yield from self._stream_mlx_generation(
                 self.model.generate_voice_design,
                 label="voice_design_mlx",
+                max_tokens=utterance_max_new_tokens,
                 text=text,
                 instruct=self.instruct,
                 language=self.language,
@@ -704,7 +770,7 @@ class Qwen3TTSHandler(BaseHandler):
                 instruct=self.instruct,
                 language=self.language,
                 chunk_size=self.streaming_chunk_size,
-                max_new_tokens=self.max_new_tokens,
+                max_new_tokens=utterance_max_new_tokens,
                 non_streaming_mode=self.non_streaming_mode,
             ),
             label="voice_design",

--- a/arguments_classes/qwen3_tts_arguments.py
+++ b/arguments_classes/qwen3_tts_arguments.py
@@ -89,9 +89,9 @@ class Qwen3TTSHandlerArguments:
         },
     )
     qwen3_tts_max_new_tokens: int = field(
-        default=360,
+        default=1536,
         metadata={
-            "help": "Maximum codec tokens to generate (~12 tokens per second of audio, ~30s max). Default is 360."
+            "help": "Upper cap for Qwen3-TTS codec tokens. The handler estimates a per-utterance budget from the text and clamps it to this ceiling (~12 tokens per second of audio). Raise this above 1536 if you want to allow longer utterances."
         },
     )
     qwen3_tts_blocksize: int = field(

--- a/tests/test_qwen3_tts_handler_backend.py
+++ b/tests/test_qwen3_tts_handler_backend.py
@@ -451,3 +451,142 @@ def test_process_voice_design_passes_non_streaming_mode_to_faster_backend(monkey
 
     assert len(outputs) == 1
     assert captured["non_streaming_mode"] is override
+
+
+def test_estimate_max_new_tokens_scales_with_utterance_length():
+    handler = object.__new__(Qwen3TTSHandler)
+    handler.streaming_chunk_size = 8
+    handler.max_new_tokens = 1536
+
+    short_budget = handler._estimate_max_new_tokens("Hello there.")
+    long_text = " ".join(
+        ["This is a deliberately long sentence for the Qwen3 TTS budget estimator."]
+        * 12
+    )
+    long_budget = handler._estimate_max_new_tokens(long_text)
+
+    assert short_budget == 360
+    assert long_budget > short_budget
+    assert long_budget % handler.streaming_chunk_size == 0
+    assert long_budget <= handler.max_new_tokens
+
+
+def test_estimate_max_new_tokens_respects_configured_cap():
+    handler = object.__new__(Qwen3TTSHandler)
+    handler.streaming_chunk_size = 8
+    handler.max_new_tokens = 400
+
+    long_text = " ".join(
+        ["This is a deliberately long sentence for the Qwen3 TTS budget estimator."]
+        * 12
+    )
+
+    assert handler._estimate_max_new_tokens(long_text) == 400
+
+
+def test_estimate_max_new_tokens_can_exceed_default_ceiling_when_raised():
+    handler = object.__new__(Qwen3TTSHandler)
+    handler.streaming_chunk_size = 8
+    handler.max_new_tokens = 2400
+
+    long_text = " ".join(
+        ["This is a deliberately long sentence for the Qwen3 TTS budget estimator."]
+        * 30
+    )
+
+    assert handler._estimate_max_new_tokens(long_text) > 1536
+
+
+def test_process_voice_clone_scales_max_new_tokens_for_faster_backend(monkeypatch):
+    captured = {}
+    handler = object.__new__(Qwen3TTSHandler)
+    handler.should_listen = Event()
+    handler.runtime_config = None
+    handler.cancel_scope = None
+    handler.ref_audio = "TTS/ref_audio.wav"
+    handler.ref_text = "Reference text."
+    handler.speaker = None
+    handler.instruct = None
+    handler.language = "English"
+    handler.xvec_only = False
+    handler.parity_mode = False
+    handler.non_streaming_mode = None
+    handler.streaming_chunk_size = 8
+    handler.max_new_tokens = 1536
+    handler.blocksize = 512
+    handler.backend = "faster_qwen3_tts"
+    handler.queue_in = Queue()
+    handler.model = SimpleNamespace(
+        model=SimpleNamespace(model=SimpleNamespace(tts_model_type="base")),
+        generate_voice_clone_streaming=lambda **kwargs: (
+            captured.update(kwargs),
+            iter([(_audible_stream_chunk(), 16000, {})]),
+        )[1],
+    )
+
+    monkeypatch.setattr(qwen3_tts_module.console, "print", lambda *args, **kwargs: None)
+
+    long_text = " ".join(
+        ["This is a deliberately long sentence for the faster Qwen3 TTS backend."]
+        * 12
+    )
+    outputs = list(handler.process(long_text))
+
+    assert len(outputs) == 1
+    assert captured["max_new_tokens"] == handler._estimate_max_new_tokens(long_text)
+    assert captured["max_new_tokens"] > 360
+
+
+def test_process_voice_clone_scales_max_tokens_for_mlx_backend(monkeypatch):
+    captured = {}
+
+    class _FakeMLXLockContext:
+        def __init__(self, handler_name, timeout):
+            self.handler_name = handler_name
+            self.timeout = timeout
+
+        def __enter__(self):
+            return True
+
+        def __exit__(self, exc_type, exc, tb):
+            return False
+
+    handler = object.__new__(Qwen3TTSHandler)
+    handler.should_listen = Event()
+    handler.runtime_config = None
+    handler.cancel_scope = None
+    handler.ref_audio = "TTS/ref_audio.wav"
+    handler.ref_text = "Reference text."
+    handler.speaker = None
+    handler.instruct = None
+    handler.language = "English"
+    handler.xvec_only = False
+    handler.parity_mode = False
+    handler.non_streaming_mode = None
+    handler.streaming_chunk_size = 4
+    handler.max_new_tokens = 1536
+    handler.blocksize = 512
+    handler.backend = "mlx"
+    handler.gen_kwargs = {}
+    handler.queue_in = Queue()
+    handler.model = SimpleNamespace(
+        config=SimpleNamespace(tts_model_type="base"),
+        generate=lambda **kwargs: (
+            captured.update(kwargs),
+            iter([(_audible_stream_chunk(), 16000, {})]),
+        )[1],
+    )
+    handler._prepare_mlx_ref_audio = lambda ref_audio: ref_audio
+
+    monkeypatch.setattr(qwen3_tts_module.console, "print", lambda *args, **kwargs: None)
+    monkeypatch.setattr(qwen3_tts_module, "MLXLockContext", _FakeMLXLockContext)
+
+    long_text = " ".join(
+        ["This is a deliberately long sentence for the MLX Qwen3 TTS backend."]
+        * 12
+    )
+    outputs = list(handler.process(long_text))
+
+    assert len(outputs) == 1
+    assert captured["max_tokens"] == handler._estimate_max_new_tokens(long_text)
+    assert captured["max_tokens"] > 360


### PR DESCRIPTION
## What changed
This PR replaces the fixed Qwen3-TTS `max_new_tokens` budget with an utterance-aware estimate that scales with the amount of text being synthesized.

The estimator now:
- derives a per-utterance codec-token budget from text length
- adds a conservative flat `0.5s` pause for each punctuation mark
- aligns the requested budget to the streaming chunk size
- clamps the estimate to `qwen3_tts_max_new_tokens`, which remains configurable above the default when longer utterances are needed

It also updates the Qwen3-TTS argument help text and adds backend coverage for both the MLX and `faster-qwen3-tts` paths.

## Why this changed
Long utterances could be truncated because the handler always passed the same fixed codec-token budget to Qwen3-TTS, regardless of how much text it was asked to speak.

## Impact
This makes long responses safer by giving Qwen3-TTS more room when the utterance is longer, while still keeping a ceiling in place for callers that want to bound generation.

This branch is intentionally scoped to the Qwen3-TTS fix only and does not include the separate VAD work from the other branch.

## Validation
- `python -m pytest tests/test_qwen3_tts_handler_backend.py`
- `python -m pytest tests/test_tts_input_coalescing.py`
