### PR TITLE
Remove STT language prompts from LLM context

### DIFF
--- a/README.md
+++ b/README.md
@@ -180,7 +180,7 @@ The pipeline currently supports English, French, Spanish, Chinese, Japanese, and
 Two use cases are considered:
 
 - **Single-language conversation**: Enforce the language setting using the `--language` flag, specifying the target language code (default is 'en').
-- **Language switching**: Set `--language` to 'auto'. In this case, Whisper detects the language for each spoken prompt, and the LLM is prompted with "`Please reply to my message in ...`" to ensure the response is in the detected language.
+- **Automatic language detection**: Set `--language` to 'auto'. In this case, Whisper detects the language for each spoken prompt when supported by the selected STT backend.
 
 Please note that you must use STT and LLM checkpoints compatible with the target language(s). For multilingual TTS, use Melo (English, French, Spanish, Chinese, Japanese, and Korean) or Chat-TTS.
 

--- a/src/speech_to_speech/LLM/README.md
+++ b/src/speech_to_speech/LLM/README.md
@@ -74,11 +74,7 @@ Common options:
 
 ## LLM Behavior
 
-When STT is set to language auto-detection (`--language auto`), LLM handlers can receive `(text, language_code)` and prepend a language control instruction like:
-
-- `Please reply to my message in <language>.`
-
-This helps the assistant respond in the detected language.
+LLM handlers generate responses from the conversation text and configured instructions.
 
 ## Setup
 

--- a/src/speech_to_speech/LLM/language_model.py
+++ b/src/speech_to_speech/LLM/language_model.py
@@ -33,7 +33,7 @@ from speech_to_speech.LLM.chat import Chat
 from speech_to_speech.LLM.tool_call.function_call import extract_function_calls_from_text
 from speech_to_speech.LLM.tool_call.function_tool import FunctionTool
 from speech_to_speech.LLM.tool_call.tool_prompt import END_CODE, ENTER_CODE, build_block_regex, build_tool_system_prompt
-from speech_to_speech.LLM.utils import image_url_to_pil, remove_unspeechable, resolve_auto_language
+from speech_to_speech.LLM.utils import image_url_to_pil, remove_unspeechable
 from speech_to_speech.LLM.voice_prompt import build_voice_system_prompt
 from speech_to_speech.pipeline.cancel_scope import CancelScope
 from speech_to_speech.pipeline.handler_types import LLMIn, LLMOut
@@ -456,7 +456,6 @@ class BaseLanguageModelHandler(BaseHandler[LLMIn, LLMOut], ABC):
             response = req.response
             original_chat = runtime_config.chat
             active_chat = original_chat.copy()
-            language_code = req.language_code
             instructions = (
                 response.instructions if response and response.instructions else runtime_config.session.instructions
             )
@@ -465,18 +464,11 @@ class BaseLanguageModelHandler(BaseHandler[LLMIn, LLMOut], ABC):
                 response.tool_choice if response and response.tool_choice else runtime_config.session.tool_choice
             )
             self._apply_instructions(active_chat, instructions, tools, str(tool_choice) if tool_choice else None, ctx)
-            language_code, lang_name = resolve_auto_language(language_code)
-            if lang_name:
-                active_chat.append({"role": self.user_role, "content": f"Please reply to my message in {lang_name}."})
         elif isinstance(request, Transcription):
             original_chat = self.chat
             active_chat = original_chat
             logger.debug("infering language model...")
-            language_code = request.language_code
             prompt_text = request.text
-            language_code, lang_name = resolve_auto_language(language_code)
-            if lang_name:
-                prompt_text = f"Please reply to my message in {lang_name}. " + prompt_text
             active_chat.append({"role": self.user_role, "content": prompt_text})
         else:
             raise TypeError(f"Unexpected request type: {type(request)}")

--- a/src/speech_to_speech/LLM/openai_api_language_model.py
+++ b/src/speech_to_speech/LLM/openai_api_language_model.py
@@ -20,7 +20,7 @@ from openai.types.responses import (
 
 from speech_to_speech.baseHandler import BaseHandler
 from speech_to_speech.LLM.chat import Chat
-from speech_to_speech.LLM.utils import remove_unspeechable, resolve_auto_language
+from speech_to_speech.LLM.utils import remove_unspeechable
 from speech_to_speech.LLM.voice_prompt import build_voice_system_prompt
 from speech_to_speech.pipeline.cancel_scope import CancelScope
 from speech_to_speech.pipeline.handler_types import LLMIn, LLMOut
@@ -140,7 +140,6 @@ class OpenApiModelHandler(BaseHandler[LLMIn, LLMOut]):
             response = req.response
             original_chat = runtime_config.chat
             active_chat = original_chat.copy()
-            language_code = req.language_code
             instructions = (
                 response.instructions if response and response.instructions else runtime_config.session.instructions
             )
@@ -149,23 +148,11 @@ class OpenApiModelHandler(BaseHandler[LLMIn, LLMOut]):
                 response.tool_choice if response and response.tool_choice else runtime_config.session.tool_choice
             )
             self._apply_config(active_chat, instructions)
-            language_code, lang_name = resolve_auto_language(language_code)
-            if lang_name:
-                active_chat.append(
-                    {
-                        "role": self.user_role,
-                        "content": [{"type": "input_text", "text": f"Please reply to my message in {lang_name}."}],
-                    }
-                )
         elif isinstance(request, Transcription):
             original_chat = self.chat
             active_chat = original_chat
             logger.debug("call api language model...")
-            language_code = request.language_code
             prompt_text = request.text
-            language_code, lang_name = resolve_auto_language(language_code)
-            if lang_name:
-                prompt_text = f"Please reply to my message in {lang_name}. " + prompt_text
             active_chat.append({"role": self.user_role, "content": [{"type": "input_text", "text": prompt_text}]})
         else:
             raise TypeError(f"Unexpected request type: {type(request)}")

--- a/src/speech_to_speech/LLM/utils.py
+++ b/src/speech_to_speech/LLM/utils.py
@@ -1,7 +1,6 @@
 import base64
 import io
 import re
-from typing import Optional
 
 import requests  # type: ignore[import-untyped]
 from PIL import Image
@@ -27,37 +26,6 @@ def remove_unspeechable(text: str) -> str:
     """
     text = text.translate(SMART_PUNCT_TRANSLATION)
     return SPEECHABLE_PATTERN.sub("", text)
-
-
-WHISPER_LANGUAGE_TO_LLM_LANGUAGE = {
-    "en": "english",
-    "fr": "french",
-    "es": "spanish",
-    "zh": "chinese",
-    "ja": "japanese",
-    "ko": "korean",
-    "hi": "hindi",
-    "de": "german",
-    "pt": "portuguese",
-    "pl": "polish",
-    "it": "italian",
-    "nl": "dutch",
-}
-
-
-def resolve_auto_language(language_code: Optional[str]) -> tuple[Optional[str], Optional[str]]:
-    """Strip the ``-auto`` suffix and resolve the human-readable language name.
-
-    Returns ``(clean_code, language_name)``.  ``language_name`` is non-None
-    when the code (with or without ``-auto``) maps to a known language.
-    """
-    if not language_code:
-        return language_code, None
-    if language_code.endswith("-auto"):
-        language_code = language_code[:-5]
-    if language_code not in WHISPER_LANGUAGE_TO_LLM_LANGUAGE:
-        return language_code, None
-    return language_code, WHISPER_LANGUAGE_TO_LLM_LANGUAGE.get(language_code)
 
 
 def image_url_to_pil(image_url: str) -> Image.Image:

--- a/src/speech_to_speech/TTS/README.md
+++ b/src/speech_to_speech/TTS/README.md
@@ -25,7 +25,7 @@ python s2s_pipeline.py \
   --melo_speaker_to_id en
 ```
 
-Language switching can occur automatically when STT emits `(text, language_code)` tuples.
+Language selection is controlled by the TTS handler configuration.
 
 Apple Silicon MPS note:
 - If MeloTTS fails with `Output channels > 65536 not supported at the MPS device`, update macOS first.

--- a/src/speech_to_speech/api/openai_realtime/service.py
+++ b/src/speech_to_speech/api/openai_realtime/service.py
@@ -296,12 +296,7 @@ class RealtimeService:
 
         queue = self.text_prompt_queue
         if queue and transcript:
-            queue.put(
-                GenerateResponseRequest(
-                    runtime_config=cfg,
-                    language_code=event.language_code,
-                )
-            )
+            queue.put(GenerateResponseRequest(runtime_config=cfg))
 
         return events
 

--- a/src/speech_to_speech/pipeline/messages.py
+++ b/src/speech_to_speech/pipeline/messages.py
@@ -118,7 +118,6 @@ class GenerateResponseRequest(PipelineMessage):
     tag: Literal["generate_response"] = "generate_response"
     runtime_config: RuntimeConfig
     response: RealtimeResponseCreateParams | None = None
-    language_code: Optional[str] = None
 
 
 # ── Binary sentinels (audio/output queue) ─────────────────────────────

--- a/tests/test_openai_api_language_model.py
+++ b/tests/test_openai_api_language_model.py
@@ -9,10 +9,11 @@ from openai.types.responses import (
     ResponseTextDeltaEvent,
 )
 
+from speech_to_speech.api.openai_realtime.runtime_config import RuntimeConfig
 from speech_to_speech.LLM.chat import Chat
 from speech_to_speech.LLM.openai_api_language_model import OpenApiModelHandler
 from speech_to_speech.pipeline.cancel_scope import CancelScope
-from speech_to_speech.pipeline.messages import EndOfResponse, LLMResponseChunk, Transcription
+from speech_to_speech.pipeline.messages import EndOfResponse, GenerateResponseRequest, LLMResponseChunk, Transcription
 
 
 def _make_text_delta_event(text):
@@ -167,6 +168,68 @@ def test_no_disable_thinking_omits_extra_body():
     list(handler.process(Transcription(text="Hi")))
 
     assert captured.get("extra_body") is None
+
+
+def test_transcription_language_code_is_not_sent_to_llm_or_chunks():
+    handler = _make_handler()
+    captured = {}
+
+    def fake_create(**kwargs):
+        captured.update(kwargs)
+        return _make_stream(
+            [
+                _make_text_delta_event("Ok."),
+                _make_output_item_done_event(content="Ok."),
+            ]
+        )
+
+    handler.client = SimpleNamespace(responses=SimpleNamespace(create=fake_create))
+
+    outputs = list(handler.process(Transcription(text="Hi", language_code="en-auto")))
+
+    user_messages = [item for item in captured["input"] if item.get("role") == "user"]
+    assert user_messages == [
+        {
+            "type": "message",
+            "role": "user",
+            "content": [{"type": "input_text", "text": "Hi"}],
+        }
+    ]
+    assert "Please reply to my message" not in str(captured["input"])
+    assert "en-auto" not in str(captured["input"])
+
+    chunks = [output for output in outputs if isinstance(output, LLMResponseChunk)]
+    assert chunks[0].language_code is None
+
+
+def test_realtime_generation_does_not_add_language_instruction():
+    handler = _make_handler(stream=False)
+    runtime_config = RuntimeConfig()
+    runtime_config.chat.append({"role": "user", "content": "Hi"})
+    captured = {}
+
+    def fake_create(**kwargs):
+        captured.update(kwargs)
+        return _make_response(
+            output=[
+                SimpleNamespace(
+                    type="message",
+                    role="assistant",
+                    content=[SimpleNamespace(type="output_text", text="Ok.")],
+                )
+            ]
+        )
+
+    handler.client = SimpleNamespace(responses=SimpleNamespace(create=fake_create))
+
+    outputs = list(handler.process(GenerateResponseRequest(runtime_config=runtime_config)))
+
+    user_messages = [item for item in captured["input"] if item.get("role") == "user"]
+    assert user_messages == [{"type": "message", "role": "user", "content": "Hi"}]
+    assert "Please reply to my message" not in str(captured["input"])
+
+    chunks = [output for output in outputs if isinstance(output, LLMResponseChunk)]
+    assert chunks[0].language_code is None
 
 
 def test_second_turn_flattens_assistant_history_for_responses():


### PR DESCRIPTION
## Summary

This removes the synthetic language-control messages that were added to LLM conversations from STT language detection, such as asking the model to reply in the detected language.

The LLM path now treats transcription language metadata as unrelated to response generation. Realtime transcription still emits its transcript event metadata, but `GenerateResponseRequest` no longer carries the STT language code into the LLM handler.

## Changes

- Stop adding language-control user messages in local/MLX and OpenAI API LLM handlers.
- Remove STT language-code propagation from realtime `GenerateResponseRequest`.
- Delete the now-unused LLM language resolver/mapping.
- Update LLM/TTS docs to avoid claiming STT language detection controls response/TTS language.
- Add OpenAI API handler tests covering both transcription and realtime generation paths.

## Validation

```bash
uv run pytest tests/test_openai_api_language_model.py tests/openai_realtime/test_realtime_service.py
```

Result: 101 passed.
