### PR TITLE
Keep pipeline main thread alive

### DIFF
--- a/src/speech_to_speech/s2s_pipeline.py
+++ b/src/speech_to_speech/s2s_pipeline.py
@@ -751,6 +751,7 @@ def main() -> None:
 
     try:
         pipeline_manager.start()
+        pipeline_manager.wait()
     except KeyboardInterrupt:
         if not shutdown_requested[0]:
             console.print("\n[yellow]Shutting down gracefully...[/yellow]")

--- a/src/speech_to_speech/utils/thread_manager.py
+++ b/src/speech_to_speech/utils/thread_manager.py
@@ -22,6 +22,10 @@ class ThreadManager:
             self.threads.append(thread)
             thread.start()
 
+    def wait(self) -> None:
+        for thread in self.threads:
+            thread.join()
+
     def stop(self) -> None:
         # Signal all handlers to stop
         for handler in self.handlers:


### PR DESCRIPTION
## Summary

This fixes a realtime startup race where `main()` could return immediately after starting pipeline worker threads. On some machines, Python would begin interpreter shutdown while the realtime server thread was still initializing, causing:

```text
RuntimeError: can't create new thread at interpreter shutdown
```

The pipeline manager now exposes `wait()`, which joins the worker threads after startup, and `s2s_pipeline.main()` calls it so the process lifetime matches the pipeline lifetime.

## Impact

This should not affect steady-state STT, LLM, TTS, websocket, or audio processing latency. It only prevents the main thread from exiting while the pipeline is meant to keep running.

## Validation

Ran the user's realtime command with Parakeet TDT, OpenAI API LLM, and Qwen3 TTS:

```bash
uv run speech-to-speech --thresh 0.6 --log_level debug \
  --stt parakeet-tdt \
  --llm open_api \
  --tts qwen3 \
  --qwen3_tts_mlx_quantization 6bit \
  --open_api_model_name "gpt-5.4-mini" \
  --open_api_api_key "$OPENAI_API_KEY" \
  --open_api_chat_size 30 \
  --open_api_stream \
  --enable_live_transcription \
  --mode realtime
```

Confirmed uvicorn reached `Application startup complete`, `GET /v1/usage` returned JSON, and Ctrl-C shut the pipeline down cleanly.
