### PR TITLE
Add per-session VAD diagnostics reports

### DIFF
--- a/README.md
+++ b/README.md
@@ -263,6 +263,7 @@ See [VADHandlerArguments](./src/speech_to_speech/arguments_classes/vad_arguments
 - `--thresh`: Threshold value to trigger voice activity detection.
 - `--min_speech_ms`: Minimum duration of detected voice activity to be considered speech.
 - `--min_silence_ms`: Minimum length of silence intervals for segmenting speech, balancing sentence cutting and latency reduction.
+- `--vad_diagnostics_dir`: Save one directory per session with `audio.wav`, raw VAD frame data, and an HTML report that visualizes the waveform, speech state, and thresholds.
 
 
 ### STT, LM and TTS parameters

--- a/src/speech_to_speech/VAD/vad_diagnostics.py
+++ b/src/speech_to_speech/VAD/vad_diagnostics.py
@@ -164,6 +164,15 @@ class VADDiagnosticsRecorder:
             )
             for event in events
         )
+        event_chips = "".join(
+            (
+                f'<button class="event-chip" type="button" data-seek-ms="{float(event["timestamp_ms"]):.3f}">'
+                f"{html.escape(self._event_marker_label(str(event['kind'])))} "
+                f"<span>{float(event['timestamp_ms']):.1f} ms</span>"
+                "</button>"
+            )
+            for event in events
+        )
         return f"""<!DOCTYPE html>
 <html lang="en">
 <head>
@@ -238,6 +247,40 @@ class VADDiagnosticsRecorder:
       padding: 1px 5px;
       border-radius: 6px;
     }}
+    .audio-toolbar {{
+      display: flex;
+      gap: 12px;
+      flex-wrap: wrap;
+      align-items: center;
+      margin-top: 10px;
+      font-size: 13px;
+      color: #555;
+    }}
+    .charts-note {{
+      margin-top: 8px;
+      font-size: 13px;
+      color: #666;
+    }}
+    .event-jumps {{
+      display: flex;
+      gap: 8px;
+      flex-wrap: wrap;
+      margin-top: 14px;
+    }}
+    .event-chip {{
+      border: 1px solid #d7d7cf;
+      background: #f8f8f4;
+      border-radius: 999px;
+      padding: 6px 10px;
+      font-size: 12px;
+      cursor: pointer;
+    }}
+    .event-chip:hover {{
+      background: #efefe8;
+    }}
+    .event-chip span {{
+      color: #666;
+    }}
   </style>
 </head>
 <body>
@@ -246,7 +289,14 @@ class VADDiagnosticsRecorder:
   <div class="section">
     <h2>Audio</h2>
     <p>The raw mono recording captured by the VAD path for this session.</p>
-    <audio controls preload="metadata" src="audio.wav"></audio>
+    <audio id="session-audio" controls preload="metadata" src="audio.wav"></audio>
+    <div class="audio-toolbar">
+      <span id="playback-time">Playback: 0.0 ms</span>
+      <span>Click a chart or event chip to seek the audio.</span>
+    </div>
+    <div class="event-jumps">
+      {event_chips or "<span>No event markers recorded.</span>"}
+    </div>
   </div>
   <div class="section">
     <h2>Summary</h2>
@@ -270,6 +320,7 @@ class VADDiagnosticsRecorder:
   <div class="section">
     <h2>VAD Probability</h2>
     {self._build_probability_svg(frames, events, duration_ms)}
+    <p class="charts-note">The red playhead follows audio playback. Click inside the chart to seek.</p>
     <div class="legend">
       <span><span class="swatch" style="background:#cdeccf"></span>Triggered speech</span>
       <span><span class="swatch" style="background:#ffe1b5"></span>End-candidate grace period</span>
@@ -280,7 +331,7 @@ class VADDiagnosticsRecorder:
   </div>
   <div class="section">
     <h2>Waveform</h2>
-    {self._build_waveform_svg(audio, frames, duration_ms)}
+    {self._build_waveform_svg(audio, frames, events, duration_ms)}
   </div>
   <div class="section">
     <h2>Events</h2>
@@ -294,6 +345,80 @@ class VADDiagnosticsRecorder:
     </table>
     <p>Raw frame-by-frame data is stored in <code>diagnostics.json</code>.</p>
   </div>
+  <script>
+    (() => {{
+      const audio = document.getElementById("session-audio");
+      const playbackTime = document.getElementById("playback-time");
+      const charts = Array.from(document.querySelectorAll("svg[data-duration-ms]"));
+      const eventButtons = Array.from(document.querySelectorAll(".event-chip[data-seek-ms]"));
+
+      function clamp(value, min, max) {{
+        return Math.min(Math.max(value, min), max);
+      }}
+
+      function formatMs(ms) {{
+        return `${{ms.toFixed(1)}} ms`;
+      }}
+
+      function updatePlayheads() {{
+        const currentMs = audio.currentTime * 1000;
+        playbackTime.textContent = `Playback: ${{formatMs(currentMs)}}`;
+        for (const svg of charts) {{
+          const durationMs = parseFloat(svg.dataset.durationMs || "0");
+          const left = parseFloat(svg.dataset.left || "0");
+          const right = parseFloat(svg.dataset.right || "0");
+          const playhead = svg.querySelector(".playhead");
+          if (!playhead || durationMs <= 0 || right <= left) {{
+            continue;
+          }}
+          const progress = clamp(currentMs / durationMs, 0, 1);
+          const x = left + progress * (right - left);
+          const line = playhead.querySelector("line");
+          const text = playhead.querySelector("text");
+          line.setAttribute("x1", x.toFixed(2));
+          line.setAttribute("x2", x.toFixed(2));
+          text.setAttribute("x", (x + 6).toFixed(2));
+          text.textContent = formatMs(currentMs);
+          playhead.setAttribute("visibility", "visible");
+        }}
+      }}
+
+      function seekFromSvgEvent(svg, event) {{
+        const rect = svg.getBoundingClientRect();
+        const viewBox = svg.viewBox.baseVal;
+        const left = parseFloat(svg.dataset.left || "0");
+        const right = parseFloat(svg.dataset.right || "0");
+        const durationMs = parseFloat(svg.dataset.durationMs || "0");
+        if (durationMs <= 0 || right <= left || rect.width <= 0) {{
+          return;
+        }}
+        const relativeX = (event.clientX - rect.left) / rect.width;
+        const svgX = viewBox.x + relativeX * viewBox.width;
+        const clampedX = clamp(svgX, left, right);
+        const timeMs = ((clampedX - left) / (right - left)) * durationMs;
+        audio.currentTime = timeMs / 1000;
+        updatePlayheads();
+      }}
+
+      for (const svg of charts) {{
+        svg.style.cursor = "pointer";
+        svg.addEventListener("click", (event) => seekFromSvgEvent(svg, event));
+      }}
+
+      for (const button of eventButtons) {{
+        button.addEventListener("click", () => {{
+          const ms = parseFloat(button.dataset.seekMs || "0");
+          audio.currentTime = ms / 1000;
+          updatePlayheads();
+        }});
+      }}
+
+      audio.addEventListener("timeupdate", updatePlayheads);
+      audio.addEventListener("seeked", updatePlayheads);
+      audio.addEventListener("loadedmetadata", updatePlayheads);
+      updatePlayheads();
+    }})();
+  </script>
 </body>
 </html>
 """
@@ -367,19 +492,21 @@ class VADDiagnosticsRecorder:
             f"{x_pos((frame['start_ms'] + frame['end_ms']) / 2):.2f},{y_pos(frame['negative_threshold']):.2f}"
             for frame in frames
         )
-        event_lines = "".join(
-            (
-                f'<line x1="{x_pos(float(event["timestamp_ms"])):.2f}" y1="{top}" '
-                f'x2="{x_pos(float(event["timestamp_ms"])):.2f}" y2="{height - bottom}" '
-                f'stroke="#6f6f6f" stroke-width="1" stroke-dasharray="4 4" />'
-                f'<text x="{x_pos(float(event["timestamp_ms"])) + 4:.2f}" y="14" font-size="11" fill="#555">'
-                f"<title>{html.escape(str(event['kind']))}</title>"
-                f"{html.escape(self._event_marker_label(str(event['kind'])))}</text>"
-            )
-            for event in events
+        event_lines = self._build_event_lines(
+            events,
+            x_pos=x_pos,
+            top=top,
+            bottom=height - bottom,
+            label_y=14,
+        )
+        playhead = self._build_playhead(
+            left=left,
+            top=top,
+            bottom=height - bottom,
+            label_y=top + 16,
         )
         return f"""
-<svg viewBox="0 0 {width} {height}" role="img" aria-label="VAD probability chart">
+<svg viewBox="0 0 {width} {height}" role="img" aria-label="VAD probability chart" data-duration-ms="{duration_ms:.3f}" data-left="{left}" data-right="{width - right}">
   <rect x="{left}" y="{top}" width="{plot_width}" height="{plot_height}" fill="#fcfcfb" />
   {grid_lines}
   {state_rects}
@@ -388,6 +515,7 @@ class VADDiagnosticsRecorder:
   <polyline fill="none" stroke="#4d8fe6" stroke-width="2.5" points="{probability_points}" />
   <rect x="{left}" y="{top}" width="{plot_width}" height="{plot_height}" fill="none" stroke="#cfcfc8" />
   {event_lines}
+  {playhead}
   <text x="{left}" y="{height - 8}" font-size="12" fill="#666">time (ms)</text>
   <text x="{width - right - 70}" y="{height - 8}" font-size="12" fill="#666">{duration_ms:.1f} ms</text>
 </svg>
@@ -397,6 +525,7 @@ class VADDiagnosticsRecorder:
         self,
         audio: np.ndarray,
         frames: list[dict[str, object]],
+        events: list[dict[str, object]],
         duration_ms: float,
     ) -> str:
         width = 1120
@@ -414,19 +543,69 @@ class VADDiagnosticsRecorder:
             return left + (ms / duration_ms) * plot_width
 
         state_rects = self._build_state_rects(frames, x_pos, top, plot_height)
+        event_lines = self._build_event_lines(
+            events,
+            x_pos=x_pos,
+            top=top,
+            bottom=height - bottom,
+            label_y=top + 12,
+        )
         path_commands = self._waveform_path(
             audio, left, plot_width, center_y, amplitude
         )
+        playhead = self._build_playhead(
+            left=left,
+            top=top,
+            bottom=height - bottom,
+            label_y=top + 16,
+        )
         return f"""
-<svg viewBox="0 0 {width} {height}" role="img" aria-label="Audio waveform chart">
+<svg viewBox="0 0 {width} {height}" role="img" aria-label="Audio waveform chart" data-duration-ms="{duration_ms:.3f}" data-left="{left}" data-right="{width - right}">
   <rect x="{left}" y="{top}" width="{plot_width}" height="{plot_height}" fill="#fcfcfb" />
   {state_rects}
   <line x1="{left}" y1="{center_y:.2f}" x2="{width - right}" y2="{center_y:.2f}" stroke="#ecece7" stroke-width="1" />
   <path d="{path_commands}" fill="none" stroke="#303f59" stroke-width="1.2" />
   <rect x="{left}" y="{top}" width="{plot_width}" height="{plot_height}" fill="none" stroke="#cfcfc8" />
+  {event_lines}
+  {playhead}
   <text x="{left}" y="{height - 6}" font-size="12" fill="#666">recorded waveform</text>
 </svg>
 """
+
+    def _build_event_lines(
+        self,
+        events: list[dict[str, object]],
+        *,
+        x_pos,
+        top: int,
+        bottom: int,
+        label_y: int,
+    ) -> str:
+        return "".join(
+            (
+                f'<line x1="{x_pos(float(event["timestamp_ms"])):.2f}" y1="{top}" '
+                f'x2="{x_pos(float(event["timestamp_ms"])):.2f}" y2="{bottom}" '
+                f'stroke="#6f6f6f" stroke-width="1" stroke-dasharray="4 4" />'
+                f'<text x="{x_pos(float(event["timestamp_ms"])) + 4:.2f}" y="{label_y}" font-size="11" fill="#555">'
+                f"<title>{html.escape(str(event['kind']))}</title>"
+                f"{html.escape(self._event_marker_label(str(event['kind'])))}</text>"
+            )
+            for event in events
+        )
+
+    def _build_playhead(
+        self,
+        *,
+        left: int,
+        top: int,
+        bottom: int,
+        label_y: int,
+    ) -> str:
+        return f"""
+  <g class="playhead" visibility="hidden">
+    <line x1="{left}" y1="{top}" x2="{left}" y2="{bottom}" stroke="#d13a2f" stroke-width="2" />
+    <text x="{left + 6}" y="{label_y}" font-size="11" fill="#d13a2f">0.0 ms</text>
+  </g>"""
 
     def _build_state_rects(
         self,

--- a/src/speech_to_speech/VAD/vad_diagnostics.py
+++ b/src/speech_to_speech/VAD/vad_diagnostics.py
@@ -312,6 +312,18 @@ class VADDiagnosticsRecorder:
         ]
         return ", ".join(details) if details else "-"
 
+    def _event_marker_label(self, kind: str) -> str:
+        labels = {
+            "speech_started": "SS",
+            "speech_stopped": "ST",
+            "segment_emitted": "EM",
+            "segment_discarded": "DD",
+            "phantom_trigger": "PT",
+            "session_end": "SE",
+            "cleanup_flush": "CF",
+        }
+        return labels.get(kind, kind[:2].upper())
+
     def _build_probability_svg(
         self,
         frames: list[dict[str, object]],
@@ -361,7 +373,8 @@ class VADDiagnosticsRecorder:
                 f'x2="{x_pos(float(event["timestamp_ms"])):.2f}" y2="{height - bottom}" '
                 f'stroke="#6f6f6f" stroke-width="1" stroke-dasharray="4 4" />'
                 f'<text x="{x_pos(float(event["timestamp_ms"])) + 4:.2f}" y="14" font-size="11" fill="#555">'
-                f"{html.escape(str(event['kind']))}</text>"
+                f"<title>{html.escape(str(event['kind']))}</title>"
+                f"{html.escape(self._event_marker_label(str(event['kind'])))}</text>"
             )
             for event in events
         )

--- a/src/speech_to_speech/VAD/vad_diagnostics.py
+++ b/src/speech_to_speech/VAD/vad_diagnostics.py
@@ -1,0 +1,505 @@
+from __future__ import annotations
+
+from dataclasses import asdict
+from datetime import datetime, timezone
+import html
+import json
+from pathlib import Path
+import wave
+
+import numpy as np
+
+from speech_to_speech.VAD.vad_iterator import VADStateSnapshot
+
+
+class VADDiagnosticsRecorder:
+    def __init__(
+        self,
+        output_dir: str | Path,
+        sample_rate: int,
+        *,
+        config: dict[str, object] | None = None,
+    ) -> None:
+        self.output_dir = Path(output_dir)
+        self.output_dir.mkdir(parents=True, exist_ok=True)
+        self.sample_rate = sample_rate
+        self.config = dict(config or {})
+        self._session_counter = 0
+        self._reset_session()
+
+    def _reset_session(self) -> None:
+        self._created_at: datetime | None = None
+        self._audio_chunks: list[np.ndarray] = []
+        self._frames: list[dict[str, object]] = []
+        self._events: list[dict[str, object]] = []
+
+    @property
+    def has_data(self) -> bool:
+        return bool(self._audio_chunks or self._frames or self._events)
+
+    def _ensure_session_started(self) -> None:
+        if self._created_at is None:
+            self._created_at = datetime.now(timezone.utc)
+
+    def _samples_to_ms(self, samples: int) -> float:
+        return round(samples / self.sample_rate * 1000, 3)
+
+    def record_chunk(
+        self, audio_chunk: np.ndarray, snapshot: VADStateSnapshot | None
+    ) -> None:
+        if snapshot is None:
+            return
+        self._ensure_session_started()
+        audio_chunk = np.asarray(audio_chunk, dtype=np.int16).copy()
+        self._audio_chunks.append(audio_chunk)
+
+        start_sample = snapshot.current_sample - snapshot.window_size_samples
+        frame = asdict(snapshot)
+        frame.update(
+            {
+                "index": len(self._frames),
+                "start_sample": start_sample,
+                "end_sample": snapshot.current_sample,
+                "start_ms": self._samples_to_ms(start_sample),
+                "end_ms": self._samples_to_ms(snapshot.current_sample),
+                "duration_ms": self._samples_to_ms(snapshot.window_size_samples),
+                "ending": snapshot.temp_end_sample > 0 and snapshot.triggered,
+                "pre_speech_ms": self._samples_to_ms(snapshot.pre_speech_samples),
+                "active_speech_ms": self._samples_to_ms(snapshot.active_speech_samples),
+                "prefix_ms": self._samples_to_ms(snapshot.prefix_samples),
+                "temp_end_ms": self._samples_to_ms(snapshot.temp_end_sample),
+                "emitted_speech_ms": self._samples_to_ms(
+                    snapshot.emitted_speech_samples
+                ),
+            }
+        )
+        self._frames.append(frame)
+
+    def record_event(self, kind: str, timestamp_ms: float, **payload: object) -> None:
+        self._ensure_session_started()
+        self._events.append(
+            {
+                "kind": kind,
+                "timestamp_ms": round(float(timestamp_ms), 3),
+                **payload,
+            }
+        )
+
+    def flush_session(self, reason: str) -> Path | None:
+        if not self.has_data:
+            return None
+
+        self._ensure_session_started()
+        session_dir = self._create_session_dir()
+        audio = (
+            np.concatenate(self._audio_chunks)
+            if self._audio_chunks
+            else np.empty(0, dtype=np.int16)
+        )
+        duration_ms = self._samples_to_ms(len(audio))
+        session_payload = {
+            "created_at": self._created_at.isoformat(),
+            "flushed_at": datetime.now(timezone.utc).isoformat(),
+            "flush_reason": reason,
+            "sample_rate": self.sample_rate,
+            "duration_ms": duration_ms,
+            "chunk_count": len(self._frames),
+            "event_count": len(self._events),
+            "config": self.config,
+            "frames": self._frames,
+            "events": self._events,
+        }
+
+        self._write_audio(session_dir / "audio.wav", audio)
+        (session_dir / "diagnostics.json").write_text(
+            json.dumps(session_payload, indent=2),
+            encoding="utf-8",
+        )
+        (session_dir / "report.html").write_text(
+            self._build_report(session_payload, audio),
+            encoding="utf-8",
+        )
+        self._reset_session()
+        return session_dir
+
+    def _create_session_dir(self) -> Path:
+        timestamp = datetime.now(timezone.utc).strftime("%Y%m%d-%H%M%S-%f")
+        base_name = f"session-{timestamp}-{self._session_counter:04d}"
+        self._session_counter += 1
+        session_dir = self.output_dir / base_name
+        session_dir.mkdir(parents=True, exist_ok=False)
+        return session_dir
+
+    def _write_audio(self, path: Path, audio: np.ndarray) -> None:
+        with wave.open(str(path), "wb") as wav_file:
+            wav_file.setnchannels(1)
+            wav_file.setsampwidth(2)
+            wav_file.setframerate(self.sample_rate)
+            wav_file.writeframes(audio.astype(np.int16).tobytes())
+
+    def _build_report(self, payload: dict[str, object], audio: np.ndarray) -> str:
+        frames = payload["frames"]
+        events = payload["events"]
+        duration_ms = max(float(payload["duration_ms"]), 1.0)
+        summary_rows = [
+            ("Created", payload["created_at"]),
+            ("Flush reason", payload["flush_reason"]),
+            ("Duration", f"{float(payload['duration_ms']):.1f} ms"),
+            ("Chunks", str(payload["chunk_count"])),
+            ("Events", str(payload["event_count"])),
+            ("Sample rate", f"{payload['sample_rate']} Hz"),
+        ]
+        config_rows = [
+            (key.replace("_", " "), str(value))
+            for key, value in sorted(dict(payload["config"]).items())
+            if value is not None
+        ]
+        events_rows = "".join(
+            (
+                "<tr>"
+                f"<td>{html.escape(event['kind'])}</td>"
+                f"<td>{float(event['timestamp_ms']):.1f}</td>"
+                f"<td>{html.escape(self._format_event_details(event))}</td>"
+                "</tr>"
+            )
+            for event in events
+        )
+        return f"""<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="utf-8">
+  <title>VAD Session Diagnostics</title>
+  <style>
+    body {{
+      font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", sans-serif;
+      margin: 24px;
+      color: #1d1d1f;
+      background: #fafaf8;
+    }}
+    h1, h2 {{
+      margin: 0 0 12px;
+    }}
+    p {{
+      margin: 0 0 16px;
+    }}
+    .section {{
+      margin-top: 24px;
+      padding: 20px;
+      background: white;
+      border: 1px solid #e5e5df;
+      border-radius: 16px;
+      box-shadow: 0 1px 2px rgba(0, 0, 0, 0.03);
+    }}
+    .grid {{
+      display: grid;
+      gap: 20px;
+      grid-template-columns: repeat(auto-fit, minmax(260px, 1fr));
+    }}
+    table {{
+      width: 100%;
+      border-collapse: collapse;
+      font-size: 14px;
+    }}
+    th, td {{
+      text-align: left;
+      padding: 8px 0;
+      border-bottom: 1px solid #ecece7;
+      vertical-align: top;
+    }}
+    .legend {{
+      display: flex;
+      gap: 14px;
+      flex-wrap: wrap;
+      margin-top: 10px;
+      font-size: 13px;
+    }}
+    .swatch {{
+      display: inline-block;
+      width: 12px;
+      height: 12px;
+      border-radius: 3px;
+      margin-right: 6px;
+      vertical-align: middle;
+    }}
+    audio {{
+      width: 100%;
+      margin-top: 8px;
+    }}
+    svg {{
+      width: 100%;
+      height: auto;
+      display: block;
+      background: #fcfcfb;
+      border: 1px solid #ecece7;
+      border-radius: 12px;
+    }}
+    code {{
+      background: #f4f4ef;
+      padding: 1px 5px;
+      border-radius: 6px;
+    }}
+  </style>
+</head>
+<body>
+  <h1>VAD Session Diagnostics</h1>
+  <p>Session audio, per-frame VAD state, and the thresholds that were active while the iterator made decisions.</p>
+  <div class="section">
+    <h2>Audio</h2>
+    <p>The raw mono recording captured by the VAD path for this session.</p>
+    <audio controls preload="metadata" src="audio.wav"></audio>
+  </div>
+  <div class="section">
+    <h2>Summary</h2>
+    <div class="grid">
+      <div>
+        <table>
+          <tbody>
+            {self._rows_to_html(summary_rows)}
+          </tbody>
+        </table>
+      </div>
+      <div>
+        <table>
+          <tbody>
+            {self._rows_to_html(config_rows) if config_rows else "<tr><td>No custom VAD config recorded.</td></tr>"}
+          </tbody>
+        </table>
+      </div>
+    </div>
+  </div>
+  <div class="section">
+    <h2>VAD Probability</h2>
+    {self._build_probability_svg(frames, events, duration_ms)}
+    <div class="legend">
+      <span><span class="swatch" style="background:#cdeccf"></span>Triggered speech</span>
+      <span><span class="swatch" style="background:#ffe1b5"></span>End-candidate grace period</span>
+      <span><span class="swatch" style="background:#b5d7ff"></span>Speech probability</span>
+      <span><span class="swatch" style="background:#e57373"></span>Threshold</span>
+      <span><span class="swatch" style="background:#f0a35e"></span>End threshold</span>
+    </div>
+  </div>
+  <div class="section">
+    <h2>Waveform</h2>
+    {self._build_waveform_svg(audio, frames, duration_ms)}
+  </div>
+  <div class="section">
+    <h2>Events</h2>
+    <table>
+      <thead>
+        <tr><th>Kind</th><th>Time (ms)</th><th>Details</th></tr>
+      </thead>
+      <tbody>
+        {events_rows or '<tr><td colspan="3">No VAD events recorded.</td></tr>'}
+      </tbody>
+    </table>
+    <p>Raw frame-by-frame data is stored in <code>diagnostics.json</code>.</p>
+  </div>
+</body>
+</html>
+"""
+
+    def _rows_to_html(self, rows: list[tuple[str, str]]) -> str:
+        return "".join(
+            f"<tr><th>{html.escape(label)}</th><td>{html.escape(value)}</td></tr>"
+            for label, value in rows
+        )
+
+    def _format_event_details(self, event: dict[str, object]) -> str:
+        details = [
+            f"{key}={value}"
+            for key, value in event.items()
+            if key not in {"kind", "timestamp_ms"}
+        ]
+        return ", ".join(details) if details else "-"
+
+    def _build_probability_svg(
+        self,
+        frames: list[dict[str, object]],
+        events: list[dict[str, object]],
+        duration_ms: float,
+    ) -> str:
+        width = 1120
+        height = 320
+        left = 56
+        right = 18
+        top = 20
+        bottom = 30
+        plot_width = width - left - right
+        plot_height = height - top - bottom
+
+        def x_pos(ms: float) -> float:
+            return left + (ms / duration_ms) * plot_width
+
+        def y_pos(probability: float) -> float:
+            clipped = min(max(probability, 0.0), 1.0)
+            return top + (1.0 - clipped) * plot_height
+
+        grid_lines = "".join(
+            (
+                f'<line x1="{left}" y1="{y_pos(level):.2f}" x2="{width - right}" '
+                f'y2="{y_pos(level):.2f}" stroke="#ecece7" stroke-width="1" />'
+                f'<text x="10" y="{y_pos(level) + 4:.2f}" font-size="12" fill="#666">{level:.1f}</text>'
+            )
+            for level in (0.0, 0.25, 0.5, 0.75, 1.0)
+        )
+        state_rects = self._build_state_rects(frames, x_pos, top, plot_height)
+        probability_points = " ".join(
+            f"{x_pos((frame['start_ms'] + frame['end_ms']) / 2):.2f},{y_pos(frame['speech_prob']):.2f}"
+            for frame in frames
+        )
+        threshold_points = " ".join(
+            f"{x_pos((frame['start_ms'] + frame['end_ms']) / 2):.2f},{y_pos(frame['threshold']):.2f}"
+            for frame in frames
+        )
+        negative_threshold_points = " ".join(
+            f"{x_pos((frame['start_ms'] + frame['end_ms']) / 2):.2f},{y_pos(frame['negative_threshold']):.2f}"
+            for frame in frames
+        )
+        event_lines = "".join(
+            (
+                f'<line x1="{x_pos(float(event["timestamp_ms"])):.2f}" y1="{top}" '
+                f'x2="{x_pos(float(event["timestamp_ms"])):.2f}" y2="{height - bottom}" '
+                f'stroke="#6f6f6f" stroke-width="1" stroke-dasharray="4 4" />'
+                f'<text x="{x_pos(float(event["timestamp_ms"])) + 4:.2f}" y="14" font-size="11" fill="#555">'
+                f"{html.escape(str(event['kind']))}</text>"
+            )
+            for event in events
+        )
+        return f"""
+<svg viewBox="0 0 {width} {height}" role="img" aria-label="VAD probability chart">
+  <rect x="{left}" y="{top}" width="{plot_width}" height="{plot_height}" fill="#fcfcfb" />
+  {grid_lines}
+  {state_rects}
+  <polyline fill="none" stroke="#e57373" stroke-width="2" stroke-dasharray="6 6" points="{threshold_points}" />
+  <polyline fill="none" stroke="#f0a35e" stroke-width="2" stroke-dasharray="3 5" points="{negative_threshold_points}" />
+  <polyline fill="none" stroke="#4d8fe6" stroke-width="2.5" points="{probability_points}" />
+  <rect x="{left}" y="{top}" width="{plot_width}" height="{plot_height}" fill="none" stroke="#cfcfc8" />
+  {event_lines}
+  <text x="{left}" y="{height - 8}" font-size="12" fill="#666">time (ms)</text>
+  <text x="{width - right - 70}" y="{height - 8}" font-size="12" fill="#666">{duration_ms:.1f} ms</text>
+</svg>
+"""
+
+    def _build_waveform_svg(
+        self,
+        audio: np.ndarray,
+        frames: list[dict[str, object]],
+        duration_ms: float,
+    ) -> str:
+        width = 1120
+        height = 220
+        left = 56
+        right = 18
+        top = 18
+        bottom = 22
+        plot_width = width - left - right
+        plot_height = height - top - bottom
+        center_y = top + plot_height / 2
+        amplitude = plot_height / 2 - 4
+
+        def x_pos(ms: float) -> float:
+            return left + (ms / duration_ms) * plot_width
+
+        state_rects = self._build_state_rects(frames, x_pos, top, plot_height)
+        path_commands = self._waveform_path(
+            audio, left, plot_width, center_y, amplitude
+        )
+        return f"""
+<svg viewBox="0 0 {width} {height}" role="img" aria-label="Audio waveform chart">
+  <rect x="{left}" y="{top}" width="{plot_width}" height="{plot_height}" fill="#fcfcfb" />
+  {state_rects}
+  <line x1="{left}" y1="{center_y:.2f}" x2="{width - right}" y2="{center_y:.2f}" stroke="#ecece7" stroke-width="1" />
+  <path d="{path_commands}" fill="none" stroke="#303f59" stroke-width="1.2" />
+  <rect x="{left}" y="{top}" width="{plot_width}" height="{plot_height}" fill="none" stroke="#cfcfc8" />
+  <text x="{left}" y="{height - 6}" font-size="12" fill="#666">recorded waveform</text>
+</svg>
+"""
+
+    def _build_state_rects(
+        self,
+        frames: list[dict[str, object]],
+        x_pos,
+        top: int,
+        plot_height: int,
+    ) -> str:
+        triggered_rects = self._render_spans(
+            self._spans(frames, lambda frame: bool(frame["triggered"])),
+            x_pos,
+            top,
+            plot_height,
+            fill="#cdeccf",
+        )
+        ending_rects = self._render_spans(
+            self._spans(frames, lambda frame: bool(frame["ending"])),
+            x_pos,
+            top,
+            plot_height,
+            fill="#ffe1b5",
+        )
+        return ending_rects + triggered_rects
+
+    def _render_spans(
+        self,
+        spans: list[tuple[float, float]],
+        x_pos,
+        top: int,
+        plot_height: int,
+        *,
+        fill: str,
+    ) -> str:
+        return "".join(
+            (
+                f'<rect x="{x_pos(start_ms):.2f}" y="{top}" '
+                f'width="{max(x_pos(end_ms) - x_pos(start_ms), 1.0):.2f}" '
+                f'height="{plot_height}" fill="{fill}" opacity="0.65" />'
+            )
+            for start_ms, end_ms in spans
+        )
+
+    def _spans(
+        self,
+        frames: list[dict[str, object]],
+        predicate,
+    ) -> list[tuple[float, float]]:
+        spans: list[tuple[float, float]] = []
+        current_start: float | None = None
+        previous_end = 0.0
+        for frame in frames:
+            active = predicate(frame)
+            start_ms = float(frame["start_ms"])
+            end_ms = float(frame["end_ms"])
+            if active and current_start is None:
+                current_start = start_ms
+            if not active and current_start is not None:
+                spans.append((current_start, previous_end))
+                current_start = None
+            previous_end = end_ms
+        if current_start is not None:
+            spans.append((current_start, previous_end))
+        return spans
+
+    def _waveform_path(
+        self,
+        audio: np.ndarray,
+        left: int,
+        plot_width: int,
+        center_y: float,
+        amplitude: float,
+    ) -> str:
+        if len(audio) == 0:
+            return f"M {left} {center_y:.2f} L {left + plot_width} {center_y:.2f}"
+
+        points = min(plot_width, len(audio))
+        edges = np.linspace(0, len(audio), num=points + 1, dtype=int)
+        commands: list[str] = []
+        for index in range(points):
+            segment = audio[edges[index] : edges[index + 1]]
+            if len(segment) == 0:
+                continue
+            x = left + (index / max(points - 1, 1)) * plot_width
+            min_value = float(segment.min()) / 32768.0
+            max_value = float(segment.max()) / 32768.0
+            y_min = center_y - max_value * amplitude
+            y_max = center_y - min_value * amplitude
+            commands.append(f"M {x:.2f} {y_min:.2f} L {x:.2f} {y_max:.2f}")
+        return " ".join(commands)

--- a/src/speech_to_speech/VAD/vad_handler.py
+++ b/src/speech_to_speech/VAD/vad_handler.py
@@ -18,6 +18,7 @@ from speech_to_speech.pipeline.handler_types import VADIn, VADOut
 from speech_to_speech.pipeline.messages import VADAudio
 from speech_to_speech.pipeline.queue_types import TextEventItem
 from speech_to_speech.utils.utils import int2float
+from speech_to_speech.VAD.vad_diagnostics import VADDiagnosticsRecorder
 from speech_to_speech.VAD.vad_iterator import VADIterator
 
 logger = logging.getLogger(__name__)
@@ -53,6 +54,7 @@ class VADHandler(BaseHandler[VADIn, VADOut]):
         enable_realtime_transcription: bool = False,
         realtime_processing_pause: float = 0.25,
         text_output_queue: Queue[TextEventItem] | None = None,
+        vad_diagnostics_dir: str | None = None,
     ) -> None:
         self.should_listen = should_listen
         self.sample_rate = sample_rate
@@ -75,6 +77,23 @@ class VADHandler(BaseHandler[VADIn, VADOut]):
             sampling_rate=sample_rate,
             min_silence_duration_ms=min_silence_ms,
             speech_pad_ms=speech_pad_ms,
+        )
+        self.diagnostics_recorder = (
+            VADDiagnosticsRecorder(
+                vad_diagnostics_dir,
+                sample_rate=sample_rate,
+                config={
+                    "threshold": thresh,
+                    "min_silence_ms": min_silence_ms,
+                    "min_speech_ms": min_speech_ms,
+                    "max_speech_ms": max_speech_ms,
+                    "speech_pad_ms": speech_pad_ms,
+                    "enable_realtime_transcription": enable_realtime_transcription,
+                    "realtime_processing_pause": realtime_processing_pause,
+                },
+            )
+            if vad_diagnostics_dir
+            else None
         )
         self.audio_enhancement = audio_enhancement
         if audio_enhancement:
@@ -133,8 +152,24 @@ class VADHandler(BaseHandler[VADIn, VADOut]):
             self.iterator.threshold = td["threshold"]
             logger.info(f"VAD threshold updated to {td['threshold']}")
         if "silence_duration_ms" in td:
-            self.iterator.min_silence_samples = self.sample_rate * td["silence_duration_ms"] / 1000
-            logger.info(f"VAD silence duration updated to {td['silence_duration_ms']}ms")
+            self.iterator.min_silence_samples = (
+                self.sample_rate * td["silence_duration_ms"] / 1000
+            )
+            logger.info(
+                f"VAD silence duration updated to {td['silence_duration_ms']}ms"
+            )
+
+    def _record_vad_chunk(self, audio_int16: np.ndarray) -> None:
+        if self.diagnostics_recorder is None:
+            return
+        self.diagnostics_recorder.record_chunk(audio_int16, self.iterator.last_snapshot)
+
+    def _record_vad_event(
+        self, kind: str, timestamp_ms: float, **payload: object
+    ) -> None:
+        if self.diagnostics_recorder is None:
+            return
+        self.diagnostics_recorder.record_event(kind, timestamp_ms, **payload)
 
     def process(self, audio_chunk: VADIn) -> Iterator[VADOut]:
         runtime_config = None
@@ -152,6 +187,7 @@ class VADHandler(BaseHandler[VADIn, VADOut]):
         audio_float32 = int2float(audio_int16)
 
         vad_output = self.iterator(torch.from_numpy(audio_float32))
+        self._record_vad_chunk(audio_int16)
 
         # Deferred speech_started: only emit once buffer >= min_speech_ms
         is_triggered_now = self.iterator.triggered
@@ -162,9 +198,19 @@ class VADHandler(BaseHandler[VADIn, VADOut]):
                 self._speech_started_emitted = True
                 self._log_speech_starts += 1
                 start_ms = max(0, self._audio_ms - int(buffer_duration_ms))
-                logger.info("Speech started (confirmed, %.0fms buffered)", buffer_duration_ms)
+                logger.info(
+                    "Speech started (confirmed, %.0fms buffered)", buffer_duration_ms
+                )
+                self._record_vad_event(
+                    "speech_started",
+                    start_ms,
+                    audio_start_ms=start_ms,
+                    buffered_ms=round(buffer_duration_ms, 3),
+                )
                 if self.text_output_queue:
-                    self.text_output_queue.put(SpeechStartedEvent(audio_start_ms=start_ms))
+                    self.text_output_queue.put(
+                        SpeechStartedEvent(audio_start_ms=start_ms)
+                    )
 
         # Log a summary once per second instead of every chunk
         now = time.time()
@@ -194,13 +240,17 @@ class VADHandler(BaseHandler[VADIn, VADOut]):
             current_time = time.time()
 
             # Yield accumulated audio periodically while speaking
-            if (current_time - self.last_process_time) >= self.realtime_processing_pause:
+            if (
+                current_time - self.last_process_time
+            ) >= self.realtime_processing_pause:
                 array = torch.cat(self.iterator.speech_buffer()).cpu().numpy()
                 duration_ms = len(array) / self.sample_rate * 1000
 
                 if duration_ms >= self.min_speech_ms:
                     self._log_progressive_yields += 1
-                    logger.debug(f"VAD: yielding progressive audio ({duration_ms:.0f}ms)")
+                    logger.debug(
+                        f"VAD: yielding progressive audio ({duration_ms:.0f}ms)"
+                    )
                     yield VADAudio(audio=array, mode="progressive")
                     self.last_process_time = current_time
 
@@ -208,8 +258,16 @@ class VADHandler(BaseHandler[VADIn, VADOut]):
         if vad_output is not None:
             if len(vad_output) == 0:
                 logger.info("VAD: phantom trigger (empty buffer), closing speech pair")
+                self._record_vad_event("phantom_trigger", self._audio_ms)
                 if self._speech_started_emitted and self.text_output_queue:
-                    self.text_output_queue.put(SpeechStoppedEvent(audio_end_ms=self._audio_ms))
+                    self._record_vad_event(
+                        "speech_stopped",
+                        self._audio_ms,
+                        audio_end_ms=self._audio_ms,
+                    )
+                    self.text_output_queue.put(
+                        SpeechStoppedEvent(audio_end_ms=self._audio_ms)
+                    )
                 self._speech_started_emitted = False
                 return
 
@@ -220,18 +278,58 @@ class VADHandler(BaseHandler[VADIn, VADOut]):
                 logger.info(
                     f"VAD: discarding {duration_ms:.0f}ms segment (bounds: {self.min_speech_ms}-{self.max_speech_ms}ms)"
                 )
+                self._record_vad_event(
+                    "segment_discarded",
+                    self._audio_ms,
+                    duration_ms=round(duration_ms, 3),
+                    audio_end_ms=self._audio_ms,
+                )
                 if self._speech_started_emitted and self.text_output_queue:
-                    self.text_output_queue.put(SpeechStoppedEvent(audio_end_ms=self._audio_ms))
+                    self._record_vad_event(
+                        "speech_stopped",
+                        self._audio_ms,
+                        audio_end_ms=self._audio_ms,
+                    )
+                    self.text_output_queue.put(
+                        SpeechStoppedEvent(audio_end_ms=self._audio_ms)
+                    )
                 self._speech_started_emitted = False
             else:
                 end_ms = self._audio_ms
+                start_ms = max(0, end_ms - int(duration_ms))
                 if not self._speech_started_emitted and self.text_output_queue:
-                    self.text_output_queue.put(SpeechStartedEvent(audio_start_ms=max(0, end_ms - int(duration_ms))))
+                    self._record_vad_event(
+                        "speech_started",
+                        start_ms,
+                        audio_start_ms=start_ms,
+                        buffered_ms=round(duration_ms, 3),
+                    )
+                    self.text_output_queue.put(
+                        SpeechStartedEvent(audio_start_ms=start_ms)
+                    )
                 self._log_speech_ends += 1
                 self.should_listen.clear()
                 logger.info(f"Speech ended ({duration_ms:.0f}ms), stop listening")
+                self._record_vad_event(
+                    "segment_emitted",
+                    end_ms,
+                    duration_ms=round(duration_ms, 3),
+                    audio_start_ms=start_ms,
+                    audio_end_ms=end_ms,
+                    mode="final",
+                )
                 if self.text_output_queue:
-                    self.text_output_queue.put(SpeechStoppedEvent(duration_s=duration_ms / 1000.0, audio_end_ms=end_ms))
+                    self._record_vad_event(
+                        "speech_stopped",
+                        end_ms,
+                        duration_s=round(duration_ms / 1000.0, 3),
+                        audio_end_ms=end_ms,
+                    )
+                    self.text_output_queue.put(
+                        SpeechStoppedEvent(
+                            duration_s=duration_ms / 1000.0, audio_end_ms=end_ms
+                        )
+                    )
                 if self.audio_enhancement:
                     array = self._apply_audio_enhancement(array)
                 yield VADAudio(audio=array, mode="final")
@@ -243,8 +341,16 @@ class VADHandler(BaseHandler[VADIn, VADOut]):
         if vad_output is not None:
             if len(vad_output) == 0:
                 logger.info("VAD: phantom trigger (empty buffer), closing speech pair")
+                self._record_vad_event("phantom_trigger", self._audio_ms)
                 if self._speech_started_emitted and self.text_output_queue:
-                    self.text_output_queue.put(SpeechStoppedEvent(audio_end_ms=self._audio_ms))
+                    self._record_vad_event(
+                        "speech_stopped",
+                        self._audio_ms,
+                        audio_end_ms=self._audio_ms,
+                    )
+                    self.text_output_queue.put(
+                        SpeechStoppedEvent(audio_end_ms=self._audio_ms)
+                    )
                 self._speech_started_emitted = False
                 return
 
@@ -254,18 +360,58 @@ class VADHandler(BaseHandler[VADIn, VADOut]):
                 logger.info(
                     f"VAD: discarding {duration_ms:.0f}ms segment (bounds: {self.min_speech_ms}-{self.max_speech_ms}ms)"
                 )
+                self._record_vad_event(
+                    "segment_discarded",
+                    self._audio_ms,
+                    duration_ms=round(duration_ms, 3),
+                    audio_end_ms=self._audio_ms,
+                )
                 if self._speech_started_emitted and self.text_output_queue:
-                    self.text_output_queue.put(SpeechStoppedEvent(audio_end_ms=self._audio_ms))
+                    self._record_vad_event(
+                        "speech_stopped",
+                        self._audio_ms,
+                        audio_end_ms=self._audio_ms,
+                    )
+                    self.text_output_queue.put(
+                        SpeechStoppedEvent(audio_end_ms=self._audio_ms)
+                    )
                 self._speech_started_emitted = False
             else:
                 end_ms = self._audio_ms
+                start_ms = max(0, end_ms - int(duration_ms))
                 if not self._speech_started_emitted and self.text_output_queue:
-                    self.text_output_queue.put(SpeechStartedEvent(audio_start_ms=max(0, end_ms - int(duration_ms))))
+                    self._record_vad_event(
+                        "speech_started",
+                        start_ms,
+                        audio_start_ms=start_ms,
+                        buffered_ms=round(duration_ms, 3),
+                    )
+                    self.text_output_queue.put(
+                        SpeechStartedEvent(audio_start_ms=start_ms)
+                    )
                 self._log_speech_ends += 1
                 self.should_listen.clear()
                 logger.info(f"Speech ended ({duration_ms:.0f}ms), stop listening")
+                self._record_vad_event(
+                    "segment_emitted",
+                    end_ms,
+                    duration_ms=round(duration_ms, 3),
+                    audio_start_ms=start_ms,
+                    audio_end_ms=end_ms,
+                    mode="normal",
+                )
                 if self.text_output_queue:
-                    self.text_output_queue.put(SpeechStoppedEvent(duration_s=duration_ms / 1000.0, audio_end_ms=end_ms))
+                    self._record_vad_event(
+                        "speech_stopped",
+                        end_ms,
+                        duration_s=round(duration_ms / 1000.0, 3),
+                        audio_end_ms=end_ms,
+                    )
+                    self.text_output_queue.put(
+                        SpeechStoppedEvent(
+                            duration_s=duration_ms / 1000.0, audio_end_ms=end_ms
+                        )
+                    )
                 if self.audio_enhancement:
                     array = self._apply_audio_enhancement(array)
                 yield VADAudio(audio=array)
@@ -294,6 +440,9 @@ class VADHandler(BaseHandler[VADIn, VADOut]):
         return enhanced.numpy().squeeze()
 
     def on_session_end(self):
+        if self.diagnostics_recorder is not None and self.diagnostics_recorder.has_data:
+            self._record_vad_event("session_end", self._audio_ms)
+            self.diagnostics_recorder.flush_session("session_end")
         self.iterator.reset_states()
         self.iterator.buffer = []
         self.last_process_time = 0.0
@@ -301,6 +450,11 @@ class VADHandler(BaseHandler[VADIn, VADOut]):
         self._speech_started_emitted = False
         self.should_listen.set()
         logger.debug("VAD session state reset")
+
+    def cleanup(self):
+        if self.diagnostics_recorder is not None and self.diagnostics_recorder.has_data:
+            self._record_vad_event("cleanup_flush", self._audio_ms)
+            self.diagnostics_recorder.flush_session("cleanup")
 
     @property
     def min_time_to_debug(self) -> float:

--- a/src/speech_to_speech/VAD/vad_iterator.py
+++ b/src/speech_to_speech/VAD/vad_iterator.py
@@ -1,6 +1,23 @@
 from collections import deque
+from dataclasses import dataclass
 
 import torch
+
+
+@dataclass(frozen=True)
+class VADStateSnapshot:
+    current_sample: int
+    window_size_samples: int
+    speech_prob: float
+    threshold: float
+    negative_threshold: float
+    triggered: bool
+    pre_speech_samples: int
+    active_speech_samples: int
+    prefix_samples: int
+    temp_end_sample: int
+    transition: str
+    emitted_speech_samples: int = 0
 
 
 class VADIterator:
@@ -60,9 +77,36 @@ class VADIterator:
         self.prefix_buffer = []
         self._pre_speech_buffer.clear()
         self._pre_speech_samples = 0
+        self.last_snapshot = None
 
     def _num_samples(self, chunk: torch.Tensor) -> int:
         return len(chunk[0]) if chunk.dim() == 2 else len(chunk)
+
+    def _chunks_num_samples(self, chunks: list[torch.Tensor]) -> int:
+        return sum(self._num_samples(chunk) for chunk in chunks)
+
+    def _update_snapshot(
+        self,
+        *,
+        speech_prob: float,
+        window_size_samples: int,
+        transition: str,
+        emitted_speech_samples: int = 0,
+    ) -> None:
+        self.last_snapshot = VADStateSnapshot(
+            current_sample=self.current_sample,
+            window_size_samples=window_size_samples,
+            speech_prob=float(speech_prob),
+            threshold=float(self.threshold),
+            negative_threshold=float(self.threshold - 0.15),
+            triggered=self.triggered,
+            pre_speech_samples=self._pre_speech_samples,
+            active_speech_samples=self._chunks_num_samples(self.buffer),
+            prefix_samples=self._chunks_num_samples(self.prefix_buffer),
+            temp_end_sample=self.temp_end,
+            transition=transition,
+            emitted_speech_samples=emitted_speech_samples,
+        )
 
     def _trim_pre_speech_buffer(self) -> None:
         while (
@@ -130,31 +174,63 @@ class VADIterator:
             self._pre_speech_buffer.clear()
             self._pre_speech_samples = 0
             self.buffer.append(x)
+            self._update_snapshot(
+                speech_prob=speech_prob,
+                window_size_samples=window_size_samples,
+                transition="speech_start",
+            )
             return None
 
         if not self.triggered:
             self._remember_pre_speech(x)
+            self._update_snapshot(
+                speech_prob=speech_prob,
+                window_size_samples=window_size_samples,
+                transition="silence",
+            )
             return None
 
         if self.triggered:
             self.buffer.append(x)
             if (speech_prob >= self.threshold) and self.temp_end:
                 self.temp_end = 0
+                self._update_snapshot(
+                    speech_prob=speech_prob,
+                    window_size_samples=window_size_samples,
+                    transition="speech_resumed",
+                )
                 return None
 
             if speech_prob < self.threshold - 0.15:
                 if not self.temp_end:
                     self.temp_end = self.current_sample
                 if self.current_sample - self.temp_end < self.min_silence_samples:
+                    self._update_snapshot(
+                        speech_prob=speech_prob,
+                        window_size_samples=window_size_samples,
+                        transition="ending_grace",
+                    )
                     return None
 
                 # End of speech: keep the final low-confidence chunks that were
                 # observed before VAD decided the utterance was done.
+                emitted_speech_samples = len(torch.cat(self.speech_buffer()))
                 self.temp_end = 0
                 self.triggered = False
                 spoken_utterance = self.speech_buffer()
                 self.buffer = []
                 self.prefix_buffer = []
+                self._update_snapshot(
+                    speech_prob=speech_prob,
+                    window_size_samples=window_size_samples,
+                    transition="speech_end",
+                    emitted_speech_samples=emitted_speech_samples,
+                )
                 return spoken_utterance
 
+        self._update_snapshot(
+            speech_prob=speech_prob,
+            window_size_samples=window_size_samples,
+            transition="speech",
+        )
         return None

--- a/src/speech_to_speech/arguments_classes/vad_arguments.py
+++ b/src/speech_to_speech/arguments_classes/vad_arguments.py
@@ -55,3 +55,9 @@ class VADHandlerArguments:
             "help": "Interval (in seconds) for releasing progressive audio chunks during speech. Default is 0.2s."
         },
     )
+    vad_diagnostics_dir: str | None = field(
+        default=None,
+        metadata={
+            "help": "Optional output directory for per-session VAD diagnostics artifacts. Each session writes audio.wav, diagnostics.json, and report.html."
+        },
+    )

--- a/tests/test_vad_diagnostics.py
+++ b/tests/test_vad_diagnostics.py
@@ -1,0 +1,110 @@
+from queue import Queue
+from threading import Event
+import json
+
+import numpy as np
+import torch
+
+from speech_to_speech.VAD.vad_diagnostics import VADDiagnosticsRecorder
+from speech_to_speech.VAD.vad_handler import VADHandler
+from speech_to_speech.VAD.vad_iterator import VADStateSnapshot
+
+
+class _FakeVADModel:
+    def __init__(self, probs: list[float]) -> None:
+        self._probs = iter(probs)
+
+    def reset_states(self) -> None:
+        pass
+
+    def __call__(self, x: torch.Tensor, sampling_rate: int) -> torch.Tensor:
+        return torch.tensor(next(self._probs), dtype=torch.float32)
+
+
+def test_vad_diagnostics_recorder_writes_artifacts(tmp_path):
+    recorder = VADDiagnosticsRecorder(
+        tmp_path,
+        sample_rate=16000,
+        config={"threshold": 0.5},
+    )
+    snapshot = VADStateSnapshot(
+        current_sample=512,
+        window_size_samples=512,
+        speech_prob=0.9,
+        threshold=0.5,
+        negative_threshold=0.35,
+        triggered=True,
+        pre_speech_samples=0,
+        active_speech_samples=512,
+        prefix_samples=0,
+        temp_end_sample=0,
+        transition="speech_start",
+    )
+
+    recorder.record_chunk(np.ones(512, dtype=np.int16), snapshot)
+    recorder.record_event("speech_started", 32.0, audio_start_ms=0.0)
+    session_dir = recorder.flush_session("session_end")
+
+    assert session_dir is not None
+    assert (session_dir / "audio.wav").exists()
+    assert (session_dir / "diagnostics.json").exists()
+    assert (session_dir / "report.html").exists()
+
+    payload = json.loads((session_dir / "diagnostics.json").read_text(encoding="utf-8"))
+    assert payload["flush_reason"] == "session_end"
+    assert payload["chunk_count"] == 1
+    assert payload["frames"][0]["transition"] == "speech_start"
+    report = (session_dir / "report.html").read_text(encoding="utf-8")
+    assert "audio.wav" in report
+    assert "VAD Session Diagnostics" in report
+
+
+def test_vad_handler_flushes_session_diagnostics(tmp_path, monkeypatch):
+    fake_model = _FakeVADModel([0.1, 0.9, 0.9, 0.1, 0.1, 0.1])
+    monkeypatch.setattr(
+        "speech_to_speech.VAD.vad_handler.torch.hub.load",
+        lambda *args, **kwargs: (fake_model, None),
+    )
+
+    should_listen = Event()
+    should_listen.set()
+    handler = VADHandler(
+        stop_event=Event(),
+        queue_in=Queue(),
+        queue_out=Queue(),
+        setup_kwargs={
+            "should_listen": should_listen,
+            "thresh": 0.5,
+            "sample_rate": 16000,
+            "min_silence_ms": 64,
+            "min_speech_ms": 0,
+            "speech_pad_ms": 32,
+            "vad_diagnostics_dir": str(tmp_path),
+            "text_output_queue": Queue(),
+        },
+    )
+
+    chunks = [
+        np.zeros(512, dtype=np.int16),
+        np.ones(512, dtype=np.int16),
+        np.ones(512, dtype=np.int16) * 2,
+        np.zeros(512, dtype=np.int16),
+        np.zeros(512, dtype=np.int16),
+        np.zeros(512, dtype=np.int16),
+    ]
+    for chunk in chunks:
+        list(handler.process(chunk.tobytes()))
+
+    handler.on_session_end()
+
+    session_dirs = [path for path in tmp_path.iterdir() if path.is_dir()]
+    assert len(session_dirs) == 1
+
+    session_dir = session_dirs[0]
+    payload = json.loads((session_dir / "diagnostics.json").read_text(encoding="utf-8"))
+    assert payload["chunk_count"] >= 5
+    assert any(event["kind"] == "speech_started" for event in payload["events"])
+    assert any(event["kind"] == "speech_stopped" for event in payload["events"])
+    assert any(frame["transition"] == "speech_start" for frame in payload["frames"])
+    assert any(frame["triggered"] for frame in payload["frames"])
+    assert any(frame["ending"] for frame in payload["frames"])


### PR DESCRIPTION
## Summary
- add optional per-session VAD diagnostics capture behind `--vad_diagnostics_dir`
- write `audio.wav`, `diagnostics.json`, and a self-contained `report.html` for each completed session
- expose per-frame iterator state so speech decisions, thresholds, and end-of-speech grace periods can be visualized after the run

## Why
VAD tuning is much easier if we can inspect the full recording alongside the raw frame-by-frame VAD state after a session. This adds a lightweight diagnostics path that makes it clear where speech started, where it stayed active, and where the iterator entered its end-of-speech grace period before closing the segment.

## Impact
- normal runs are unchanged unless `--vad_diagnostics_dir` is set
- debug runs produce a session directory with raw audio plus an HTML report for quick inspection
- the report highlights active speech, the end-of-speech grace period, thresholds, and VAD/session events

## Root Cause
The pipeline previously had no durable way to inspect the iterator's internal decisions after the fact, which made it hard to validate VAD behavior or debug false triggers.

## Validation
- `pytest -q tests/test_vad_iterator.py tests/test_vad_diagnostics.py`
- `ruff check VAD/vad_iterator.py VAD/vad_diagnostics.py VAD/vad_handler.py arguments_classes/vad_arguments.py tests/test_vad_diagnostics.py`
- `ruff format --check VAD/vad_iterator.py VAD/vad_diagnostics.py VAD/vad_handler.py arguments_classes/vad_arguments.py tests/test_vad_diagnostics.py`