### PR TITLE
Quiet VAD debug logging

### DIFF
--- a/src/speech_to_speech/VAD/vad_handler.py
+++ b/src/speech_to_speech/VAD/vad_handler.py
@@ -141,7 +141,6 @@ class VADHandler(BaseHandler[VADIn, VADOut]):
         if isinstance(audio_chunk, tuple):
             audio_chunk, runtime_config = audio_chunk
         self._apply_runtime_turn_detection(runtime_config)
-        logger.debug(f"VAD received {len(audio_chunk)} bytes")
 
         if not self.should_listen.is_set():
             return


### PR DESCRIPTION
## Summary
- Remove the per-audio-chunk VAD debug log line.
- Keep the existing throttled VAD summary so debug mode remains useful without flooding logs.

## Impact
Debug logs are less noisy during normal audio streaming while preserving higher-level VAD visibility.

## Validation
- `uv run ruff check src/speech_to_speech/VAD/vad_handler.py`
- `uv run pytest tests/test_vad_iterator.py -q`