### PR TITLE
HOTFIX: fix chat history tool_call/function_call_output pairing

### DIFF
--- a/src/speech_to_speech/LLM/chat.py
+++ b/src/speech_to_speech/LLM/chat.py
@@ -1,4 +1,7 @@
+import logging
 from typing import Any
+
+logger = logging.getLogger(__name__)
 
 
 class Chat:
@@ -9,14 +12,73 @@ class Chat:
     def __init__(self, size: int) -> None:
         self.size = size
         self.init_chat_message: dict[str, Any] | None = None
-        # maxlen is necessary pair, since a each new step we add an prompt and assitant answer
+        # ``size`` is the number of user turns to keep.  When exceeded the
+        # oldest complete turn (everything up to the next ``role: "user"``)
+        # is evicted.
         self.buffer: list[dict[str, Any]] = []
+        self._pending_tool_calls: dict[str, dict[str, Any]] = {}
 
     def append(self, item: dict[str, Any]) -> None:
         self.buffer.append(item)
-        if len(self.buffer) == 2 * (self.size + 1):
+        self._track_tool_calls(item)
+        while self._count_user_turns() > self.size:
+            self._evict_oldest_turn()
+
+    def _count_user_turns(self) -> int:
+        return sum(1 for item in self.buffer if item.get("role") == "user")
+
+    def _evict_oldest_turn(self) -> None:
+        """Remove items from the front until the next ``role: "user"`` boundary."""
+        if not self.buffer:
+            return
+        self.buffer.pop(0)
+        while self.buffer and self.buffer[0].get("role") != "user":
             self.buffer.pop(0)
-            self.buffer.pop(0)
+
+    def _track_tool_calls(self, item: dict[str, Any]) -> None:
+        """Register any tool call IDs found in *item* for pending tracking.
+
+        Handles both the Responses API format (``type: "function_call"``) and
+        the Chat Completions / transformers format (``role: "assistant"`` with
+        a ``tool_calls`` list).
+        """
+        if item.get("type") == "function_call" and item.get("call_id"):
+            self._pending_tool_calls[item["call_id"]] = item
+        elif item.get("role") == "assistant" and item.get("tool_calls"):
+            for tc in item["tool_calls"]:
+                tc_id = tc.get("id", "")
+                if tc_id:
+                    self._pending_tool_calls[tc_id] = item
+
+    def _has_call_id_in_buffer(self, call_id: str) -> bool:
+        """Check whether *call_id* exists in the buffer (either format)."""
+        for entry in self.buffer:
+            if entry.get("type") == "function_call" and entry.get("call_id") == call_id:
+                return True
+            if entry.get("role") == "assistant" and entry.get("tool_calls"):
+                for tc in entry["tool_calls"]:
+                    if tc.get("id") == call_id:
+                        return True
+        return False
+
+    def append_tool_output(self, call_id: str, output_item: dict[str, Any]) -> str | None:
+        """Append a ``function_call_output``, re-injecting its ``function_call`` if evicted.
+
+        Returns ``None`` on success or an error message if *call_id* is unknown.
+        """
+        if self._has_call_id_in_buffer(call_id):
+            self._pending_tool_calls.pop(call_id, None)
+            self.append(output_item)
+            return None
+
+        if call_id in self._pending_tool_calls:
+            logger.info("Re-injecting evicted function_call for call_id=%s", call_id)
+            self.append(self._pending_tool_calls.pop(call_id))
+            self.append(output_item)
+            self._pending_tool_calls.pop(call_id, None)
+            return None
+
+        return f"No function_call with call_id '{call_id}' found in conversation history."
 
     def init_chat(self, init_chat_message: dict[str, Any]) -> None:
         self.init_chat_message = init_chat_message
@@ -32,11 +94,13 @@ class Chat:
         clone = Chat(self.size)
         clone.init_chat_message = self.init_chat_message
         clone.buffer = list(self.buffer)
+        clone._pending_tool_calls = dict(self._pending_tool_calls)
         return clone
 
     def reset(self) -> None:
         self.buffer = []
         self.init_chat_message = None
+        self._pending_tool_calls = {}
 
     def strip_images(self) -> None:
         """Remove all image content parts from every message in the buffer.

--- a/src/speech_to_speech/api/openai_realtime/handlers/conversation.py
+++ b/src/speech_to_speech/api/openai_realtime/handlers/conversation.py
@@ -40,8 +40,9 @@ class ConversationHandler(RealtimeBaseHandler):
         events: list[ServerEvent] = []
         item = event.item
 
-        if not self._append_item(conn_id, item):
-            return []
+        error = self._append_item(conn_id, item)
+        if error is not None:
+            return [self.make_error(error, "invalid_conversation_item")]
 
         if item:
             st = self._state(conn_id)
@@ -57,10 +58,10 @@ class ConversationHandler(RealtimeBaseHandler):
 
         return events
 
-    def _append_item(self, conn_id: str, item: ConversationItem) -> bool:
+    def _append_item(self, conn_id: str, item: ConversationItem) -> str | None:
         """Add a conversation item directly to the connection's chat history.
 
-        Returns ``True`` if the item was handled, ``False`` otherwise.
+        Returns ``None`` on success or an error message string on failure.
         """
         st = self._state(conn_id)
 
@@ -68,7 +69,7 @@ class ConversationHandler(RealtimeBaseHandler):
             role = getattr(item, "role", None)
             if not role or role not in ("user", "assistant"):
                 logger.warning("Unsupported message role: %s", role)
-                return False
+                return f"Unsupported message role: {role}"
             content_parts: list[dict] = []
             for part in item.content:  # type: ignore[union-attr]
                 if (part.type == "input_text" and part.text) or (part.type == "input_image" and part.image_url):  # type: ignore[union-attr]
@@ -78,22 +79,25 @@ class ConversationHandler(RealtimeBaseHandler):
             if content_parts:
                 st.runtime_config.chat.append({"role": role, "content": content_parts})
                 logger.debug("Added message to chat (role=%s, %d parts)", role, len(content_parts))
-                return True
-            return False
+                return None
+            return "Message has no supported content parts."
 
         if getattr(item, "type", None) == "function_call_output" and getattr(item, "output", None):
-            st.runtime_config.chat.append(
-                {
-                    "type": "function_call_output",
-                    "call_id": item.call_id,  # type: ignore[union-attr]
-                    "output": item.output,  # type: ignore[union-attr]
-                }
-            )
-            logger.debug("Added function_call_output to chat (call_id=%s)", item.call_id)  # type: ignore[union-attr]
-            return True
+            call_id = item.call_id  # type: ignore[union-attr]
+            output_item = {
+                "type": "function_call_output",
+                "call_id": call_id,
+                "output": item.output,  # type: ignore[union-attr]
+            }
+            error = st.runtime_config.chat.append_tool_output(call_id, output_item)
+            if error:
+                logger.warning("Rejected function_call_output: %s", error)
+                return error
+            logger.debug("Added function_call_output to chat (call_id=%s)", call_id)
+            return None
 
         logger.warning("Unsupported item type: %s", getattr(item, "type", None))
-        return False
+        return f"Unsupported item type: {getattr(item, 'type', None)}"
 
     # ── Pipeline event handlers ────────────────────
 

--- a/src/speech_to_speech/api/openai_realtime/handlers/conversation.py
+++ b/src/speech_to_speech/api/openai_realtime/handlers/conversation.py
@@ -83,7 +83,7 @@ class ConversationHandler(RealtimeBaseHandler):
             return "Message has no supported content parts."
 
         if getattr(item, "type", None) == "function_call_output" and getattr(item, "output", None):
-            call_id = item.call_id  # type: ignore[union-attr]
+            call_id: str = item.call_id or ""  # type: ignore[union-attr]
             output_item = {
                 "type": "function_call_output",
                 "call_id": call_id,

--- a/src/speech_to_speech/api/openai_realtime/handlers/response.py
+++ b/src/speech_to_speech/api/openai_realtime/handlers/response.py
@@ -143,12 +143,14 @@ class ResponseHandler(RealtimeBaseHandler):
                 message="Cannot create response while another response is in progress.",
                 _type="conversation_already_has_active_response",
             )
-        else:
-            st.in_response = True
 
         if event.response and event.response.input:
             for input_item in event.response.input:
-                self._service.conversation._append_item(conn_id, input_item)
+                error = self._service.conversation._append_item(conn_id, input_item)
+                if error is not None:
+                    return self.make_error(message=error, _type="invalid_input_item")
+
+        st.in_response = True
 
         st.current_response_params = event.response
         st.current_response_id = _generate_id("resp")

--- a/tests/openai_realtime/test_realtime_service.py
+++ b/tests/openai_realtime/test_realtime_service.py
@@ -467,9 +467,7 @@ class TestHandleResponseCreate:
         gen_msg = text_prompt_queue.get()
         assert isinstance(gen_msg, GenerateResponseRequest)
 
-    def test_response_create_rejects_invalid_function_call_output_in_input(
-        self, service, conn_id, text_prompt_queue
-    ):
+    def test_response_create_rejects_invalid_function_call_output_in_input(self, service, conn_id, text_prompt_queue):
         evt = ResponseCreateEvent(
             type="response.create",
             response={
@@ -1359,8 +1357,7 @@ class TestChatToolCallTracking:
         return {
             "role": "assistant",
             "tool_calls": [
-                {"type": "function", "id": cid, "function": {"name": f"fn_{cid}", "arguments": {}}}
-                for cid in call_ids
+                {"type": "function", "id": cid, "function": {"name": f"fn_{cid}", "arguments": {}}} for cid in call_ids
             ],
         }
 

--- a/tests/openai_realtime/test_realtime_service.py
+++ b/tests/openai_realtime/test_realtime_service.py
@@ -295,6 +295,9 @@ class TestHandleConversationItemCreate:
         assert e2[0].previous_item_id == "item_1"
 
     def test_function_call_output_forwarded(self, service, conn_id, text_prompt_queue):
+        service._state(conn_id).runtime_config.chat.append(
+            {"type": "function_call", "call_id": "call_1", "name": "get_weather", "arguments": "{}"}
+        )
         evt = ConversationItemCreateEvent(
             type="conversation.item.create",
             item={"type": "function_call_output", "output": '{"result": 42}', "call_id": "call_1"},
@@ -304,6 +307,18 @@ class TestHandleConversationItemCreate:
         assert isinstance(events[0], ConversationItemCreatedEvent)
         chat = service._state(conn_id).runtime_config.chat.to_list()
         assert chat[-1] == {"type": "function_call_output", "call_id": "call_1", "output": '{"result": 42}'}
+
+    def test_function_call_output_rejected_for_unknown_call_id(self, service, conn_id, text_prompt_queue):
+        evt = ConversationItemCreateEvent(
+            type="conversation.item.create",
+            item={"type": "function_call_output", "output": '{"result": 42}', "call_id": "call_unknown"},
+        )
+        events = service.handle_conversation_item_create(conn_id, evt)
+        assert len(events) == 1
+        assert isinstance(events[0], RealtimeErrorEvent)
+        assert "call_unknown" in events[0].error.message
+        chat = service._state(conn_id).runtime_config.chat.to_list()
+        assert not any(entry.get("type") == "function_call_output" for entry in chat)
 
     def test_input_image_forwarded(self, service, conn_id, text_prompt_queue):
         evt = ConversationItemCreateEvent(
@@ -451,6 +466,22 @@ class TestHandleResponseCreate:
         assert isinstance(result, ResponseCreatedEvent)
         gen_msg = text_prompt_queue.get()
         assert isinstance(gen_msg, GenerateResponseRequest)
+
+    def test_response_create_rejects_invalid_function_call_output_in_input(
+        self, service, conn_id, text_prompt_queue
+    ):
+        evt = ResponseCreateEvent(
+            type="response.create",
+            response={
+                "input": [
+                    {"type": "function_call_output", "output": '{"x": 1}', "call_id": "call_bogus"},
+                ],
+            },
+        )
+        result = service.handle_response_create(conn_id, evt)
+        assert isinstance(result, RealtimeErrorEvent)
+        assert "call_bogus" in result.error.message
+        assert service._state(conn_id).in_response is False
 
     def test_double_response_create_rejected(self, service, conn_id, text_prompt_queue):
         """Second response.create is rejected because in_response is set immediately."""
@@ -1239,3 +1270,177 @@ class TestChatImageLifecycle:
         last_user = chat.buffer[-1]
         assert isinstance(last_user["content"], list)
         assert any(p.get("image_url") == "new_url" for p in last_user["content"])
+
+
+# ===================================================================
+# Chat tool call tracking
+# ===================================================================
+
+
+class TestChatToolCallTracking:
+    """Tests for Chat._pending_tool_calls and append_tool_output."""
+
+    def _make_chat(self, size=10):
+        from speech_to_speech.LLM.chat import Chat
+
+        return Chat(size=size)
+
+    def _fc(self, call_id="call_1", name="f1"):
+        return {"type": "function_call", "call_id": call_id, "name": name, "arguments": "{}"}
+
+    def _fco(self, call_id="call_1"):
+        return {"type": "function_call_output", "call_id": call_id, "output": '{"ok": true}'}
+
+    def test_append_registers_pending_tool_call(self):
+        chat = self._make_chat()
+        fc = self._fc()
+        chat.append(fc)
+        assert "call_1" in chat._pending_tool_calls
+        assert chat._pending_tool_calls["call_1"] is fc
+
+    def test_append_tool_output_clears_pending(self):
+        chat = self._make_chat()
+        chat.append(self._fc())
+        assert "call_1" in chat._pending_tool_calls
+        err = chat.append_tool_output("call_1", self._fco())
+        assert err is None
+        assert "call_1" not in chat._pending_tool_calls
+        assert chat.buffer[-1]["type"] == "function_call_output"
+
+    def test_append_tool_output_reinjects_evicted_call(self):
+        chat = self._make_chat(size=1)
+        # size=1 keeps 1 user turn. The 2nd user message evicts the 1st turn
+        # (user + fc + assistant), but _pending_tool_calls retains the fc.
+        chat.append({"role": "user", "content": "hi"})
+        chat.append(self._fc("call_x"))
+        chat.append({"role": "assistant", "content": "ok"})
+        chat.append({"role": "user", "content": "more"})
+        assert not any(e.get("call_id") == "call_x" for e in chat.buffer)
+        assert "call_x" in chat._pending_tool_calls
+
+        err = chat.append_tool_output("call_x", self._fco("call_x"))
+        assert err is None
+        assert "call_x" not in chat._pending_tool_calls
+        types = [e.get("type") for e in chat.buffer]
+        assert "function_call" in types
+        assert "function_call_output" in types
+        fc_idx = next(i for i, e in enumerate(chat.buffer) if e.get("type") == "function_call")
+        fco_idx = next(i for i, e in enumerate(chat.buffer) if e.get("type") == "function_call_output")
+        assert fc_idx < fco_idx
+
+    def test_append_tool_output_rejects_unknown_call_id(self):
+        chat = self._make_chat()
+        err = chat.append_tool_output("call_nope", self._fco("call_nope"))
+        assert err is not None
+        assert "call_nope" in err
+        assert not any(e.get("type") == "function_call_output" for e in chat.buffer)
+
+    def test_copy_preserves_pending_tool_calls(self):
+        chat = self._make_chat()
+        chat.append(self._fc("call_a"))
+        clone = chat.copy()
+        assert "call_a" in clone._pending_tool_calls
+        # Mutating the clone does not affect the original
+        clone._pending_tool_calls.pop("call_a")
+        assert "call_a" in chat._pending_tool_calls
+
+    def test_reset_clears_pending_tool_calls(self):
+        chat = self._make_chat()
+        chat.append(self._fc())
+        assert chat._pending_tool_calls
+        chat.reset()
+        assert chat._pending_tool_calls == {}
+        assert chat.buffer == []
+
+    # -- transformers / Chat Completions tool_calls format --
+
+    def _assistant_with_tool_calls(self, *call_ids):
+        """Build an assistant message with tool_calls (local LLM format)."""
+        return {
+            "role": "assistant",
+            "tool_calls": [
+                {"type": "function", "id": cid, "function": {"name": f"fn_{cid}", "arguments": {}}}
+                for cid in call_ids
+            ],
+        }
+
+    def test_append_registers_pending_from_tool_calls_format(self):
+        chat = self._make_chat()
+        msg = self._assistant_with_tool_calls("tc_1", "tc_2")
+        chat.append(msg)
+        assert "tc_1" in chat._pending_tool_calls
+        assert "tc_2" in chat._pending_tool_calls
+
+    def test_append_tool_output_accepts_tool_calls_format_in_buffer(self):
+        chat = self._make_chat()
+        chat.append(self._assistant_with_tool_calls("tc_1"))
+        err = chat.append_tool_output("tc_1", self._fco("tc_1"))
+        assert err is None
+        assert chat.buffer[-1] == self._fco("tc_1")
+        assert "tc_1" not in chat._pending_tool_calls
+
+    def test_append_tool_output_reinjects_evicted_tool_calls_format(self):
+        chat = self._make_chat(size=1)
+        chat.append({"role": "user", "content": "hi"})
+        chat.append(self._assistant_with_tool_calls("tc_x"))
+        chat.append({"role": "user", "content": "a"})
+        assert not any(e.get("tool_calls") for e in chat.buffer)
+        assert "tc_x" in chat._pending_tool_calls
+
+        err = chat.append_tool_output("tc_x", self._fco("tc_x"))
+        assert err is None
+        assert "tc_x" not in chat._pending_tool_calls
+        assert any(
+            e.get("role") == "assistant" and any(tc.get("id") == "tc_x" for tc in e.get("tool_calls", []))
+            for e in chat.buffer
+        )
+        assert chat.buffer[-1] == self._fco("tc_x")
+
+    # -- turn-based eviction --
+
+    def test_eviction_removes_complete_turn(self):
+        chat = self._make_chat(size=1)
+        chat.append({"role": "user", "content": "turn 1"})
+        chat.append({"role": "assistant", "content": "thinking"})
+        chat.append(self._fc("c1"))
+        chat.append(self._fco("c1"))
+        chat.append({"role": "assistant", "content": "done"})
+        # Still 1 user turn, no eviction yet
+        assert len(chat.buffer) == 5
+
+        chat.append({"role": "user", "content": "turn 2"})
+        # 2 user turns > size=1 → oldest turn fully evicted
+        user_msgs = [e for e in chat.buffer if e.get("role") == "user"]
+        assert len(user_msgs) == 1
+        assert user_msgs[0]["content"] == "turn 2"
+        assert not any(e.get("content") == "thinking" for e in chat.buffer)
+        assert not any(e.get("call_id") == "c1" and e.get("type") == "function_call" for e in chat.buffer)
+
+    def test_eviction_preserves_size_user_turns(self):
+        chat = self._make_chat(size=2)
+        # Turn 1: short
+        chat.append({"role": "user", "content": "t1"})
+        chat.append({"role": "assistant", "content": "r1"})
+        # Turn 2: long (with tool call)
+        chat.append({"role": "user", "content": "t2"})
+        chat.append({"role": "assistant", "content": "let me check"})
+        chat.append(self._fc("c2"))
+        chat.append(self._fco("c2"))
+        chat.append({"role": "assistant", "content": "here"})
+        assert chat._count_user_turns() == 2
+
+        # Turn 3: triggers eviction of turn 1
+        chat.append({"role": "user", "content": "t3"})
+        assert chat._count_user_turns() == 2
+        user_contents = [e["content"] for e in chat.buffer if e.get("role") == "user"]
+        assert user_contents == ["t2", "t3"]
+
+    def test_pending_tool_calls_cleaned_after_reinjection(self):
+        chat = self._make_chat(size=1)
+        chat.append({"role": "user", "content": "hi"})
+        chat.append(self._fc("call_z"))
+        chat.append({"role": "user", "content": "bye"})
+        assert "call_z" in chat._pending_tool_calls
+
+        chat.append_tool_output("call_z", self._fco("call_z"))
+        assert "call_z" not in chat._pending_tool_calls

--- a/tests/test_openai_api_language_model.py
+++ b/tests/test_openai_api_language_model.py
@@ -52,7 +52,7 @@ def _make_response(output, usage=None):
     return resp
 
 
-def _make_handler(*, disable_thinking=False, stream=True, cancel_scope=None):
+def _make_handler(*, disable_thinking=False, stream=True, cancel_scope=None, chat_size=2):
     handler = object.__new__(OpenApiModelHandler)
     handler.model_name = "test-model"
     handler.stream = stream
@@ -63,7 +63,7 @@ def _make_handler(*, disable_thinking=False, stream=True, cancel_scope=None):
     handler.disable_thinking = disable_thinking
     handler._extra_body = {"chat_template_kwargs": {"enable_thinking": False}} if disable_thinking else None
     handler.user_role = "user"
-    handler.chat = Chat(1)
+    handler.chat = Chat(chat_size)
     handler.cancel_scope = cancel_scope
     handler.tools = None
     handler.tools_choice = None


### PR DESCRIPTION
## Summary

- Fix Chat eviction dropping `function_call `items while their `function_call_output` was still pending, causing "unknown call_id" errors during tool-use conversations.

- Rewrite Chat.append eviction from naive pair-count to user-turn-based counting, so tool-call turns (which add extra items beyond the user+assistant pair) no longer corrupt the buffer.

- Add append_tool_output with re-injection: if a function_call was evicted, it is re-inserted before its output so the history stays valid for both OpenAI Responses API and transformers chat template paths.