### PR TITLE
Preserve smart apostrophes in speechable text

### DIFF
--- a/LLM/utils.py
+++ b/LLM/utils.py
@@ -5,6 +5,15 @@ import re
 import requests
 from PIL import Image
 
+SMART_PUNCT_TRANSLATION = str.maketrans(
+    {
+        "\u2018": "'",
+        "\u2019": "'",
+        "\u201c": '"',
+        "\u201d": '"',
+    }
+)
+
 SPEECHABLE_PATTERN = re.compile(
     r"[^\w\s.,!?;:'\"\-()\/\\@#%&*+=$€£¥₹₽¢\[\]{}<>~`^|…—–\n\r\t]",
     flags=re.UNICODE,
@@ -15,7 +24,8 @@ def remove_unspeechable(text: str) -> str:
     """Keep only speechable characters: letters, digits, punctuation, whitespace.
     support unicode characters (english, arabic, chinese, japanese, korean, etc.)
     """
-    return SPEECHABLE_PATTERN.sub('', text)
+    text = text.translate(SMART_PUNCT_TRANSLATION)
+    return SPEECHABLE_PATTERN.sub("", text)
 
 
 WHISPER_LANGUAGE_TO_LLM_LANGUAGE = {

--- a/tests/test_llm_utils.py
+++ b/tests/test_llm_utils.py
@@ -1,0 +1,17 @@
+from pathlib import Path
+import sys
+
+sys.path.insert(0, str(Path(__file__).resolve().parents[1]))
+
+from LLM.utils import remove_unspeechable
+
+
+def test_remove_unspeechable_normalizes_smart_apostrophes() -> None:
+    assert (
+        remove_unspeechable("I’ll reply if here’s the plan.")
+        == "I'll reply if here's the plan."
+    )
+
+
+def test_remove_unspeechable_keeps_text_and_drops_emoji() -> None:
+    assert remove_unspeechable("Hello 👋 lobster 🦞") == "Hello  lobster "


### PR DESCRIPTION
## Summary
- normalize smart single and double quotes to ASCII before applying the speechable-character filter
- preserve contractions like `I’ll` and `here’s` instead of collapsing them to `Ill` / `heres`
- add a regression test covering smart apostrophes and emoji stripping

## Root Cause
`remove_unspeechable()` allowed straight ASCII apostrophes but dropped typographic apostrophes such as `’`. When the LLM emitted smart punctuation, the sanitizer removed the apostrophe before TTS received the text, which made contractions sound and read incorrectly.

## Validation
- `pytest -q tests/test_llm_utils.py`
- `ruff check LLM/utils.py tests/test_llm_utils.py`
- `ruff format --check LLM/utils.py tests/test_llm_utils.py`
