### PR TITLE
Refactor Chat into typed abstraction

### DIFF
--- a/src/speech_to_speech/LLM/chat.py
+++ b/src/speech_to_speech/LLM/chat.py
@@ -1,4 +1,7 @@
+import logging
 from typing import Any
+
+logger = logging.getLogger(__name__)
 
 
 class Chat:
@@ -9,14 +12,73 @@ class Chat:
     def __init__(self, size: int) -> None:
         self.size = size
         self.init_chat_message: dict[str, Any] | None = None
-        # maxlen is necessary pair, since a each new step we add an prompt and assitant answer
+        # ``size`` is the number of user turns to keep.  When exceeded the
+        # oldest complete turn (everything up to the next ``role: "user"``)
+        # is evicted.
         self.buffer: list[dict[str, Any]] = []
+        self._pending_tool_calls: dict[str, dict[str, Any]] = {}
 
     def append(self, item: dict[str, Any]) -> None:
         self.buffer.append(item)
-        if len(self.buffer) == 2 * (self.size + 1):
+        self._track_tool_calls(item)
+        while self._count_user_turns() > self.size:
+            self._evict_oldest_turn()
+
+    def _count_user_turns(self) -> int:
+        return sum(1 for item in self.buffer if item.get("role") == "user")
+
+    def _evict_oldest_turn(self) -> None:
+        """Remove items from the front until the next ``role: "user"`` boundary."""
+        if not self.buffer:
+            return
+        self.buffer.pop(0)
+        while self.buffer and self.buffer[0].get("role") != "user":
             self.buffer.pop(0)
-            self.buffer.pop(0)
+
+    def _track_tool_calls(self, item: dict[str, Any]) -> None:
+        """Register any tool call IDs found in *item* for pending tracking.
+
+        Handles both the Responses API format (``type: "function_call"``) and
+        the Chat Completions / transformers format (``role: "assistant"`` with
+        a ``tool_calls`` list).
+        """
+        if item.get("type") == "function_call" and item.get("call_id"):
+            self._pending_tool_calls[item["call_id"]] = item
+        elif item.get("role") == "assistant" and item.get("tool_calls"):
+            for tc in item["tool_calls"]:
+                tc_id = tc.get("id", "")
+                if tc_id:
+                    self._pending_tool_calls[tc_id] = item
+
+    def _has_call_id_in_buffer(self, call_id: str) -> bool:
+        """Check whether *call_id* exists in the buffer (either format)."""
+        for entry in self.buffer:
+            if entry.get("type") == "function_call" and entry.get("call_id") == call_id:
+                return True
+            if entry.get("role") == "assistant" and entry.get("tool_calls"):
+                for tc in entry["tool_calls"]:
+                    if tc.get("id") == call_id:
+                        return True
+        return False
+
+    def append_tool_output(self, call_id: str, output_item: dict[str, Any]) -> str | None:
+        """Append a ``function_call_output``, re-injecting its ``function_call`` if evicted.
+
+        Returns ``None`` on success or an error message if *call_id* is unknown.
+        """
+        if self._has_call_id_in_buffer(call_id):
+            self._pending_tool_calls.pop(call_id, None)
+            self.append(output_item)
+            return None
+
+        if call_id in self._pending_tool_calls:
+            logger.info("Re-injecting evicted function_call for call_id=%s", call_id)
+            self.append(self._pending_tool_calls.pop(call_id))
+            self.append(output_item)
+            self._pending_tool_calls.pop(call_id, None)
+            return None
+
+        return f"No function_call with call_id '{call_id}' found in conversation history."
 
     def init_chat(self, init_chat_message: dict[str, Any]) -> None:
         self.init_chat_message = init_chat_message
@@ -32,11 +94,13 @@ class Chat:
         clone = Chat(self.size)
         clone.init_chat_message = self.init_chat_message
         clone.buffer = list(self.buffer)
+        clone._pending_tool_calls = dict(self._pending_tool_calls)
         return clone
 
     def reset(self) -> None:
         self.buffer = []
         self.init_chat_message = None
+        self._pending_tool_calls = {}
 
     def strip_images(self) -> None:
         """Remove all image content parts from every message in the buffer.

--- a/src/speech_to_speech/LLM/chat.py
+++ b/src/speech_to_speech/LLM/chat.py
@@ -32,6 +32,7 @@ from openai.types.responses.response_input_param import (
 )
 from openai.types.responses.response_input_text_param import ResponseInputTextParam
 from openai.types.responses.response_output_text_param import ResponseOutputTextParam
+from pydantic import BaseModel
 
 from speech_to_speech.utils.utils import _generate_id
 
@@ -154,7 +155,6 @@ class Chat:
             logger.debug("Added assistant message to chat (%d parts)", len(item.content))
 
         elif isinstance(item, RealtimeConversationItemFunctionCall):
-            item.id = _generate_id("fc")
             if not item.call_id:
                 raise ChatItemError("function_call item is missing a call_id.")
             self.buffer.append(item)
@@ -253,66 +253,58 @@ class Chat:
         User messages containing images keep ``content`` as a list of dicts so
         VLM pipelines can process them.
         """
-        result: list[dict[str, Any]] = []
+        messages: list[TransformersChatMessage] = []
         if self.init_chat_message:
             text = " ".join(p.text for p in self.init_chat_message.content if p.text)
-            result.append({"role": "system", "content": text})
+            messages.append(TransformersSystemMessage(content=text))
         for item in self.buffer:
             if isinstance(item, RealtimeConversationItemUserMessage):
                 has_images = any(p.type == "input_image" for p in item.content)
                 if has_images:
-                    result.append(
-                        {
-                            "role": "user",
-                            "content": [p.model_dump(exclude_none=True) for p in item.content],
-                        }
+                    messages.append(
+                        TransformersUserMessage(content=[p.model_dump(exclude_none=True) for p in item.content])
                     )
                 else:
                     text = " ".join(p.text for p in item.content if p.type == "input_text" and p.text)
-                    result.append({"role": "user", "content": text})
+                    messages.append(TransformersUserMessage(content=text))
             elif isinstance(item, RealtimeConversationItemAssistantMessage):
                 text = " ".join(p.text for p in item.content if p.text)
-                result.append({"role": "assistant", "content": text})
+                messages.append(TransformersAssistantMessage(content=text))
             elif isinstance(item, RealtimeConversationItemFunctionCall):
+                assert item.call_id is not None and item.call_id != ""
                 args: Any = item.arguments
                 try:
                     args = json.loads(args) if isinstance(args, str) else args
                 except (json.JSONDecodeError, TypeError):
                     args = {}
-                result.append(
-                    {
-                        "role": "assistant",
-                        "tool_calls": [
-                            {
-                                "type": "function",
-                                "id": item.call_id,
-                                "function": {
-                                    "name": item.name,
-                                    "arguments": args,
-                                },
-                            }
-                        ],
-                    }
+                messages.append(
+                    TransformersFunctionCallMessage(
+                        tool_calls=[
+                            TransformersToolCall(
+                                id=item.call_id,
+                                function=TransformersToolCallFunction(name=item.name, arguments=args),
+                            )
+                        ]
+                    )
                 )
             elif isinstance(item, RealtimeConversationItemFunctionCallOutput):
                 name = ""
-                for prev in reversed(result):
-                    if prev.get("role") == "assistant" and "tool_calls" in prev:
-                        for tc in prev["tool_calls"]:
-                            if tc.get("id") == item.call_id:
-                                name = tc.get("function", {}).get("name", "")
+                for prev in reversed(messages):
+                    if isinstance(prev, TransformersFunctionCallMessage):
+                        for tc in prev.tool_calls:
+                            if tc.id == item.call_id:
+                                name = tc.function.name
                                 break
                         if name:
                             break
-                result.append(
-                    {
-                        "role": "tool",
-                        "tool_call_id": item.call_id,
-                        "name": name,
-                        "content": item.output,
-                    }
+                messages.append(
+                    TransformersToolMessage(
+                        tool_call_id=item.call_id,
+                        name=name,
+                        content=item.output,
+                    )
                 )
-        return result
+        return [m.model_dump() for m in messages]
 
     def copy(self) -> Chat:
         """Return a shallow snapshot safe for concurrent read access."""
@@ -338,6 +330,58 @@ class Chat:
         for item in self.buffer:
             if isinstance(item, RealtimeConversationItemUserMessage):
                 item.content = [p for p in item.content if p.type != "input_image"]
+
+
+# ---------------------------------------------------------------------------
+# Transformers chat message models
+# ---------------------------------------------------------------------------
+
+
+class TransformersToolCallFunction(BaseModel):
+    name: str
+    arguments: dict[str, Any]
+
+
+class TransformersToolCall(BaseModel):
+    type: Literal["function"] = "function"
+    id: str
+    function: TransformersToolCallFunction
+
+
+class TransformersSystemMessage(BaseModel):
+    role: Literal["system"] = "system"
+    content: str
+
+
+class TransformersUserMessage(BaseModel):
+    role: Literal["user"] = "user"
+    content: str | list[dict[str, Any]]
+
+
+class TransformersAssistantMessage(BaseModel):
+    role: Literal["assistant"] = "assistant"
+    content: str
+
+
+class TransformersFunctionCallMessage(BaseModel):
+    role: Literal["assistant"] = "assistant"
+    tool_calls: list[TransformersToolCall]
+
+
+class TransformersToolMessage(BaseModel):
+    role: Literal["tool"] = "tool"
+    tool_call_id: str
+    name: str
+    content: str
+
+
+TransformersChatMessage = Union[
+    TransformersSystemMessage,
+    TransformersUserMessage,
+    TransformersAssistantMessage,
+    TransformersFunctionCallMessage,
+    TransformersToolMessage,
+]
 
 
 # ---------------------------------------------------------------------------

--- a/src/speech_to_speech/LLM/chat.py
+++ b/src/speech_to_speech/LLM/chat.py
@@ -129,12 +129,14 @@ class Chat:
         """
 
         if isinstance(item, RealtimeConversationItemSystemMessage):
-            item.id = _generate_id("sys")
+            if item.id is None or not item.id.startswith("sys_"):
+                item.id = _generate_id("sys")
             self.init_chat(item)
             logger.debug("Set system message via conversation item")
 
         elif isinstance(item, RealtimeConversationItemUserMessage):
-            item.id = _generate_id("msg")
+            if item.id is None or not item.id.startswith("msg_"):
+                item.id = _generate_id("msg")
             item.content = [
                 p
                 for p in item.content
@@ -147,7 +149,8 @@ class Chat:
             logger.debug("Added user message to chat (%d parts)", len(item.content))
 
         elif isinstance(item, RealtimeConversationItemAssistantMessage):
-            item.id = _generate_id("msg")
+            if item.id is None or not item.id.startswith("msg_"):
+                item.id = _generate_id("msg")
             item.content = [p for p in item.content if p.type == "output_text" and p.text]
             if not item.content:
                 raise ChatItemError("Assistant message has no text content.")
@@ -155,14 +158,17 @@ class Chat:
             logger.debug("Added assistant message to chat (%d parts)", len(item.content))
 
         elif isinstance(item, RealtimeConversationItemFunctionCall):
-            if not item.call_id:
-                raise ChatItemError("function_call item is missing a call_id.")
+            if item.id is None or not item.id.startswith("fc_"):
+                item.id = _generate_id("fc")
+            if item.call_id is None or not item.call_id.startswith("call_"):
+                item.call_id = _generate_id("call")
             self.buffer.append(item)
             self._pending_tool_calls[item.call_id] = item
             logger.debug("Added function_call to chat (call_id=%s)", item.call_id)
 
         elif isinstance(item, RealtimeConversationItemFunctionCallOutput):
-            item.id = _generate_id("fco")
+            if item.id is None or not item.id.startswith("fco_"):
+                item.id = _generate_id("fco")
             self.append_tool_output(item.call_id, item)
             logger.debug("Added function_call_output to chat (call_id=%s)", item.call_id)
 

--- a/src/speech_to_speech/LLM/chat.py
+++ b/src/speech_to_speech/LLM/chat.py
@@ -43,6 +43,14 @@ class ChatItemError(Exception):
     """Raised when a conversation item fails validation in :meth:`Chat.add_item`."""
 
 
+def _ensure_id(value: str | None, prefix: str) -> str:
+    if value is None:
+        return _generate_id(prefix)
+    if not value.startswith(f"{prefix}_"):
+        raise ChatItemError(f"ID must start with '{prefix}_', got {value!r}")
+    return value
+
+
 SupportedItem = Union[
     RealtimeConversationItemSystemMessage,
     RealtimeConversationItemUserMessage,
@@ -129,14 +137,12 @@ class Chat:
         """
 
         if isinstance(item, RealtimeConversationItemSystemMessage):
-            if item.id is None or not item.id.startswith("sys_"):
-                item.id = _generate_id("sys")
+            item.id = _ensure_id(item.id, "sys")
             self.init_chat(item)
             logger.debug("Set system message via conversation item")
 
         elif isinstance(item, RealtimeConversationItemUserMessage):
-            if item.id is None or not item.id.startswith("msg_"):
-                item.id = _generate_id("msg")
+            item.id = _ensure_id(item.id, "msg")
             item.content = [
                 p
                 for p in item.content
@@ -149,8 +155,7 @@ class Chat:
             logger.debug("Added user message to chat (%d parts)", len(item.content))
 
         elif isinstance(item, RealtimeConversationItemAssistantMessage):
-            if item.id is None or not item.id.startswith("msg_"):
-                item.id = _generate_id("msg")
+            item.id = _ensure_id(item.id, "msg")
             item.content = [p for p in item.content if p.type == "output_text" and p.text]
             if not item.content:
                 raise ChatItemError("Assistant message has no text content.")
@@ -158,17 +163,14 @@ class Chat:
             logger.debug("Added assistant message to chat (%d parts)", len(item.content))
 
         elif isinstance(item, RealtimeConversationItemFunctionCall):
-            if item.id is None or not item.id.startswith("fc_"):
-                item.id = _generate_id("fc")
-            if item.call_id is None or not item.call_id.startswith("call_"):
-                item.call_id = _generate_id("call")
+            item.id = _ensure_id(item.id, "fc")
+            item.call_id = _ensure_id(item.call_id, "call")
             self.buffer.append(item)
             self._pending_tool_calls[item.call_id] = item
             logger.debug("Added function_call to chat (call_id=%s)", item.call_id)
 
         elif isinstance(item, RealtimeConversationItemFunctionCallOutput):
-            if item.id is None or not item.id.startswith("fco_"):
-                item.id = _generate_id("fco")
+            item.id = _ensure_id(item.id, "fco")
             self.append_tool_output(item.call_id, item)
             logger.debug("Added function_call_output to chat (call_id=%s)", item.call_id)
 

--- a/src/speech_to_speech/LLM/chat.py
+++ b/src/speech_to_speech/LLM/chat.py
@@ -1,122 +1,369 @@
+from __future__ import annotations
+
+import json
 import logging
-from typing import Any
+from typing import Any, Literal, Union
+
+from openai.types.realtime.conversation_item import (
+    RealtimeConversationItemAssistantMessage,
+    RealtimeConversationItemFunctionCall,
+    RealtimeConversationItemFunctionCallOutput,
+    RealtimeConversationItemSystemMessage,
+    RealtimeConversationItemUserMessage,
+)
+from openai.types.realtime.realtime_conversation_item_assistant_message import (
+    Content as AssistantContent,
+)
+from openai.types.realtime.realtime_conversation_item_system_message import Content as SystemContent
+from openai.types.realtime.realtime_conversation_item_user_message import Content as UserContent
+from openai.types.responses.response_input_image_param import ResponseInputImageParam
+from openai.types.responses.response_input_message_content_list_param import (
+    ResponseInputMessageContentListParam,
+)
+from openai.types.responses.response_input_param import (
+    FunctionCallOutput,
+    ResponseFunctionToolCallParam,
+    ResponseInputItemParam,
+    ResponseInputParam,
+    ResponseOutputMessageParam,
+)
+from openai.types.responses.response_input_param import (
+    Message as ResponseMessage,
+)
+from openai.types.responses.response_input_text_param import ResponseInputTextParam
+from openai.types.responses.response_output_text_param import ResponseOutputTextParam
+
+from speech_to_speech.utils.utils import _generate_id
 
 logger = logging.getLogger(__name__)
 
 
+class ChatItemError(Exception):
+    """Raised when a conversation item fails validation in :meth:`Chat.add_item`."""
+
+
+SupportedItem = Union[
+    RealtimeConversationItemSystemMessage,
+    RealtimeConversationItemUserMessage,
+    RealtimeConversationItemAssistantMessage,
+    RealtimeConversationItemFunctionCall,
+    RealtimeConversationItemFunctionCallOutput,
+]
+
+
 class Chat:
-    """
-    Handles the chat using to avoid OOM issues.
+    """Manages conversation history with bounded size to avoid OOM issues.
+
+    The buffer stores ``ConversationItem`` objects (user messages, assistant
+    messages, function calls, function call outputs).  System messages are
+    stored separately in ``init_chat_message`` and never placed in the buffer.
     """
 
     def __init__(self, size: int) -> None:
         self.size = size
-        self.init_chat_message: dict[str, Any] | None = None
+        self.init_chat_message: RealtimeConversationItemSystemMessage | None = None
         # ``size`` is the number of user turns to keep.  When exceeded the
-        # oldest complete turn (everything up to the next ``role: "user"``)
+        # oldest complete turn (everything up to the next user message)
         # is evicted.
-        self.buffer: list[dict[str, Any]] = []
-        self._pending_tool_calls: dict[str, dict[str, Any]] = {}
-
-    def append(self, item: dict[str, Any]) -> None:
-        self.buffer.append(item)
-        self._track_tool_calls(item)
-        while self._count_user_turns() > self.size:
-            self._evict_oldest_turn()
-
-    def _count_user_turns(self) -> int:
-        return sum(1 for item in self.buffer if item.get("role") == "user")
+        self.buffer: list[SupportedItem] = []
+        self._pending_tool_calls: dict[str, RealtimeConversationItemFunctionCall] = {}
+        self._user_turn_count: int = 0
 
     def _evict_oldest_turn(self) -> None:
-        """Remove items from the front until the next ``role: "user"`` boundary."""
+        """Remove items from the front until the next user message boundary."""
         if not self.buffer:
             return
-        self.buffer.pop(0)
-        while self.buffer and self.buffer[0].get("role") != "user":
+        first = self.buffer.pop(0)
+        if isinstance(first, RealtimeConversationItemUserMessage):
+            self._user_turn_count -= 1
+        while self.buffer and not isinstance(self.buffer[0], RealtimeConversationItemUserMessage):
             self.buffer.pop(0)
 
-    def _track_tool_calls(self, item: dict[str, Any]) -> None:
-        """Register any tool call IDs found in *item* for pending tracking.
-
-        Handles both the Responses API format (``type: "function_call"``) and
-        the Chat Completions / transformers format (``role: "assistant"`` with
-        a ``tool_calls`` list).
-        """
-        if item.get("type") == "function_call" and item.get("call_id"):
-            self._pending_tool_calls[item["call_id"]] = item
-        elif item.get("role") == "assistant" and item.get("tool_calls"):
-            for tc in item["tool_calls"]:
-                tc_id = tc.get("id", "")
-                if tc_id:
-                    self._pending_tool_calls[tc_id] = item
-
     def _has_call_id_in_buffer(self, call_id: str) -> bool:
-        """Check whether *call_id* exists in the buffer (either format)."""
         for entry in self.buffer:
-            if entry.get("type") == "function_call" and entry.get("call_id") == call_id:
+            if isinstance(entry, RealtimeConversationItemFunctionCall) and entry.call_id == call_id:
                 return True
-            if entry.get("role") == "assistant" and entry.get("tool_calls"):
-                for tc in entry["tool_calls"]:
-                    if tc.get("id") == call_id:
-                        return True
         return False
 
-    def append_tool_output(self, call_id: str, output_item: dict[str, Any]) -> str | None:
+    def _mark_call_completed(
+        self, call_id: str, status: Literal["completed", "incomplete", "in_progress"] | None = None
+    ) -> None:
+        """Set ``status`` to ``"completed"`` on the matching function_call."""
+        for entry in self.buffer:
+            if isinstance(entry, RealtimeConversationItemFunctionCall) and entry.call_id == call_id:
+                entry.status = "completed" if status is None else status
+                return
+
+    def append_tool_output(self, call_id: str, output_item: RealtimeConversationItemFunctionCallOutput) -> None:
         """Append a ``function_call_output``, re-injecting its ``function_call`` if evicted.
 
-        Returns ``None`` on success or an error message if *call_id* is unknown.
+        Also marks the paired ``function_call`` as ``"completed"`` if its
+        status was ``None``.
+
+        Raises :class:`ChatItemError` if *call_id* is unknown.
         """
         if self._has_call_id_in_buffer(call_id):
             self._pending_tool_calls.pop(call_id, None)
-            self.append(output_item)
-            return None
+            self._mark_call_completed(call_id, output_item.status)
+            self.buffer.append(output_item)
+            return
 
         if call_id in self._pending_tool_calls:
             logger.info("Re-injecting evicted function_call for call_id=%s", call_id)
-            self.append(self._pending_tool_calls.pop(call_id))
-            self.append(output_item)
-            self._pending_tool_calls.pop(call_id, None)
-            return None
+            fc = self._pending_tool_calls.pop(call_id)
+            fc.status = "completed" if output_item.status is None else output_item.status
+            self.buffer.append(fc)
+            self.buffer.append(output_item)
+            return
 
-        return f"No function_call with call_id '{call_id}' found in conversation history."
+        raise ChatItemError(f"No function_call with call_id '{call_id}' found in conversation history.")
 
-    def init_chat(self, init_chat_message: dict[str, Any]) -> None:
-        self.init_chat_message = init_chat_message
+    def init_chat(self, message: RealtimeConversationItemSystemMessage) -> None:
+        self.init_chat_message = message
 
-    def to_list(self) -> list[dict[str, Any]]:
-        if self.init_chat_message:
-            return [self.init_chat_message] + self.buffer
+    def add_item(self, item: SupportedItem) -> SupportedItem:
+        """Validate and route a conversation item into the chat.
+
+        Raises :class:`ChatItemError` if the item fails validation.
+        """
+
+        if isinstance(item, RealtimeConversationItemSystemMessage):
+            item.id = _generate_id("sys")
+            self.init_chat(item)
+            logger.debug("Set system message via conversation item")
+
+        elif isinstance(item, RealtimeConversationItemUserMessage):
+            item.id = _generate_id("msg")
+            item.content = [
+                p
+                for p in item.content
+                if (p.type == "input_text" and p.text) or (p.type == "input_image" and p.image_url)
+            ]
+            if not item.content:
+                raise ChatItemError("Message has no supported content. Supported modalities: input_text, input_image.")
+            self.buffer.append(item)
+            self._user_turn_count += 1
+            logger.debug("Added user message to chat (%d parts)", len(item.content))
+
+        elif isinstance(item, RealtimeConversationItemAssistantMessage):
+            item.id = _generate_id("msg")
+            item.content = [p for p in item.content if p.type == "output_text" and p.text]
+            if not item.content:
+                raise ChatItemError("Assistant message has no text content.")
+            self.buffer.append(item)
+            logger.debug("Added assistant message to chat (%d parts)", len(item.content))
+
+        elif isinstance(item, RealtimeConversationItemFunctionCall):
+            item.id = _generate_id("fc")
+            if not item.call_id:
+                raise ChatItemError("function_call item is missing a call_id.")
+            self.buffer.append(item)
+            self._pending_tool_calls[item.call_id] = item
+            logger.debug("Added function_call to chat (call_id=%s)", item.call_id)
+
+        elif isinstance(item, RealtimeConversationItemFunctionCallOutput):
+            item.id = _generate_id("fco")
+            self.append_tool_output(item.call_id, item)
+            logger.debug("Added function_call_output to chat (call_id=%s)", item.call_id)
+
         else:
-            return self.buffer
+            raise ChatItemError(f"Unsupported item type: {getattr(item, 'type', None)}")
 
-    def copy(self) -> "Chat":
+        while self._user_turn_count > self.size:
+            self._evict_oldest_turn()
+
+        return item
+
+    def to_response_api_chat(self) -> ResponseInputParam:
+        """Serialize the full chat (system prompt + buffer) for the OpenAI Responses API."""
+        result: list[ResponseInputItemParam] = []
+        if self.init_chat_message:
+            result.append(
+                ResponseMessage(
+                    content=[
+                        ResponseInputTextParam(text=p.text or "A helpful AI assistant.", type="input_text")
+                        for p in self.init_chat_message.content
+                    ],
+                    role="system",
+                    type="message",
+                )
+            )
+        for item in self.buffer:
+            assert item.id is not None and item.id != "", f"item.id is {item.id}"
+            if isinstance(item, RealtimeConversationItemUserMessage):
+                content: ResponseInputMessageContentListParam = []
+                for user_part in item.content:
+                    if user_part.type == "input_text" and user_part.text is not None:
+                        content.append(ResponseInputTextParam(text=user_part.text or "", type="input_text"))
+                    elif user_part.type == "input_image" and user_part.image_url is not None:
+                        img = ResponseInputImageParam(type="input_image", detail=user_part.detail or "auto")
+                        if user_part.image_url is not None:
+                            img["image_url"] = user_part.image_url
+                        content.append(img)
+                if content:
+                    result.append(ResponseMessage(content=content, role="user", type="message"))
+            elif isinstance(item, RealtimeConversationItemAssistantMessage):
+                assistant_content: list[ResponseOutputTextParam] = []
+                for assistant_part in item.content:
+                    if assistant_part.type == "output_text" and assistant_part.text is not None:
+                        assistant_content.append(
+                            ResponseOutputTextParam(text=assistant_part.text, type="output_text", annotations=[])
+                        )
+                if assistant_content:
+                    result.append(
+                        ResponseOutputMessageParam(
+                            id=item.id,
+                            content=assistant_content,
+                            role="assistant",
+                            status=item.status or "completed",
+                            type="message",
+                        )
+                    )
+            elif isinstance(item, RealtimeConversationItemFunctionCall) and item.call_id is not None:
+                assert item.call_id is not None and item.call_id != ""
+                function_call = ResponseFunctionToolCallParam(
+                    arguments=item.arguments,
+                    call_id=item.call_id,
+                    name=item.name,
+                    type="function_call",
+                    id=item.id,
+                )
+                if item.id is not None:
+                    function_call["id"] = item.id
+                if item.status is not None:
+                    function_call["status"] = item.status
+                result.append(function_call)
+            elif isinstance(item, RealtimeConversationItemFunctionCallOutput):
+                function_call_output = FunctionCallOutput(
+                    call_id=item.call_id,
+                    output=item.output,
+                    type="function_call_output",
+                )
+                if item.id is not None:
+                    function_call_output["id"] = item.id
+                if item.status is not None:
+                    function_call_output["status"] = item.status
+                result.append(function_call_output)
+        return result
+
+    def to_transformers_chat(self) -> list[dict[str, Any]]:
+        """Serialize the full chat for HuggingFace transformers ``apply_chat_template``.
+
+        User messages with only text produce a plain string ``content`` value.
+        User messages containing images keep ``content`` as a list of dicts so
+        VLM pipelines can process them.
+        """
+        result: list[dict[str, Any]] = []
+        if self.init_chat_message:
+            text = " ".join(p.text for p in self.init_chat_message.content if p.text)
+            result.append({"role": "system", "content": text})
+        for item in self.buffer:
+            if isinstance(item, RealtimeConversationItemUserMessage):
+                has_images = any(p.type == "input_image" for p in item.content)
+                if has_images:
+                    result.append(
+                        {
+                            "role": "user",
+                            "content": [p.model_dump(exclude_none=True) for p in item.content],
+                        }
+                    )
+                else:
+                    text = " ".join(p.text for p in item.content if p.type == "input_text" and p.text)
+                    result.append({"role": "user", "content": text})
+            elif isinstance(item, RealtimeConversationItemAssistantMessage):
+                text = " ".join(p.text for p in item.content if p.text)
+                result.append({"role": "assistant", "content": text})
+            elif isinstance(item, RealtimeConversationItemFunctionCall):
+                args: Any = item.arguments
+                try:
+                    args = json.loads(args) if isinstance(args, str) else args
+                except (json.JSONDecodeError, TypeError):
+                    args = {}
+                result.append(
+                    {
+                        "role": "assistant",
+                        "tool_calls": [
+                            {
+                                "type": "function",
+                                "id": item.call_id,
+                                "function": {
+                                    "name": item.name,
+                                    "arguments": args,
+                                },
+                            }
+                        ],
+                    }
+                )
+            elif isinstance(item, RealtimeConversationItemFunctionCallOutput):
+                name = ""
+                for prev in reversed(result):
+                    if prev.get("role") == "assistant" and "tool_calls" in prev:
+                        for tc in prev["tool_calls"]:
+                            if tc.get("id") == item.call_id:
+                                name = tc.get("function", {}).get("name", "")
+                                break
+                        if name:
+                            break
+                result.append(
+                    {
+                        "role": "tool",
+                        "tool_call_id": item.call_id,
+                        "name": name,
+                        "content": item.output,
+                    }
+                )
+        return result
+
+    def copy(self) -> Chat:
         """Return a shallow snapshot safe for concurrent read access."""
         clone = Chat(self.size)
         clone.init_chat_message = self.init_chat_message
         clone.buffer = list(self.buffer)
         clone._pending_tool_calls = dict(self._pending_tool_calls)
+        clone._user_turn_count = self._user_turn_count
         return clone
 
     def reset(self) -> None:
         self.buffer = []
         self.init_chat_message = None
         self._pending_tool_calls = {}
+        self._user_turn_count = 0
 
     def strip_images(self) -> None:
-        """Remove all image content parts from every message in the buffer.
+        """Remove all image content parts from user messages in the buffer.
 
         Called after appending the assistant response so images don't persist
-        across turns.  Handles both Realtime-style ``input_image`` and
-        Chat Completions-style ``image_url`` types.
+        across turns.
         """
-        _IMAGE_TYPES = {"input_image", "image_url"}
-        for msg in self.buffer:
-            content = msg.get("content")
-            if not isinstance(content, list):
-                continue
-            text_parts = [
-                p
-                for p in content
-                if (p.get("type") if isinstance(p, dict) else getattr(p, "type", None)) not in _IMAGE_TYPES
-            ]
-            msg["content"] = text_parts
+        for item in self.buffer:
+            if isinstance(item, RealtimeConversationItemUserMessage):
+                item.content = [p for p in item.content if p.type != "input_image"]
+
+
+# ---------------------------------------------------------------------------
+# Factory helpers -- hide verbose constructors behind simple calls
+# ---------------------------------------------------------------------------
+
+
+def make_user_message(text: str) -> RealtimeConversationItemUserMessage:
+    return RealtimeConversationItemUserMessage(
+        type="message",
+        role="user",
+        content=[UserContent(type="input_text", text=text)],
+    )
+
+
+def make_assistant_message(text: str) -> RealtimeConversationItemAssistantMessage:
+    return RealtimeConversationItemAssistantMessage(
+        type="message",
+        role="assistant",
+        content=[AssistantContent(type="output_text", text=text)],
+    )
+
+
+def make_system_message(text: str) -> RealtimeConversationItemSystemMessage:
+    return RealtimeConversationItemSystemMessage(
+        type="message",
+        role="system",
+        content=[SystemContent(type="input_text", text=text)],
+    )

--- a/src/speech_to_speech/LLM/chat.py
+++ b/src/speech_to_speech/LLM/chat.py
@@ -158,7 +158,7 @@ class Chat:
             item.id = _ensure_id(item.id, "msg")
             item.content = [p for p in item.content if p.type == "output_text" and p.text]
             if not item.content:
-                raise ChatItemError("Assistant message has no text content.")
+                return item
             self.buffer.append(item)
             logger.debug("Added assistant message to chat (%d parts)", len(item.content))
 

--- a/src/speech_to_speech/LLM/language_model.py
+++ b/src/speech_to_speech/LLM/language_model.py
@@ -1,6 +1,5 @@
 from __future__ import annotations
 
-import json
 import logging
 from abc import ABC, abstractmethod
 from collections.abc import Iterable, Iterator, Sized
@@ -10,6 +9,9 @@ from typing import Any, Literal, Optional, Protocol, runtime_checkable
 
 import torch
 from nltk import sent_tokenize
+from openai.types.realtime.realtime_conversation_item_function_call import (
+    RealtimeConversationItemFunctionCall,
+)
 from openai.types.realtime.realtime_response_create_params import RealtimeResponseCreateParams
 from openai.types.responses import ResponseFunctionToolCall
 from pydantic import BaseModel, ConfigDict, Field
@@ -29,7 +31,7 @@ from transformers import (
 
 from speech_to_speech.api.openai_realtime.runtime_config import RuntimeConfig
 from speech_to_speech.baseHandler import BaseHandler
-from speech_to_speech.LLM.chat import Chat
+from speech_to_speech.LLM.chat import Chat, make_assistant_message, make_system_message, make_user_message
 from speech_to_speech.LLM.tool_call.function_call import extract_function_calls_from_text
 from speech_to_speech.LLM.tool_call.function_tool import FunctionTool
 from speech_to_speech.LLM.tool_call.tool_prompt import END_CODE, ENTER_CODE, build_block_regex, build_tool_system_prompt
@@ -42,7 +44,6 @@ from speech_to_speech.pipeline.messages import (
     GenerateResponseRequest,
     LLMResponseChunk,
     TokenUsage,
-    Transcription,
 )
 
 try:
@@ -145,13 +146,11 @@ class BaseLanguageModelHandler(BaseHandler[LLMIn, LLMOut], ABC):
         torch_dtype: str = "float16",
         gen_kwargs: dict[str, Any] = {},
         user_role: str = "user",
-        chat_size: int = 1,
-        init_chat_role: Optional[str] = None,
-        init_chat_prompt: str = "You are a helpful AI assistant.",
         cancel_scope: CancelScope | None = None,
         backend: Literal["transformers", "mlx"] = "transformers",
         enable_thinking: bool = False,
         stream_batch_sentences: int = 3,
+        **_kwargs: Any,
     ) -> None:
         self.backend = backend
         self.cancel_scope = cancel_scope
@@ -161,14 +160,6 @@ class BaseLanguageModelHandler(BaseHandler[LLMIn, LLMOut], ABC):
         self.stream_batch_sentences = max(1, stream_batch_sentences)
 
         self._load_model(model_name, device, torch_dtype, gen_kwargs)
-
-        # TODO: chat is not used in the realtime pipeline, but still need to be kept for backward compatibility. Remove it in the future.
-        self.chat = Chat(chat_size)
-        if init_chat_role:
-            if not init_chat_prompt:
-                raise ValueError("An initial promt needs to be specified when setting init_chat_role.")
-            full_prompt = build_voice_system_prompt(init_chat_prompt)
-            self.chat.init_chat({"role": init_chat_role, "content": full_prompt})
 
         self.user_role = user_role
 
@@ -216,63 +207,6 @@ class BaseLanguageModelHandler(BaseHandler[LLMIn, LLMOut], ABC):
     # Shared helpers
     # ------------------------------------------------------------------
 
-    @staticmethod
-    def _prepare_chat_for_transformers(chat_messages: list[dict[str, Any]]) -> list[dict[str, Any]]:
-        """Convert Responses-API-style tool items to the transformers chat format.
-
-        - ``function_call_output`` items become ``{"role": "tool", ...}``
-        - Messages with ``tool_calls`` and regular messages pass through as-is
-        - ``function_call`` items (from the OpenAI Responses API path) are
-          converted to assistant messages with ``tool_calls``
-        """
-        result: list[dict[str, Any]] = []
-        for msg in chat_messages:
-            item_type = msg.get("type")
-            if item_type == "function_call_output":
-                call_id = msg.get("call_id", "")
-                name = ""
-                for prev in reversed(result):
-                    if prev.get("role") == "assistant" and "tool_calls" in prev:
-                        for tc in prev["tool_calls"]:
-                            if tc.get("id") == call_id:
-                                name = tc.get("function", {}).get("name", "")
-                                break
-                        if name:
-                            break
-                result.append(
-                    {
-                        "role": "tool",
-                        "tool_call_id": call_id,
-                        "name": name,
-                        "content": msg.get("output", ""),
-                    }
-                )
-            elif item_type == "function_call":
-                args = msg.get("arguments", "{}")
-                if isinstance(args, str):
-                    try:
-                        args = json.loads(args)
-                    except (json.JSONDecodeError, TypeError):
-                        args = {}
-                result.append(
-                    {
-                        "role": "assistant",
-                        "tool_calls": [
-                            {
-                                "type": "function",
-                                "id": msg.get("call_id", ""),
-                                "function": {
-                                    "name": msg.get("name", ""),
-                                    "arguments": args,
-                                },
-                            }
-                        ],
-                    }
-                )
-            else:
-                result.append(msg)
-        return result
-
     def _apply_instructions(
         self,
         chat: Chat,
@@ -300,7 +234,7 @@ class BaseLanguageModelHandler(BaseHandler[LLMIn, LLMOut], ABC):
             enter_code = None
             end_code = None
 
-        chat.init_chat({"role": "system", "content": full_instructions})
+        chat.add_item(make_system_message(full_instructions))
 
         if ctx is not None:
             ctx.function_tools = function_tools
@@ -445,41 +379,25 @@ class BaseLanguageModelHandler(BaseHandler[LLMIn, LLMOut], ABC):
     # ------------------------------------------------------------------
 
     def process(self, request: LLMIn) -> Iterator[LLMOut]:
-        language_code = None
-        runtime_config = None
-        response = None
         ctx = StreamContext()
 
-        if isinstance(request, GenerateResponseRequest):
-            req = request
-            runtime_config = req.runtime_config
-            response = req.response
-            original_chat = runtime_config.chat
-            active_chat = original_chat.copy()
-            language_code = req.language_code
-            instructions = (
-                response.instructions if response and response.instructions else runtime_config.session.instructions
-            )
-            tools = response.tools if response and response.tools else runtime_config.session.tools
-            tool_choice = (
-                response.tool_choice if response and response.tool_choice else runtime_config.session.tool_choice
-            )
-            self._apply_instructions(active_chat, instructions, tools, str(tool_choice) if tool_choice else None, ctx)
-            language_code, lang_name = resolve_auto_language(language_code)
-            if lang_name:
-                active_chat.append({"role": self.user_role, "content": f"Please reply to my message in {lang_name}."})
-        elif isinstance(request, Transcription):
-            original_chat = self.chat
-            active_chat = original_chat
-            logger.debug("infering language model...")
-            language_code = request.language_code
-            prompt_text = request.text
-            language_code, lang_name = resolve_auto_language(language_code)
-            if lang_name:
-                prompt_text = f"Please reply to my message in {lang_name}. " + prompt_text
-            active_chat.append({"role": self.user_role, "content": prompt_text})
-        else:
+        if not isinstance(request, GenerateResponseRequest):
             raise TypeError(f"Unexpected request type: {type(request)}")
+
+        runtime_config = request.runtime_config
+        response = request.response
+        original_chat = runtime_config.chat
+        active_chat = original_chat.copy()
+        language_code = request.language_code
+        instructions = (
+            response.instructions if response and response.instructions else runtime_config.session.instructions
+        )
+        tools = response.tools if response and response.tools else runtime_config.session.tools
+        tool_choice = response.tool_choice if response and response.tool_choice else runtime_config.session.tool_choice
+        self._apply_instructions(active_chat, instructions, tools, str(tool_choice) if tool_choice else None, ctx)
+        language_code, lang_name = resolve_auto_language(language_code)
+        if lang_name:
+            active_chat.add_item(make_user_message(f"Please reply to my message in {lang_name}."))
 
         gen = self.cancel_scope.generation if self.cancel_scope else None
 
@@ -488,26 +406,17 @@ class BaseLanguageModelHandler(BaseHandler[LLMIn, LLMOut], ABC):
         if ctx.stopped:
             return
 
-        original_chat.append({"role": "assistant", "content": ctx.generated_text})
+        original_chat.add_item(make_assistant_message(ctx.generated_text))
         if ctx.tools:
-            original_chat.append(
-                {
-                    "role": "assistant",
-                    "tool_calls": [
-                        {
-                            "type": "function",
-                            "id": t.call_id or "",
-                            "function": {
-                                "name": t.name or "",
-                                "arguments": json.loads(t.arguments)
-                                if isinstance(t.arguments, str)
-                                else (t.arguments or {}),
-                            },
-                        }
-                        for t in ctx.tools
-                    ],
-                }
-            )
+            for t in ctx.tools:
+                original_chat.add_item(
+                    RealtimeConversationItemFunctionCall(
+                        type="function_call",
+                        name=t.name,
+                        arguments=t.arguments,
+                        status=t.status,
+                    )
+                )
         original_chat.strip_images()
         logger.debug("Clean text: %s", ctx.generated_text)
         logger.info(f"Tools: {ctx.tools}")
@@ -516,7 +425,7 @@ class BaseLanguageModelHandler(BaseHandler[LLMIn, LLMOut], ABC):
             yield LLMResponseChunk(
                 text=ctx.printable_text.strip(),
                 language_code=language_code,
-                tools=[t.model_dump() for t in ctx.tools],
+                tools=list(ctx.tools),
                 runtime_config=runtime_config,
                 response=response,
             )
@@ -591,7 +500,7 @@ class LanguageModelHandler(BaseLanguageModelHandler):
         runtime_config: RuntimeConfig | None = None,
         response: RealtimeResponseCreateParams | None = None,
     ) -> Iterator[LLMResponseChunk]:
-        chat_messages = self._prepare_chat_for_transformers(chat.to_list())
+        chat_messages = chat.to_transformers_chat()
         chat_input = self.tokenizer.apply_chat_template(chat_messages, tokenize=True)
         ctx.input_tokens += len(chat_input if isinstance(chat_input, list) else chat_input["input_ids"])  # type: ignore[index]
         logger.debug("Prompt token count: %d", ctx.input_tokens)
@@ -722,7 +631,7 @@ class VisionLanguageModelHandler(BaseLanguageModelHandler):
         runtime_config: RuntimeConfig | None = None,
         response: RealtimeResponseCreateParams | None = None,
     ) -> Iterator[LLMResponseChunk]:
-        prepared = self._prepare_chat_for_transformers(chat.to_list())
+        prepared = chat.to_transformers_chat()
         if self.backend == "mlx":
             images, formatted_prompt = self._prepare_mlx_vlm_inputs(prepared)
             ctx.input_tokens += len(self.tokenizer.encode(formatted_prompt))

--- a/src/speech_to_speech/LLM/language_model.py
+++ b/src/speech_to_speech/LLM/language_model.py
@@ -412,6 +412,8 @@ class BaseLanguageModelHandler(BaseHandler[LLMIn, LLMOut], ABC):
                 original_chat.add_item(
                     RealtimeConversationItemFunctionCall(
                         type="function_call",
+                        id=t.id,
+                        call_id=t.call_id,
                         name=t.name,
                         arguments=t.arguments,
                         status=t.status,

--- a/src/speech_to_speech/LLM/lm_output_processor.py
+++ b/src/speech_to_speech/LLM/lm_output_processor.py
@@ -70,9 +70,7 @@ class LMOutputProcessor(BaseHandler[LLMOut, TTSIn]):
             event = AssistantTextEvent(text=lm_output.text)
             if lm_output.tools:
                 event.tools = lm_output.tools
-                logger.info(
-                    f"Sending to clients: text='{lm_output.text}', tools={[t['name'] for t in lm_output.tools]}"
-                )
+                logger.info(f"Sending to clients: text='{lm_output.text}', tools={[t.name for t in lm_output.tools]}")
             else:
                 logger.debug(f"Sending to clients: text='{lm_output.text}' (no tools)")
             self.text_output_queue.put(event)

--- a/src/speech_to_speech/LLM/openai_api_language_model.py
+++ b/src/speech_to_speech/LLM/openai_api_language_model.py
@@ -190,6 +190,8 @@ class OpenApiModelHandler(BaseHandler[LLMIn, LLMOut]):
                             printable_text = sentences[-1]
                     elif isinstance(raw_event, ResponseOutputItemDoneEvent):
                         if isinstance(raw_event.item, ResponseFunctionToolCall):
+                            raw_event.item.call_id = _generate_id("call")
+                            raw_event.item.id = _generate_id("fc")
                             tools.append(raw_event.item)
                             original_chat.add_item(
                                 RealtimeConversationItemFunctionCall(

--- a/src/speech_to_speech/LLM/openai_api_language_model.py
+++ b/src/speech_to_speech/LLM/openai_api_language_model.py
@@ -245,19 +245,18 @@ class OpenApiModelHandler(BaseHandler[LLMIn, LLMOut]):
                         output_tokens = usage.output_tokens or 0
                     for message in api_response.output:
                         if isinstance(message, ResponseFunctionToolCall):
-                            message.call_id = _generate_id("call")
-                            message.id = _generate_id("fc")
-                            tools.append(message)
-                            original_chat.add_item(
+                            item = original_chat.add_item(
                                 RealtimeConversationItemFunctionCall(
                                     type="function_call",
-                                    call_id=message.call_id,
-                                    id=message.id,
                                     name=message.name,
                                     arguments=message.arguments,
                                     status="in_progress",
                                 )
                             )
+                            assert (hasattr(item, "call_id") and item.call_id is not None) and item.id is not None
+                            message.call_id = item.call_id
+                            message.id = item.id
+                            tools.append(message)
                         elif isinstance(message, ResponseOutputMessage):
                             content = [
                                 AssistantContent(

--- a/src/speech_to_speech/LLM/openai_api_language_model.py
+++ b/src/speech_to_speech/LLM/openai_api_language_model.py
@@ -8,6 +8,13 @@ from typing import Any, Optional
 import httpx
 from nltk import sent_tokenize
 from openai import OpenAI, Stream
+from openai.types.realtime.conversation_item import (
+    RealtimeConversationItemAssistantMessage,
+    RealtimeConversationItemFunctionCall,
+)
+from openai.types.realtime.realtime_conversation_item_assistant_message import (
+    Content as AssistantContent,
+)
 from openai.types.responses import (
     Response,
     ResponseCompletedEvent,
@@ -19,18 +26,17 @@ from openai.types.responses import (
 )
 
 from speech_to_speech.baseHandler import BaseHandler
-from speech_to_speech.LLM.chat import Chat
+from speech_to_speech.LLM.chat import Chat, make_system_message, make_user_message
 from speech_to_speech.LLM.utils import remove_unspeechable, resolve_auto_language
 from speech_to_speech.LLM.voice_prompt import build_voice_system_prompt
 from speech_to_speech.pipeline.cancel_scope import CancelScope
 from speech_to_speech.pipeline.handler_types import LLMIn, LLMOut
 from speech_to_speech.pipeline.messages import (
     EndOfResponse,
-    GenerateResponseRequest,
     LLMResponseChunk,
     TokenUsage,
-    Transcription,
 )
+from speech_to_speech.utils.utils import _generate_id
 
 logger = logging.getLogger(__name__)
 
@@ -49,13 +55,11 @@ class OpenApiModelHandler(BaseHandler[LLMIn, LLMOut]):
         api_key: Optional[str] = None,
         stream: bool = False,
         user_role: str = "user",
-        chat_size: int = 1,
-        init_chat_role: str = "system",
-        init_chat_prompt: str = "You are a helpful AI assistant.",
         cancel_scope: CancelScope | None = None,
         disable_thinking: bool = True,
         request_timeout_s: float = 20.0,
         stream_batch_sentences: int = 3,
+        **_kwargs: Any,
     ) -> None:
         self.cancel_scope = cancel_scope
         self.model_name = model_name
@@ -68,14 +72,6 @@ class OpenApiModelHandler(BaseHandler[LLMIn, LLMOut]):
             connect=min(10.0, self.request_timeout_s),
         )
 
-        # TODO: chat is not used in the realtime pipeline, but still need to be kept for backward compatibility. Remove it in the future.
-        self.chat = Chat(chat_size)
-        if init_chat_role:
-            if not init_chat_prompt:
-                raise ValueError("An initial promt needs to be specified when setting init_chat_role.")
-            full_prompt = build_voice_system_prompt(init_chat_prompt)
-            self.chat.init_chat({"role": init_chat_role, "content": full_prompt})
-
         self.user_role = user_role
         self.client = OpenAI(api_key=api_key, base_url=base_url)
         self._extra_body = (
@@ -84,21 +80,6 @@ class OpenApiModelHandler(BaseHandler[LLMIn, LLMOut]):
             else None
         )
         self.warmup()
-
-    def _prepare_chat_messages(self, chat: Chat) -> list[dict[str, Any]]:
-        """Convert chat messages to OpenAI Responses API input format.
-
-        Regular messages are wrapped with ``type: "message"``.
-        Tool-related items (``function_call``, ``function_call_output``)
-        are passed through as top-level input items per the Responses API spec.
-        """
-        result: list[dict[str, Any]] = []
-        for msg in chat.to_list():
-            if msg.get("type") in ("function_call", "function_call_output"):
-                result.append(msg)
-            else:
-                result.append({"type": "message", "role": msg["role"], "content": msg["content"]})
-        return result
 
     def warmup(self) -> None:
         logger.info(f"Warming up {self.__class__.__name__}")
@@ -125,50 +106,35 @@ class OpenApiModelHandler(BaseHandler[LLMIn, LLMOut]):
     ) -> None:
         if instructions:
             full_instructions = build_voice_system_prompt(instructions)
-            chat.init_chat({"role": "system", "content": [{"type": "input_text", "text": full_instructions}]})
+            chat.add_item(make_system_message(full_instructions))
 
     def process(self, request: LLMIn) -> Iterator[LLMOut]:
-        language_code = None
-        runtime_config = None
-        response = None
-        req_tools = None
-        req_tool_choice = None
+        """
+        Process a language model request and yield LLMResponseChunks.
 
-        if isinstance(request, GenerateResponseRequest):
-            req = request
-            runtime_config = req.runtime_config
-            response = req.response
-            original_chat = runtime_config.chat
-            active_chat = original_chat.copy()
-            language_code = req.language_code
-            instructions = (
-                response.instructions if response and response.instructions else runtime_config.session.instructions
-            )
-            req_tools = response.tools if response and response.tools else runtime_config.session.tools
-            req_tool_choice = (
-                response.tool_choice if response and response.tool_choice else runtime_config.session.tool_choice
-            )
-            self._apply_config(active_chat, instructions)
-            language_code, lang_name = resolve_auto_language(language_code)
-            if lang_name:
-                active_chat.append(
-                    {
-                        "role": self.user_role,
-                        "content": [{"type": "input_text", "text": f"Please reply to my message in {lang_name}."}],
-                    }
-                )
-        elif isinstance(request, Transcription):
-            original_chat = self.chat
-            active_chat = original_chat
-            logger.debug("call api language model...")
-            language_code = request.language_code
-            prompt_text = request.text
-            language_code, lang_name = resolve_auto_language(language_code)
-            if lang_name:
-                prompt_text = f"Please reply to my message in {lang_name}. " + prompt_text
-            active_chat.append({"role": self.user_role, "content": [{"type": "input_text", "text": prompt_text}]})
-        else:
-            raise TypeError(f"Unexpected request type: {type(request)}")
+        Args:
+            request: The LLMIn request containing runtime configuration and response parameters.
+
+        Yields:
+            LLMResponseChunk: Chunks of text and tools from the language model response.
+        """
+
+        runtime_config = request.runtime_config
+        response = request.response
+        original_chat = runtime_config.chat
+        active_chat = original_chat.copy()
+        language_code = request.language_code
+        instructions = (
+            response.instructions if response and response.instructions else runtime_config.session.instructions
+        ) or ""
+        req_tools = response.tools if response and response.tools else runtime_config.session.tools
+        req_tool_choice = (
+            response.tool_choice if response and response.tool_choice else runtime_config.session.tool_choice
+        )
+        self._apply_config(active_chat, instructions)
+        language_code, lang_name = resolve_auto_language(language_code)
+        if lang_name:
+            active_chat.add_item(make_user_message(f"Please reply to my message in {lang_name}."))
 
         optional_kwargs: dict[str, Any] = {}
         if req_tools is not None:
@@ -183,14 +149,14 @@ class OpenApiModelHandler(BaseHandler[LLMIn, LLMOut]):
         # end (IPC and lifecycle cost).
         gen = self.cancel_scope.generation if self.cancel_scope else None
         api_response: Response | Stream[ResponseStreamEvent] | None = None
-        tools: list[dict[str, str]] = []
+        tools: list[ResponseFunctionToolCall] = []
         clean_text = ""
         input_tokens = 0
         output_tokens = 0
         try:
             api_response = self.client.responses.create(
                 model=self.model_name,
-                input=self._prepare_chat_messages(active_chat),  # type: ignore[arg-type]
+                input=active_chat.to_response_api_chat(),
                 stream=self.stream,
                 extra_body=self._extra_body,
                 timeout=self.request_timeout,
@@ -224,13 +190,29 @@ class OpenApiModelHandler(BaseHandler[LLMIn, LLMOut]):
                             printable_text = sentences[-1]
                     elif isinstance(raw_event, ResponseOutputItemDoneEvent):
                         if isinstance(raw_event.item, ResponseFunctionToolCall):
-                            tools.append(raw_event.item.model_dump())
+                            tools.append(raw_event.item)
+                            original_chat.add_item(
+                                RealtimeConversationItemFunctionCall(
+                                    type="function_call",
+                                    name=raw_event.item.name,
+                                    arguments=raw_event.item.arguments,
+                                    call_id=raw_event.item.call_id,
+                                    id=raw_event.item.id,
+                                    status=raw_event.item.status,
+                                )
+                            )
                         elif isinstance(raw_event.item, ResponseOutputMessage):
-                            original_chat.append(
-                                {
-                                    "role": raw_event.item.role,
-                                    "content": raw_event.item.content,
-                                }
+                            content = [
+                                AssistantContent(
+                                    type="output_text",
+                                    text=c.text if c.type == "output_text" else c.refusal,
+                                )
+                                for c in raw_event.item.content
+                            ]
+                            original_chat.add_item(
+                                RealtimeConversationItemAssistantMessage(
+                                    type="message", role="assistant", content=content
+                                )
                             )
                     elif isinstance(raw_event, ResponseCompletedEvent):
                         usage = getattr(raw_event.response, "usage", None)
@@ -238,8 +220,6 @@ class OpenApiModelHandler(BaseHandler[LLMIn, LLMOut]):
                             input_tokens = usage.input_tokens or 0
                             output_tokens = usage.output_tokens or 0
                 if not cancelled:
-                    for tool in tools:
-                        original_chat.append(tool)
                     if printable_text.strip():
                         sentence_batch.append(printable_text.strip())
                     remaining = " ".join(sentence_batch)
@@ -262,22 +242,38 @@ class OpenApiModelHandler(BaseHandler[LLMIn, LLMOut]):
                         input_tokens = usage.input_tokens or 0
                         output_tokens = usage.output_tokens or 0
                     for message in api_response.output:
-                        if message.type == "function_call":
-                            tools.append(message.model_dump())
-                        elif message.type == "message":
-                            original_chat.append(
-                                {
-                                    "role": message.role,
-                                    "content": message.content,
-                                }
+                        if isinstance(message, ResponseFunctionToolCall):
+                            message.call_id = _generate_id("call")
+                            message.id = _generate_id("fc")
+                            tools.append(message)
+                            original_chat.add_item(
+                                RealtimeConversationItemFunctionCall(
+                                    type="function_call",
+                                    call_id=message.call_id,
+                                    id=message.id,
+                                    name=message.name,
+                                    arguments=message.arguments,
+                                    status="in_progress",
+                                )
+                            )
+                        elif isinstance(message, ResponseOutputMessage):
+                            content = [
+                                AssistantContent(
+                                    type="output_text",
+                                    text=c.text if c.type == "output_text" else c.refusal,
+                                )
+                                for c in message.content
+                            ]
+                            original_chat.add_item(
+                                RealtimeConversationItemAssistantMessage(
+                                    type="message", role="assistant", content=content
+                                )
                             )
                             for chunk in message.content:
                                 if chunk.type == "output_text":
                                     clean_text += remove_unspeechable(chunk.text)
                         else:
                             logger.warning(f"Not supported message type: {message.type}")
-                    for tool in tools:
-                        original_chat.append(tool)
                     logger.debug(f"Clean text: {clean_text}")
                     logger.info(f"Tools: {tools}")
                     if clean_text.strip() or tools:

--- a/src/speech_to_speech/LLM/tool_call/function_call.py
+++ b/src/speech_to_speech/LLM/tool_call/function_call.py
@@ -199,6 +199,8 @@ class FunctionToolCall(BaseModel):
             arguments=json.dumps(arguments),
             call_id=f"call_{uuid4()}",
             type="function_call",
+            id=f"fc_{uuid4()}",
+            status="in_progress",
         )
 
 

--- a/src/speech_to_speech/LLM/tool_call/function_call.py
+++ b/src/speech_to_speech/LLM/tool_call/function_call.py
@@ -14,12 +14,12 @@ import re
 import tokenize
 from collections import OrderedDict
 from typing import Any, Dict, List, Tuple
-from uuid import uuid4
 
 from openai.types.responses import ResponseFunctionToolCall
 from pydantic import BaseModel
 
 from speech_to_speech.LLM.tool_call.function_tool import FunctionTool
+from speech_to_speech.utils.utils import _generate_id
 
 logger = logging.getLogger(__name__)
 
@@ -197,9 +197,9 @@ class FunctionToolCall(BaseModel):
         return ResponseFunctionToolCall(
             name=self.function_name,
             arguments=json.dumps(arguments),
-            call_id=f"call_{uuid4()}",
+            call_id=_generate_id("call"),
             type="function_call",
-            id=f"fc_{uuid4()}",
+            id=_generate_id("fc"),
             status="in_progress",
         )
 

--- a/src/speech_to_speech/STT/transcription_notifier.py
+++ b/src/speech_to_speech/STT/transcription_notifier.py
@@ -2,29 +2,41 @@ from __future__ import annotations
 
 import logging
 from queue import Queue
-from typing import Iterator
+from typing import Iterator, Union
 
+from speech_to_speech.api.openai_realtime.runtime_config import RuntimeConfig
 from speech_to_speech.baseHandler import BaseHandler
+from speech_to_speech.LLM.chat import make_user_message
 from speech_to_speech.pipeline.events import PartialTranscriptionEvent, TranscriptionCompletedEvent
-from speech_to_speech.pipeline.handler_types import STTOut
-from speech_to_speech.pipeline.messages import PartialTranscription, Transcription
+from speech_to_speech.pipeline.handler_types import LLMIn, STTOut
+from speech_to_speech.pipeline.messages import GenerateResponseRequest, PartialTranscription, Transcription
 from speech_to_speech.pipeline.queue_types import TextEventItem
 
 logger = logging.getLogger(__name__)
 
 
-class TranscriptionNotifier(BaseHandler[STTOut, STTOut]):
-    """
-    Sits between STT and LLM.  Intercepts partial and final transcriptions,
-    emitting events on ``text_output_queue`` for connected clients (Realtime
-    API or plain WebSocket) while only forwarding final transcripts to the LLM.
+class TranscriptionNotifier(BaseHandler[STTOut, Union[STTOut, LLMIn]]):
+    """Sits between STT and LLM.
+
+    For **realtime mode** (no ``runtime_config``): emits transcription events
+    on ``text_output_queue`` for protocol translation but yields nothing -- the
+    ``RealtimeService`` builds ``GenerateResponseRequest`` directly.
+
+    For **legacy mode** (``runtime_config`` provided): appends the user
+    message to ``runtime_config.chat`` and yields a
+    ``GenerateResponseRequest`` so the LLM handler receives a uniform input
+    type regardless of pipeline mode.
     """
 
-    def setup(self, text_output_queue: Queue[TextEventItem] | None = None, suppress_yield: bool = False) -> None:
+    def setup(
+        self,
+        text_output_queue: Queue[TextEventItem] | None = None,
+        runtime_config: RuntimeConfig | None = None,
+    ) -> None:
         self.text_output_queue = text_output_queue
-        self.suppress_yield = suppress_yield
+        self.runtime_config = runtime_config
 
-    def process(self, transcription: STTOut) -> Iterator[STTOut]:
+    def process(self, transcription: STTOut) -> Iterator[Union[STTOut, LLMIn]]:
         if isinstance(transcription, PartialTranscription):
             if self.text_output_queue and transcription.text:
                 self.text_output_queue.put(PartialTranscriptionEvent(delta=str(transcription.text)))
@@ -42,5 +54,9 @@ class TranscriptionNotifier(BaseHandler[STTOut, STTOut]):
             self.text_output_queue.put(TranscriptionCompletedEvent(transcript=str(text), language_code=language_code))
             logger.debug("Transcription completed: %s", str(text)[:80])
 
-        if not self.suppress_yield:
-            yield transcription
+        if self.runtime_config is not None and text:
+            self.runtime_config.chat.add_item(make_user_message(str(text)))
+            yield GenerateResponseRequest(
+                runtime_config=self.runtime_config,
+                language_code=language_code,
+            )

--- a/src/speech_to_speech/TTS/chatTTS_handler.py
+++ b/src/speech_to_speech/TTS/chatTTS_handler.py
@@ -82,8 +82,6 @@ class ChatTTSHandler(BaseHandler[TTSIn, TTSOut]):
                     logger.info("TTS generation cancelled (interruption)")
                     return
                 if gen[0] is None or len(gen[0]) == 0:
-                    if not runtime_config:
-                        self.should_listen.set()
                     return
                 audio_chunk = librosa.resample(gen[0], orig_sr=24000, target_sr=16000)
                 audio_chunk = (audio_chunk * 32768).astype(np.int16)[0]
@@ -94,8 +92,6 @@ class ChatTTSHandler(BaseHandler[TTSIn, TTSOut]):
         else:
             wavs = wavs_gen
             if len(wavs[0]) == 0:
-                if not runtime_config:
-                    self.should_listen.set()
                 return
             audio_chunk = librosa.resample(wavs[0], orig_sr=24000, target_sr=16000)
             audio_chunk = (audio_chunk * 32768).astype(np.int16)
@@ -104,5 +100,3 @@ class ChatTTSHandler(BaseHandler[TTSIn, TTSOut]):
                     audio_chunk[i : i + self.chunk_size],
                     (0, self.chunk_size - len(audio_chunk[i : i + self.chunk_size])),
                 )
-        if not runtime_config:
-            self.should_listen.set()

--- a/src/speech_to_speech/TTS/chatTTS_handler.py
+++ b/src/speech_to_speech/TTS/chatTTS_handler.py
@@ -56,7 +56,6 @@ class ChatTTSHandler(BaseHandler[TTSIn, TTSOut]):
             yield AUDIO_RESPONSE_DONE
             return
 
-        runtime_config = tts_input.runtime_config
         text = tts_input.text
 
         _cancel_gen = self.cancel_scope.generation if self.cancel_scope else None

--- a/src/speech_to_speech/TTS/facebookmms_handler.py
+++ b/src/speech_to_speech/TTS/facebookmms_handler.py
@@ -161,8 +161,6 @@ class FacebookMMSTTSHandler(BaseHandler[TTSIn, TTSOut]):
 
         if audio_output is None or audio_output.numel() == 0:
             logger.warning("No audio output generated")
-            if not runtime_config:
-                self.should_listen.set()
             return
 
         audio_numpy = audio_output.cpu().numpy().squeeze()
@@ -190,9 +188,6 @@ class FacebookMMSTTSHandler(BaseHandler[TTSIn, TTSOut]):
                     audio_int16[i : i + self.chunk_size],
                     (0, self.chunk_size - len(audio_int16[i : i + self.chunk_size])),
                 )
-
-        if not runtime_config:
-            self.should_listen.set()
 
     def on_session_end(self) -> None:
         if self.language != self._initial_language:

--- a/src/speech_to_speech/TTS/facebookmms_handler.py
+++ b/src/speech_to_speech/TTS/facebookmms_handler.py
@@ -140,7 +140,6 @@ class FacebookMMSTTSHandler(BaseHandler[TTSIn, TTSOut]):
 
         gen = self.cancel_scope.generation if self.cancel_scope else None
         language_code = tts_input.language_code
-        runtime_config = tts_input.runtime_config
         text = tts_input.text
 
         console.print(f"[green]ASSISTANT: {text}")

--- a/src/speech_to_speech/TTS/kokoro_handler.py
+++ b/src/speech_to_speech/TTS/kokoro_handler.py
@@ -259,9 +259,6 @@ class KokoroTTSHandler(BaseHandler[TTSIn, TTSOut]):
         else:
             yield from self._process_kokoro(text, language_code)
 
-        if not runtime_config:
-            self.should_listen.set()
-
     def _process_mlx(self, llm_sentence: str, language_code: Optional[str] = None) -> Iterator[np.ndarray]:
         """Process using MLX backend with Apple Silicon optimizations."""
         from scipy.signal import resample_poly

--- a/src/speech_to_speech/TTS/melo_handler.py
+++ b/src/speech_to_speech/TTS/melo_handler.py
@@ -100,8 +100,6 @@ class MeloTTSHandler(BaseHandler[TTSIn, TTSOut]):
             logger.error(f"Error in MeloTTSHandler: {e}")
             audio_chunk = np.array([])
         if len(audio_chunk) == 0:
-            if not runtime_config:
-                self.should_listen.set()
             return
         audio_chunk = librosa.resample(audio_chunk, orig_sr=44100, target_sr=16000)
         audio_chunk = (audio_chunk * 32768).astype(np.int16)
@@ -113,9 +111,6 @@ class MeloTTSHandler(BaseHandler[TTSIn, TTSOut]):
                 audio_chunk[i : i + self.blocksize],
                 (0, self.blocksize - len(audio_chunk[i : i + self.blocksize])),
             )
-
-        if not runtime_config:
-            self.should_listen.set()
 
     def on_session_end(self) -> None:
         if self.language != self._initial_language:

--- a/src/speech_to_speech/TTS/melo_handler.py
+++ b/src/speech_to_speech/TTS/melo_handler.py
@@ -70,7 +70,6 @@ class MeloTTSHandler(BaseHandler[TTSIn, TTSOut]):
 
         gen = self.cancel_scope.generation if self.cancel_scope else None
         language_code = tts_input.language_code
-        runtime_config = tts_input.runtime_config
         text = tts_input.text
 
         console.print(f"[green]ASSISTANT: {text}")

--- a/src/speech_to_speech/TTS/pocket_tts_handler.py
+++ b/src/speech_to_speech/TTS/pocket_tts_handler.py
@@ -208,6 +208,3 @@ class PocketTTSHandler(BaseHandler[TTSIn, TTSOut]):
                 if len(chunk) < self.blocksize:
                     chunk = np.pad(chunk, (0, self.blocksize - len(chunk)))
                 yield chunk
-
-        if not runtime_config:
-            self.should_listen.set()

--- a/src/speech_to_speech/TTS/pocket_tts_handler.py
+++ b/src/speech_to_speech/TTS/pocket_tts_handler.py
@@ -99,7 +99,6 @@ class PocketTTSHandler(BaseHandler[TTSIn, TTSOut]):
 
         gen = self.cancel_scope.generation if self.cancel_scope else None
         language_code = tts_input.language_code
-        runtime_config = tts_input.runtime_config
         text = tts_input.text
         logger.debug(f"Received language code: {language_code}")
 

--- a/src/speech_to_speech/TTS/qwen3_tts_handler.py
+++ b/src/speech_to_speech/TTS/qwen3_tts_handler.py
@@ -635,9 +635,6 @@ class Qwen3TTSHandler(BaseHandler[TTSIn, TTSOut]):
         except Exception as e:
             logger.error(f"Error during Qwen3-TTS generation: {e}", exc_info=True)
 
-        if not runtime_config:
-            self.should_listen.set()
-
     def _mlx_streaming_interval(self) -> float:
         return max(1, self.streaming_chunk_size) / MLX_STREAMING_TOKENS_PER_SECOND
 

--- a/src/speech_to_speech/api/openai_realtime/handlers/base.py
+++ b/src/speech_to_speech/api/openai_realtime/handlers/base.py
@@ -1,21 +1,18 @@
 from __future__ import annotations
 
 import logging
-import uuid
 from queue import Queue
 from threading import Event as ThreadingEvent
 from typing import TYPE_CHECKING
 
 from openai.types.realtime import RealtimeErrorEvent
 
+from speech_to_speech.utils.utils import _generate_id
+
 if TYPE_CHECKING:
     from speech_to_speech.api.openai_realtime.service import ConnState, RealtimeService
 
 logger = logging.getLogger(__name__)
-
-
-def _generate_id(prefix: str) -> str:
-    return f"{prefix}_{uuid.uuid4().hex[:12]}"
 
 
 class RealtimeBaseHandler:

--- a/src/speech_to_speech/api/openai_realtime/handlers/conversation.py
+++ b/src/speech_to_speech/api/openai_realtime/handlers/conversation.py
@@ -40,8 +40,9 @@ class ConversationHandler(RealtimeBaseHandler):
         events: list[ServerEvent] = []
         item = event.item
 
-        if not self._append_item(conn_id, item):
-            return []
+        error = self._append_item(conn_id, item)
+        if error is not None:
+            return [self.make_error(error, "invalid_conversation_item")]
 
         if item:
             st = self._state(conn_id)
@@ -57,10 +58,10 @@ class ConversationHandler(RealtimeBaseHandler):
 
         return events
 
-    def _append_item(self, conn_id: str, item: ConversationItem) -> bool:
+    def _append_item(self, conn_id: str, item: ConversationItem) -> str | None:
         """Add a conversation item directly to the connection's chat history.
 
-        Returns ``True`` if the item was handled, ``False`` otherwise.
+        Returns ``None`` on success or an error message string on failure.
         """
         st = self._state(conn_id)
 
@@ -68,7 +69,7 @@ class ConversationHandler(RealtimeBaseHandler):
             role = getattr(item, "role", None)
             if not role or role not in ("user", "assistant"):
                 logger.warning("Unsupported message role: %s", role)
-                return False
+                return f"Unsupported message role: {role}"
             content_parts: list[dict] = []
             for part in item.content:  # type: ignore[union-attr]
                 if (part.type == "input_text" and part.text) or (part.type == "input_image" and part.image_url):  # type: ignore[union-attr]
@@ -78,22 +79,25 @@ class ConversationHandler(RealtimeBaseHandler):
             if content_parts:
                 st.runtime_config.chat.append({"role": role, "content": content_parts})
                 logger.debug("Added message to chat (role=%s, %d parts)", role, len(content_parts))
-                return True
-            return False
+                return None
+            return "Message has no supported content parts."
 
         if getattr(item, "type", None) == "function_call_output" and getattr(item, "output", None):
-            st.runtime_config.chat.append(
-                {
-                    "type": "function_call_output",
-                    "call_id": item.call_id,  # type: ignore[union-attr]
-                    "output": item.output,  # type: ignore[union-attr]
-                }
-            )
-            logger.debug("Added function_call_output to chat (call_id=%s)", item.call_id)  # type: ignore[union-attr]
-            return True
+            call_id = item.call_id  # type: ignore[union-attr]
+            output_item = {
+                "type": "function_call_output",
+                "call_id": call_id,
+                "output": item.output,  # type: ignore[union-attr]
+            }
+            error = st.runtime_config.chat.append_tool_output(call_id, output_item)
+            if error:
+                logger.warning("Rejected function_call_output: %s", error)
+                return error
+            logger.debug("Added function_call_output to chat (call_id=%s)", call_id)
+            return None
 
         logger.warning("Unsupported item type: %s", getattr(item, "type", None))
-        return False
+        return f"Unsupported item type: {getattr(item, 'type', None)}"
 
     # ── Pipeline event handlers ────────────────────
 

--- a/src/speech_to_speech/api/openai_realtime/handlers/conversation.py
+++ b/src/speech_to_speech/api/openai_realtime/handlers/conversation.py
@@ -83,7 +83,7 @@ class ConversationHandler(RealtimeBaseHandler):
             return "Message has no supported content parts."
 
         if getattr(item, "type", None) == "function_call_output" and getattr(item, "output", None):
-            call_id = item.call_id  # type: ignore[union-attr]
+            call_id: str = item.call_id or ""  # type: ignore[union-attr]
             output_item = {
                 "type": "function_call_output",
                 "call_id": call_id,

--- a/src/speech_to_speech/api/openai_realtime/handlers/conversation.py
+++ b/src/speech_to_speech/api/openai_realtime/handlers/conversation.py
@@ -74,6 +74,8 @@ class ConversationHandler(RealtimeBaseHandler):
         """
         chat = self._state(conn_id).runtime_config.chat
 
+        # call_id on function_call items must be client-supplied: it is referenced later by
+        # function_call_output items, so we cannot silently generate one here.
         if isinstance(item, RealtimeConversationItemFunctionCall) and (
             item.call_id is None or not item.call_id.startswith("call_")
         ):

--- a/src/speech_to_speech/api/openai_realtime/handlers/conversation.py
+++ b/src/speech_to_speech/api/openai_realtime/handlers/conversation.py
@@ -10,11 +10,19 @@ from openai.types.realtime import (
     ConversationItemInputAudioTranscriptionCompletedEvent,
     ConversationItemInputAudioTranscriptionDeltaEvent,
 )
+from openai.types.realtime.conversation_item import (
+    RealtimeConversationItemAssistantMessage,
+    RealtimeConversationItemFunctionCall,
+    RealtimeConversationItemFunctionCallOutput,
+    RealtimeConversationItemSystemMessage,
+    RealtimeConversationItemUserMessage,
+)
 from openai.types.realtime.conversation_item_input_audio_transcription_completed_event import (
     UsageTranscriptTextUsageDuration,
 )
 
 from speech_to_speech.api.openai_realtime.handlers.base import RealtimeBaseHandler
+from speech_to_speech.LLM.chat import ChatItemError
 from speech_to_speech.pipeline.events import PartialTranscriptionEvent, TranscriptionCompletedEvent
 
 if TYPE_CHECKING:
@@ -40,9 +48,10 @@ class ConversationHandler(RealtimeBaseHandler):
         events: list[ServerEvent] = []
         item = event.item
 
-        error = self._append_item(conn_id, item)
-        if error is not None:
-            return [self.make_error(error, "invalid_conversation_item")]
+        try:
+            self._append_item(conn_id, item)
+        except ChatItemError as exc:
+            return [self.make_error(str(exc), "invalid_conversation_item")]
 
         if item:
             st = self._state(conn_id)
@@ -58,46 +67,26 @@ class ConversationHandler(RealtimeBaseHandler):
 
         return events
 
-    def _append_item(self, conn_id: str, item: ConversationItem) -> str | None:
-        """Add a conversation item directly to the connection's chat history.
+    def _append_item(self, conn_id: str, item: ConversationItem) -> None:
+        """Narrow ``ConversationItem`` to ``SupportedItem`` and delegate to ``Chat.add_item``.
 
-        Returns ``None`` on success or an error message string on failure.
+        Raises :class:`ChatItemError` on validation failure or unsupported type.
         """
-        st = self._state(conn_id)
+        chat = self._state(conn_id).runtime_config.chat
+        if isinstance(
+            item,
+            (
+                RealtimeConversationItemSystemMessage,
+                RealtimeConversationItemUserMessage,
+                RealtimeConversationItemAssistantMessage,
+                RealtimeConversationItemFunctionCall,
+                RealtimeConversationItemFunctionCallOutput,
+            ),
+        ):
+            chat.add_item(item)
+            return
 
-        if getattr(item, "type", None) == "message" and getattr(item, "content", None):
-            role = getattr(item, "role", None)
-            if not role or role not in ("user", "assistant"):
-                logger.warning("Unsupported message role: %s", role)
-                return f"Unsupported message role: {role}"
-            content_parts: list[dict] = []
-            for part in item.content:  # type: ignore[union-attr]
-                if (part.type == "input_text" and part.text) or (part.type == "input_image" and part.image_url):  # type: ignore[union-attr]
-                    content_parts.append(part.model_dump(exclude_none=True))
-                else:
-                    logger.warning("Unsupported content part type: %s", part.type)
-            if content_parts:
-                st.runtime_config.chat.append({"role": role, "content": content_parts})
-                logger.debug("Added message to chat (role=%s, %d parts)", role, len(content_parts))
-                return None
-            return "Message has no supported content parts."
-
-        if getattr(item, "type", None) == "function_call_output" and getattr(item, "output", None):
-            call_id: str = item.call_id or ""  # type: ignore[union-attr]
-            output_item = {
-                "type": "function_call_output",
-                "call_id": call_id,
-                "output": item.output,  # type: ignore[union-attr]
-            }
-            error = st.runtime_config.chat.append_tool_output(call_id, output_item)
-            if error:
-                logger.warning("Rejected function_call_output: %s", error)
-                return error
-            logger.debug("Added function_call_output to chat (call_id=%s)", call_id)
-            return None
-
-        logger.warning("Unsupported item type: %s", getattr(item, "type", None))
-        return f"Unsupported item type: {getattr(item, 'type', None)}"
+        raise ChatItemError(f"Unsupported item type: {getattr(item, 'type', None)}")
 
     # ── Pipeline event handlers ────────────────────
 

--- a/src/speech_to_speech/api/openai_realtime/handlers/conversation.py
+++ b/src/speech_to_speech/api/openai_realtime/handlers/conversation.py
@@ -73,6 +73,12 @@ class ConversationHandler(RealtimeBaseHandler):
         Raises :class:`ChatItemError` on validation failure or unsupported type.
         """
         chat = self._state(conn_id).runtime_config.chat
+
+        if isinstance(item, RealtimeConversationItemFunctionCall) and (
+            item.call_id is None or not item.call_id.startswith("call_")
+        ):
+            raise ChatItemError("function_call item is missing a call_id. The call_id should start with 'call_'.")
+
         if isinstance(
             item,
             (

--- a/src/speech_to_speech/api/openai_realtime/handlers/response.py
+++ b/src/speech_to_speech/api/openai_realtime/handlers/response.py
@@ -143,12 +143,14 @@ class ResponseHandler(RealtimeBaseHandler):
                 message="Cannot create response while another response is in progress.",
                 _type="conversation_already_has_active_response",
             )
-        else:
-            st.in_response = True
 
         if event.response and event.response.input:
             for input_item in event.response.input:
-                self._service.conversation._append_item(conn_id, input_item)
+                error = self._service.conversation._append_item(conn_id, input_item)
+                if error is not None:
+                    return self.make_error(message=error, _type="invalid_input_item")
+
+        st.in_response = True
 
         st.current_response_params = event.response
         st.current_response_id = _generate_id("resp")

--- a/src/speech_to_speech/api/openai_realtime/handlers/response.py
+++ b/src/speech_to_speech/api/openai_realtime/handlers/response.py
@@ -1,6 +1,5 @@
 from __future__ import annotations
 
-import json
 import logging
 from typing import TYPE_CHECKING, Optional
 
@@ -17,9 +16,11 @@ from openai.types.realtime.realtime_response import Audio, AudioOutput
 from openai.types.realtime.realtime_response_status import RealtimeResponseStatus
 from openai.types.realtime.realtime_response_usage import RealtimeResponseUsage
 
-from speech_to_speech.api.openai_realtime.handlers.base import RealtimeBaseHandler, _generate_id
+from speech_to_speech.api.openai_realtime.handlers.base import RealtimeBaseHandler
+from speech_to_speech.LLM.chat import ChatItemError
 from speech_to_speech.pipeline.events import AssistantTextEvent
 from speech_to_speech.pipeline.messages import GenerateResponseRequest
+from speech_to_speech.utils.utils import _generate_id
 
 if TYPE_CHECKING:
     from speech_to_speech.api.openai_realtime.service import ServerEvent, _ResponseStatus, _StatusReason
@@ -146,9 +147,10 @@ class ResponseHandler(RealtimeBaseHandler):
 
         if event.response and event.response.input:
             for input_item in event.response.input:
-                error = self._service.conversation._append_item(conn_id, input_item)
-                if error is not None:
-                    return self.make_error(message=error, _type="invalid_input_item")
+                try:
+                    self._service.conversation._append_item(conn_id, input_item)
+                except ChatItemError as exc:
+                    return self.make_error(message=str(exc), _type="invalid_input_item")
 
         st.in_response = True
 
@@ -237,15 +239,13 @@ class ResponseHandler(RealtimeBaseHandler):
         if event.tools:
             st.response_usage.tool_calls += len(event.tools)
             for tool in event.tools:
-                raw_args = tool.get("arguments")
-                arguments = raw_args if isinstance(raw_args, str) else json.dumps(raw_args or {})
                 events.append(
                     ResponseFunctionCallArgumentsDoneEvent(
                         type="response.function_call_arguments.done",
                         event_id=self._next_event_id(),
-                        call_id=tool.get("call_id", ""),
-                        name=tool.get("name", ""),
-                        arguments=arguments,
+                        call_id=tool.call_id,
+                        name=tool.name,
+                        arguments=tool.arguments,
                         item_id=item_id,
                         output_index=output_idx,
                         response_id=resp_id,

--- a/src/speech_to_speech/api/openai_realtime/service.py
+++ b/src/speech_to_speech/api/openai_realtime/service.py
@@ -34,9 +34,8 @@ from speech_to_speech.api.openai_realtime.handlers import (
     ResponseHandler,
     SessionHandler,
 )
-from speech_to_speech.api.openai_realtime.handlers.base import _generate_id
 from speech_to_speech.api.openai_realtime.runtime_config import RuntimeConfig
-from speech_to_speech.LLM.chat import Chat
+from speech_to_speech.LLM.chat import Chat, make_user_message
 from speech_to_speech.pipeline.events import (
     AssistantTextEvent,
     PartialTranscriptionEvent,
@@ -48,6 +47,7 @@ from speech_to_speech.pipeline.events import (
 )
 from speech_to_speech.pipeline.messages import GenerateResponseRequest
 from speech_to_speech.pipeline.queue_types import TextPromptItem
+from speech_to_speech.utils.utils import _generate_id
 
 logger = logging.getLogger(__name__)
 
@@ -292,7 +292,7 @@ class RealtimeService:
         cfg = st.runtime_config
         transcript = event.transcript
         if transcript:
-            cfg.chat.append({"role": "user", "content": transcript})
+            cfg.chat.add_item(make_user_message(transcript))
 
         queue = self.text_prompt_queue
         if queue and transcript:

--- a/src/speech_to_speech/connections/local_audio_streamer.py
+++ b/src/speech_to_speech/connections/local_audio_streamer.py
@@ -6,6 +6,7 @@ from queue import Queue
 import numpy as np
 import sounddevice as sd
 
+from speech_to_speech.pipeline.messages import AUDIO_RESPONSE_DONE
 from speech_to_speech.pipeline.queue_types import AudioInItem, AudioOutItem
 
 logger = logging.getLogger(__name__)
@@ -16,6 +17,7 @@ class LocalAudioStreamer:
         self,
         input_queue: Queue[AudioInItem],
         output_queue: Queue[AudioOutItem],
+        should_listen: threading.Event,
         list_play_chunk_size: int = 512,
     ) -> None:
         self.list_play_chunk_size = list_play_chunk_size
@@ -23,6 +25,7 @@ class LocalAudioStreamer:
         self.stop_event = threading.Event()
         self.input_queue = input_queue
         self.output_queue = output_queue
+        self.should_listen = should_listen
 
     def run(self) -> None:
         # Pre-generate a static dither buffer (±1 LSB, -96 dB) to keep the
@@ -42,9 +45,12 @@ class LocalAudioStreamer:
             else:
                 try:
                     audio_chunk = self.output_queue.get_nowait()
-                    # Validate audio chunk is numpy array
                     if isinstance(audio_chunk, np.ndarray):
                         outdata[:] = audio_chunk[:, np.newaxis]
+                    elif audio_chunk == AUDIO_RESPONSE_DONE:
+                        self.should_listen.set()
+                        logger.debug("Response complete, listening re-enabled")
+                        outdata[:] = 0 * outdata
                     else:
                         outdata[:] = 0 * outdata
                 except Exception:

--- a/src/speech_to_speech/connections/socket_sender.py
+++ b/src/speech_to_speech/connections/socket_sender.py
@@ -7,7 +7,7 @@ import numpy as np
 from rich.console import Console
 
 from speech_to_speech.pipeline.control import PipelineControlMessage
-from speech_to_speech.pipeline.messages import PIPELINE_END
+from speech_to_speech.pipeline.messages import AUDIO_RESPONSE_DONE, PIPELINE_END
 from speech_to_speech.pipeline.queue_types import AudioOutItem
 
 logger = logging.getLogger(__name__)
@@ -24,11 +24,13 @@ class SocketSender:
         self,
         stop_event: Event,
         queue_in: Queue[AudioOutItem],
+        should_listen: Event,
         host: str = "0.0.0.0",
         port: int = 12346,
     ) -> None:
         self.stop_event = stop_event
         self.queue_in = queue_in
+        self.should_listen = should_listen
         self.host = host
         self.port = port
 
@@ -47,6 +49,9 @@ class SocketSender:
             except Empty:
                 continue
             if isinstance(audio_chunk, PipelineControlMessage):
+                continue
+            if isinstance(audio_chunk, bytes) and audio_chunk == AUDIO_RESPONSE_DONE:
+                self.should_listen.set()
                 continue
             payload: bytes
             if isinstance(audio_chunk, bytes):

--- a/src/speech_to_speech/connections/websocket_streamer.py
+++ b/src/speech_to_speech/connections/websocket_streamer.py
@@ -10,7 +10,7 @@ from websockets.asyncio.server import ServerConnection
 
 from speech_to_speech.pipeline.control import SESSION_END, PipelineControlMessage, is_control_message
 from speech_to_speech.pipeline.events import PipelineEvent
-from speech_to_speech.pipeline.messages import PIPELINE_END
+from speech_to_speech.pipeline.messages import AUDIO_RESPONSE_DONE, PIPELINE_END
 from speech_to_speech.pipeline.queue_types import AudioInItem, AudioOutItem, TextEventItem
 
 logger = logging.getLogger(__name__)
@@ -169,6 +169,17 @@ class WebSocketStreamer:
                                 return_exceptions=True,
                             )
                         break
+                    if isinstance(audio_chunk, bytes) and audio_chunk == AUDIO_RESPONSE_DONE:
+                        if audio_buffer and self.clients:
+                            data = bytes(audio_buffer)
+                            audio_buffer.clear()
+                            await asyncio.gather(
+                                *[client.send(data) for client in self.clients],
+                                return_exceptions=True,
+                            )
+                        self.should_listen.set()
+                        logger.debug("Response complete, listening re-enabled")
+                        continue
                     if is_control_message(audio_chunk, SESSION_END.kind):
                         audio_buffer.clear()
                         continue

--- a/src/speech_to_speech/pipeline/events.py
+++ b/src/speech_to_speech/pipeline/events.py
@@ -10,6 +10,7 @@ from __future__ import annotations
 
 from typing import Literal, Optional
 
+from openai.types.responses.response_function_tool_call import ResponseFunctionToolCall
 from pydantic import BaseModel, Field
 
 
@@ -57,7 +58,7 @@ class TranscriptionCompletedEvent(PipelineEvent):
 class AssistantTextEvent(PipelineEvent):
     type: Literal["assistant_text"] = "assistant_text"
     text: str
-    tools: list[dict] = Field(default_factory=list)
+    tools: list[ResponseFunctionToolCall] = Field(default_factory=list)
 
 
 class TokenUsageEvent(PipelineEvent):

--- a/src/speech_to_speech/pipeline/handler_types.py
+++ b/src/speech_to_speech/pipeline/handler_types.py
@@ -35,7 +35,7 @@ STTIn: TypeAlias = VADAudio
 STTOut: TypeAlias = PartialTranscription | Transcription
 
 # ── LLM stage ─────────────────────────────────────────────────────────
-LLMIn: TypeAlias = Transcription | GenerateResponseRequest
+LLMIn: TypeAlias = GenerateResponseRequest
 LLMOut: TypeAlias = LLMResponseChunk | TokenUsage | EndOfResponse
 
 # ── TTS stage ─────────────────────────────────────────────────────────

--- a/src/speech_to_speech/pipeline/messages.py
+++ b/src/speech_to_speech/pipeline/messages.py
@@ -12,6 +12,7 @@ from typing import Final, Literal, Optional, TypeAlias
 
 import numpy as np
 from openai.types.realtime.realtime_response_create_params import RealtimeResponseCreateParams
+from openai.types.responses.response_function_tool_call import ResponseFunctionToolCall
 from pydantic import BaseModel, ConfigDict, Field
 
 from speech_to_speech.api.openai_realtime.runtime_config import RuntimeConfig
@@ -69,7 +70,7 @@ class LLMResponseChunk(PipelineMessage):
     tag: Literal["llm_response_chunk"] = "llm_response_chunk"
     text: str
     language_code: Optional[str] = None
-    tools: list = Field(default_factory=list)
+    tools: list[ResponseFunctionToolCall] = Field(default_factory=list)
     runtime_config: RuntimeConfig | None = None
     response: RealtimeResponseCreateParams | None = None
 

--- a/src/speech_to_speech/s2s_pipeline.py
+++ b/src/speech_to_speech/s2s_pipeline.py
@@ -15,6 +15,7 @@ import torch
 from rich.console import Console
 from transformers import HfArgumentParser
 
+from speech_to_speech.api.openai_realtime.runtime_config import RuntimeConfig
 from speech_to_speech.arguments_classes.chat_tts_arguments import ChatTTSHandlerArguments
 from speech_to_speech.arguments_classes.facebookmms_tts_arguments import FacebookMMSTTSHandlerArguments
 from speech_to_speech.arguments_classes.faster_whisper_stt_arguments import (
@@ -40,6 +41,7 @@ from speech_to_speech.arguments_classes.vad_arguments import VADHandlerArguments
 from speech_to_speech.arguments_classes.websocket_streamer_arguments import WebSocketStreamerArguments
 from speech_to_speech.arguments_classes.whisper_stt_arguments import WhisperSTTHandlerArguments
 from speech_to_speech.baseHandler import BaseHandler
+from speech_to_speech.LLM.chat import Chat
 from speech_to_speech.pipeline.cancel_scope import CancelScope
 from speech_to_speech.pipeline.handler_types import LLMIn, LLMOut, STTIn, STTOut, TTSIn, TTSOut
 from speech_to_speech.pipeline.queue_types import (
@@ -52,6 +54,7 @@ from speech_to_speech.pipeline.queue_types import (
     TTSInItem,
     VADOutItem,
 )
+from speech_to_speech.STT.transcription_notifier import TranscriptionNotifier
 from speech_to_speech.utils.thread_manager import ThreadManager
 from speech_to_speech.VAD.vad_handler import VADHandler
 
@@ -299,6 +302,7 @@ def build_pipeline(
     text_output_queue = (
         None  # Only set for websocket/realtime modes; kept None otherwise to avoid unbounded queue growth
     )
+
     comms_handlers: list[Any] = []
     if module_kwargs.mode == "local":
         from speech_to_speech.connections.local_audio_streamer import LocalAudioStreamer
@@ -394,14 +398,12 @@ def build_pipeline(
         setup_kwargs=vars(vad_handler_kwargs),
     )
 
-    from speech_to_speech.STT.transcription_notifier import TranscriptionNotifier
-
-    transcription_notifier_kwargs = {
+    transcription_notifier_kwargs: dict[str, Any] = {
         "text_output_queue": text_output_queue,
-        "suppress_yield": False,
     }
-    if module_kwargs.mode == "realtime":
-        transcription_notifier_kwargs["suppress_yield"] = True
+    if module_kwargs.mode != "realtime":
+        _lm_vars = vars(language_model_handler_kwargs)
+        transcription_notifier_kwargs["runtime_config"] = RuntimeConfig(chat=Chat(_lm_vars.get("chat_size", 30)))
 
     transcription_notifier = TranscriptionNotifier(
         stop_event,

--- a/src/speech_to_speech/s2s_pipeline.py
+++ b/src/speech_to_speech/s2s_pipeline.py
@@ -308,7 +308,9 @@ def build_pipeline(
         from speech_to_speech.connections.local_audio_streamer import LocalAudioStreamer
 
         local_audio_streamer = LocalAudioStreamer(
-            input_queue=recv_audio_chunks_queue, output_queue=send_audio_chunks_queue
+            input_queue=recv_audio_chunks_queue,
+            output_queue=send_audio_chunks_queue,
+            should_listen=should_listen,
         )
         comms_handlers = [local_audio_streamer]
         should_listen.set()

--- a/src/speech_to_speech/s2s_pipeline.py
+++ b/src/speech_to_speech/s2s_pipeline.py
@@ -12,6 +12,7 @@ from typing import Any, Optional
 
 import nltk
 import torch
+from openai.types.realtime import RealtimeSessionCreateRequest
 from rich.console import Console
 from transformers import HfArgumentParser
 
@@ -405,7 +406,13 @@ def build_pipeline(
     }
     if module_kwargs.mode != "realtime":
         _lm_vars = vars(language_model_handler_kwargs)
-        transcription_notifier_kwargs["runtime_config"] = RuntimeConfig(chat=Chat(_lm_vars.get("chat_size", 30)))
+        transcription_notifier_kwargs["runtime_config"] = RuntimeConfig(
+            chat=Chat(_lm_vars.get("chat_size", 30)),
+            session=RealtimeSessionCreateRequest(
+                type="realtime",
+                instructions=_lm_vars.get("init_chat_prompt"),
+            ),
+        )
 
     transcription_notifier = TranscriptionNotifier(
         stop_event,

--- a/src/speech_to_speech/s2s_pipeline.py
+++ b/src/speech_to_speech/s2s_pipeline.py
@@ -383,6 +383,7 @@ def build_pipeline(
             SocketSender(
                 stop_event,
                 send_audio_chunks_queue,
+                should_listen,
                 host=socket_sender_kwargs.send_host,
                 port=socket_sender_kwargs.send_port,
             ),
@@ -405,14 +406,24 @@ def build_pipeline(
         "text_output_queue": text_output_queue,
     }
     if module_kwargs.mode != "realtime":
-        _lm_vars = vars(language_model_handler_kwargs)
-        transcription_notifier_kwargs["runtime_config"] = RuntimeConfig(
-            chat=Chat(_lm_vars.get("chat_size", 30)),
-            session=RealtimeSessionCreateRequest(
-                type="realtime",
-                instructions=_lm_vars.get("init_chat_prompt"),
-            ),
-        )
+        if module_kwargs.llm == "open_api":
+            _lm_vars = vars(open_api_language_model_handler_kwargs)
+            transcription_notifier_kwargs["runtime_config"] = RuntimeConfig(
+                chat=Chat(_lm_vars.get("open_api_chat_size", 30)),
+                session=RealtimeSessionCreateRequest(
+                    type="realtime",
+                    instructions=_lm_vars.get("open_api_init_chat_prompt"),
+                ),
+            )
+        else:
+            _lm_vars = vars(language_model_handler_kwargs)
+            transcription_notifier_kwargs["runtime_config"] = RuntimeConfig(
+                chat=Chat(_lm_vars.get("chat_size", 30)),
+                session=RealtimeSessionCreateRequest(
+                    type="realtime",
+                    instructions=_lm_vars.get("init_chat_prompt"),
+                ),
+            )
 
     transcription_notifier = TranscriptionNotifier(
         stop_event,

--- a/src/speech_to_speech/utils/utils.py
+++ b/src/speech_to_speech/utils/utils.py
@@ -1,8 +1,14 @@
+import uuid
+
 import numpy as np
 
 
 def next_power_of_2(x: int) -> int:
     return 1 if x == 0 else 2 ** (x - 1).bit_length()
+
+
+def _generate_id(prefix: str) -> str:
+    return f"{prefix}_{uuid.uuid4().hex}"
 
 
 def int2float(sound: np.ndarray) -> np.ndarray:

--- a/tests/openai_realtime/test_openai_client.py
+++ b/tests/openai_realtime/test_openai_client.py
@@ -499,7 +499,7 @@ class TestSDKTextInput:
                 {
                     "type": "conversation.item.create",
                     "item": {
-                        "id": "item_sdk_1",
+                        "id": "msg_sdk_1",
                         "type": "message",
                         "role": "user",
                         "content": [{"type": "input_text", "text": "Hello from SDK"}],
@@ -524,7 +524,7 @@ class TestSDKTextInput:
                 {
                     "type": "conversation.item.create",
                     "item": {
-                        "id": "item_a",
+                        "id": "msg_a",
                         "type": "message",
                         "role": "user",
                         "content": [{"type": "input_text", "text": "first"}],
@@ -538,7 +538,7 @@ class TestSDKTextInput:
                 {
                     "type": "conversation.item.create",
                     "item": {
-                        "id": "item_b",
+                        "id": "msg_b",
                         "type": "message",
                         "role": "user",
                         "content": [{"type": "input_text", "text": "second"}],

--- a/tests/openai_realtime/test_openai_client.py
+++ b/tests/openai_realtime/test_openai_client.py
@@ -438,9 +438,10 @@ class TestSDKToolCalling:
                     text="Checking weather",
                     tools=[
                         {
+                            "type": "function_call",
                             "call_id": "call_xyz",
                             "name": "get_weather",
-                            "arguments": {"city": "Tokyo"},
+                            "arguments": '{"city": "Tokyo"}',
                         }
                     ],
                 )
@@ -467,8 +468,8 @@ class TestSDKToolCalling:
                 AssistantTextEvent(
                     text="",
                     tools=[
-                        {"call_id": "c1", "name": "tool_a", "arguments": {}},
-                        {"call_id": "c2", "name": "tool_b", "arguments": {"x": 1}},
+                        {"type": "function_call", "call_id": "c1", "name": "tool_a", "arguments": "{}"},
+                        {"type": "function_call", "call_id": "c2", "name": "tool_b", "arguments": '{"x": 1}'},
                     ],
                 )
             )
@@ -545,7 +546,7 @@ class TestSDKTextInput:
                 }
             )
             e2 = await _recv(conn)
-            assert e2.previous_item_id == "item_a"
+            assert e2.previous_item_id == e1.item.id
 
 
 # ===================================================================

--- a/tests/openai_realtime/test_realtime_service.py
+++ b/tests/openai_realtime/test_realtime_service.py
@@ -467,9 +467,7 @@ class TestHandleResponseCreate:
         gen_msg = text_prompt_queue.get()
         assert isinstance(gen_msg, GenerateResponseRequest)
 
-    def test_response_create_rejects_invalid_function_call_output_in_input(
-        self, service, conn_id, text_prompt_queue
-    ):
+    def test_response_create_rejects_invalid_function_call_output_in_input(self, service, conn_id, text_prompt_queue):
         evt = ResponseCreateEvent(
             type="response.create",
             response={
@@ -1359,8 +1357,7 @@ class TestChatToolCallTracking:
         return {
             "role": "assistant",
             "tool_calls": [
-                {"type": "function", "id": cid, "function": {"name": f"fn_{cid}", "arguments": {}}}
-                for cid in call_ids
+                {"type": "function", "id": cid, "function": {"name": f"fn_{cid}", "arguments": {}}} for cid in call_ids
             ],
         }
 

--- a/tests/openai_realtime/test_realtime_service.py
+++ b/tests/openai_realtime/test_realtime_service.py
@@ -295,6 +295,9 @@ class TestHandleConversationItemCreate:
         assert e2[0].previous_item_id == "item_1"
 
     def test_function_call_output_forwarded(self, service, conn_id, text_prompt_queue):
+        service._state(conn_id).runtime_config.chat.append(
+            {"type": "function_call", "call_id": "call_1", "name": "get_weather", "arguments": "{}"}
+        )
         evt = ConversationItemCreateEvent(
             type="conversation.item.create",
             item={"type": "function_call_output", "output": '{"result": 42}', "call_id": "call_1"},
@@ -304,6 +307,18 @@ class TestHandleConversationItemCreate:
         assert isinstance(events[0], ConversationItemCreatedEvent)
         chat = service._state(conn_id).runtime_config.chat.to_list()
         assert chat[-1] == {"type": "function_call_output", "call_id": "call_1", "output": '{"result": 42}'}
+
+    def test_function_call_output_rejected_for_unknown_call_id(self, service, conn_id, text_prompt_queue):
+        evt = ConversationItemCreateEvent(
+            type="conversation.item.create",
+            item={"type": "function_call_output", "output": '{"result": 42}', "call_id": "call_unknown"},
+        )
+        events = service.handle_conversation_item_create(conn_id, evt)
+        assert len(events) == 1
+        assert isinstance(events[0], RealtimeErrorEvent)
+        assert "call_unknown" in events[0].error.message
+        chat = service._state(conn_id).runtime_config.chat.to_list()
+        assert not any(entry.get("type") == "function_call_output" for entry in chat)
 
     def test_input_image_forwarded(self, service, conn_id, text_prompt_queue):
         evt = ConversationItemCreateEvent(
@@ -451,6 +466,22 @@ class TestHandleResponseCreate:
         assert isinstance(result, ResponseCreatedEvent)
         gen_msg = text_prompt_queue.get()
         assert isinstance(gen_msg, GenerateResponseRequest)
+
+    def test_response_create_rejects_invalid_function_call_output_in_input(
+        self, service, conn_id, text_prompt_queue
+    ):
+        evt = ResponseCreateEvent(
+            type="response.create",
+            response={
+                "input": [
+                    {"type": "function_call_output", "output": '{"x": 1}', "call_id": "call_bogus"},
+                ],
+            },
+        )
+        result = service.handle_response_create(conn_id, evt)
+        assert isinstance(result, RealtimeErrorEvent)
+        assert "call_bogus" in result.error.message
+        assert service._state(conn_id).in_response is False
 
     def test_double_response_create_rejected(self, service, conn_id, text_prompt_queue):
         """Second response.create is rejected because in_response is set immediately."""
@@ -1239,3 +1270,177 @@ class TestChatImageLifecycle:
         last_user = chat.buffer[-1]
         assert isinstance(last_user["content"], list)
         assert any(p.get("image_url") == "new_url" for p in last_user["content"])
+
+
+# ===================================================================
+# Chat tool call tracking
+# ===================================================================
+
+
+class TestChatToolCallTracking:
+    """Tests for Chat._pending_tool_calls and append_tool_output."""
+
+    def _make_chat(self, size=10):
+        from speech_to_speech.LLM.chat import Chat
+
+        return Chat(size=size)
+
+    def _fc(self, call_id="call_1", name="f1"):
+        return {"type": "function_call", "call_id": call_id, "name": name, "arguments": "{}"}
+
+    def _fco(self, call_id="call_1"):
+        return {"type": "function_call_output", "call_id": call_id, "output": '{"ok": true}'}
+
+    def test_append_registers_pending_tool_call(self):
+        chat = self._make_chat()
+        fc = self._fc()
+        chat.append(fc)
+        assert "call_1" in chat._pending_tool_calls
+        assert chat._pending_tool_calls["call_1"] is fc
+
+    def test_append_tool_output_clears_pending(self):
+        chat = self._make_chat()
+        chat.append(self._fc())
+        assert "call_1" in chat._pending_tool_calls
+        err = chat.append_tool_output("call_1", self._fco())
+        assert err is None
+        assert "call_1" not in chat._pending_tool_calls
+        assert chat.buffer[-1]["type"] == "function_call_output"
+
+    def test_append_tool_output_reinjects_evicted_call(self):
+        chat = self._make_chat(size=1)
+        # size=1 keeps 1 user turn. The 2nd user message evicts the 1st turn
+        # (user + fc + assistant), but _pending_tool_calls retains the fc.
+        chat.append({"role": "user", "content": "hi"})
+        chat.append(self._fc("call_x"))
+        chat.append({"role": "assistant", "content": "ok"})
+        chat.append({"role": "user", "content": "more"})
+        assert not any(e.get("call_id") == "call_x" for e in chat.buffer)
+        assert "call_x" in chat._pending_tool_calls
+
+        err = chat.append_tool_output("call_x", self._fco("call_x"))
+        assert err is None
+        assert "call_x" not in chat._pending_tool_calls
+        types = [e.get("type") for e in chat.buffer]
+        assert "function_call" in types
+        assert "function_call_output" in types
+        fc_idx = next(i for i, e in enumerate(chat.buffer) if e.get("type") == "function_call")
+        fco_idx = next(i for i, e in enumerate(chat.buffer) if e.get("type") == "function_call_output")
+        assert fc_idx < fco_idx
+
+    def test_append_tool_output_rejects_unknown_call_id(self):
+        chat = self._make_chat()
+        err = chat.append_tool_output("call_nope", self._fco("call_nope"))
+        assert err is not None
+        assert "call_nope" in err
+        assert not any(e.get("type") == "function_call_output" for e in chat.buffer)
+
+    def test_copy_preserves_pending_tool_calls(self):
+        chat = self._make_chat()
+        chat.append(self._fc("call_a"))
+        clone = chat.copy()
+        assert "call_a" in clone._pending_tool_calls
+        # Mutating the clone does not affect the original
+        clone._pending_tool_calls.pop("call_a")
+        assert "call_a" in chat._pending_tool_calls
+
+    def test_reset_clears_pending_tool_calls(self):
+        chat = self._make_chat()
+        chat.append(self._fc())
+        assert chat._pending_tool_calls
+        chat.reset()
+        assert chat._pending_tool_calls == {}
+        assert chat.buffer == []
+
+    # -- transformers / Chat Completions tool_calls format --
+
+    def _assistant_with_tool_calls(self, *call_ids):
+        """Build an assistant message with tool_calls (local LLM format)."""
+        return {
+            "role": "assistant",
+            "tool_calls": [
+                {"type": "function", "id": cid, "function": {"name": f"fn_{cid}", "arguments": {}}}
+                for cid in call_ids
+            ],
+        }
+
+    def test_append_registers_pending_from_tool_calls_format(self):
+        chat = self._make_chat()
+        msg = self._assistant_with_tool_calls("tc_1", "tc_2")
+        chat.append(msg)
+        assert "tc_1" in chat._pending_tool_calls
+        assert "tc_2" in chat._pending_tool_calls
+
+    def test_append_tool_output_accepts_tool_calls_format_in_buffer(self):
+        chat = self._make_chat()
+        chat.append(self._assistant_with_tool_calls("tc_1"))
+        err = chat.append_tool_output("tc_1", self._fco("tc_1"))
+        assert err is None
+        assert chat.buffer[-1] == self._fco("tc_1")
+        assert "tc_1" not in chat._pending_tool_calls
+
+    def test_append_tool_output_reinjects_evicted_tool_calls_format(self):
+        chat = self._make_chat(size=1)
+        chat.append({"role": "user", "content": "hi"})
+        chat.append(self._assistant_with_tool_calls("tc_x"))
+        chat.append({"role": "user", "content": "a"})
+        assert not any(e.get("tool_calls") for e in chat.buffer)
+        assert "tc_x" in chat._pending_tool_calls
+
+        err = chat.append_tool_output("tc_x", self._fco("tc_x"))
+        assert err is None
+        assert "tc_x" not in chat._pending_tool_calls
+        assert any(
+            e.get("role") == "assistant" and any(tc.get("id") == "tc_x" for tc in e.get("tool_calls", []))
+            for e in chat.buffer
+        )
+        assert chat.buffer[-1] == self._fco("tc_x")
+
+    # -- turn-based eviction --
+
+    def test_eviction_removes_complete_turn(self):
+        chat = self._make_chat(size=1)
+        chat.append({"role": "user", "content": "turn 1"})
+        chat.append({"role": "assistant", "content": "thinking"})
+        chat.append(self._fc("c1"))
+        chat.append(self._fco("c1"))
+        chat.append({"role": "assistant", "content": "done"})
+        # Still 1 user turn, no eviction yet
+        assert len(chat.buffer) == 5
+
+        chat.append({"role": "user", "content": "turn 2"})
+        # 2 user turns > size=1 → oldest turn fully evicted
+        user_msgs = [e for e in chat.buffer if e.get("role") == "user"]
+        assert len(user_msgs) == 1
+        assert user_msgs[0]["content"] == "turn 2"
+        assert not any(e.get("content") == "thinking" for e in chat.buffer)
+        assert not any(e.get("call_id") == "c1" and e.get("type") == "function_call" for e in chat.buffer)
+
+    def test_eviction_preserves_size_user_turns(self):
+        chat = self._make_chat(size=2)
+        # Turn 1: short
+        chat.append({"role": "user", "content": "t1"})
+        chat.append({"role": "assistant", "content": "r1"})
+        # Turn 2: long (with tool call)
+        chat.append({"role": "user", "content": "t2"})
+        chat.append({"role": "assistant", "content": "let me check"})
+        chat.append(self._fc("c2"))
+        chat.append(self._fco("c2"))
+        chat.append({"role": "assistant", "content": "here"})
+        assert chat._count_user_turns() == 2
+
+        # Turn 3: triggers eviction of turn 1
+        chat.append({"role": "user", "content": "t3"})
+        assert chat._count_user_turns() == 2
+        user_contents = [e["content"] for e in chat.buffer if e.get("role") == "user"]
+        assert user_contents == ["t2", "t3"]
+
+    def test_pending_tool_calls_cleaned_after_reinjection(self):
+        chat = self._make_chat(size=1)
+        chat.append({"role": "user", "content": "hi"})
+        chat.append(self._fc("call_z"))
+        chat.append({"role": "user", "content": "bye"})
+        assert "call_z" in chat._pending_tool_calls
+
+        chat.append_tool_output("call_z", self._fco("call_z"))
+        assert "call_z" not in chat._pending_tool_calls

--- a/tests/openai_realtime/test_realtime_service.py
+++ b/tests/openai_realtime/test_realtime_service.py
@@ -259,7 +259,7 @@ class TestHandleSessionUpdate:
 
 
 class TestHandleConversationItemCreate:
-    def _text_event(self, text: str = "hello", item_id: str = "item_abc") -> ConversationItemCreateEvent:
+    def _text_event(self, text: str = "hello", item_id: str = "msg_abc") -> ConversationItemCreateEvent:
         return ConversationItemCreateEvent(
             type="conversation.item.create",
             item={  # type: ignore[arg-type]
@@ -290,8 +290,8 @@ class TestHandleConversationItemCreate:
         assert last.content[0].text == "hi"
 
     def test_text_input_previous_item_id_chain(self, service, conn_id):
-        e1 = service.handle_conversation_item_create(conn_id, self._text_event("a", "item_1"))
-        e2 = service.handle_conversation_item_create(conn_id, self._text_event("b", "item_2"))
+        e1 = service.handle_conversation_item_create(conn_id, self._text_event("a", "msg_1"))
+        e2 = service.handle_conversation_item_create(conn_id, self._text_event("b", "msg_2"))
         assert e1[0].previous_item_id is None
         assert e2[0].previous_item_id == e1[0].item.id
 
@@ -846,7 +846,7 @@ class TestIdAndStateManagement:
         evt = ConversationItemCreateEvent(
             type="conversation.item.create",
             item={
-                "id": "item_manual",
+                "id": "msg_manual",
                 "type": "message",
                 "role": "user",
                 "content": [{"type": "input_text", "text": "x"}],

--- a/tests/openai_realtime/test_realtime_service.py
+++ b/tests/openai_realtime/test_realtime_service.py
@@ -284,19 +284,26 @@ class TestHandleConversationItemCreate:
         assert evt.item.role == "user"
         assert evt.item.content[0].type == "input_text"
         assert evt.item.content[0].text == "hi"
-        chat = service._state(conn_id).runtime_config.chat.to_list()
-        assert chat[-1]["role"] == "user"
-        assert chat[-1]["content"] == [{"type": "input_text", "text": "hi"}]
+        last = service._state(conn_id).runtime_config.chat.buffer[-1]
+        assert last.role == "user"
+        assert last.content[0].type == "input_text"
+        assert last.content[0].text == "hi"
 
     def test_text_input_previous_item_id_chain(self, service, conn_id):
         e1 = service.handle_conversation_item_create(conn_id, self._text_event("a", "item_1"))
         e2 = service.handle_conversation_item_create(conn_id, self._text_event("b", "item_2"))
         assert e1[0].previous_item_id is None
-        assert e2[0].previous_item_id == "item_1"
+        assert e2[0].previous_item_id == e1[0].item.id
 
     def test_function_call_output_forwarded(self, service, conn_id, text_prompt_queue):
-        service._state(conn_id).runtime_config.chat.append(
-            {"type": "function_call", "call_id": "call_1", "name": "get_weather", "arguments": "{}"}
+        from openai.types.realtime.realtime_conversation_item_function_call import (
+            RealtimeConversationItemFunctionCall,
+        )
+
+        service._state(conn_id).runtime_config.chat.add_item(
+            RealtimeConversationItemFunctionCall(
+                type="function_call", call_id="call_1", name="get_weather", arguments="{}"
+            )
         )
         evt = ConversationItemCreateEvent(
             type="conversation.item.create",
@@ -305,8 +312,10 @@ class TestHandleConversationItemCreate:
         events = service.handle_conversation_item_create(conn_id, evt)
         assert len(events) == 1
         assert isinstance(events[0], ConversationItemCreatedEvent)
-        chat = service._state(conn_id).runtime_config.chat.to_list()
-        assert chat[-1] == {"type": "function_call_output", "call_id": "call_1", "output": '{"result": 42}'}
+        last = service._state(conn_id).runtime_config.chat.buffer[-1]
+        assert last.type == "function_call_output"
+        assert last.call_id == "call_1"
+        assert last.output == '{"result": 42}'
 
     def test_function_call_output_rejected_for_unknown_call_id(self, service, conn_id, text_prompt_queue):
         evt = ConversationItemCreateEvent(
@@ -317,8 +326,10 @@ class TestHandleConversationItemCreate:
         assert len(events) == 1
         assert isinstance(events[0], RealtimeErrorEvent)
         assert "call_unknown" in events[0].error.message
-        chat = service._state(conn_id).runtime_config.chat.to_list()
-        assert not any(entry.get("type") == "function_call_output" for entry in chat)
+        assert not any(
+            getattr(e, "type", None) == "function_call_output"
+            for e in service._state(conn_id).runtime_config.chat.buffer
+        )
 
     def test_input_image_forwarded(self, service, conn_id, text_prompt_queue):
         evt = ConversationItemCreateEvent(
@@ -332,12 +343,10 @@ class TestHandleConversationItemCreate:
         events = service.handle_conversation_item_create(conn_id, evt)
         assert len(events) == 1
         assert isinstance(events[0], ConversationItemCreatedEvent)
-        chat = service._state(conn_id).runtime_config.chat.to_list()
-        last = chat[-1]
-        assert last["role"] == "user"
-        assert isinstance(last["content"], list)
-        assert last["content"][0]["type"] == "input_image"
-        assert last["content"][0]["image_url"] == "https://example.com/img.png"
+        last = service._state(conn_id).runtime_config.chat.buffer[-1]
+        assert last.role == "user"
+        assert last.content[0].type == "input_image"
+        assert last.content[0].image_url == "https://example.com/img.png"
 
     def test_mixed_text_and_image_forwarded(self, service, conn_id, text_prompt_queue):
         evt = ConversationItemCreateEvent(
@@ -353,14 +362,13 @@ class TestHandleConversationItemCreate:
         )
         events = service.handle_conversation_item_create(conn_id, evt)
         assert len(events) == 1
-        chat = service._state(conn_id).runtime_config.chat.to_list()
-        last = chat[-1]
-        assert last["role"] == "user"
-        assert isinstance(last["content"], list)
-        assert len(last["content"]) == 2
-        assert last["content"][0] == {"type": "input_text", "text": "What is this?"}
-        assert last["content"][1]["type"] == "input_image"
-        assert last["content"][1]["image_url"] == "data:image/png;base64,abc123"
+        last = service._state(conn_id).runtime_config.chat.buffer[-1]
+        assert last.role == "user"
+        assert len(last.content) == 2
+        assert last.content[0].type == "input_text"
+        assert last.content[0].text == "What is this?"
+        assert last.content[1].type == "input_image"
+        assert last.content[1].image_url == "data:image/png;base64,abc123"
 
 
 # ===================================================================
@@ -724,8 +732,8 @@ class TestDispatchPipelineEvent:
             AssistantTextEvent(
                 text="Let me check",
                 tools=[
-                    {"call_id": "c1", "name": "get_weather", "arguments": '{"city": "Paris"}'},
-                    {"call_id": "c2", "name": "get_time", "arguments": "{}"},
+                    {"type": "function_call", "call_id": "c1", "name": "get_weather", "arguments": '{"city": "Paris"}'},
+                    {"type": "function_call", "call_id": "c2", "name": "get_time", "arguments": "{}"},
                 ],
             ),
         )
@@ -745,7 +753,7 @@ class TestDispatchPipelineEvent:
             conn_id,
             AssistantTextEvent(
                 text="",
-                tools=[{"call_id": "c1", "name": "f1", "arguments": "{}"}],
+                tools=[{"type": "function_call", "call_id": "c1", "name": "f1", "arguments": "{}"}],
             ),
         )
         assert len(events) == 1
@@ -845,7 +853,7 @@ class TestIdAndStateManagement:
             },
         )
         events = service.handle_conversation_item_create(conn_id, evt)
-        assert st.last_item_id == "item_manual"
+        assert st.last_item_id == events[0].item.id
         assert events[0].previous_item_id == output_id
 
     def test_content_index_resets_on_new_item(self, service, conn_id):
@@ -1107,8 +1115,8 @@ class TestUsageMetricsTracking:
             AssistantTextEvent(
                 text="",
                 tools=[
-                    {"call_id": "c1", "name": "f1", "arguments": "{}"},
-                    {"call_id": "c2", "name": "f2", "arguments": "{}"},
+                    {"type": "function_call", "call_id": "c1", "name": "f1", "arguments": "{}"},
+                    {"type": "function_call", "call_id": "c2", "name": "f2", "arguments": "{}"},
                 ],
             ),
         )
@@ -1120,7 +1128,7 @@ class TestUsageMetricsTracking:
             conn_id,
             AssistantTextEvent(
                 text="",
-                tools=[{"call_id": "c1", "name": "f1", "arguments": "{}"}],
+                tools=[{"type": "function_call", "call_id": "c1", "name": "f1", "arguments": "{}"}],
             ),
         )
         service.finish_audio_response(conn_id)
@@ -1185,7 +1193,7 @@ class TestUsageMetricsTracking:
             conn_id,
             AssistantTextEvent(
                 text="hi",
-                tools=[{"call_id": "c1", "name": "f1", "arguments": "{}"}],
+                tools=[{"type": "function_call", "call_id": "c1", "name": "f1", "arguments": "{}"}],
             ),
         )
         service.finish_audio_response(conn_id)
@@ -1217,57 +1225,57 @@ class TestChatImageLifecycle:
 
         return Chat(size=10)
 
-    def test_strip_images_removes_image_parts(self):
-        chat = self._make_chat()
-        chat.append(
-            {
-                "role": "user",
-                "content": [
-                    {"type": "input_text", "text": "What is this?"},
-                    {"type": "input_image", "image_url": "data:image/png;base64,abc"},
-                ],
-            }
+    def _user_msg(self, *parts):
+        from openai.types.realtime.realtime_conversation_item_user_message import (
+            Content as UserContent,
         )
-        chat.append({"role": "assistant", "content": "It's a cat."})
+        from openai.types.realtime.realtime_conversation_item_user_message import (
+            RealtimeConversationItemUserMessage,
+        )
+
+        content = []
+        for p in parts:
+            if p[0] == "text":
+                content.append(UserContent(type="input_text", text=p[1]))
+            elif p[0] == "image":
+                content.append(UserContent(type="input_image", image_url=p[1]))
+        return RealtimeConversationItemUserMessage(type="message", role="user", content=content)
+
+    def test_strip_images_removes_image_parts(self):
+        from speech_to_speech.LLM.chat import make_assistant_message
+
+        chat = self._make_chat()
+        chat.add_item(self._user_msg(("text", "What is this?"), ("image", "data:image/png;base64,abc")))
+        chat.add_item(make_assistant_message("It's a cat."))
         chat.strip_images()
         user_msg = chat.buffer[0]
-        assert user_msg["content"] == [{"type": "input_text", "text": "What is this?"}]
+        assert len(user_msg.content) == 1
+        assert user_msg.content[0].type == "input_text"
+        assert user_msg.content[0].text == "What is this?"
 
     def test_strip_images_noop_on_text_only(self):
+        from speech_to_speech.LLM.chat import make_assistant_message, make_user_message
+
         chat = self._make_chat()
-        chat.append({"role": "user", "content": "hello"})
-        chat.append({"role": "assistant", "content": "hi"})
+        chat.add_item(make_user_message("hello"))
+        chat.add_item(make_assistant_message("hi"))
         chat.strip_images()
-        assert chat.buffer[0]["content"] == "hello"
-        assert chat.buffer[1]["content"] == "hi"
+        assert chat.buffer[0].content[0].text == "hello"
+        assert chat.buffer[1].content[0].text == "hi"
 
     def test_strip_then_new_image_cycle(self):
-        chat = self._make_chat()
-        chat.append(
-            {
-                "role": "user",
-                "content": [
-                    {"type": "input_text", "text": "look"},
-                    {"type": "input_image", "image_url": "old_url"},
-                ],
-            }
-        )
-        chat.append({"role": "assistant", "content": "I see it."})
-        chat.strip_images()
-        assert chat.buffer[0]["content"] == [{"type": "input_text", "text": "look"}]
+        from speech_to_speech.LLM.chat import make_assistant_message
 
-        chat.append(
-            {
-                "role": "user",
-                "content": [
-                    {"type": "input_text", "text": "now this"},
-                    {"type": "input_image", "image_url": "new_url"},
-                ],
-            }
-        )
+        chat = self._make_chat()
+        chat.add_item(self._user_msg(("text", "look"), ("image", "old_url")))
+        chat.add_item(make_assistant_message("I see it."))
+        chat.strip_images()
+        assert len(chat.buffer[0].content) == 1
+        assert chat.buffer[0].content[0].type == "input_text"
+
+        chat.add_item(self._user_msg(("text", "now this"), ("image", "new_url")))
         last_user = chat.buffer[-1]
-        assert isinstance(last_user["content"], list)
-        assert any(p.get("image_url") == "new_url" for p in last_user["content"])
+        assert any(p.image_url == "new_url" for p in last_user.content)
 
 
 # ===================================================================
@@ -1284,160 +1292,135 @@ class TestChatToolCallTracking:
         return Chat(size=size)
 
     def _fc(self, call_id="call_1", name="f1"):
-        return {"type": "function_call", "call_id": call_id, "name": name, "arguments": "{}"}
+        from openai.types.realtime.realtime_conversation_item_function_call import (
+            RealtimeConversationItemFunctionCall,
+        )
+
+        return RealtimeConversationItemFunctionCall(type="function_call", call_id=call_id, name=name, arguments="{}")
 
     def _fco(self, call_id="call_1"):
-        return {"type": "function_call_output", "call_id": call_id, "output": '{"ok": true}'}
+        from openai.types.realtime.realtime_conversation_item_function_call_output import (
+            RealtimeConversationItemFunctionCallOutput,
+        )
 
-    def test_append_registers_pending_tool_call(self):
+        return RealtimeConversationItemFunctionCallOutput(
+            type="function_call_output", call_id=call_id, output='{"ok": true}'
+        )
+
+    def _user(self, text):
+        from speech_to_speech.LLM.chat import make_user_message
+
+        return make_user_message(text)
+
+    def _assistant(self, text):
+        from speech_to_speech.LLM.chat import make_assistant_message
+
+        return make_assistant_message(text)
+
+    def test_add_item_registers_pending_tool_call(self):
         chat = self._make_chat()
         fc = self._fc()
-        chat.append(fc)
+        chat.add_item(fc)
         assert "call_1" in chat._pending_tool_calls
         assert chat._pending_tool_calls["call_1"] is fc
 
     def test_append_tool_output_clears_pending(self):
         chat = self._make_chat()
-        chat.append(self._fc())
+        chat.add_item(self._fc())
         assert "call_1" in chat._pending_tool_calls
-        err = chat.append_tool_output("call_1", self._fco())
-        assert err is None
+        chat.append_tool_output("call_1", self._fco())
         assert "call_1" not in chat._pending_tool_calls
-        assert chat.buffer[-1]["type"] == "function_call_output"
+        assert chat.buffer[-1].type == "function_call_output"
 
     def test_append_tool_output_reinjects_evicted_call(self):
         chat = self._make_chat(size=1)
-        # size=1 keeps 1 user turn. The 2nd user message evicts the 1st turn
-        # (user + fc + assistant), but _pending_tool_calls retains the fc.
-        chat.append({"role": "user", "content": "hi"})
-        chat.append(self._fc("call_x"))
-        chat.append({"role": "assistant", "content": "ok"})
-        chat.append({"role": "user", "content": "more"})
-        assert not any(e.get("call_id") == "call_x" for e in chat.buffer)
+        chat.add_item(self._user("hi"))
+        chat.add_item(self._fc("call_x"))
+        chat.add_item(self._assistant("ok"))
+        chat.add_item(self._user("more"))
+        assert not any(getattr(e, "call_id", None) == "call_x" for e in chat.buffer)
         assert "call_x" in chat._pending_tool_calls
 
-        err = chat.append_tool_output("call_x", self._fco("call_x"))
-        assert err is None
-        assert "call_x" not in chat._pending_tool_calls
-        types = [e.get("type") for e in chat.buffer]
+        chat.append_tool_output("call_x", self._fco("call_x"))
+        assert chat._has_call_id_in_buffer("call_x")
+        types = [e.type for e in chat.buffer]
         assert "function_call" in types
         assert "function_call_output" in types
-        fc_idx = next(i for i, e in enumerate(chat.buffer) if e.get("type") == "function_call")
-        fco_idx = next(i for i, e in enumerate(chat.buffer) if e.get("type") == "function_call_output")
+        fc_idx = next(i for i, e in enumerate(chat.buffer) if e.type == "function_call")
+        fco_idx = next(i for i, e in enumerate(chat.buffer) if e.type == "function_call_output")
         assert fc_idx < fco_idx
 
     def test_append_tool_output_rejects_unknown_call_id(self):
+        from speech_to_speech.LLM.chat import ChatItemError
+
         chat = self._make_chat()
-        err = chat.append_tool_output("call_nope", self._fco("call_nope"))
-        assert err is not None
-        assert "call_nope" in err
-        assert not any(e.get("type") == "function_call_output" for e in chat.buffer)
+        with pytest.raises(ChatItemError, match="call_nope"):
+            chat.append_tool_output("call_nope", self._fco("call_nope"))
+        assert not any(getattr(e, "type", None) == "function_call_output" for e in chat.buffer)
 
     def test_copy_preserves_pending_tool_calls(self):
         chat = self._make_chat()
-        chat.append(self._fc("call_a"))
+        chat.add_item(self._fc("call_a"))
         clone = chat.copy()
         assert "call_a" in clone._pending_tool_calls
-        # Mutating the clone does not affect the original
         clone._pending_tool_calls.pop("call_a")
         assert "call_a" in chat._pending_tool_calls
 
     def test_reset_clears_pending_tool_calls(self):
         chat = self._make_chat()
-        chat.append(self._fc())
+        chat.add_item(self._fc())
         assert chat._pending_tool_calls
         chat.reset()
         assert chat._pending_tool_calls == {}
         assert chat.buffer == []
 
-    # -- transformers / Chat Completions tool_calls format --
-
-    def _assistant_with_tool_calls(self, *call_ids):
-        """Build an assistant message with tool_calls (local LLM format)."""
-        return {
-            "role": "assistant",
-            "tool_calls": [
-                {"type": "function", "id": cid, "function": {"name": f"fn_{cid}", "arguments": {}}} for cid in call_ids
-            ],
-        }
-
-    def test_append_registers_pending_from_tool_calls_format(self):
-        chat = self._make_chat()
-        msg = self._assistant_with_tool_calls("tc_1", "tc_2")
-        chat.append(msg)
-        assert "tc_1" in chat._pending_tool_calls
-        assert "tc_2" in chat._pending_tool_calls
-
-    def test_append_tool_output_accepts_tool_calls_format_in_buffer(self):
-        chat = self._make_chat()
-        chat.append(self._assistant_with_tool_calls("tc_1"))
-        err = chat.append_tool_output("tc_1", self._fco("tc_1"))
-        assert err is None
-        assert chat.buffer[-1] == self._fco("tc_1")
-        assert "tc_1" not in chat._pending_tool_calls
-
-    def test_append_tool_output_reinjects_evicted_tool_calls_format(self):
-        chat = self._make_chat(size=1)
-        chat.append({"role": "user", "content": "hi"})
-        chat.append(self._assistant_with_tool_calls("tc_x"))
-        chat.append({"role": "user", "content": "a"})
-        assert not any(e.get("tool_calls") for e in chat.buffer)
-        assert "tc_x" in chat._pending_tool_calls
-
-        err = chat.append_tool_output("tc_x", self._fco("tc_x"))
-        assert err is None
-        assert "tc_x" not in chat._pending_tool_calls
-        assert any(
-            e.get("role") == "assistant" and any(tc.get("id") == "tc_x" for tc in e.get("tool_calls", []))
-            for e in chat.buffer
-        )
-        assert chat.buffer[-1] == self._fco("tc_x")
-
     # -- turn-based eviction --
 
     def test_eviction_removes_complete_turn(self):
         chat = self._make_chat(size=1)
-        chat.append({"role": "user", "content": "turn 1"})
-        chat.append({"role": "assistant", "content": "thinking"})
-        chat.append(self._fc("c1"))
-        chat.append(self._fco("c1"))
-        chat.append({"role": "assistant", "content": "done"})
-        # Still 1 user turn, no eviction yet
+        chat.add_item(self._user("turn 1"))
+        chat.add_item(self._assistant("thinking"))
+        chat.add_item(self._fc("c1"))
+        chat.add_item(self._fco("c1"))
+        chat.add_item(self._assistant("done"))
         assert len(chat.buffer) == 5
 
-        chat.append({"role": "user", "content": "turn 2"})
-        # 2 user turns > size=1 → oldest turn fully evicted
-        user_msgs = [e for e in chat.buffer if e.get("role") == "user"]
+        chat.add_item(self._user("turn 2"))
+        from openai.types.realtime.realtime_conversation_item_user_message import (
+            RealtimeConversationItemUserMessage,
+        )
+
+        user_msgs = [e for e in chat.buffer if isinstance(e, RealtimeConversationItemUserMessage)]
         assert len(user_msgs) == 1
-        assert user_msgs[0]["content"] == "turn 2"
-        assert not any(e.get("content") == "thinking" for e in chat.buffer)
-        assert not any(e.get("call_id") == "c1" and e.get("type") == "function_call" for e in chat.buffer)
+        assert user_msgs[0].content[0].text == "turn 2"
+        assert not any(getattr(e, "call_id", None) == "c1" and e.type == "function_call" for e in chat.buffer)
 
     def test_eviction_preserves_size_user_turns(self):
-        chat = self._make_chat(size=2)
-        # Turn 1: short
-        chat.append({"role": "user", "content": "t1"})
-        chat.append({"role": "assistant", "content": "r1"})
-        # Turn 2: long (with tool call)
-        chat.append({"role": "user", "content": "t2"})
-        chat.append({"role": "assistant", "content": "let me check"})
-        chat.append(self._fc("c2"))
-        chat.append(self._fco("c2"))
-        chat.append({"role": "assistant", "content": "here"})
-        assert chat._count_user_turns() == 2
+        from openai.types.realtime.realtime_conversation_item_user_message import (
+            RealtimeConversationItemUserMessage,
+        )
 
-        # Turn 3: triggers eviction of turn 1
-        chat.append({"role": "user", "content": "t3"})
-        assert chat._count_user_turns() == 2
-        user_contents = [e["content"] for e in chat.buffer if e.get("role") == "user"]
-        assert user_contents == ["t2", "t3"]
+        chat = self._make_chat(size=2)
+        chat.add_item(self._user("t1"))
+        chat.add_item(self._assistant("r1"))
+        chat.add_item(self._user("t2"))
+        chat.add_item(self._assistant("let me check"))
+        chat.add_item(self._fc("c2"))
+        chat.add_item(self._fco("c2"))
+        chat.add_item(self._assistant("here"))
+        assert chat._user_turn_count == 2
+
+        chat.add_item(self._user("t3"))
+        assert chat._user_turn_count == 2
+        user_texts = [e.content[0].text for e in chat.buffer if isinstance(e, RealtimeConversationItemUserMessage)]
+        assert user_texts == ["t2", "t3"]
 
     def test_pending_tool_calls_cleaned_after_reinjection(self):
         chat = self._make_chat(size=1)
-        chat.append({"role": "user", "content": "hi"})
-        chat.append(self._fc("call_z"))
-        chat.append({"role": "user", "content": "bye"})
+        chat.add_item(self._user("hi"))
+        chat.add_item(self._fc("call_z"))
+        chat.add_item(self._user("bye"))
         assert "call_z" in chat._pending_tool_calls
 
         chat.append_tool_output("call_z", self._fco("call_z"))
-        assert "call_z" not in chat._pending_tool_calls
+        assert chat._has_call_id_in_buffer("call_z")

--- a/tests/openai_realtime/test_realtime_service.py
+++ b/tests/openai_realtime/test_realtime_service.py
@@ -1296,6 +1296,8 @@ class TestChatToolCallTracking:
             RealtimeConversationItemFunctionCall,
         )
 
+        if not call_id.startswith("call_"):
+            call_id = f"call_{call_id}"
         return RealtimeConversationItemFunctionCall(type="function_call", call_id=call_id, name=name, arguments="{}")
 
     def _fco(self, call_id="call_1"):
@@ -1303,6 +1305,8 @@ class TestChatToolCallTracking:
             RealtimeConversationItemFunctionCallOutput,
         )
 
+        if not call_id.startswith("call_"):
+            call_id = f"call_{call_id}"
         return RealtimeConversationItemFunctionCallOutput(
             type="function_call_output", call_id=call_id, output='{"ok": true}'
         )
@@ -1393,7 +1397,7 @@ class TestChatToolCallTracking:
         user_msgs = [e for e in chat.buffer if isinstance(e, RealtimeConversationItemUserMessage)]
         assert len(user_msgs) == 1
         assert user_msgs[0].content[0].text == "turn 2"
-        assert not any(getattr(e, "call_id", None) == "c1" and e.type == "function_call" for e in chat.buffer)
+        assert not any(getattr(e, "call_id", None) == "call_c1" and e.type == "function_call" for e in chat.buffer)
 
     def test_eviction_preserves_size_user_turns(self):
         from openai.types.realtime.realtime_conversation_item_user_message import (

--- a/tests/test_chat.py
+++ b/tests/test_chat.py
@@ -52,6 +52,8 @@ def _system(text: str) -> RealtimeConversationItemSystemMessage:
 
 
 def _fc(call_id: str = "call_1", name: str = "my_func", arguments: str = "{}") -> RealtimeConversationItemFunctionCall:
+    if not call_id.startswith("call_"):
+        call_id = f"call_{call_id}"
     return RealtimeConversationItemFunctionCall(
         type="function_call",
         id=f"fc_{call_id}",
@@ -64,6 +66,8 @@ def _fc(call_id: str = "call_1", name: str = "my_func", arguments: str = "{}") -
 def _fco(
     call_id: str = "call_1", output: str = '{"ok": true}', status=None
 ) -> RealtimeConversationItemFunctionCallOutput:
+    if not call_id.startswith("call_"):
+        call_id = f"call_{call_id}"
     return RealtimeConversationItemFunctionCallOutput(
         type="function_call_output",
         call_id=call_id,
@@ -193,10 +197,10 @@ class TestAddItemEviction:
         chat = Chat(size=5)
         fc = _fc("cid_1")
         chat.add_item(fc)
-        assert "cid_1" in chat._pending_tool_calls
-        assert chat._pending_tool_calls["cid_1"] is fc
+        assert "call_cid_1" in chat._pending_tool_calls
+        assert chat._pending_tool_calls["call_cid_1"] is fc
 
-    def test_add_function_call_none_call_id_raises(self):
+    def test_add_function_call_none_call_id_auto_generates(self):
         chat = Chat(size=5)
         fc = RealtimeConversationItemFunctionCall(
             type="function_call",
@@ -204,8 +208,9 @@ class TestAddItemEviction:
             name="f",
             arguments="{}",
         )
-        with pytest.raises(ChatItemError, match="missing a call_id"):
-            chat.add_item(fc)
+        chat.add_item(fc)
+        assert fc.call_id is not None
+        assert fc.call_id.startswith("call_")
 
     def test_eviction_when_exceeding_size(self):
         chat = Chat(size=1)
@@ -265,9 +270,9 @@ class TestAppendToolOutput:
         chat = Chat(size=5)
         chat.add_item(_fc("c1"))
         fco = _fco("c1")
-        chat.append_tool_output("c1", fco)
+        chat.append_tool_output("call_c1", fco)
 
-        assert "c1" not in chat._pending_tool_calls
+        assert "call_c1" not in chat._pending_tool_calls
         assert chat.buffer[-1] is fco
 
     def test_marks_function_call_completed_on_none_status(self):
@@ -275,7 +280,7 @@ class TestAppendToolOutput:
         fc = _fc("c1")
         chat.add_item(fc)
         fco = _fco("c1", status=None)
-        chat.append_tool_output("c1", fco)
+        chat.append_tool_output("call_c1", fco)
 
         assert fc.status == "completed"
 
@@ -284,7 +289,7 @@ class TestAppendToolOutput:
         fc = _fc("c1")
         chat.add_item(fc)
         fco = _fco("c1", status="incomplete")
-        chat.append_tool_output("c1", fco)
+        chat.append_tool_output("call_c1", fco)
 
         assert fc.status == "incomplete"
 
@@ -293,13 +298,15 @@ class TestAppendToolOutput:
         chat.add_item(_user("u1"))
         chat.add_item(_fc("cx"))
         chat.add_item(_user("u2"))
-        assert not chat._has_call_id_in_buffer("cx")
-        assert "cx" in chat._pending_tool_calls
+        assert not chat._has_call_id_in_buffer("call_cx")
+        assert "call_cx" in chat._pending_tool_calls
 
-        chat.append_tool_output("cx", _fco("cx"))
-        assert chat._has_call_id_in_buffer("cx")
-        assert any(isinstance(e, RealtimeConversationItemFunctionCall) and e.call_id == "cx" for e in chat.buffer)
-        assert any(isinstance(e, RealtimeConversationItemFunctionCallOutput) and e.call_id == "cx" for e in chat.buffer)
+        chat.append_tool_output("call_cx", _fco("cx"))
+        assert chat._has_call_id_in_buffer("call_cx")
+        assert any(isinstance(e, RealtimeConversationItemFunctionCall) and e.call_id == "call_cx" for e in chat.buffer)
+        assert any(
+            isinstance(e, RealtimeConversationItemFunctionCallOutput) and e.call_id == "call_cx" for e in chat.buffer
+        )
 
     def test_reinjection_sets_status(self):
         chat = Chat(size=1)
@@ -309,9 +316,9 @@ class TestAppendToolOutput:
         chat.add_item(_user("u2"))
 
         fco = _fco("cx", status="incomplete")
-        chat.append_tool_output("cx", fco)
+        chat.append_tool_output("call_cx", fco)
         reinjected = next(
-            e for e in chat.buffer if isinstance(e, RealtimeConversationItemFunctionCall) and e.call_id == "cx"
+            e for e in chat.buffer if isinstance(e, RealtimeConversationItemFunctionCall) and e.call_id == "call_cx"
         )
         assert reinjected.status == "incomplete"
 
@@ -412,9 +419,9 @@ class TestAddItem:
         fc = _fc("c1", "do_stuff")
         chat.add_item(fc)
         assert len(chat.buffer) == 1
-        assert chat.buffer[0].call_id == "c1"
+        assert chat.buffer[0].call_id == "call_c1"
 
-    def test_function_call_missing_call_id_raises(self):
+    def test_function_call_missing_call_id_auto_generates(self):
         chat = Chat(size=5)
         fc = RealtimeConversationItemFunctionCall(
             type="function_call",
@@ -422,10 +429,11 @@ class TestAddItem:
             name="f",
             arguments="{}",
         )
-        with pytest.raises(ChatItemError, match="missing a call_id"):
-            chat.add_item(fc)
+        chat.add_item(fc)
+        assert fc.call_id is not None
+        assert fc.call_id.startswith("call_")
 
-    def test_function_call_empty_call_id_raises(self):
+    def test_function_call_empty_call_id_auto_generates(self):
         chat = Chat(size=5)
         fc = RealtimeConversationItemFunctionCall(
             type="function_call",
@@ -433,8 +441,9 @@ class TestAddItem:
             name="f",
             arguments="{}",
         )
-        with pytest.raises(ChatItemError, match="missing a call_id"):
-            chat.add_item(fc)
+        chat.add_item(fc)
+        assert fc.call_id is not None
+        assert fc.call_id.startswith("call_")
 
     # -- Function call output --
 
@@ -529,7 +538,7 @@ class TestToResponseApiChat:
         assert len(result) == 1
         entry = result[0]
         assert entry["type"] == "function_call"
-        assert entry["call_id"] == "c1"
+        assert entry["call_id"] == "call_c1"
         assert entry["name"] == "search"
         assert entry["arguments"] == '{"q": "test"}'
         assert entry["id"] == fc.id
@@ -541,7 +550,7 @@ class TestToResponseApiChat:
         chat.add_item(fc)
         result = chat.to_response_api_chat()
         entry = result[0]
-        assert entry["call_id"] == "c2"
+        assert entry["call_id"] == "call_c2"
         assert entry["id"] == fc.id
         assert "status" not in entry
 
@@ -554,7 +563,7 @@ class TestToResponseApiChat:
         result = chat.to_response_api_chat()
         entry = result[-1]
         assert entry["type"] == "function_call_output"
-        assert entry["call_id"] == "c1"
+        assert entry["call_id"] == "call_c1"
         assert entry["output"] == '{"result": 42}'
         assert entry["id"] == fco.id
         assert entry["status"] == "completed"
@@ -651,7 +660,7 @@ class TestToTransformersChat:
         assert len(entry["tool_calls"]) == 1
         tc = entry["tool_calls"][0]
         assert tc["type"] == "function"
-        assert tc["id"] == "c1"
+        assert tc["id"] == "call_c1"
         assert tc["function"]["name"] == "search"
         assert tc["function"]["arguments"] == {"query": "test"}
 
@@ -675,7 +684,7 @@ class TestToTransformersChat:
         result = chat.to_transformers_chat()
         tool_entry = result[1]
         assert tool_entry["role"] == "tool"
-        assert tool_entry["tool_call_id"] == "c1"
+        assert tool_entry["tool_call_id"] == "call_c1"
         assert tool_entry["name"] == "lookup"
         assert tool_entry["content"] == "result_data"
 
@@ -731,9 +740,9 @@ class TestCopyAndReset:
         chat = Chat(size=5)
         chat.add_item(_fc("c1"))
         clone = chat.copy()
-        assert "c1" in clone._pending_tool_calls
-        clone._pending_tool_calls.pop("c1")
-        assert "c1" in chat._pending_tool_calls
+        assert "call_c1" in clone._pending_tool_calls
+        clone._pending_tool_calls.pop("call_c1")
+        assert "call_c1" in chat._pending_tool_calls
 
     def test_copy_preserves_size(self):
         chat = Chat(size=7)
@@ -812,21 +821,21 @@ class TestMarkCallCompleted:
         chat = Chat(size=5)
         fc = _fc("c1")
         chat.add_item(fc)
-        chat._mark_call_completed("c1", status=None)
+        chat._mark_call_completed("call_c1", status=None)
         assert fc.status == "completed"
 
     def test_explicit_status_used(self):
         chat = Chat(size=5)
         fc = _fc("c1")
         chat.add_item(fc)
-        chat._mark_call_completed("c1", status="incomplete")
+        chat._mark_call_completed("call_c1", status="incomplete")
         assert fc.status == "incomplete"
 
     def test_in_progress_status(self):
         chat = Chat(size=5)
         fc = _fc("c1")
         chat.add_item(fc)
-        chat._mark_call_completed("c1", status="in_progress")
+        chat._mark_call_completed("call_c1", status="in_progress")
         assert fc.status == "in_progress"
 
     def test_no_match_is_noop(self):
@@ -839,6 +848,6 @@ class TestMarkCallCompleted:
         chat = Chat(size=5)
         chat.add_item(_user("hi"))
         chat.add_item(_fc("c1"))
-        chat._mark_call_completed("c1")
+        chat._mark_call_completed("call_c1")
         fc = next(e for e in chat.buffer if isinstance(e, RealtimeConversationItemFunctionCall))
         assert fc.status == "completed"

--- a/tests/test_chat.py
+++ b/tests/test_chat.py
@@ -54,6 +54,7 @@ def _system(text: str) -> RealtimeConversationItemSystemMessage:
 def _fc(call_id: str = "call_1", name: str = "my_func", arguments: str = "{}") -> RealtimeConversationItemFunctionCall:
     return RealtimeConversationItemFunctionCall(
         type="function_call",
+        id=f"fc_{call_id}",
         call_id=call_id,
         name=name,
         arguments=arguments,

--- a/tests/test_chat.py
+++ b/tests/test_chat.py
@@ -1,0 +1,843 @@
+"""Extensive tests for speech_to_speech.LLM.chat.
+
+Covers Chat class (init, add_item validation/eviction,
+serialization to both Response API and transformers formats,
+copy/reset, strip_images, internal helpers) and the three factory
+functions (make_user_message, make_assistant_message, make_system_message).
+"""
+
+from __future__ import annotations
+
+import pytest
+from openai.types.realtime.conversation_item import (
+    RealtimeConversationItemAssistantMessage,
+    RealtimeConversationItemFunctionCall,
+    RealtimeConversationItemFunctionCallOutput,
+    RealtimeConversationItemSystemMessage,
+    RealtimeConversationItemUserMessage,
+)
+from openai.types.realtime.realtime_conversation_item_assistant_message import (
+    Content as AssistantContent,
+)
+from openai.types.realtime.realtime_conversation_item_system_message import (
+    Content as SystemContent,
+)
+from openai.types.realtime.realtime_conversation_item_user_message import (
+    Content as UserContent,
+)
+
+from speech_to_speech.LLM.chat import (
+    Chat,
+    ChatItemError,
+    make_assistant_message,
+    make_system_message,
+    make_user_message,
+)
+
+# ===================================================================
+# Helpers
+# ===================================================================
+
+
+def _user(text: str) -> RealtimeConversationItemUserMessage:
+    return make_user_message(text)
+
+
+def _assistant(text: str) -> RealtimeConversationItemAssistantMessage:
+    return make_assistant_message(text)
+
+
+def _system(text: str) -> RealtimeConversationItemSystemMessage:
+    return make_system_message(text)
+
+
+def _fc(call_id: str = "call_1", name: str = "my_func", arguments: str = "{}") -> RealtimeConversationItemFunctionCall:
+    return RealtimeConversationItemFunctionCall(
+        type="function_call",
+        call_id=call_id,
+        name=name,
+        arguments=arguments,
+    )
+
+
+def _fco(
+    call_id: str = "call_1", output: str = '{"ok": true}', status=None
+) -> RealtimeConversationItemFunctionCallOutput:
+    return RealtimeConversationItemFunctionCallOutput(
+        type="function_call_output",
+        call_id=call_id,
+        output=output,
+        status=status,
+    )
+
+
+def _user_msg_with_parts(*parts) -> RealtimeConversationItemUserMessage:
+    """Build a user message with arbitrary content parts.
+
+    Each *part* is a tuple like ``("text", "hello")`` or ``("image", "url")``.
+    """
+    content = []
+    for kind, value in parts:
+        if kind == "text":
+            content.append(UserContent(type="input_text", text=value))
+        elif kind == "image":
+            content.append(UserContent(type="input_image", image_url=value))
+        elif kind == "audio":
+            content.append(UserContent(type="input_audio", transcript=value))
+    return RealtimeConversationItemUserMessage(type="message", role="user", content=content)
+
+
+def _assistant_msg_with_parts(*parts) -> RealtimeConversationItemAssistantMessage:
+    content = []
+    for kind, value in parts:
+        if kind == "text":
+            content.append(AssistantContent(type="output_text", text=value))
+        elif kind == "audio":
+            content.append(AssistantContent(type="output_audio", transcript=value))
+    return RealtimeConversationItemAssistantMessage(type="message", role="assistant", content=content)
+
+
+# ===================================================================
+# 1. TestChatInit
+# ===================================================================
+
+
+class TestChatInit:
+    def test_default_state(self):
+        chat = Chat(size=5)
+        assert chat.size == 5
+        assert chat.buffer == []
+        assert chat.init_chat_message is None
+        assert chat._pending_tool_calls == {}
+        assert chat._user_turn_count == 0
+
+    def test_size_stored(self):
+        for s in (0, 1, 100):
+            assert Chat(size=s).size == s
+
+
+# ===================================================================
+# 2. TestFactoryHelpers
+# ===================================================================
+
+
+class TestFactoryHelpers:
+    def test_make_user_message(self):
+        msg = make_user_message("hello")
+        assert isinstance(msg, RealtimeConversationItemUserMessage)
+        assert msg.role == "user"
+        assert msg.type == "message"
+        assert len(msg.content) == 1
+        assert msg.content[0].type == "input_text"
+        assert msg.content[0].text == "hello"
+
+    def test_make_assistant_message(self):
+        msg = make_assistant_message("world")
+        assert isinstance(msg, RealtimeConversationItemAssistantMessage)
+        assert msg.role == "assistant"
+        assert msg.type == "message"
+        assert len(msg.content) == 1
+        assert msg.content[0].type == "output_text"
+        assert msg.content[0].text == "world"
+
+    def test_make_system_message(self):
+        msg = make_system_message("You are helpful.")
+        assert isinstance(msg, RealtimeConversationItemSystemMessage)
+        assert msg.role == "system"
+        assert msg.type == "message"
+        assert len(msg.content) == 1
+        assert msg.content[0].type == "input_text"
+        assert msg.content[0].text == "You are helpful."
+
+
+# ===================================================================
+# 3. TestInitChat
+# ===================================================================
+
+
+class TestInitChat:
+    def test_sets_init_chat_message(self):
+        chat = Chat(size=5)
+        sys_msg = _system("Be concise.")
+        chat.init_chat(sys_msg)
+        assert chat.init_chat_message is sys_msg
+
+    def test_overwrite_replaces_previous(self):
+        chat = Chat(size=5)
+        chat.init_chat(_system("first"))
+        chat.init_chat(_system("second"))
+        assert chat.init_chat_message.content[0].text == "second"
+
+    def test_system_message_not_in_buffer(self):
+        chat = Chat(size=5)
+        chat.init_chat(_system("system"))
+        assert chat.buffer == []
+
+
+# ===================================================================
+# 4. TestAddItemEviction
+# ===================================================================
+
+
+class TestAddItemEviction:
+    def test_add_user_increments_turn_count(self):
+        chat = Chat(size=5)
+        assert chat._user_turn_count == 0
+        chat.add_item(_user("hi"))
+        assert chat._user_turn_count == 1
+        chat.add_item(_user("there"))
+        assert chat._user_turn_count == 2
+
+    def test_add_function_call_registers_pending(self):
+        chat = Chat(size=5)
+        fc = _fc("cid_1")
+        chat.add_item(fc)
+        assert "cid_1" in chat._pending_tool_calls
+        assert chat._pending_tool_calls["cid_1"] is fc
+
+    def test_add_function_call_none_call_id_raises(self):
+        chat = Chat(size=5)
+        fc = RealtimeConversationItemFunctionCall(
+            type="function_call",
+            call_id=None,
+            name="f",
+            arguments="{}",
+        )
+        with pytest.raises(ChatItemError, match="missing a call_id"):
+            chat.add_item(fc)
+
+    def test_eviction_when_exceeding_size(self):
+        chat = Chat(size=1)
+        chat.add_item(_user("t1"))
+        chat.add_item(_assistant("r1"))
+        assert chat._user_turn_count == 1
+
+        chat.add_item(_user("t2"))
+        assert chat._user_turn_count == 1
+        assert chat.buffer[0].content[0].text == "t2"
+
+    def test_eviction_removes_up_to_next_user_boundary(self):
+        chat = Chat(size=1)
+        chat.add_item(_user("t1"))
+        chat.add_item(_assistant("a1"))
+        chat.add_item(_fc("c1"))
+        chat.add_item(_fco("c1"))
+        chat.add_item(_assistant("a2"))
+        assert len(chat.buffer) == 5
+
+        chat.add_item(_user("t2"))
+        assert chat._user_turn_count == 1
+        remaining_types = [e.type for e in chat.buffer]
+        assert "message" in remaining_types
+        assert chat.buffer[0].content[0].text == "t2"
+
+    def test_size_zero_evicts_every_user_message(self):
+        chat = Chat(size=0)
+        chat.add_item(_user("a"))
+        assert chat._user_turn_count == 0
+        assert len(chat.buffer) == 0
+
+    def test_non_user_items_do_not_trigger_eviction(self):
+        chat = Chat(size=1)
+        chat.add_item(_assistant("a"))
+        chat.add_item(_fc("c1"))
+        chat.add_item(_assistant("b"))
+        assert len(chat.buffer) == 3
+
+    def test_multiple_evictions(self):
+        chat = Chat(size=2)
+        for i in range(5):
+            chat.add_item(_user(f"u{i}"))
+            chat.add_item(_assistant(f"a{i}"))
+        assert chat._user_turn_count == 2
+        user_texts = [e.content[0].text for e in chat.buffer if isinstance(e, RealtimeConversationItemUserMessage)]
+        assert user_texts == ["u3", "u4"]
+
+
+# ===================================================================
+# 5. TestAppendToolOutput
+# ===================================================================
+
+
+class TestAppendToolOutput:
+    def test_happy_path(self):
+        chat = Chat(size=5)
+        chat.add_item(_fc("c1"))
+        fco = _fco("c1")
+        chat.append_tool_output("c1", fco)
+
+        assert "c1" not in chat._pending_tool_calls
+        assert chat.buffer[-1] is fco
+
+    def test_marks_function_call_completed_on_none_status(self):
+        chat = Chat(size=5)
+        fc = _fc("c1")
+        chat.add_item(fc)
+        fco = _fco("c1", status=None)
+        chat.append_tool_output("c1", fco)
+
+        assert fc.status == "completed"
+
+    def test_status_propagation_from_output(self):
+        chat = Chat(size=5)
+        fc = _fc("c1")
+        chat.add_item(fc)
+        fco = _fco("c1", status="incomplete")
+        chat.append_tool_output("c1", fco)
+
+        assert fc.status == "incomplete"
+
+    def test_reinjection_path(self):
+        chat = Chat(size=1)
+        chat.add_item(_user("u1"))
+        chat.add_item(_fc("cx"))
+        chat.add_item(_user("u2"))
+        assert not chat._has_call_id_in_buffer("cx")
+        assert "cx" in chat._pending_tool_calls
+
+        chat.append_tool_output("cx", _fco("cx"))
+        assert chat._has_call_id_in_buffer("cx")
+        assert any(isinstance(e, RealtimeConversationItemFunctionCall) and e.call_id == "cx" for e in chat.buffer)
+        assert any(isinstance(e, RealtimeConversationItemFunctionCallOutput) and e.call_id == "cx" for e in chat.buffer)
+
+    def test_reinjection_sets_status(self):
+        chat = Chat(size=1)
+        chat.add_item(_user("u1"))
+        fc = _fc("cx")
+        chat.add_item(fc)
+        chat.add_item(_user("u2"))
+
+        fco = _fco("cx", status="incomplete")
+        chat.append_tool_output("cx", fco)
+        reinjected = next(
+            e for e in chat.buffer if isinstance(e, RealtimeConversationItemFunctionCall) and e.call_id == "cx"
+        )
+        assert reinjected.status == "incomplete"
+
+    def test_unknown_call_id_raises(self):
+        chat = Chat(size=5)
+        with pytest.raises(ChatItemError, match="unknown_id"):
+            chat.append_tool_output("unknown_id", _fco("unknown_id"))
+
+
+# ===================================================================
+# 6. TestAddItem
+# ===================================================================
+
+
+class TestAddItem:
+    # -- System message --
+
+    def test_system_message_routed_to_init_chat(self):
+        chat = Chat(size=5)
+        sys_msg = _system("You are an expert.")
+        chat.add_item(sys_msg)
+        assert chat.init_chat_message is sys_msg
+        assert chat.buffer == []
+
+    # -- User message --
+
+    def test_user_message_text_appended(self):
+        chat = Chat(size=5)
+        chat.add_item(_user("hi"))
+        assert len(chat.buffer) == 1
+        assert chat.buffer[0].content[0].text == "hi"
+
+    def test_user_message_filters_unsupported_content(self):
+        chat = Chat(size=5)
+        msg = _user_msg_with_parts(("text", "hello"), ("audio", "transcript"))
+        chat.add_item(msg)
+        assert len(chat.buffer[0].content) == 1
+        assert chat.buffer[0].content[0].type == "input_text"
+
+    def test_user_message_keeps_image_content(self):
+        chat = Chat(size=5)
+        msg = _user_msg_with_parts(("text", "look"), ("image", "http://img.png"))
+        chat.add_item(msg)
+        assert len(chat.buffer[0].content) == 2
+
+    def test_user_message_empty_after_filter_raises(self):
+        chat = Chat(size=5)
+        msg = _user_msg_with_parts(("audio", "transcript only"))
+        with pytest.raises(ChatItemError, match="no supported content"):
+            chat.add_item(msg)
+
+    def test_user_message_empty_text_raises(self):
+        chat = Chat(size=5)
+        msg = RealtimeConversationItemUserMessage(
+            type="message",
+            role="user",
+            content=[UserContent(type="input_text", text="")],
+        )
+        with pytest.raises(ChatItemError, match="no supported content"):
+            chat.add_item(msg)
+
+    # -- Assistant message --
+
+    def test_assistant_message_appended(self):
+        chat = Chat(size=5)
+        chat.add_item(_user("hi"))
+        chat.add_item(_assistant("hello"))
+        assert len(chat.buffer) == 2
+        assert chat.buffer[1].content[0].text == "hello"
+
+    def test_assistant_message_filters_non_text(self):
+        chat = Chat(size=5)
+        msg = _assistant_msg_with_parts(("text", "ok"), ("audio", "audio_data"))
+        chat.add_item(msg)
+        assert len(chat.buffer[0].content) == 1
+        assert chat.buffer[0].content[0].type == "output_text"
+
+    def test_assistant_message_empty_after_filter_raises(self):
+        chat = Chat(size=5)
+        msg = _assistant_msg_with_parts(("audio", "only audio"))
+        with pytest.raises(ChatItemError, match="no text content"):
+            chat.add_item(msg)
+
+    def test_assistant_message_empty_text_raises(self):
+        chat = Chat(size=5)
+        msg = RealtimeConversationItemAssistantMessage(
+            type="message",
+            role="assistant",
+            content=[AssistantContent(type="output_text", text="")],
+        )
+        with pytest.raises(ChatItemError, match="no text content"):
+            chat.add_item(msg)
+
+    # -- Function call --
+
+    def test_function_call_appended(self):
+        chat = Chat(size=5)
+        fc = _fc("c1", "do_stuff")
+        chat.add_item(fc)
+        assert len(chat.buffer) == 1
+        assert chat.buffer[0].call_id == "c1"
+
+    def test_function_call_missing_call_id_raises(self):
+        chat = Chat(size=5)
+        fc = RealtimeConversationItemFunctionCall(
+            type="function_call",
+            call_id=None,
+            name="f",
+            arguments="{}",
+        )
+        with pytest.raises(ChatItemError, match="missing a call_id"):
+            chat.add_item(fc)
+
+    def test_function_call_empty_call_id_raises(self):
+        chat = Chat(size=5)
+        fc = RealtimeConversationItemFunctionCall(
+            type="function_call",
+            call_id="",
+            name="f",
+            arguments="{}",
+        )
+        with pytest.raises(ChatItemError, match="missing a call_id"):
+            chat.add_item(fc)
+
+    # -- Function call output --
+
+    def test_function_call_output_delegates_to_append_tool_output(self):
+        chat = Chat(size=5)
+        chat.add_item(_fc("c1"))
+        fco = _fco("c1")
+        chat.add_item(fco)
+        assert chat.buffer[-1] is fco
+
+    def test_function_call_output_unknown_raises(self):
+        chat = Chat(size=5)
+        with pytest.raises(ChatItemError, match="no_such_call"):
+            chat.add_item(_fco("no_such_call"))
+
+
+# ===================================================================
+# 7. TestToResponseApiChat
+# ===================================================================
+
+
+class TestToResponseApiChat:
+    def test_empty_chat(self):
+        chat = Chat(size=5)
+        assert chat.to_response_api_chat() == []
+
+    def test_system_message_serialized(self):
+        chat = Chat(size=5)
+        chat.init_chat(_system("Be brief."))
+        result = chat.to_response_api_chat()
+        assert len(result) == 1
+        assert result[0]["role"] == "system"
+        assert result[0]["type"] == "message"
+        assert result[0]["content"][0]["text"] == "Be brief."
+        assert result[0]["content"][0]["type"] == "input_text"
+
+    def test_system_message_empty_text_fallback(self):
+        chat = Chat(size=5)
+        sys_msg = RealtimeConversationItemSystemMessage(
+            type="message",
+            role="system",
+            content=[SystemContent(type="input_text", text="")],
+        )
+        chat.init_chat(sys_msg)
+        result = chat.to_response_api_chat()
+        assert result[0]["content"][0]["text"] == "A helpful AI assistant."
+
+    def test_user_text_message(self):
+        chat = Chat(size=5)
+        chat.add_item(_user("What is 2+2?"))
+        result = chat.to_response_api_chat()
+        assert len(result) == 1
+        assert result[0]["role"] == "user"
+        assert result[0]["content"][0]["text"] == "What is 2+2?"
+
+    def test_user_image_message(self):
+        chat = Chat(size=5)
+        msg = _user_msg_with_parts(("text", "Describe"), ("image", "http://img.png"))
+        chat.add_item(msg)
+        result = chat.to_response_api_chat()
+        content = result[0]["content"]
+        assert len(content) == 2
+        assert content[0]["type"] == "input_text"
+        assert content[1]["type"] == "input_image"
+        assert content[1]["image_url"] == "http://img.png"
+
+    def test_assistant_message(self):
+        chat = Chat(size=5)
+        msg = make_assistant_message("Hello there.")
+        msg.status = "completed"
+        chat.add_item(msg)
+        result = chat.to_response_api_chat()
+        assert len(result) == 1
+        assert result[0]["role"] == "assistant"
+        assert result[0]["id"] == msg.id
+        assert result[0]["status"] == "completed"
+        assert result[0]["content"][0]["text"] == "Hello there."
+
+    def test_assistant_message_default_status(self):
+        chat = Chat(size=5)
+        msg = make_assistant_message("hi")
+        chat.add_item(msg)
+        result = chat.to_response_api_chat()
+        assert result[0]["status"] == "completed"
+
+    def test_function_call_with_id_and_status(self):
+        chat = Chat(size=5)
+        fc = _fc("c1", "search", '{"q": "test"}')
+        fc.status = "completed"
+        chat.add_item(fc)
+        result = chat.to_response_api_chat()
+        assert len(result) == 1
+        entry = result[0]
+        assert entry["type"] == "function_call"
+        assert entry["call_id"] == "c1"
+        assert entry["name"] == "search"
+        assert entry["arguments"] == '{"q": "test"}'
+        assert entry["id"] == fc.id
+        assert entry["status"] == "completed"
+
+    def test_function_call_without_optional_fields(self):
+        chat = Chat(size=5)
+        fc = _fc("c2", "noop")
+        chat.add_item(fc)
+        result = chat.to_response_api_chat()
+        entry = result[0]
+        assert entry["call_id"] == "c2"
+        assert entry["id"] == fc.id
+        assert "status" not in entry
+
+    def test_function_call_output_with_id_and_status(self):
+        chat = Chat(size=5)
+        chat.add_item(_fc("c1"))
+        fco = _fco("c1", '{"result": 42}')
+        fco.status = "completed"
+        chat.add_item(fco)
+        result = chat.to_response_api_chat()
+        entry = result[-1]
+        assert entry["type"] == "function_call_output"
+        assert entry["call_id"] == "c1"
+        assert entry["output"] == '{"result": 42}'
+        assert entry["id"] == fco.id
+        assert entry["status"] == "completed"
+
+    def test_function_call_output_without_optional_fields(self):
+        chat = Chat(size=5)
+        chat.add_item(_fc("c1"))
+        fco = _fco("c1")
+        chat.add_item(fco)
+        result = chat.to_response_api_chat()
+        entry = result[-1]
+        assert entry["id"] == fco.id
+        assert "status" not in entry
+
+    def test_full_mixed_conversation(self):
+        chat = Chat(size=10)
+        chat.init_chat(_system("You are helpful."))
+        chat.add_item(_user("Call my tool"))
+        chat.add_item(_fc("c1", "tool_a", '{"x": 1}'))
+        fco = _fco("c1", '{"y": 2}')
+        chat.add_item(fco)
+        chat.add_item(_assistant("Done."))
+
+        result = chat.to_response_api_chat()
+        assert len(result) == 5
+        assert result[0]["role"] == "system"
+        assert result[1]["role"] == "user"
+        assert result[2]["type"] == "function_call"
+        assert result[3]["type"] == "function_call_output"
+        assert result[4]["role"] == "assistant"
+
+
+# ===================================================================
+# 8. TestToTransformersChat
+# ===================================================================
+
+
+class TestToTransformersChat:
+    def test_empty_chat(self):
+        chat = Chat(size=5)
+        assert chat.to_transformers_chat() == []
+
+    def test_system_message(self):
+        chat = Chat(size=5)
+        chat.init_chat(_system("Be concise."))
+        result = chat.to_transformers_chat()
+        assert result == [{"role": "system", "content": "Be concise."}]
+
+    def test_user_text_only_produces_string_content(self):
+        chat = Chat(size=5)
+        chat.add_item(_user("hi there"))
+        result = chat.to_transformers_chat()
+        assert len(result) == 1
+        assert result[0]["role"] == "user"
+        assert isinstance(result[0]["content"], str)
+        assert result[0]["content"] == "hi there"
+
+    def test_user_multi_text_parts_joined(self):
+        chat = Chat(size=5)
+        msg = _user_msg_with_parts(("text", "hello"), ("text", "world"))
+        chat.add_item(msg)
+        result = chat.to_transformers_chat()
+        assert result[0]["content"] == "hello world"
+
+    def test_user_with_images_produces_list_content(self):
+        chat = Chat(size=5)
+        msg = _user_msg_with_parts(("text", "look"), ("image", "http://img.png"))
+        chat.add_item(msg)
+        result = chat.to_transformers_chat()
+        assert result[0]["role"] == "user"
+        assert isinstance(result[0]["content"], list)
+        assert len(result[0]["content"]) == 2
+
+    def test_assistant_message_text_joined(self):
+        chat = Chat(size=5)
+        msg = RealtimeConversationItemAssistantMessage(
+            type="message",
+            role="assistant",
+            content=[
+                AssistantContent(type="output_text", text="part1"),
+                AssistantContent(type="output_text", text="part2"),
+            ],
+        )
+        chat.add_item(msg)
+        result = chat.to_transformers_chat()
+        assert result[0] == {"role": "assistant", "content": "part1 part2"}
+
+    def test_function_call_valid_json_args(self):
+        chat = Chat(size=5)
+        chat.add_item(_fc("c1", "search", '{"query": "test"}'))
+        result = chat.to_transformers_chat()
+        entry = result[0]
+        assert entry["role"] == "assistant"
+        assert len(entry["tool_calls"]) == 1
+        tc = entry["tool_calls"][0]
+        assert tc["type"] == "function"
+        assert tc["id"] == "c1"
+        assert tc["function"]["name"] == "search"
+        assert tc["function"]["arguments"] == {"query": "test"}
+
+    def test_function_call_invalid_json_falls_back(self):
+        chat = Chat(size=5)
+        chat.add_item(_fc("c1", "broken", "not valid json"))
+        result = chat.to_transformers_chat()
+        assert result[0]["tool_calls"][0]["function"]["arguments"] == {}
+
+    def test_function_call_empty_string_args(self):
+        chat = Chat(size=5)
+        fc = _fc("c1", "f", "")
+        chat.add_item(fc)
+        result = chat.to_transformers_chat()
+        assert result[0]["tool_calls"][0]["function"]["arguments"] == {}
+
+    def test_function_call_output_resolves_name(self):
+        chat = Chat(size=5)
+        chat.add_item(_fc("c1", "lookup"))
+        chat.add_item(_fco("c1", "result_data"))
+        result = chat.to_transformers_chat()
+        tool_entry = result[1]
+        assert tool_entry["role"] == "tool"
+        assert tool_entry["tool_call_id"] == "c1"
+        assert tool_entry["name"] == "lookup"
+        assert tool_entry["content"] == "result_data"
+
+    def test_function_call_output_no_matching_call_empty_name(self):
+        chat = Chat(size=5)
+        fco = _fco("orphan_id", "data")
+        fco.id = "fco_orphan"
+        chat.buffer.append(fco)
+        result = chat.to_transformers_chat()
+        assert result[0]["name"] == ""
+
+    def test_full_mixed_conversation(self):
+        chat = Chat(size=10)
+        chat.init_chat(_system("System prompt"))
+        chat.add_item(_user("Do it"))
+        chat.add_item(_fc("c1", "action", '{"a": 1}'))
+        chat.add_item(_fco("c1", "done"))
+        chat.add_item(_assistant("All set."))
+
+        result = chat.to_transformers_chat()
+        assert len(result) == 5
+        assert result[0] == {"role": "system", "content": "System prompt"}
+        assert result[1] == {"role": "user", "content": "Do it"}
+        assert result[2]["role"] == "assistant"
+        assert "tool_calls" in result[2]
+        assert result[3]["role"] == "tool"
+        assert result[3]["name"] == "action"
+        assert result[4] == {"role": "assistant", "content": "All set."}
+
+
+# ===================================================================
+# 9. TestCopyAndReset
+# ===================================================================
+
+
+class TestCopyAndReset:
+    def test_copy_buffer_independent(self):
+        chat = Chat(size=5)
+        chat.add_item(_user("original"))
+        clone = chat.copy()
+        clone.add_item(_user("extra"))
+        assert len(chat.buffer) == 1
+        assert len(clone.buffer) == 2
+
+    def test_copy_preserves_init_chat_message(self):
+        chat = Chat(size=5)
+        sys_msg = _system("Keep it short.")
+        chat.init_chat(sys_msg)
+        clone = chat.copy()
+        assert clone.init_chat_message is sys_msg
+
+    def test_copy_preserves_pending_tool_calls_independently(self):
+        chat = Chat(size=5)
+        chat.add_item(_fc("c1"))
+        clone = chat.copy()
+        assert "c1" in clone._pending_tool_calls
+        clone._pending_tool_calls.pop("c1")
+        assert "c1" in chat._pending_tool_calls
+
+    def test_copy_preserves_size(self):
+        chat = Chat(size=7)
+        clone = chat.copy()
+        assert clone.size == 7
+
+    def test_copy_preserves_user_turn_count(self):
+        chat = Chat(size=5)
+        chat.add_item(_user("u1"))
+        chat.add_item(_user("u2"))
+        clone = chat.copy()
+        assert clone._user_turn_count == 2
+
+    def test_reset_clears_everything(self):
+        chat = Chat(size=5)
+        chat.init_chat(_system("sys"))
+        chat.add_item(_user("u"))
+        chat.add_item(_fc("c1"))
+        assert len(chat.buffer) > 0
+        assert chat.init_chat_message is not None
+        assert len(chat._pending_tool_calls) > 0
+        assert chat._user_turn_count > 0
+
+        chat.reset()
+        assert chat.buffer == []
+        assert chat.init_chat_message is None
+        assert chat._pending_tool_calls == {}
+        assert chat._user_turn_count == 0
+
+    def test_reset_preserves_size(self):
+        chat = Chat(size=3)
+        chat.reset()
+        assert chat.size == 3
+
+
+# ===================================================================
+# 10. TestStripImages
+# ===================================================================
+
+
+class TestStripImages:
+    def test_multiple_user_messages_images_removed(self):
+        chat = Chat(size=10)
+        chat.add_item(_user_msg_with_parts(("text", "a"), ("image", "url1")))
+        chat.add_item(_assistant("ok"))
+        chat.add_item(_user_msg_with_parts(("text", "b"), ("image", "url2")))
+        chat.strip_images()
+
+        for item in chat.buffer:
+            if isinstance(item, RealtimeConversationItemUserMessage):
+                assert all(p.type != "input_image" for p in item.content)
+                assert any(p.type == "input_text" for p in item.content)
+
+    def test_no_user_messages_noop(self):
+        chat = Chat(size=10)
+        chat.add_item(_assistant("solo"))
+        chat.add_item(_fc("c1"))
+        chat.strip_images()
+        assert len(chat.buffer) == 2
+
+    def test_text_only_messages_unchanged(self):
+        chat = Chat(size=10)
+        chat.add_item(_user("just text"))
+        chat.strip_images()
+        assert chat.buffer[0].content[0].text == "just text"
+        assert len(chat.buffer[0].content) == 1
+
+
+# ===================================================================
+# 11. TestMarkCallCompleted
+# ===================================================================
+
+
+class TestMarkCallCompleted:
+    def test_none_status_sets_completed(self):
+        chat = Chat(size=5)
+        fc = _fc("c1")
+        chat.add_item(fc)
+        chat._mark_call_completed("c1", status=None)
+        assert fc.status == "completed"
+
+    def test_explicit_status_used(self):
+        chat = Chat(size=5)
+        fc = _fc("c1")
+        chat.add_item(fc)
+        chat._mark_call_completed("c1", status="incomplete")
+        assert fc.status == "incomplete"
+
+    def test_in_progress_status(self):
+        chat = Chat(size=5)
+        fc = _fc("c1")
+        chat.add_item(fc)
+        chat._mark_call_completed("c1", status="in_progress")
+        assert fc.status == "in_progress"
+
+    def test_no_match_is_noop(self):
+        chat = Chat(size=5)
+        chat.add_item(_fc("c1"))
+        chat._mark_call_completed("nonexistent", status=None)
+        assert chat.buffer[0].status is None
+
+    def test_only_function_calls_checked(self):
+        chat = Chat(size=5)
+        chat.add_item(_user("hi"))
+        chat.add_item(_fc("c1"))
+        chat._mark_call_completed("c1")
+        fc = next(e for e in chat.buffer if isinstance(e, RealtimeConversationItemFunctionCall))
+        assert fc.status == "completed"

--- a/tests/test_chat.py
+++ b/tests/test_chat.py
@@ -433,7 +433,19 @@ class TestAddItem:
         assert fc.call_id is not None
         assert fc.call_id.startswith("call_")
 
-    def test_function_call_empty_call_id_auto_generates(self):
+    def test_function_call_none_call_id_auto_generates(self):
+        chat = Chat(size=5)
+        fc = RealtimeConversationItemFunctionCall(
+            type="function_call",
+            call_id=None,
+            name="f",
+            arguments="{}",
+        )
+        chat.add_item(fc)
+        assert fc.call_id is not None
+        assert fc.call_id.startswith("call_")
+
+    def test_function_call_bad_call_id_prefix_raises(self):
         chat = Chat(size=5)
         fc = RealtimeConversationItemFunctionCall(
             type="function_call",
@@ -441,9 +453,8 @@ class TestAddItem:
             name="f",
             arguments="{}",
         )
-        chat.add_item(fc)
-        assert fc.call_id is not None
-        assert fc.call_id.startswith("call_")
+        with pytest.raises(ChatItemError, match="call_"):
+            chat.add_item(fc)
 
     # -- Function call output --
 

--- a/tests/test_chat.py
+++ b/tests/test_chat.py
@@ -396,21 +396,21 @@ class TestAddItem:
         assert len(chat.buffer[0].content) == 1
         assert chat.buffer[0].content[0].type == "output_text"
 
-    def test_assistant_message_empty_after_filter_raises(self):
+    def test_assistant_message_empty_after_filter_skipped(self):
         chat = Chat(size=5)
         msg = _assistant_msg_with_parts(("audio", "only audio"))
-        with pytest.raises(ChatItemError, match="no text content"):
-            chat.add_item(msg)
+        chat.add_item(msg)
+        assert len(chat.buffer) == 0
 
-    def test_assistant_message_empty_text_raises(self):
+    def test_assistant_message_empty_text_skipped(self):
         chat = Chat(size=5)
         msg = RealtimeConversationItemAssistantMessage(
             type="message",
             role="assistant",
             content=[AssistantContent(type="output_text", text="")],
         )
-        with pytest.raises(ChatItemError, match="no text content"):
-            chat.add_item(msg)
+        chat.add_item(msg)
+        assert len(chat.buffer) == 0
 
     # -- Function call --
 

--- a/tests/test_openai_api_language_model.py
+++ b/tests/test_openai_api_language_model.py
@@ -52,7 +52,7 @@ def _make_response(output, usage=None):
     return resp
 
 
-def _make_handler(*, disable_thinking=False, stream=True, cancel_scope=None):
+def _make_handler(*, disable_thinking=False, stream=True, cancel_scope=None, chat_size=2):
     handler = object.__new__(OpenApiModelHandler)
     handler.model_name = "test-model"
     handler.stream = stream
@@ -63,7 +63,7 @@ def _make_handler(*, disable_thinking=False, stream=True, cancel_scope=None):
     handler.disable_thinking = disable_thinking
     handler._extra_body = {"chat_template_kwargs": {"enable_thinking": False}} if disable_thinking else None
     handler.user_role = "user"
-    handler.chat = Chat(1)
+    handler.chat = Chat(chat_size)
     handler.cancel_scope = cancel_scope
     handler.tools = None
     handler.tools_choice = None

--- a/tests/test_openai_api_language_model.py
+++ b/tests/test_openai_api_language_model.py
@@ -6,13 +6,16 @@ from openai import Stream
 from openai.types.responses import (
     Response,
     ResponseOutputItemDoneEvent,
+    ResponseOutputMessage,
     ResponseTextDeltaEvent,
 )
+from openai.types.responses.response_output_text import ResponseOutputText
 
-from speech_to_speech.LLM.chat import Chat
+from speech_to_speech.api.openai_realtime.runtime_config import RuntimeConfig
+from speech_to_speech.LLM.chat import Chat, make_user_message
 from speech_to_speech.LLM.openai_api_language_model import OpenApiModelHandler
 from speech_to_speech.pipeline.cancel_scope import CancelScope
-from speech_to_speech.pipeline.messages import EndOfResponse, LLMResponseChunk, Transcription
+from speech_to_speech.pipeline.messages import EndOfResponse, GenerateResponseRequest, LLMResponseChunk
 
 
 def _make_text_delta_event(text):
@@ -52,7 +55,22 @@ def _make_response(output, usage=None):
     return resp
 
 
-def _make_handler(*, disable_thinking=False, stream=True, cancel_scope=None, chat_size=2):
+def _make_runtime_config(chat_size=2, instructions="You are a helpful AI assistant."):
+    from openai.types.realtime import RealtimeSessionCreateRequest
+
+    return RuntimeConfig(
+        chat=Chat(chat_size),
+        session=RealtimeSessionCreateRequest(type="realtime", instructions=instructions),
+    )
+
+
+def _make_request(text="Hi", chat_size=2):
+    cfg = _make_runtime_config(chat_size=chat_size)
+    cfg.chat.add_item(make_user_message(text))
+    return GenerateResponseRequest(runtime_config=cfg)
+
+
+def _make_handler(*, disable_thinking=False, stream=True, cancel_scope=None):
     handler = object.__new__(OpenApiModelHandler)
     handler.model_name = "test-model"
     handler.stream = stream
@@ -63,7 +81,6 @@ def _make_handler(*, disable_thinking=False, stream=True, cancel_scope=None, cha
     handler.disable_thinking = disable_thinking
     handler._extra_body = {"chat_template_kwargs": {"enable_thinking": False}} if disable_thinking else None
     handler.user_role = "user"
-    handler.chat = Chat(chat_size)
     handler.cancel_scope = cancel_scope
     handler.tools = None
     handler.tools_choice = None
@@ -85,7 +102,7 @@ def test_process_streams_text_from_response_events():
         )
     )
 
-    outputs = list(handler.process(Transcription(text="Hi")))
+    outputs = list(handler.process(_make_request("Hi")))
 
     assert len(outputs) == 3
     assert isinstance(outputs[0], LLMResponseChunk) and outputs[0].text == "Hello."
@@ -103,7 +120,7 @@ def test_process_handles_cancellation():
 
     handler.client = SimpleNamespace(responses=SimpleNamespace(create=fake_create))
 
-    outputs = list(handler.process(Transcription(text="Hi")))
+    outputs = list(handler.process(_make_request("Hi")))
 
     assert len(outputs) == 1
     assert isinstance(outputs[0], EndOfResponse)
@@ -119,7 +136,7 @@ def test_process_read_timeout_ends_response_cleanly():
 
     handler.client = SimpleNamespace(responses=SimpleNamespace(create=lambda **kwargs: make_timeout_stream()))
 
-    outputs = list(handler.process(Transcription(text="Hi")))
+    outputs = list(handler.process(_make_request("Hi")))
 
     assert len(outputs) == 2
     assert (
@@ -144,7 +161,7 @@ def test_disable_thinking_passes_extra_body():
 
     handler.client = SimpleNamespace(responses=SimpleNamespace(create=fake_create))
 
-    list(handler.process(Transcription(text="Hi")))
+    list(handler.process(_make_request("Hi")))
 
     assert captured["extra_body"] == {"chat_template_kwargs": {"enable_thinking": False}}
 
@@ -164,7 +181,7 @@ def test_no_disable_thinking_omits_extra_body():
 
     handler.client = SimpleNamespace(responses=SimpleNamespace(create=fake_create))
 
-    list(handler.process(Transcription(text="Hi")))
+    list(handler.process(_make_request("Hi")))
 
     assert captured.get("extra_body") is None
 
@@ -172,13 +189,16 @@ def test_no_disable_thinking_omits_extra_body():
 def test_second_turn_flattens_assistant_history_for_responses():
     handler = _make_handler(stream=False)
     captured = {}
+    cfg = _make_runtime_config(chat_size=2)
 
     first_response = _make_response(
         output=[
-            SimpleNamespace(
+            ResponseOutputMessage(
+                id="msg_1",
                 type="message",
                 role="assistant",
-                content=[SimpleNamespace(type="output_text", text="Hello.")],
+                status="completed",
+                content=[ResponseOutputText(type="output_text", text="Hello.", annotations=[])],
             )
         ],
     )
@@ -195,14 +215,17 @@ def test_second_turn_flattens_assistant_history_for_responses():
 
     handler.client = SimpleNamespace(responses=SimpleNamespace(create=fake_create))
 
-    list(handler.process(Transcription(text="Hi")))
-    list(handler.process(Transcription(text="Again")))
+    cfg.chat.add_item(make_user_message("Hi"))
+    list(handler.process(GenerateResponseRequest(runtime_config=cfg)))
+    cfg.chat.add_item(make_user_message("Again"))
+    list(handler.process(GenerateResponseRequest(runtime_config=cfg)))
 
     assistant_items = [item for item in captured["input"] if item.get("role") == "assistant"]
-    assert assistant_items == [
-        {
-            "type": "message",
-            "role": "assistant",
-            "content": [SimpleNamespace(type="output_text", text="Hello.")],
-        }
-    ]
+    assert len(assistant_items) == 1
+    ai = assistant_items[0]
+    assert ai["role"] == "assistant"
+    assert ai["type"] == "message"
+    assert ai["status"] == "completed"
+    assert len(ai["content"]) == 1
+    assert ai["content"][0]["type"] == "output_text"
+    assert ai["content"][0]["text"] == "Hello."

--- a/tests/test_qwen3_tts_handler_backend.py
+++ b/tests/test_qwen3_tts_handler_backend.py
@@ -268,7 +268,8 @@ def test_process_only_reenables_listening_after_end_of_response(monkeypatch):
     assert end_outputs == [AUDIO_RESPONSE_DONE]
 
 
-def test_process_reenables_listening_when_generation_fails_outside_realtime(monkeypatch):
+def test_process_does_not_set_should_listen_when_generation_fails(monkeypatch):
+    """TTS no longer manages should_listen; the I/O streamer does via AUDIO_RESPONSE_DONE."""
     handler = object.__new__(Qwen3TTSHandler)
     handler.should_listen = Event()
     handler.cancel_scope = None
@@ -292,7 +293,7 @@ def test_process_reenables_listening_when_generation_fails_outside_realtime(monk
     outputs = list(handler.process(TTSInput(text="Hello there.")))
 
     assert outputs == []
-    assert handler.should_listen.is_set() is True
+    assert handler.should_listen.is_set() is False
 
 
 def test_process_voice_clone_passes_non_streaming_mode_to_faster_backend(monkeypatch):


### PR DESCRIPTION
## Summary

Rework the `Chat` class into a typed conversation-history abstraction backed by OpenAI SDK models (`ConversationItem` / `ResponseInputParam`), replacing the previous raw-dict approach. This gives us:

- Strongly-typed items (system, user, assistant, function_call, function_call_output) with validation on add.
- Automatic pairing of `tool_call` ↔ `function_call_output` by `call_id`, preventing orphaned entries that broke the API.
- Bounded-buffer eviction per user-turn instead of per-message.
- Dual serialisation (`to_response_api_chat()` / `to_transformers_chat()`) for respectively the Responses API and the Transformers API.