### PR TITLE
Add batch sentence streaming for LLM handlers

### DIFF
--- a/LLM/language_model.py
+++ b/LLM/language_model.py
@@ -354,6 +354,9 @@ class BaseLanguageModelHandler(BaseHandler, ABC):
             yield from chunks
 
         if ctx.sentence_batch:
+            if ctx.printable_text.strip():
+                ctx.sentence_batch.append(ctx.printable_text.strip())
+                ctx.printable_text = ""
             yield (" ".join(ctx.sentence_batch), language_code, [])
             ctx.sentence_batch = []
 

--- a/LLM/language_model.py
+++ b/LLM/language_model.py
@@ -90,6 +90,7 @@ class StreamContext(BaseModel):
     printable_text: str = ""
     tools: list[dict] = Field(default_factory=list)
     input_tokens: int = 0
+    sentence_batch: list[str] = Field(default_factory=list)
 
     @property
     def interrupted(self) -> bool:
@@ -119,12 +120,14 @@ class BaseLanguageModelHandler(BaseHandler, ABC):
         cancel_scope: CancelScope | None = None,
         backend: Literal["transformers", "mlx"] = "transformers",
         enable_thinking: bool = False,
+        stream_batch_sentences: int = 3,
     ):
         self.backend = backend
         self.cancel_scope = cancel_scope
         self.device = device
         self.model_name = model_name
         self.enable_thinking = enable_thinking
+        self.stream_batch_sentences = max(1, stream_batch_sentences)
 
         self._load_model(model_name, device, torch_dtype, gen_kwargs)
 
@@ -257,12 +260,16 @@ class BaseLanguageModelHandler(BaseHandler, ABC):
 
     def _process_printable_text(
         self, printable_text: str, language_code: str | None, tools: list[dict],
+        ctx: StreamContext,
     ) -> tuple[list[tuple], list[dict], str]:
         """Extract complete code blocks and return complete sentences to yield.
 
         Returns ``(chunks_to_yield, updated_tools, remaining_printable_text)``.
         Each element in *chunks_to_yield* is a ``(text, language_code, [])`` tuple
         ready to be yielded to the downstream pipeline.
+
+        Sentences are accumulated in ``ctx.sentence_batch`` and only yielded
+        when the batch reaches ``self.stream_batch_sentences``.
         """
         chunks: list[tuple] = []
 
@@ -284,7 +291,10 @@ class BaseLanguageModelHandler(BaseHandler, ABC):
             before = printable_text[:idx]
             if before.strip():
                 for s in sent_tokenize(before):
-                    chunks.append((s, language_code, []))
+                    ctx.sentence_batch.append(s)
+                    if len(ctx.sentence_batch) >= self.stream_batch_sentences:
+                        chunks.append((" ".join(ctx.sentence_batch), language_code, []))
+                        ctx.sentence_batch = []
             printable_text = printable_text[idx:]
             return chunks, tools, printable_text
 
@@ -292,7 +302,10 @@ class BaseLanguageModelHandler(BaseHandler, ABC):
             sentences = sent_tokenize(printable_text)
             if len(sentences) > 1:
                 for s in sentences[:-1]:
-                    chunks.append((s, language_code, []))
+                    ctx.sentence_batch.append(s)
+                    if len(ctx.sentence_batch) >= self.stream_batch_sentences:
+                        chunks.append((" ".join(ctx.sentence_batch), language_code, []))
+                        ctx.sentence_batch = []
                 printable_text = sentences[-1]
 
         return chunks, tools, printable_text
@@ -336,9 +349,13 @@ class BaseLanguageModelHandler(BaseHandler, ABC):
             ctx.generated_text += clean
             ctx.printable_text += clean
             chunks, ctx.tools, ctx.printable_text = self._process_printable_text(
-                ctx.printable_text, language_code, ctx.tools,
+                ctx.printable_text, language_code, ctx.tools, ctx,
             )
             yield from chunks
+
+        if ctx.sentence_batch:
+            yield (" ".join(ctx.sentence_batch), language_code, [])
+            ctx.sentence_batch = []
 
     # ------------------------------------------------------------------
     # Main pipeline entry point

--- a/LLM/openai_api_language_model.py
+++ b/LLM/openai_api_language_model.py
@@ -50,10 +50,12 @@ class OpenApiModelHandler(BaseHandler):
         cancel_scope: CancelScope | None = None,
         disable_thinking=True,
         request_timeout_s=20.0,
+        stream_batch_sentences=3,
     ):
         self.cancel_scope = cancel_scope
         self.model_name = model_name
         self.stream = stream
+        self.stream_batch_sentences = max(1, stream_batch_sentences)
         self.gen_kwargs = dict(gen_kwargs)
         self.request_timeout_s = float(request_timeout_s)
         self.request_timeout = httpx.Timeout(
@@ -182,6 +184,7 @@ class OpenApiModelHandler(BaseHandler):
             if self.stream:
                 cancelled = False
                 printable_text = ""
+                sentence_batch: list[str] = []
                 for event in response:
                     if gen is not None and self.cancel_scope.is_stale(gen):
                         logger.info("LLM generation cancelled (interruption)")
@@ -194,7 +197,10 @@ class OpenApiModelHandler(BaseHandler):
                         sentences = sent_tokenize(printable_text)
                         if len(sentences) > 1:
                             for s in sentences[:-1]:
-                                yield s, language_code, []
+                                sentence_batch.append(s)
+                                if len(sentence_batch) >= self.stream_batch_sentences:
+                                    yield " ".join(sentence_batch), language_code, []
+                                    sentence_batch = []
                             printable_text = sentences[-1]
                     elif event.type == "response.output_item.done":
 
@@ -212,10 +218,15 @@ class OpenApiModelHandler(BaseHandler):
                             input_tokens = usage.input_tokens or 0
                             output_tokens = usage.output_tokens or 0
                 if not cancelled:
-                    if printable_text.strip() or tools:
+                    remaining = " ".join(sentence_batch) if sentence_batch else ""
+                    if remaining and printable_text.strip():
+                        remaining += " " + printable_text.strip()
+                    elif printable_text.strip():
+                        remaining = printable_text.strip()
+                    if remaining or tools:
                         logger.debug(f"Clean text: {clean_text}")
                         logger.info(f"Tools: {tools}")
-                        yield printable_text.strip(), language_code, tools
+                        yield remaining, language_code, tools
             else:
                 if gen is not None and self.cancel_scope.is_stale(gen):
                     logger.info("LLM generation cancelled (interruption)")

--- a/LLM/openai_api_language_model.py
+++ b/LLM/openai_api_language_model.py
@@ -218,11 +218,9 @@ class OpenApiModelHandler(BaseHandler):
                             input_tokens = usage.input_tokens or 0
                             output_tokens = usage.output_tokens or 0
                 if not cancelled:
-                    remaining = " ".join(sentence_batch) if sentence_batch else ""
-                    if remaining and printable_text.strip():
-                        remaining += " " + printable_text.strip()
-                    elif printable_text.strip():
-                        remaining = printable_text.strip()
+                    if printable_text.strip():
+                        sentence_batch.append(printable_text.strip())
+                    remaining = " ".join(sentence_batch)
                     if remaining or tools:
                         logger.debug(f"Clean text: {clean_text}")
                         logger.info(f"Tools: {tools}")

--- a/arguments_classes/language_model_arguments.py
+++ b/arguments_classes/language_model_arguments.py
@@ -77,3 +77,10 @@ metadata={
                     "Default is False."
         },
     )
+    lm_stream_batch_sentences: int = field(
+        default=3,
+        metadata={
+            "help": "Number of sentences to accumulate before yielding a batch during streaming. "
+                    "Set to 1 for sentence-by-sentence streaming. Default is 3."
+        },
+    )

--- a/arguments_classes/open_api_language_model_arguments.py
+++ b/arguments_classes/open_api_language_model_arguments.py
@@ -62,3 +62,10 @@ class OpenApiLanguageModelHandlerArguments:
                     "For Together Qwen3.5 models this sends chat_template_kwargs.enable_thinking=false."
         },
     )
+    open_api_stream_batch_sentences: int = field(
+        default=3,
+        metadata={
+            "help": "Number of sentences to accumulate before yielding a batch during streaming. "
+                    "Set to 1 for sentence-by-sentence streaming. Default is 3."
+        },
+    )


### PR DESCRIPTION
Instead of yielding sentences one at a time during streaming, accumulate multiple sentences before sending them to the TTS pipeline. This reduces the number of TTS invocations and can improve audio coherence.

A new CLI argument `--lm_stream_batch_sentences` / `--open_api_stream_batch_sentences` (default: 3) controls how many sentences are batched together. Set to 1 to restore the previous behavior.