### PR TITLE
Add VAD start persistence

### DIFF
--- a/VAD/vad_handler.py
+++ b/VAD/vad_handler.py
@@ -18,6 +18,7 @@ logger = logging.getLogger(__name__)
 # Optional import for audio enhancement
 try:
     from df.enhance import enhance, init_df
+
     HAS_DF = True
 except (ImportError, ModuleNotFoundError) as e:
     HAS_DF = False
@@ -39,6 +40,7 @@ class VADHandler(BaseHandler[bytes | tuple[bytes, RuntimeConfig]]):
         min_speech_ms=500,
         max_speech_ms=float("inf"),
         speech_pad_ms=30,
+        start_persistence_ms=128,
         audio_enhancement=False,
         enable_realtime_transcription=False,
         realtime_processing_pause=0.25,
@@ -65,11 +67,14 @@ class VADHandler(BaseHandler[bytes | tuple[bytes, RuntimeConfig]]):
             sampling_rate=sample_rate,
             min_silence_duration_ms=min_silence_ms,
             speech_pad_ms=speech_pad_ms,
+            start_persistence_ms=start_persistence_ms,
         )
         self.audio_enhancement = audio_enhancement
         if audio_enhancement:
             if not HAS_DF:
-                logger.error("Audio enhancement requested but DeepFilterNet is not available. Disabling audio enhancement.")
+                logger.error(
+                    "Audio enhancement requested but DeepFilterNet is not available. Disabling audio enhancement."
+                )
                 self.audio_enhancement = False
             else:
                 self.enhanced_model, self.df_state, _ = init_df()
@@ -119,7 +124,9 @@ class VADHandler(BaseHandler[bytes | tuple[bytes, RuntimeConfig]]):
             self.iterator.min_silence_samples = (
                 self.sample_rate * td["silence_duration_ms"] / 1000
             )
-            logger.info(f"VAD silence duration updated to {td['silence_duration_ms']}ms")
+            logger.info(
+                f"VAD silence duration updated to {td['silence_duration_ms']}ms"
+            )
 
     def process(self, audio_chunk: bytes | tuple[bytes, RuntimeConfig]):
         runtime_config = None
@@ -148,9 +155,13 @@ class VADHandler(BaseHandler[bytes | tuple[bytes, RuntimeConfig]]):
                 self._speech_started_emitted = True
                 self._log_speech_starts += 1
                 start_ms = max(0, self._audio_ms - int(buffer_duration_ms))
-                logger.info("Speech started (confirmed, %.0fms buffered)", buffer_duration_ms)
+                logger.info(
+                    "Speech started (confirmed, %.0fms buffered)", buffer_duration_ms
+                )
                 if self.text_output_queue:
-                    self.text_output_queue.put(SpeechStartedEvent(audio_start_ms=start_ms))
+                    self.text_output_queue.put(
+                        SpeechStartedEvent(audio_start_ms=start_ms)
+                    )
 
         # Log a summary once per second instead of every chunk
         now = time.time()
@@ -180,13 +191,17 @@ class VADHandler(BaseHandler[bytes | tuple[bytes, RuntimeConfig]]):
             current_time = time.time()
 
             # Yield accumulated audio periodically while speaking
-            if (current_time - self.last_process_time) >= self.realtime_processing_pause:
+            if (
+                current_time - self.last_process_time
+            ) >= self.realtime_processing_pause:
                 array = torch.cat(self.iterator.speech_buffer()).cpu().numpy()
                 duration_ms = len(array) / self.sample_rate * 1000
 
                 if duration_ms >= self.min_speech_ms:
                     self._log_progressive_yields += 1
-                    logger.debug(f"VAD: yielding progressive audio ({duration_ms:.0f}ms)")
+                    logger.debug(
+                        f"VAD: yielding progressive audio ({duration_ms:.0f}ms)"
+                    )
                     yield VADAudio(audio=array, mode="progressive")
                     self.last_process_time = current_time
 
@@ -195,7 +210,9 @@ class VADHandler(BaseHandler[bytes | tuple[bytes, RuntimeConfig]]):
             if len(vad_output) == 0:
                 logger.info("VAD: phantom trigger (empty buffer), closing speech pair")
                 if self._speech_started_emitted and self.text_output_queue:
-                    self.text_output_queue.put(SpeechStoppedEvent(audio_end_ms=self._audio_ms))
+                    self.text_output_queue.put(
+                        SpeechStoppedEvent(audio_end_ms=self._audio_ms)
+                    )
                 self._speech_started_emitted = False
                 return
 
@@ -208,17 +225,27 @@ class VADHandler(BaseHandler[bytes | tuple[bytes, RuntimeConfig]]):
                     f"(bounds: {self.min_speech_ms}-{self.max_speech_ms}ms)"
                 )
                 if self._speech_started_emitted and self.text_output_queue:
-                    self.text_output_queue.put(SpeechStoppedEvent(audio_end_ms=self._audio_ms))
+                    self.text_output_queue.put(
+                        SpeechStoppedEvent(audio_end_ms=self._audio_ms)
+                    )
                 self._speech_started_emitted = False
             else:
                 end_ms = self._audio_ms
                 if not self._speech_started_emitted and self.text_output_queue:
-                    self.text_output_queue.put(SpeechStartedEvent(audio_start_ms=max(0, end_ms - int(duration_ms))))
+                    self.text_output_queue.put(
+                        SpeechStartedEvent(
+                            audio_start_ms=max(0, end_ms - int(duration_ms))
+                        )
+                    )
                 self._log_speech_ends += 1
                 self.should_listen.clear()
                 logger.info(f"Speech ended ({duration_ms:.0f}ms), stop listening")
                 if self.text_output_queue:
-                    self.text_output_queue.put(SpeechStoppedEvent(duration_s=duration_ms / 1000.0, audio_end_ms=end_ms))
+                    self.text_output_queue.put(
+                        SpeechStoppedEvent(
+                            duration_s=duration_ms / 1000.0, audio_end_ms=end_ms
+                        )
+                    )
                 if self.audio_enhancement:
                     array = self._apply_audio_enhancement(array)
                 yield VADAudio(audio=array, mode="final")
@@ -231,7 +258,9 @@ class VADHandler(BaseHandler[bytes | tuple[bytes, RuntimeConfig]]):
             if len(vad_output) == 0:
                 logger.info("VAD: phantom trigger (empty buffer), closing speech pair")
                 if self._speech_started_emitted and self.text_output_queue:
-                    self.text_output_queue.put(SpeechStoppedEvent(audio_end_ms=self._audio_ms))
+                    self.text_output_queue.put(
+                        SpeechStoppedEvent(audio_end_ms=self._audio_ms)
+                    )
                 self._speech_started_emitted = False
                 return
 
@@ -243,17 +272,27 @@ class VADHandler(BaseHandler[bytes | tuple[bytes, RuntimeConfig]]):
                     f"(bounds: {self.min_speech_ms}-{self.max_speech_ms}ms)"
                 )
                 if self._speech_started_emitted and self.text_output_queue:
-                    self.text_output_queue.put(SpeechStoppedEvent(audio_end_ms=self._audio_ms))
+                    self.text_output_queue.put(
+                        SpeechStoppedEvent(audio_end_ms=self._audio_ms)
+                    )
                 self._speech_started_emitted = False
             else:
                 end_ms = self._audio_ms
                 if not self._speech_started_emitted and self.text_output_queue:
-                    self.text_output_queue.put(SpeechStartedEvent(audio_start_ms=max(0, end_ms - int(duration_ms))))
+                    self.text_output_queue.put(
+                        SpeechStartedEvent(
+                            audio_start_ms=max(0, end_ms - int(duration_ms))
+                        )
+                    )
                 self._log_speech_ends += 1
                 self.should_listen.clear()
                 logger.info(f"Speech ended ({duration_ms:.0f}ms), stop listening")
                 if self.text_output_queue:
-                    self.text_output_queue.put(SpeechStoppedEvent(duration_s=duration_ms / 1000.0, audio_end_ms=end_ms))
+                    self.text_output_queue.put(
+                        SpeechStoppedEvent(
+                            duration_s=duration_ms / 1000.0, audio_end_ms=end_ms
+                        )
+                    )
                 if self.audio_enhancement:
                     array = self._apply_audio_enhancement(array)
                 yield VADAudio(audio=array)

--- a/VAD/vad_iterator.py
+++ b/VAD/vad_iterator.py
@@ -11,6 +11,7 @@ class VADIterator:
         sampling_rate: int = 16000,
         min_silence_duration_ms: int = 100,
         speech_pad_ms: int = 30,
+        start_persistence_ms: int = 128,
     ):
         """
         Mainly taken from https://github.com/snakers4/silero-vad
@@ -33,6 +34,10 @@ class VADIterator:
         speech_pad_ms: int (default - 30 milliseconds)
             Retain up to speech_pad_ms of audio before VAD triggers and prepend it
             to the detected speech chunk
+
+        start_persistence_ms: int (default - 128 milliseconds)
+            Require this much contiguous above-threshold speech before the iterator
+            promotes pending chunks into an active speech segment.
         """
 
         self.model = model
@@ -43,6 +48,8 @@ class VADIterator:
         self.prefix_buffer = []
         self._pre_speech_buffer = deque()
         self._pre_speech_samples = 0
+        self._pending_speech_buffer = []
+        self._pending_speech_samples = 0
 
         if sampling_rate not in [8000, 16000]:
             raise ValueError(
@@ -51,6 +58,9 @@ class VADIterator:
 
         self.min_silence_samples = int(sampling_rate * min_silence_duration_ms / 1000)
         self.speech_pad_samples = int(sampling_rate * speech_pad_ms / 1000)
+        self.start_persistence_samples = int(
+            sampling_rate * start_persistence_ms / 1000
+        )
         self.reset_states()
 
     def reset_states(self):
@@ -62,6 +72,8 @@ class VADIterator:
         self.prefix_buffer = []
         self._pre_speech_buffer.clear()
         self._pre_speech_samples = 0
+        self._pending_speech_buffer = []
+        self._pending_speech_samples = 0
 
     def _num_samples(self, chunk: torch.Tensor) -> int:
         return len(chunk[0]) if chunk.dim() == 2 else len(chunk)
@@ -102,6 +114,10 @@ class VADIterator:
             return list(self.buffer)
         return [*self.prefix_buffer, *self.buffer]
 
+    def _reset_pending_speech(self) -> None:
+        self._pending_speech_buffer = []
+        self._pending_speech_samples = 0
+
     def speech_buffer(self) -> list[torch.Tensor]:
         return self._speech_buffer()
 
@@ -126,15 +142,22 @@ class VADIterator:
 
         speech_prob = self.model(x, self.sampling_rate).item()
 
-        if (speech_prob >= self.threshold) and not self.triggered:
-            self.triggered = True
-            self.prefix_buffer = list(self._pre_speech_buffer)
-            self._pre_speech_buffer.clear()
-            self._pre_speech_samples = 0
-            self.buffer.append(x)
+        if not self.triggered and speech_prob >= self.threshold:
+            self._pending_speech_buffer.append(x)
+            self._pending_speech_samples += window_size_samples
+
+            if self._pending_speech_samples >= self.start_persistence_samples:
+                self.triggered = True
+                self.prefix_buffer = list(self._pre_speech_buffer)
+                self._pre_speech_buffer.clear()
+                self._pre_speech_samples = 0
+                self.buffer = list(self._pending_speech_buffer)
+                self._reset_pending_speech()
             return None
 
         if not self.triggered:
+            if self._pending_speech_buffer:
+                self._reset_pending_speech()
             self._remember_pre_speech(x)
             return None
 

--- a/arguments_classes/vad_arguments.py
+++ b/arguments_classes/vad_arguments.py
@@ -27,6 +27,12 @@ class VADHandlerArguments:
             "help": "Minimum length of speech segments to be considered valid speech. Measured in milliseconds. Default is 500 ms."
         },
     )
+    start_persistence_ms: int = field(
+        default=128,
+        metadata={
+            "help": "Minimum contiguous above-threshold speech required before VAD opens a speech segment. Measured in milliseconds. Default is 128 ms."
+        },
+    )
     max_speech_ms: float = field(
         default=float("inf"),
         metadata={

--- a/tests/test_vad_iterator.py
+++ b/tests/test_vad_iterator.py
@@ -31,6 +31,7 @@ def test_triggering_chunk_is_kept_in_buffer() -> None:
         sampling_rate=16000,
         min_silence_duration_ms=100,
         speech_pad_ms=0,
+        start_persistence_ms=0,
     )
 
     first_chunk = torch.ones(512)
@@ -56,6 +57,7 @@ def test_pre_speech_padding_is_prepended_to_final_utterance() -> None:
         sampling_rate=16000,
         min_silence_duration_ms=100,
         speech_pad_ms=64,
+        start_persistence_ms=0,
     )
 
     first_chunk = torch.ones(512)
@@ -88,6 +90,7 @@ def test_speech_buffer_keeps_prefix_out_of_active_speech_buffer() -> None:
         sampling_rate=16000,
         min_silence_duration_ms=100,
         speech_pad_ms=32,
+        start_persistence_ms=0,
     )
 
     older_chunk = torch.ones(512)
@@ -115,6 +118,7 @@ def test_final_samples_are_kept_until_vad_declares_done() -> None:
         sampling_rate=16000,
         min_silence_duration_ms=100,
         speech_pad_ms=64,
+        start_persistence_ms=0,
     )
 
     first_chunk = torch.ones(512)
@@ -147,6 +151,7 @@ def test_brief_silence_is_preserved_when_speech_resumes() -> None:
         sampling_rate=16000,
         min_silence_duration_ms=100,
         speech_pad_ms=0,
+        start_persistence_ms=0,
     )
 
     first_chunk = torch.ones(512)
@@ -168,3 +173,100 @@ def test_brief_silence_is_preserved_when_speech_resumes() -> None:
     assert torch.equal(spoken_utterance[2], pause_chunks[1])
     assert torch.equal(spoken_utterance[3], resumed_chunk)
     assert all(torch.equal(chunk, ending_silence) for chunk in spoken_utterance[4:])
+
+
+def test_start_persistence_requires_contiguous_speech_before_triggering() -> None:
+    model = _FakeVADModel([0.9, 0.9, 0.9, 0.9, 0.1, 0.1, 0.1, 0.1, 0.1])
+    iterator = VADIterator(
+        model=model,
+        threshold=0.5,
+        sampling_rate=16000,
+        min_silence_duration_ms=100,
+        speech_pad_ms=0,
+        start_persistence_ms=128,
+    )
+
+    speech_chunks = [torch.ones(512) * value for value in (1, 2, 3, 4)]
+    silence_chunk = torch.zeros(512)
+
+    for chunk in speech_chunks[:3]:
+        assert iterator(chunk) is None
+        assert not iterator.triggered
+        assert iterator.buffer == []
+
+    assert iterator(speech_chunks[3]) is None
+    assert iterator.triggered
+    assert len(iterator.buffer) == 4
+    for buffered, expected in zip(iterator.buffer, speech_chunks):
+        assert torch.equal(buffered, expected)
+
+    spoken_utterance = _finish_utterance(iterator, silence_chunk)
+
+    assert spoken_utterance is not None
+    assert len(spoken_utterance) == 9
+    for buffered, expected in zip(spoken_utterance[:4], speech_chunks):
+        assert torch.equal(buffered, expected)
+    assert all(torch.equal(chunk, silence_chunk) for chunk in spoken_utterance[4:])
+
+
+def test_false_start_is_discarded_when_start_persistence_is_not_met() -> None:
+    model = _FakeVADModel(
+        [
+            0.9,
+            0.9,
+            0.1,
+            0.9,
+            0.9,
+            0.9,
+            0.9,
+            0.1,
+            0.1,
+            0.1,
+            0.1,
+            0.1,
+        ]
+    )
+    iterator = VADIterator(
+        model=model,
+        threshold=0.5,
+        sampling_rate=16000,
+        min_silence_duration_ms=100,
+        speech_pad_ms=32,
+        start_persistence_ms=128,
+    )
+
+    false_start_chunks = [torch.ones(512) * value for value in (1, 2)]
+    separating_silence = torch.zeros(512)
+    real_speech_chunks = [torch.ones(512) * value for value in (10, 11, 12, 13)]
+
+    for chunk in false_start_chunks:
+        assert iterator(chunk) is None
+        assert not iterator.triggered
+        assert iterator.buffer == []
+
+    assert iterator(separating_silence) is None
+    assert not iterator.triggered
+    assert iterator.buffer == []
+
+    for chunk in real_speech_chunks[:-1]:
+        assert iterator(chunk) is None
+        assert not iterator.triggered
+        assert iterator.buffer == []
+
+    assert iterator(real_speech_chunks[-1]) is None
+    assert iterator.triggered
+
+    spoken_utterance = _finish_utterance(iterator, separating_silence)
+
+    assert spoken_utterance is not None
+    assert len(spoken_utterance) == 10
+    assert torch.equal(spoken_utterance[0], separating_silence)
+    for buffered, expected in zip(spoken_utterance[1:5], real_speech_chunks):
+        assert torch.equal(buffered, expected)
+    assert all(torch.equal(chunk, separating_silence) for chunk in spoken_utterance[5:])
+    assert all(
+        not torch.equal(chunk, false_start_chunks[0]) for chunk in spoken_utterance
+    )
+    assert all(
+        not torch.equal(chunk, false_start_chunks[1]) for chunk in spoken_utterance
+    )


### PR DESCRIPTION
## Summary
- add a configurable `start_persistence_ms` gate before VAD opens a speech segment
- keep tentative above-threshold chunks in a pending buffer until the start-persistence threshold is met
- discard false starts cleanly so short bursts do not contaminate the speech buffer or pre-speech prefix
- cover the new behavior with VAD iterator tests and set the default start persistence to 128 ms

## Root Cause
The VAD iterator switched into a triggered speech state on the first above-threshold chunk. Short bursts of noise could therefore open a speech segment immediately, even though the segment might later be discarded by `min_speech_ms`. That still polluted the active speech buffer and could interfere with pre-speech padding behavior.

## Validation
- `pytest -q tests/test_vad_iterator.py`
- `ruff check VAD/vad_iterator.py VAD/vad_handler.py arguments_classes/vad_arguments.py tests/test_vad_iterator.py`
- `ruff format --check VAD/vad_iterator.py VAD/vad_handler.py arguments_classes/vad_arguments.py tests/test_vad_iterator.py`
