### PR TITLE
Add speculative turn revisions

### DIFF
--- a/README.md
+++ b/README.md
@@ -243,7 +243,6 @@ with client.beta.realtime.connect(model="model_name") as conn:
 | `response.created` | Emitted on the first outbound audio chunk (response is `in_progress`). |
 | `response.output_audio.delta` | Base64 PCM audio chunk from TTS. |
 | `response.output_audio.done` | Audio stream complete for the current output item. |
-| `output_audio_buffer.cleared` | Server-side VAD interruption cleared already-buffered assistant audio. |
 | `response.output_audio_transcript.done` | Full assistant text transcript for the turn. |
 | `response.function_call_arguments.done` | Tool call with `call_id`, `name`, and JSON `arguments`. |
 | `response.done` | Response finished (`completed`, `cancelled` with reason `turn_detected` or `client_cancelled`). |

--- a/README.md
+++ b/README.md
@@ -243,6 +243,7 @@ with client.beta.realtime.connect(model="model_name") as conn:
 | `response.created` | Emitted on the first outbound audio chunk (response is `in_progress`). |
 | `response.output_audio.delta` | Base64 PCM audio chunk from TTS. |
 | `response.output_audio.done` | Audio stream complete for the current output item. |
+| `output_audio_buffer.cleared` | Server-side VAD interruption cleared already-buffered assistant audio. |
 | `response.output_audio_transcript.done` | Full assistant text transcript for the turn. |
 | `response.function_call_arguments.done` | Tool call with `call_id`, `name`, and JSON `arguments`. |
 | `response.done` | Response finished (`completed`, `cancelled` with reason `turn_detected` or `client_cancelled`). |

--- a/archive/TTS/melo_handler.py
+++ b/archive/TTS/melo_handler.py
@@ -14,6 +14,7 @@ from speech_to_speech.baseHandler import BaseHandler
 from speech_to_speech.pipeline.cancel_scope import CancelScope
 from speech_to_speech.pipeline.handler_types import TTSIn, TTSOut
 from speech_to_speech.pipeline.messages import AUDIO_RESPONSE_DONE, EndOfResponse
+from speech_to_speech.pipeline.speculative_turns import SpeculativeTurnTracker
 
 logger = logging.getLogger(__name__)
 
@@ -48,9 +49,11 @@ class MeloTTSHandler(BaseHandler[TTSIn, TTSOut]):
         gen_kwargs: dict[str, Any] = {},  # Unused
         blocksize: int = 512,
         cancel_scope: CancelScope | None = None,
+        speculative_turns: SpeculativeTurnTracker | None = None,
     ) -> None:
         self.should_listen = should_listen
         self.cancel_scope = cancel_scope
+        self.speculative_turns = speculative_turns
         self.device = device
         self.language = language
         self.model = TTS(language=WHISPER_LANGUAGE_TO_MELO_LANGUAGE[self.language], device=device)
@@ -66,6 +69,14 @@ class MeloTTSHandler(BaseHandler[TTSIn, TTSOut]):
     def process(self, tts_input: TTSIn) -> Iterator[TTSOut]:
         if isinstance(tts_input, EndOfResponse):
             yield AUDIO_RESPONSE_DONE
+            return
+
+        speculative_turns = getattr(self, "speculative_turns", None)
+        if speculative_turns and not speculative_turns.is_latest(
+            tts_input.turn_id,
+            tts_input.turn_revision,
+        ):
+            logger.debug("Dropping stale TTS input for turn=%s rev=%s", tts_input.turn_id, tts_input.turn_revision)
             return
 
         gen = self.cancel_scope.generation if self.cancel_scope else None

--- a/scripts/listen_and_play_realtime.py
+++ b/scripts/listen_and_play_realtime.py
@@ -258,8 +258,6 @@ async def listen_and_play_realtime(args: ListenAndPlayRealtimeArguments) -> None
                 speaker_active_until[0] = time.monotonic() + max(0.15, len(audio) / (2 * args.recv_rate))
             elif event.type == "response.output_audio.done":
                 print("ASSISTANT: <audio done>", flush=True)
-            elif event.type == "output_audio_buffer.cleared":
-                clear_playback_buffer()
             elif event.type == "response.output_audio_transcript.done":
                 print(f"ASSISTANT: {event.transcript}", flush=True)
             elif event.type == "response.function_call_arguments.done":

--- a/scripts/listen_and_play_realtime.py
+++ b/scripts/listen_and_play_realtime.py
@@ -76,7 +76,9 @@ class ListenAndPlayRealtimeArguments:
     )
     block_mic_during_playback: bool = field(
         default=False,
-        metadata={"help": "If set, pause microphone capture while speaker audio is playing. Disabled by default so barge-in works."},
+        metadata={
+            "help": "If set, pause microphone capture while speaker audio is playing. Disabled by default so barge-in works."
+        },
     )
 
 
@@ -256,6 +258,8 @@ async def listen_and_play_realtime(args: ListenAndPlayRealtimeArguments) -> None
                 speaker_active_until[0] = time.monotonic() + max(0.15, len(audio) / (2 * args.recv_rate))
             elif event.type == "response.output_audio.done":
                 print("ASSISTANT: <audio done>", flush=True)
+            elif event.type == "output_audio_buffer.cleared":
+                clear_playback_buffer()
             elif event.type == "response.output_audio_transcript.done":
                 print(f"ASSISTANT: {event.transcript}", flush=True)
             elif event.type == "response.function_call_arguments.done":
@@ -347,9 +351,7 @@ def main() -> None:
     parser.add_argument(
         "--voice",
         default=defaults.voice,
-        help=(
-            "session.audio.output.voice (Kokoro id like bm_fable, or OpenAI name like marin)."
-        ),
+        help=("session.audio.output.voice (Kokoro id like bm_fable, or OpenAI name like marin)."),
     )
     parser.add_argument("--print-json", action="store_true", default=defaults.print_json)
     parser.add_argument(

--- a/src/speech_to_speech/LLM/chat.py
+++ b/src/speech_to_speech/LLM/chat.py
@@ -583,7 +583,7 @@ class Chat:
             fco_call_ids_in_range = {
                 x.call_id
                 for x in self.buffer
-                if x.id in marker_ids and isinstance(x, RealtimeConversationItemFunctionCallOutput)
+                if isinstance(x, RealtimeConversationItemFunctionCallOutput) and x.id in marker_ids
             }
             fc_ids_to_keep = {
                 x.id

--- a/src/speech_to_speech/LLM/chat.py
+++ b/src/speech_to_speech/LLM/chat.py
@@ -181,6 +181,22 @@ class Chat:
 
         return item
 
+    def replace_user_message_text(self, item_id: str, text: str) -> bool:
+        """Replace the text content of an existing user message.
+
+        Used by speculative turn revisions: the conversation turn remains the
+        same, but the STT transcript is superseded by a transcription of a
+        longer raw-audio buffer.
+        """
+
+        for item in self.buffer:
+            if not isinstance(item, RealtimeConversationItemUserMessage) or item.id != item_id:
+                continue
+            item.content = [UserContent(type="input_text", text=text)]
+            logger.debug("Replaced speculative user message %s", item_id)
+            return True
+        return False
+
     def to_responses_api_chat(self) -> ResponseInputParam:
         """Serialize the full chat (system prompt + buffer) for the OpenAI Responses API."""
         result: list[ResponseInputItemParam] = []

--- a/src/speech_to_speech/LLM/chat.py
+++ b/src/speech_to_speech/LLM/chat.py
@@ -197,6 +197,18 @@ class Chat:
             return True
         return False
 
+    def remove_user_message(self, item_id: str) -> bool:
+        """Remove an existing user message from the bounded chat buffer."""
+
+        for index, item in enumerate(self.buffer):
+            if not isinstance(item, RealtimeConversationItemUserMessage) or item.id != item_id:
+                continue
+            del self.buffer[index]
+            self._user_turn_count -= 1
+            logger.debug("Removed speculative user message %s", item_id)
+            return True
+        return False
+
     def to_responses_api_chat(self) -> ResponseInputParam:
         """Serialize the full chat (system prompt + buffer) for the OpenAI Responses API."""
         result: list[ResponseInputItemParam] = []

--- a/src/speech_to_speech/LLM/language_model.py
+++ b/src/speech_to_speech/LLM/language_model.py
@@ -176,7 +176,7 @@ class BaseLanguageModelHandler(BaseHandler[LLMIn, LLMOut], ABC):
     def _turn_output_allowed(self, turn_id: str | None, turn_revision: int | None) -> bool:
         if self.speculative_turns is None:
             return True
-        return self.speculative_turns.is_latest_after_pending_reopen(turn_id, turn_revision)
+        return self.speculative_turns.is_latest_after_reopen_grace(turn_id, turn_revision)
 
     @abstractmethod
     def _load_model(

--- a/src/speech_to_speech/LLM/language_model.py
+++ b/src/speech_to_speech/LLM/language_model.py
@@ -171,15 +171,13 @@ class BaseLanguageModelHandler(BaseHandler[LLMIn, LLMOut], ABC):
         self.user_role = user_role
 
     def _turn_is_latest(self, turn_id: str | None, turn_revision: int | None) -> bool:
-        speculative_turns = getattr(self, "speculative_turns", None)
-        return speculative_turns is None or speculative_turns.is_latest(turn_id, turn_revision)
+        return self.speculative_turns is None or self.speculative_turns.is_latest(turn_id, turn_revision)
 
     def _turn_output_allowed(self, turn_id: str | None, turn_revision: int | None) -> bool:
-        speculative_turns = getattr(self, "speculative_turns", None)
-        if speculative_turns is None:
+        if self.speculative_turns is None:
             return True
-        speculative_turns.wait_for_pending_reopen(turn_id, turn_revision)
-        return speculative_turns.is_latest(turn_id, turn_revision)
+        self.speculative_turns.wait_for_pending_reopen(turn_id, turn_revision)
+        return self.speculative_turns.is_latest(turn_id, turn_revision)
 
     @abstractmethod
     def _load_model(

--- a/src/speech_to_speech/LLM/language_model.py
+++ b/src/speech_to_speech/LLM/language_model.py
@@ -176,8 +176,7 @@ class BaseLanguageModelHandler(BaseHandler[LLMIn, LLMOut], ABC):
     def _turn_output_allowed(self, turn_id: str | None, turn_revision: int | None) -> bool:
         if self.speculative_turns is None:
             return True
-        self.speculative_turns.wait_for_pending_reopen(turn_id, turn_revision)
-        return self.speculative_turns.is_latest(turn_id, turn_revision)
+        return self.speculative_turns.is_latest_after_pending_reopen(turn_id, turn_revision)
 
     @abstractmethod
     def _load_model(

--- a/src/speech_to_speech/LLM/language_model.py
+++ b/src/speech_to_speech/LLM/language_model.py
@@ -174,6 +174,13 @@ class BaseLanguageModelHandler(BaseHandler[LLMIn, LLMOut], ABC):
         speculative_turns = getattr(self, "speculative_turns", None)
         return speculative_turns is None or speculative_turns.is_latest(turn_id, turn_revision)
 
+    def _turn_output_allowed(self, turn_id: str | None, turn_revision: int | None) -> bool:
+        speculative_turns = getattr(self, "speculative_turns", None)
+        if speculative_turns is None:
+            return True
+        speculative_turns.wait_for_pending_reopen(turn_id, turn_revision)
+        return speculative_turns.is_latest(turn_id, turn_revision)
+
     @abstractmethod
     def _load_model(
         self,
@@ -379,12 +386,20 @@ class BaseLanguageModelHandler(BaseHandler[LLMIn, LLMOut], ABC):
                 runtime_config,
                 response,
             )
+            if chunks and not self._turn_output_allowed(ctx.turn_id, ctx.turn_revision):
+                ctx.cancelled = True
+                logger.info("LLM generation cancelled (stale speculative turn)")
+                break
             yield from chunks
 
         if ctx.sentence_batch and not ctx.interrupted:
             if ctx.printable_text.strip():
                 ctx.sentence_batch.append(ctx.printable_text.strip())
                 ctx.printable_text = ""
+            if not self._turn_output_allowed(ctx.turn_id, ctx.turn_revision):
+                ctx.cancelled = True
+                logger.info("LLM generation cancelled (stale speculative turn)")
+                return
             yield LLMResponseChunk(
                 text=" ".join(ctx.sentence_batch),
                 language_code=language_code,
@@ -434,9 +449,10 @@ class BaseLanguageModelHandler(BaseHandler[LLMIn, LLMOut], ABC):
         if ctx.stopped:
             return
 
-        if not ctx.cancelled and self._turn_is_latest(ctx.turn_id, ctx.turn_revision):
+        turn_output_allowed = not ctx.cancelled and self._turn_output_allowed(ctx.turn_id, ctx.turn_revision)
+        if turn_output_allowed:
             original_chat.add_item(make_assistant_message(ctx.generated_text))
-        if not ctx.cancelled and self._turn_is_latest(ctx.turn_id, ctx.turn_revision) and ctx.tools:
+        if turn_output_allowed and ctx.tools:
             for t in ctx.tools:
                 original_chat.add_item(
                     RealtimeConversationItemFunctionCall(
@@ -448,12 +464,12 @@ class BaseLanguageModelHandler(BaseHandler[LLMIn, LLMOut], ABC):
                         status=t.status,
                     )
                 )
-        if self._turn_is_latest(ctx.turn_id, ctx.turn_revision):
+        if turn_output_allowed:
             original_chat.strip_images()
         logger.debug("Clean text: %s", ctx.generated_text)
         logger.info(f"Tools: {ctx.tools}")
 
-        if not ctx.cancelled and (ctx.printable_text.strip() or ctx.tools):
+        if turn_output_allowed and (ctx.printable_text.strip() or ctx.tools):
             yield LLMResponseChunk(
                 text=ctx.printable_text.strip(),
                 language_code=language_code,
@@ -465,7 +481,7 @@ class BaseLanguageModelHandler(BaseHandler[LLMIn, LLMOut], ABC):
             )
 
         output_tokens = len(self.tokenizer.encode(ctx.raw_generated_text)) if ctx.raw_generated_text else 0
-        if self._turn_is_latest(ctx.turn_id, ctx.turn_revision) and (ctx.input_tokens or output_tokens):
+        if turn_output_allowed and (ctx.input_tokens or output_tokens):
             yield TokenUsage(
                 input_tokens=ctx.input_tokens,
                 output_tokens=output_tokens,

--- a/src/speech_to_speech/LLM/language_model.py
+++ b/src/speech_to_speech/LLM/language_model.py
@@ -123,6 +123,7 @@ class StreamContext(BaseModel):
     sentence_batch: list[str] = Field(default_factory=list)
     turn_id: str | None = None
     turn_revision: int | None = None
+    speech_stopped_at_s: float | None = None
 
     @property
     def interrupted(self) -> bool:
@@ -304,6 +305,7 @@ class BaseLanguageModelHandler(BaseHandler[LLMIn, LLMOut], ABC):
                                 response=response,
                                 turn_id=ctx.turn_id,
                                 turn_revision=ctx.turn_revision,
+                                speech_stopped_at_s=ctx.speech_stopped_at_s,
                             )
                         )
                         ctx.sentence_batch = []
@@ -324,6 +326,7 @@ class BaseLanguageModelHandler(BaseHandler[LLMIn, LLMOut], ABC):
                                 response=response,
                                 turn_id=ctx.turn_id,
                                 turn_revision=ctx.turn_revision,
+                                speech_stopped_at_s=ctx.speech_stopped_at_s,
                             )
                         )
                         ctx.sentence_batch = []
@@ -404,6 +407,7 @@ class BaseLanguageModelHandler(BaseHandler[LLMIn, LLMOut], ABC):
                 response=response,
                 turn_id=ctx.turn_id,
                 turn_revision=ctx.turn_revision,
+                speech_stopped_at_s=ctx.speech_stopped_at_s,
             )
             ctx.sentence_batch = []
 
@@ -419,6 +423,7 @@ class BaseLanguageModelHandler(BaseHandler[LLMIn, LLMOut], ABC):
 
         ctx.turn_id = request.turn_id
         ctx.turn_revision = request.turn_revision
+        ctx.speech_stopped_at_s = request.speech_stopped_at_s
         if not self._turn_is_latest(ctx.turn_id, ctx.turn_revision):
             logger.info("Skipping stale LLM request for turn=%s rev=%s", ctx.turn_id, ctx.turn_revision)
             yield EndOfResponse(turn_id=ctx.turn_id, turn_revision=ctx.turn_revision)
@@ -475,6 +480,7 @@ class BaseLanguageModelHandler(BaseHandler[LLMIn, LLMOut], ABC):
                 response=response,
                 turn_id=ctx.turn_id,
                 turn_revision=ctx.turn_revision,
+                speech_stopped_at_s=ctx.speech_stopped_at_s,
             )
 
         output_tokens = len(self.tokenizer.encode(ctx.raw_generated_text)) if ctx.raw_generated_text else 0

--- a/src/speech_to_speech/LLM/language_model.py
+++ b/src/speech_to_speech/LLM/language_model.py
@@ -125,6 +125,7 @@ class StreamContext(BaseModel):
     turn_id: str | None = None
     turn_revision: int | None = None
     speech_stopped_at_s: float | None = None
+    cancel_generation: int | None = None
 
     @property
     def interrupted(self) -> bool:
@@ -323,6 +324,7 @@ class BaseLanguageModelHandler(BaseHandler[LLMIn, LLMOut], ABC):
                                 turn_id=ctx.turn_id,
                                 turn_revision=ctx.turn_revision,
                                 speech_stopped_at_s=ctx.speech_stopped_at_s,
+                                cancel_generation=ctx.cancel_generation,
                             )
                         )
                         ctx.sentence_batch = []
@@ -344,6 +346,7 @@ class BaseLanguageModelHandler(BaseHandler[LLMIn, LLMOut], ABC):
                                 turn_id=ctx.turn_id,
                                 turn_revision=ctx.turn_revision,
                                 speech_stopped_at_s=ctx.speech_stopped_at_s,
+                                cancel_generation=ctx.cancel_generation,
                             )
                         )
                         ctx.sentence_batch = []
@@ -425,6 +428,7 @@ class BaseLanguageModelHandler(BaseHandler[LLMIn, LLMOut], ABC):
                 turn_id=ctx.turn_id,
                 turn_revision=ctx.turn_revision,
                 speech_stopped_at_s=ctx.speech_stopped_at_s,
+                cancel_generation=ctx.cancel_generation,
             )
             ctx.sentence_batch = []
 
@@ -462,6 +466,7 @@ class BaseLanguageModelHandler(BaseHandler[LLMIn, LLMOut], ABC):
             active_chat.add_item(make_user_message(f"Please reply to my message in {lang_name}."))
 
         gen = self.cancel_scope.generation if self.cancel_scope else None
+        ctx.cancel_generation = gen
 
         yield from self._generate(active_chat, language_code, gen, ctx, runtime_config, response)
 
@@ -499,6 +504,7 @@ class BaseLanguageModelHandler(BaseHandler[LLMIn, LLMOut], ABC):
                 turn_id=ctx.turn_id,
                 turn_revision=ctx.turn_revision,
                 speech_stopped_at_s=ctx.speech_stopped_at_s,
+                cancel_generation=ctx.cancel_generation,
             )
 
         output_tokens = len(self.tokenizer.encode(ctx.raw_generated_text)) if ctx.raw_generated_text else 0
@@ -509,7 +515,11 @@ class BaseLanguageModelHandler(BaseHandler[LLMIn, LLMOut], ABC):
                 turn_id=ctx.turn_id,
                 turn_revision=ctx.turn_revision,
             )
-        yield EndOfResponse(turn_id=ctx.turn_id, turn_revision=ctx.turn_revision)
+        yield EndOfResponse(
+            turn_id=ctx.turn_id,
+            turn_revision=ctx.turn_revision,
+            cancel_generation=ctx.cancel_generation,
+        )
 
     def on_session_end(self) -> None:
         logger.debug("Language model session state reset")

--- a/src/speech_to_speech/LLM/language_model.py
+++ b/src/speech_to_speech/LLM/language_model.py
@@ -45,6 +45,7 @@ from speech_to_speech.pipeline.messages import (
     LLMResponseChunk,
     TokenUsage,
 )
+from speech_to_speech.pipeline.speculative_turns import SpeculativeTurnTracker
 
 try:
     import mlx.core as mx
@@ -120,6 +121,8 @@ class StreamContext(BaseModel):
     end_code: Optional[str] = None
     input_tokens: int = 0
     sentence_batch: list[str] = Field(default_factory=list)
+    turn_id: str | None = None
+    turn_revision: int | None = None
 
     @property
     def interrupted(self) -> bool:
@@ -147,6 +150,7 @@ class BaseLanguageModelHandler(BaseHandler[LLMIn, LLMOut], ABC):
         gen_kwargs: dict[str, Any] = {},
         user_role: str = "user",
         cancel_scope: CancelScope | None = None,
+        speculative_turns: SpeculativeTurnTracker | None = None,
         backend: Literal["transformers", "mlx"] = "transformers",
         enable_thinking: bool = False,
         stream_batch_sentences: int = 3,
@@ -155,6 +159,7 @@ class BaseLanguageModelHandler(BaseHandler[LLMIn, LLMOut], ABC):
     ) -> None:
         self.backend = backend
         self.cancel_scope = cancel_scope
+        self.speculative_turns = speculative_turns
         self.device = device
         self.model_name = model_name
         self.enable_thinking = enable_thinking
@@ -164,6 +169,10 @@ class BaseLanguageModelHandler(BaseHandler[LLMIn, LLMOut], ABC):
         self._load_model(model_name, device, torch_dtype, gen_kwargs)
 
         self.user_role = user_role
+
+    def _turn_is_latest(self, turn_id: str | None, turn_revision: int | None) -> bool:
+        speculative_turns = getattr(self, "speculative_turns", None)
+        return speculative_turns is None or speculative_turns.is_latest(turn_id, turn_revision)
 
     @abstractmethod
     def _load_model(
@@ -289,6 +298,8 @@ class BaseLanguageModelHandler(BaseHandler[LLMIn, LLMOut], ABC):
                                 language_code=language_code,
                                 runtime_config=runtime_config,
                                 response=response,
+                                turn_id=ctx.turn_id,
+                                turn_revision=ctx.turn_revision,
                             )
                         )
                         ctx.sentence_batch = []
@@ -307,6 +318,8 @@ class BaseLanguageModelHandler(BaseHandler[LLMIn, LLMOut], ABC):
                                 language_code=language_code,
                                 runtime_config=runtime_config,
                                 response=response,
+                                turn_id=ctx.turn_id,
+                                turn_revision=ctx.turn_revision,
                             )
                         )
                         ctx.sentence_batch = []
@@ -319,6 +332,10 @@ class BaseLanguageModelHandler(BaseHandler[LLMIn, LLMOut], ABC):
         if gen is not None and self.cancel_scope is not None and self.cancel_scope.is_stale(gen):
             ctx.cancelled = True
             logger.info("LLM generation cancelled (interruption)")
+            return True
+        if not self._turn_is_latest(ctx.turn_id, ctx.turn_revision):
+            ctx.cancelled = True
+            logger.info("LLM generation cancelled (stale speculative turn)")
             return True
         if self.stop_event.is_set():
             ctx.stopped = True
@@ -364,7 +381,7 @@ class BaseLanguageModelHandler(BaseHandler[LLMIn, LLMOut], ABC):
             )
             yield from chunks
 
-        if ctx.sentence_batch:
+        if ctx.sentence_batch and not ctx.interrupted:
             if ctx.printable_text.strip():
                 ctx.sentence_batch.append(ctx.printable_text.strip())
                 ctx.printable_text = ""
@@ -373,6 +390,8 @@ class BaseLanguageModelHandler(BaseHandler[LLMIn, LLMOut], ABC):
                 language_code=language_code,
                 runtime_config=runtime_config,
                 response=response,
+                turn_id=ctx.turn_id,
+                turn_revision=ctx.turn_revision,
             )
             ctx.sentence_batch = []
 
@@ -385,6 +404,13 @@ class BaseLanguageModelHandler(BaseHandler[LLMIn, LLMOut], ABC):
 
         if not isinstance(request, GenerateResponseRequest):
             raise TypeError(f"Unexpected request type: {type(request)}")
+
+        ctx.turn_id = request.turn_id
+        ctx.turn_revision = request.turn_revision
+        if not self._turn_is_latest(ctx.turn_id, ctx.turn_revision):
+            logger.info("Skipping stale LLM request for turn=%s rev=%s", ctx.turn_id, ctx.turn_revision)
+            yield EndOfResponse(turn_id=ctx.turn_id, turn_revision=ctx.turn_revision)
+            return
 
         runtime_config = request.runtime_config
         response = request.response
@@ -408,8 +434,9 @@ class BaseLanguageModelHandler(BaseHandler[LLMIn, LLMOut], ABC):
         if ctx.stopped:
             return
 
-        original_chat.add_item(make_assistant_message(ctx.generated_text))
-        if ctx.tools:
+        if not ctx.cancelled and self._turn_is_latest(ctx.turn_id, ctx.turn_revision):
+            original_chat.add_item(make_assistant_message(ctx.generated_text))
+        if not ctx.cancelled and self._turn_is_latest(ctx.turn_id, ctx.turn_revision) and ctx.tools:
             for t in ctx.tools:
                 original_chat.add_item(
                     RealtimeConversationItemFunctionCall(
@@ -421,7 +448,8 @@ class BaseLanguageModelHandler(BaseHandler[LLMIn, LLMOut], ABC):
                         status=t.status,
                     )
                 )
-        original_chat.strip_images()
+        if self._turn_is_latest(ctx.turn_id, ctx.turn_revision):
+            original_chat.strip_images()
         logger.debug("Clean text: %s", ctx.generated_text)
         logger.info(f"Tools: {ctx.tools}")
 
@@ -432,12 +460,19 @@ class BaseLanguageModelHandler(BaseHandler[LLMIn, LLMOut], ABC):
                 tools=list(ctx.tools),
                 runtime_config=runtime_config,
                 response=response,
+                turn_id=ctx.turn_id,
+                turn_revision=ctx.turn_revision,
             )
 
         output_tokens = len(self.tokenizer.encode(ctx.raw_generated_text)) if ctx.raw_generated_text else 0
-        if ctx.input_tokens or output_tokens:
-            yield TokenUsage(input_tokens=ctx.input_tokens, output_tokens=output_tokens)
-        yield EndOfResponse()
+        if self._turn_is_latest(ctx.turn_id, ctx.turn_revision) and (ctx.input_tokens or output_tokens):
+            yield TokenUsage(
+                input_tokens=ctx.input_tokens,
+                output_tokens=output_tokens,
+                turn_id=ctx.turn_id,
+                turn_revision=ctx.turn_revision,
+            )
+        yield EndOfResponse(turn_id=ctx.turn_id, turn_revision=ctx.turn_revision)
 
     def on_session_end(self) -> None:
         logger.debug("Language model session state reset")

--- a/src/speech_to_speech/LLM/lm_output_processor.py
+++ b/src/speech_to_speech/LLM/lm_output_processor.py
@@ -74,6 +74,17 @@ class LMOutputProcessor(BaseHandler[LLMOut, TTSIn]):
             return
 
         if isinstance(lm_output, EndOfResponse):
+            speculative_turns = getattr(self, "speculative_turns", None)
+            if speculative_turns and not speculative_turns.is_latest(
+                lm_output.turn_id,
+                lm_output.turn_revision,
+            ):
+                logger.debug(
+                    "Dropping stale end-of-response for turn=%s rev=%s",
+                    lm_output.turn_id,
+                    lm_output.turn_revision,
+                )
+                return
             yield EndOfResponse(turn_id=lm_output.turn_id, turn_revision=lm_output.turn_revision)
             return
 

--- a/src/speech_to_speech/LLM/lm_output_processor.py
+++ b/src/speech_to_speech/LLM/lm_output_processor.py
@@ -45,6 +45,13 @@ class LMOutputProcessor(BaseHandler[LLMOut, TTSIn]):
         self.text_output_queue = text_output_queue
         self.speculative_turns = speculative_turns
 
+    def _turn_is_latest_after_pending_reopen(self, turn_id: str | None, turn_revision: int | None) -> bool:
+        speculative_turns = getattr(self, "speculative_turns", None)
+        if speculative_turns is None:
+            return True
+        speculative_turns.wait_for_pending_reopen(turn_id, turn_revision)
+        return speculative_turns.is_latest(turn_id, turn_revision)
+
     def process(self, lm_output: LLMOut) -> Iterator[TTSIn]:
         """
         Process LLM output: send text/tools to WebSocket, forward clean text to TTS.
@@ -53,8 +60,7 @@ class LMOutputProcessor(BaseHandler[LLMOut, TTSIn]):
             :class:`TTSInput` or :class:`EndOfResponse` for TTS
         """
         if isinstance(lm_output, TokenUsage):
-            speculative_turns = getattr(self, "speculative_turns", None)
-            if speculative_turns and not speculative_turns.is_latest(
+            if not self._turn_is_latest_after_pending_reopen(
                 lm_output.turn_id,
                 lm_output.turn_revision,
             ):
@@ -74,8 +80,7 @@ class LMOutputProcessor(BaseHandler[LLMOut, TTSIn]):
             return
 
         if isinstance(lm_output, EndOfResponse):
-            speculative_turns = getattr(self, "speculative_turns", None)
-            if speculative_turns and not speculative_turns.is_latest(
+            if not self._turn_is_latest_after_pending_reopen(
                 lm_output.turn_id,
                 lm_output.turn_revision,
             ):
@@ -92,8 +97,7 @@ class LMOutputProcessor(BaseHandler[LLMOut, TTSIn]):
             logger.warning("LMOutputProcessor received unexpected type: %s", type(lm_output))
             return
 
-        speculative_turns = getattr(self, "speculative_turns", None)
-        if speculative_turns and not speculative_turns.is_latest(
+        if not self._turn_is_latest_after_pending_reopen(
             lm_output.turn_id,
             lm_output.turn_revision,
         ):

--- a/src/speech_to_speech/LLM/lm_output_processor.py
+++ b/src/speech_to_speech/LLM/lm_output_processor.py
@@ -126,4 +126,5 @@ class LMOutputProcessor(BaseHandler[LLMOut, TTSIn]):
                 response=lm_output.response,
                 turn_id=lm_output.turn_id,
                 turn_revision=lm_output.turn_revision,
+                speech_stopped_at_s=lm_output.speech_stopped_at_s,
             )

--- a/src/speech_to_speech/LLM/lm_output_processor.py
+++ b/src/speech_to_speech/LLM/lm_output_processor.py
@@ -48,8 +48,7 @@ class LMOutputProcessor(BaseHandler[LLMOut, TTSIn]):
     def _turn_is_latest_after_pending_reopen(self, turn_id: str | None, turn_revision: int | None) -> bool:
         if self.speculative_turns is None:
             return True
-        self.speculative_turns.wait_for_pending_reopen(turn_id, turn_revision)
-        return self.speculative_turns.is_latest(turn_id, turn_revision)
+        return self.speculative_turns.is_latest_after_pending_reopen(turn_id, turn_revision)
 
     def process(self, lm_output: LLMOut) -> Iterator[TTSIn]:
         """

--- a/src/speech_to_speech/LLM/lm_output_processor.py
+++ b/src/speech_to_speech/LLM/lm_output_processor.py
@@ -17,6 +17,7 @@ from speech_to_speech.pipeline.events import AssistantTextEvent, TokenUsageEvent
 from speech_to_speech.pipeline.handler_types import LLMOut, TTSIn
 from speech_to_speech.pipeline.messages import EndOfResponse, LLMResponseChunk, TokenUsage, TTSInput
 from speech_to_speech.pipeline.queue_types import TextEventItem
+from speech_to_speech.pipeline.speculative_turns import SpeculativeTurnTracker
 
 logger = logging.getLogger(__name__)
 
@@ -30,7 +31,11 @@ class LMOutputProcessor(BaseHandler[LLMOut, TTSIn]):
     Side effect: Sends :class:`AssistantTextEvent` / :class:`TokenUsageEvent` to text_output_queue
     """
 
-    def setup(self, text_output_queue: Queue[TextEventItem] | None = None) -> None:
+    def setup(
+        self,
+        text_output_queue: Queue[TextEventItem] | None = None,
+        speculative_turns: SpeculativeTurnTracker | None = None,
+    ) -> None:
         """
         Initialize the processor.
 
@@ -38,6 +43,7 @@ class LMOutputProcessor(BaseHandler[LLMOut, TTSIn]):
             text_output_queue: Queue to send text messages and tool calls
         """
         self.text_output_queue = text_output_queue
+        self.speculative_turns = speculative_turns
 
     def process(self, lm_output: LLMOut) -> Iterator[TTSIn]:
         """
@@ -47,27 +53,50 @@ class LMOutputProcessor(BaseHandler[LLMOut, TTSIn]):
             :class:`TTSInput` or :class:`EndOfResponse` for TTS
         """
         if isinstance(lm_output, TokenUsage):
+            speculative_turns = getattr(self, "speculative_turns", None)
+            if speculative_turns and not speculative_turns.is_latest(
+                lm_output.turn_id,
+                lm_output.turn_revision,
+            ):
+                logger.debug(
+                    "Dropping stale token usage for turn=%s rev=%s", lm_output.turn_id, lm_output.turn_revision
+                )
+                return
             if self.text_output_queue is not None:
                 self.text_output_queue.put(
                     TokenUsageEvent(
                         input_tokens=lm_output.input_tokens or 0,
                         output_tokens=lm_output.output_tokens or 0,
+                        turn_id=lm_output.turn_id,
+                        turn_revision=lm_output.turn_revision,
                     )
                 )
             return
 
         if isinstance(lm_output, EndOfResponse):
-            yield EndOfResponse()
+            yield EndOfResponse(turn_id=lm_output.turn_id, turn_revision=lm_output.turn_revision)
             return
 
         if not isinstance(lm_output, LLMResponseChunk):
             logger.warning("LMOutputProcessor received unexpected type: %s", type(lm_output))
             return
 
+        speculative_turns = getattr(self, "speculative_turns", None)
+        if speculative_turns and not speculative_turns.is_latest(
+            lm_output.turn_id,
+            lm_output.turn_revision,
+        ):
+            logger.debug("Dropping stale LLM chunk for turn=%s rev=%s", lm_output.turn_id, lm_output.turn_revision)
+            return
+
         logger.debug(f"LM processor: text='{lm_output.text}', tools={lm_output.tools}")
 
         if self.text_output_queue is not None:
-            event = AssistantTextEvent(text=lm_output.text)
+            event = AssistantTextEvent(
+                text=lm_output.text,
+                turn_id=lm_output.turn_id,
+                turn_revision=lm_output.turn_revision,
+            )
             if lm_output.tools:
                 event.tools = lm_output.tools
                 logger.info(f"Sending to clients: text='{lm_output.text}', tools={[t.name for t in lm_output.tools]}")
@@ -82,4 +111,6 @@ class LMOutputProcessor(BaseHandler[LLMOut, TTSIn]):
                 language_code=lm_output.language_code,
                 runtime_config=lm_output.runtime_config,
                 response=lm_output.response,
+                turn_id=lm_output.turn_id,
+                turn_revision=lm_output.turn_revision,
             )

--- a/src/speech_to_speech/LLM/lm_output_processor.py
+++ b/src/speech_to_speech/LLM/lm_output_processor.py
@@ -46,11 +46,10 @@ class LMOutputProcessor(BaseHandler[LLMOut, TTSIn]):
         self.speculative_turns = speculative_turns
 
     def _turn_is_latest_after_pending_reopen(self, turn_id: str | None, turn_revision: int | None) -> bool:
-        speculative_turns = getattr(self, "speculative_turns", None)
-        if speculative_turns is None:
+        if self.speculative_turns is None:
             return True
-        speculative_turns.wait_for_pending_reopen(turn_id, turn_revision)
-        return speculative_turns.is_latest(turn_id, turn_revision)
+        self.speculative_turns.wait_for_pending_reopen(turn_id, turn_revision)
+        return self.speculative_turns.is_latest(turn_id, turn_revision)
 
     def process(self, lm_output: LLMOut) -> Iterator[TTSIn]:
         """

--- a/src/speech_to_speech/LLM/lm_output_processor.py
+++ b/src/speech_to_speech/LLM/lm_output_processor.py
@@ -88,7 +88,11 @@ class LMOutputProcessor(BaseHandler[LLMOut, TTSIn]):
                     lm_output.turn_revision,
                 )
                 return
-            yield EndOfResponse(turn_id=lm_output.turn_id, turn_revision=lm_output.turn_revision)
+            yield EndOfResponse(
+                turn_id=lm_output.turn_id,
+                turn_revision=lm_output.turn_revision,
+                cancel_generation=lm_output.cancel_generation,
+            )
             return
 
         if not isinstance(lm_output, LLMResponseChunk):
@@ -127,4 +131,5 @@ class LMOutputProcessor(BaseHandler[LLMOut, TTSIn]):
                 turn_id=lm_output.turn_id,
                 turn_revision=lm_output.turn_revision,
                 speech_stopped_at_s=lm_output.speech_stopped_at_s,
+                cancel_generation=lm_output.cancel_generation,
             )

--- a/src/speech_to_speech/LLM/lm_output_processor.py
+++ b/src/speech_to_speech/LLM/lm_output_processor.py
@@ -45,10 +45,10 @@ class LMOutputProcessor(BaseHandler[LLMOut, TTSIn]):
         self.text_output_queue = text_output_queue
         self.speculative_turns = speculative_turns
 
-    def _turn_is_latest_after_pending_reopen(self, turn_id: str | None, turn_revision: int | None) -> bool:
+    def _turn_output_allowed(self, turn_id: str | None, turn_revision: int | None) -> bool:
         if self.speculative_turns is None:
             return True
-        return self.speculative_turns.is_latest_after_pending_reopen(turn_id, turn_revision)
+        return self.speculative_turns.is_latest_after_reopen_grace(turn_id, turn_revision)
 
     def process(self, lm_output: LLMOut) -> Iterator[TTSIn]:
         """
@@ -58,7 +58,7 @@ class LMOutputProcessor(BaseHandler[LLMOut, TTSIn]):
             :class:`TTSInput` or :class:`EndOfResponse` for TTS
         """
         if isinstance(lm_output, TokenUsage):
-            if not self._turn_is_latest_after_pending_reopen(
+            if not self._turn_output_allowed(
                 lm_output.turn_id,
                 lm_output.turn_revision,
             ):
@@ -78,7 +78,7 @@ class LMOutputProcessor(BaseHandler[LLMOut, TTSIn]):
             return
 
         if isinstance(lm_output, EndOfResponse):
-            if not self._turn_is_latest_after_pending_reopen(
+            if not self._turn_output_allowed(
                 lm_output.turn_id,
                 lm_output.turn_revision,
             ):
@@ -95,7 +95,7 @@ class LMOutputProcessor(BaseHandler[LLMOut, TTSIn]):
             logger.warning("LMOutputProcessor received unexpected type: %s", type(lm_output))
             return
 
-        if not self._turn_is_latest_after_pending_reopen(
+        if not self._turn_output_allowed(
             lm_output.turn_id,
             lm_output.turn_revision,
         ):

--- a/src/speech_to_speech/LLM/responses_api_language_model.py
+++ b/src/speech_to_speech/LLM/responses_api_language_model.py
@@ -138,6 +138,7 @@ class ResponsesApiModelHandler(BaseHandler[LLMIn, LLMOut]):
         response = request.response
         turn_id = request.turn_id
         turn_revision = request.turn_revision
+        speech_stopped_at_s = request.speech_stopped_at_s
         if not self._turn_is_latest(turn_id, turn_revision):
             logger.info("Skipping stale LLM request for turn=%s rev=%s", turn_id, turn_revision)
             yield EndOfResponse(turn_id=turn_id, turn_revision=turn_revision)
@@ -216,6 +217,7 @@ class ResponsesApiModelHandler(BaseHandler[LLMIn, LLMOut]):
                                         response=response,
                                         turn_id=turn_id,
                                         turn_revision=turn_revision,
+                                        speech_stopped_at_s=speech_stopped_at_s,
                                     )
                                     sentence_batch = []
                             if cancelled:
@@ -272,6 +274,7 @@ class ResponsesApiModelHandler(BaseHandler[LLMIn, LLMOut]):
                                 response=response,
                                 turn_id=turn_id,
                                 turn_revision=turn_revision,
+                                speech_stopped_at_s=speech_stopped_at_s,
                             )
             elif isinstance(api_response, Response):
                 if (
@@ -330,6 +333,7 @@ class ResponsesApiModelHandler(BaseHandler[LLMIn, LLMOut]):
                                 response=response,
                                 turn_id=turn_id,
                                 turn_revision=turn_revision,
+                                speech_stopped_at_s=speech_stopped_at_s,
                             )
         except httpx.ReadTimeout:
             logger.warning(
@@ -343,6 +347,7 @@ class ResponsesApiModelHandler(BaseHandler[LLMIn, LLMOut]):
                     response=response,
                     turn_id=turn_id,
                     turn_revision=turn_revision,
+                    speech_stopped_at_s=speech_stopped_at_s,
                 )
         finally:
             if api_response is not None and hasattr(api_response, "close"):

--- a/src/speech_to_speech/LLM/responses_api_language_model.py
+++ b/src/speech_to_speech/LLM/responses_api_language_model.py
@@ -92,6 +92,13 @@ class ResponsesApiModelHandler(BaseHandler[LLMIn, LLMOut]):
         speculative_turns = getattr(self, "speculative_turns", None)
         return speculative_turns is None or speculative_turns.is_latest(turn_id, turn_revision)
 
+    def _turn_output_allowed(self, turn_id: str | None, turn_revision: int | None) -> bool:
+        speculative_turns = getattr(self, "speculative_turns", None)
+        if speculative_turns is None:
+            return True
+        speculative_turns.wait_for_pending_reopen(turn_id, turn_revision)
+        return speculative_turns.is_latest(turn_id, turn_revision)
+
     def warmup(self) -> None:
         logger.info(f"Warming up {self.__class__.__name__}")
         start = time.time()
@@ -201,6 +208,10 @@ class ResponsesApiModelHandler(BaseHandler[LLMIn, LLMOut]):
                             for s in sentences[:-1]:
                                 sentence_batch.append(s)
                                 if len(sentence_batch) >= self.stream_batch_sentences:
+                                    if not self._turn_output_allowed(turn_id, turn_revision):
+                                        logger.info("LLM generation cancelled (stale speculative turn)")
+                                        cancelled = True
+                                        break
                                     yield LLMResponseChunk(
                                         text=" ".join(sentence_batch),
                                         language_code=language_code,
@@ -210,6 +221,8 @@ class ResponsesApiModelHandler(BaseHandler[LLMIn, LLMOut]):
                                         turn_revision=turn_revision,
                                     )
                                     sentence_batch = []
+                            if cancelled:
+                                break
                             printable_text = sentences[-1]
                     elif isinstance(raw_event, ResponseOutputItemDoneEvent):
                         if isinstance(raw_event.item, ResponseFunctionToolCall):
@@ -249,17 +262,20 @@ class ResponsesApiModelHandler(BaseHandler[LLMIn, LLMOut]):
                         sentence_batch.append(printable_text.strip())
                     remaining = " ".join(sentence_batch)
                     if remaining or tools:
-                        logger.debug(f"Clean text: {clean_text}")
-                        logger.info(f"Tools: {tools}")
-                        yield LLMResponseChunk(
-                            text=remaining,
-                            language_code=language_code,
-                            tools=tools,
-                            runtime_config=runtime_config,
-                            response=response,
-                            turn_id=turn_id,
-                            turn_revision=turn_revision,
-                        )
+                        if not self._turn_output_allowed(turn_id, turn_revision):
+                            logger.info("LLM generation cancelled (stale speculative turn)")
+                        else:
+                            logger.debug(f"Clean text: {clean_text}")
+                            logger.info(f"Tools: {tools}")
+                            yield LLMResponseChunk(
+                                text=remaining,
+                                language_code=language_code,
+                                tools=tools,
+                                runtime_config=runtime_config,
+                                response=response,
+                                turn_id=turn_id,
+                                turn_revision=turn_revision,
+                            )
             elif isinstance(api_response, Response):
                 if (
                     gen is not None and self.cancel_scope is not None and self.cancel_scope.is_stale(gen)
@@ -306,21 +322,24 @@ class ResponsesApiModelHandler(BaseHandler[LLMIn, LLMOut]):
                     logger.debug(f"Clean text: {clean_text}")
                     logger.info(f"Tools: {tools}")
                     if clean_text.strip() or tools:
-                        yield LLMResponseChunk(
-                            text=clean_text.strip(),
-                            language_code=language_code,
-                            tools=tools,
-                            runtime_config=runtime_config,
-                            response=response,
-                            turn_id=turn_id,
-                            turn_revision=turn_revision,
-                        )
+                        if not self._turn_output_allowed(turn_id, turn_revision):
+                            logger.info("LLM generation cancelled (stale speculative turn)")
+                        else:
+                            yield LLMResponseChunk(
+                                text=clean_text.strip(),
+                                language_code=language_code,
+                                tools=tools,
+                                runtime_config=runtime_config,
+                                response=response,
+                                turn_id=turn_id,
+                                turn_revision=turn_revision,
+                            )
         except httpx.ReadTimeout:
             logger.warning(
                 "OpenAI API read timed out after %.1fs; ending the current response",
                 self.request_timeout_s,
             )
-            if self._turn_is_latest(turn_id, turn_revision):
+            if self._turn_output_allowed(turn_id, turn_revision):
                 yield LLMResponseChunk(
                     text="Wow I'm a bit slow today, could you repeat that?",
                     runtime_config=runtime_config,
@@ -335,7 +354,7 @@ class ResponsesApiModelHandler(BaseHandler[LLMIn, LLMOut]):
                 except Exception:
                     pass
 
-        if self._turn_is_latest(turn_id, turn_revision):
+        if self._turn_output_allowed(turn_id, turn_revision):
             for item in pending_chat_items:
                 original_chat.add_item(item)
             original_chat.strip_images()

--- a/src/speech_to_speech/LLM/responses_api_language_model.py
+++ b/src/speech_to_speech/LLM/responses_api_language_model.py
@@ -213,6 +213,7 @@ class ResponsesApiModelHandler(BaseHandler[LLMIn, LLMOut]):
                                         turn_id=turn_id,
                                         turn_revision=turn_revision,
                                         speech_stopped_at_s=speech_stopped_at_s,
+                                        cancel_generation=gen,
                                     )
                                     sentence_batch = []
                             if cancelled:
@@ -270,6 +271,7 @@ class ResponsesApiModelHandler(BaseHandler[LLMIn, LLMOut]):
                                 turn_id=turn_id,
                                 turn_revision=turn_revision,
                                 speech_stopped_at_s=speech_stopped_at_s,
+                                cancel_generation=gen,
                             )
             elif isinstance(api_response, Response):
                 if (
@@ -329,6 +331,7 @@ class ResponsesApiModelHandler(BaseHandler[LLMIn, LLMOut]):
                                 turn_id=turn_id,
                                 turn_revision=turn_revision,
                                 speech_stopped_at_s=speech_stopped_at_s,
+                                cancel_generation=gen,
                             )
         except httpx.ReadTimeout:
             logger.warning(
@@ -343,6 +346,7 @@ class ResponsesApiModelHandler(BaseHandler[LLMIn, LLMOut]):
                     turn_id=turn_id,
                     turn_revision=turn_revision,
                     speech_stopped_at_s=speech_stopped_at_s,
+                    cancel_generation=gen,
                 )
         finally:
             if api_response is not None and hasattr(api_response, "close"):
@@ -363,7 +367,7 @@ class ResponsesApiModelHandler(BaseHandler[LLMIn, LLMOut]):
                     turn_id=turn_id,
                     turn_revision=turn_revision,
                 )
-        yield EndOfResponse(turn_id=turn_id, turn_revision=turn_revision)
+        yield EndOfResponse(turn_id=turn_id, turn_revision=turn_revision, cancel_generation=gen)
 
     def process(self, request: LLMIn) -> Iterator[LLMOut]:
         """

--- a/src/speech_to_speech/LLM/responses_api_language_model.py
+++ b/src/speech_to_speech/LLM/responses_api_language_model.py
@@ -94,7 +94,7 @@ class ResponsesApiModelHandler(BaseHandler[LLMIn, LLMOut]):
     def _turn_output_allowed(self, turn_id: str | None, turn_revision: int | None) -> bool:
         if self.speculative_turns is None:
             return True
-        return self.speculative_turns.is_latest_after_pending_reopen(turn_id, turn_revision)
+        return self.speculative_turns.is_latest_after_reopen_grace(turn_id, turn_revision)
 
     def warmup(self) -> None:
         logger.info(f"Warming up {self.__class__.__name__}")

--- a/src/speech_to_speech/LLM/responses_api_language_model.py
+++ b/src/speech_to_speech/LLM/responses_api_language_model.py
@@ -94,8 +94,7 @@ class ResponsesApiModelHandler(BaseHandler[LLMIn, LLMOut]):
     def _turn_output_allowed(self, turn_id: str | None, turn_revision: int | None) -> bool:
         if self.speculative_turns is None:
             return True
-        self.speculative_turns.wait_for_pending_reopen(turn_id, turn_revision)
-        return self.speculative_turns.is_latest(turn_id, turn_revision)
+        return self.speculative_turns.is_latest_after_pending_reopen(turn_id, turn_revision)
 
     def warmup(self) -> None:
         logger.info(f"Warming up {self.__class__.__name__}")

--- a/src/speech_to_speech/LLM/responses_api_language_model.py
+++ b/src/speech_to_speech/LLM/responses_api_language_model.py
@@ -89,15 +89,13 @@ class ResponsesApiModelHandler(BaseHandler[LLMIn, LLMOut]):
         self.warmup()
 
     def _turn_is_latest(self, turn_id: str | None, turn_revision: int | None) -> bool:
-        speculative_turns = getattr(self, "speculative_turns", None)
-        return speculative_turns is None or speculative_turns.is_latest(turn_id, turn_revision)
+        return self.speculative_turns is None or self.speculative_turns.is_latest(turn_id, turn_revision)
 
     def _turn_output_allowed(self, turn_id: str | None, turn_revision: int | None) -> bool:
-        speculative_turns = getattr(self, "speculative_turns", None)
-        if speculative_turns is None:
+        if self.speculative_turns is None:
             return True
-        speculative_turns.wait_for_pending_reopen(turn_id, turn_revision)
-        return speculative_turns.is_latest(turn_id, turn_revision)
+        self.speculative_turns.wait_for_pending_reopen(turn_id, turn_revision)
+        return self.speculative_turns.is_latest(turn_id, turn_revision)
 
     def warmup(self) -> None:
         logger.info(f"Warming up {self.__class__.__name__}")

--- a/src/speech_to_speech/LLM/responses_api_language_model.py
+++ b/src/speech_to_speech/LLM/responses_api_language_model.py
@@ -26,7 +26,7 @@ from openai.types.responses import (
 )
 
 from speech_to_speech.baseHandler import BaseHandler
-from speech_to_speech.LLM.chat import Chat, make_system_message, make_user_message
+from speech_to_speech.LLM.chat import Chat, SupportedItem, make_system_message, make_user_message
 from speech_to_speech.LLM.utils import remove_unspeechable, resolve_auto_language
 from speech_to_speech.LLM.voice_prompt import build_voice_system_prompt
 from speech_to_speech.pipeline.cancel_scope import CancelScope
@@ -36,6 +36,7 @@ from speech_to_speech.pipeline.messages import (
     LLMResponseChunk,
     TokenUsage,
 )
+from speech_to_speech.pipeline.speculative_turns import SpeculativeTurnTracker
 from speech_to_speech.utils.utils import _generate_id
 
 logger = logging.getLogger(__name__)
@@ -56,6 +57,7 @@ class ResponsesApiModelHandler(BaseHandler[LLMIn, LLMOut]):
         stream: bool = True,
         user_role: str = "user",
         cancel_scope: CancelScope | None = None,
+        speculative_turns: SpeculativeTurnTracker | None = None,
         disable_thinking: bool = True,
         request_timeout_s: float = 20.0,
         stream_batch_sentences: int = 3,
@@ -63,6 +65,7 @@ class ResponsesApiModelHandler(BaseHandler[LLMIn, LLMOut]):
         **_kwargs: Any,
     ) -> None:
         self.cancel_scope = cancel_scope
+        self.speculative_turns = speculative_turns
         self.model_name = model_name
         self.stream = stream
         self.stream_batch_sentences = max(1, stream_batch_sentences)
@@ -84,6 +87,10 @@ class ResponsesApiModelHandler(BaseHandler[LLMIn, LLMOut]):
             else None
         )
         self.warmup()
+
+    def _turn_is_latest(self, turn_id: str | None, turn_revision: int | None) -> bool:
+        speculative_turns = getattr(self, "speculative_turns", None)
+        return speculative_turns is None or speculative_turns.is_latest(turn_id, turn_revision)
 
     def warmup(self) -> None:
         logger.info(f"Warming up {self.__class__.__name__}")
@@ -125,6 +132,13 @@ class ResponsesApiModelHandler(BaseHandler[LLMIn, LLMOut]):
 
         runtime_config = request.runtime_config
         response = request.response
+        turn_id = request.turn_id
+        turn_revision = request.turn_revision
+        if not self._turn_is_latest(turn_id, turn_revision):
+            logger.info("Skipping stale LLM request for turn=%s rev=%s", turn_id, turn_revision)
+            yield EndOfResponse(turn_id=turn_id, turn_revision=turn_revision)
+            return
+
         original_chat = runtime_config.chat
         active_chat = original_chat.copy()
         language_code = request.language_code
@@ -154,6 +168,7 @@ class ResponsesApiModelHandler(BaseHandler[LLMIn, LLMOut]):
         gen = self.cancel_scope.generation if self.cancel_scope else None
         api_response: Response | Stream[ResponseStreamEvent] | None = None
         tools: list[ResponseFunctionToolCall] = []
+        pending_chat_items: list[SupportedItem] = []
         clean_text = ""
         input_tokens = 0
         output_tokens = 0
@@ -171,7 +186,9 @@ class ResponsesApiModelHandler(BaseHandler[LLMIn, LLMOut]):
                 printable_text = ""
                 sentence_batch: list[str] = []
                 for raw_event in api_response:
-                    if gen is not None and self.cancel_scope is not None and self.cancel_scope.is_stale(gen):
+                    if (
+                        gen is not None and self.cancel_scope is not None and self.cancel_scope.is_stale(gen)
+                    ) or not self._turn_is_latest(turn_id, turn_revision):
                         logger.info("LLM generation cancelled (interruption)")
                         cancelled = True
                         break
@@ -189,6 +206,8 @@ class ResponsesApiModelHandler(BaseHandler[LLMIn, LLMOut]):
                                         language_code=language_code,
                                         runtime_config=runtime_config,
                                         response=response,
+                                        turn_id=turn_id,
+                                        turn_revision=turn_revision,
                                     )
                                     sentence_batch = []
                             printable_text = sentences[-1]
@@ -197,7 +216,7 @@ class ResponsesApiModelHandler(BaseHandler[LLMIn, LLMOut]):
                             raw_event.item.call_id = _generate_id("call")
                             raw_event.item.id = _generate_id("fc")
                             tools.append(raw_event.item)
-                            original_chat.add_item(
+                            pending_chat_items.append(
                                 RealtimeConversationItemFunctionCall(
                                     type="function_call",
                                     name=raw_event.item.name,
@@ -215,7 +234,7 @@ class ResponsesApiModelHandler(BaseHandler[LLMIn, LLMOut]):
                                 )
                                 for c in raw_event.item.content
                             ]
-                            original_chat.add_item(
+                            pending_chat_items.append(
                                 RealtimeConversationItemAssistantMessage(
                                     type="message", role="assistant", content=content
                                 )
@@ -238,9 +257,13 @@ class ResponsesApiModelHandler(BaseHandler[LLMIn, LLMOut]):
                             tools=tools,
                             runtime_config=runtime_config,
                             response=response,
+                            turn_id=turn_id,
+                            turn_revision=turn_revision,
                         )
             elif isinstance(api_response, Response):
-                if gen is not None and self.cancel_scope is not None and self.cancel_scope.is_stale(gen):
+                if (
+                    gen is not None and self.cancel_scope is not None and self.cancel_scope.is_stale(gen)
+                ) or not self._turn_is_latest(turn_id, turn_revision):
                     logger.info("LLM generation cancelled (interruption)")
                 else:
                     usage = api_response.usage
@@ -249,17 +272,18 @@ class ResponsesApiModelHandler(BaseHandler[LLMIn, LLMOut]):
                         output_tokens = usage.output_tokens or 0
                     for message in api_response.output:
                         if isinstance(message, ResponseFunctionToolCall):
-                            item = original_chat.add_item(
+                            message.call_id = _generate_id("call")
+                            message.id = _generate_id("fc")
+                            pending_chat_items.append(
                                 RealtimeConversationItemFunctionCall(
                                     type="function_call",
                                     name=message.name,
                                     arguments=message.arguments,
+                                    call_id=message.call_id,
+                                    id=message.id,
                                     status="in_progress",
                                 )
                             )
-                            assert (hasattr(item, "call_id") and item.call_id is not None) and item.id is not None
-                            message.call_id = item.call_id
-                            message.id = item.id
                             tools.append(message)
                         elif isinstance(message, ResponseOutputMessage):
                             content = [
@@ -269,7 +293,7 @@ class ResponsesApiModelHandler(BaseHandler[LLMIn, LLMOut]):
                                 )
                                 for c in message.content
                             ]
-                            original_chat.add_item(
+                            pending_chat_items.append(
                                 RealtimeConversationItemAssistantMessage(
                                     type="message", role="assistant", content=content
                                 )
@@ -288,17 +312,22 @@ class ResponsesApiModelHandler(BaseHandler[LLMIn, LLMOut]):
                             tools=tools,
                             runtime_config=runtime_config,
                             response=response,
+                            turn_id=turn_id,
+                            turn_revision=turn_revision,
                         )
         except httpx.ReadTimeout:
             logger.warning(
                 "OpenAI API read timed out after %.1fs; ending the current response",
                 self.request_timeout_s,
             )
-            yield LLMResponseChunk(
-                text="Wow I'm a bit slow today, could you repeat that?",
-                runtime_config=runtime_config,
-                response=response,
-            )
+            if self._turn_is_latest(turn_id, turn_revision):
+                yield LLMResponseChunk(
+                    text="Wow I'm a bit slow today, could you repeat that?",
+                    runtime_config=runtime_config,
+                    response=response,
+                    turn_id=turn_id,
+                    turn_revision=turn_revision,
+                )
         finally:
             if api_response is not None and hasattr(api_response, "close"):
                 try:
@@ -306,10 +335,18 @@ class ResponsesApiModelHandler(BaseHandler[LLMIn, LLMOut]):
                 except Exception:
                     pass
 
-        original_chat.strip_images()
-        if input_tokens or output_tokens:
-            yield TokenUsage(input_tokens=input_tokens, output_tokens=output_tokens)
-        yield EndOfResponse()
+        if self._turn_is_latest(turn_id, turn_revision):
+            for item in pending_chat_items:
+                original_chat.add_item(item)
+            original_chat.strip_images()
+            if input_tokens or output_tokens:
+                yield TokenUsage(
+                    input_tokens=input_tokens,
+                    output_tokens=output_tokens,
+                    turn_id=turn_id,
+                    turn_revision=turn_revision,
+                )
+        yield EndOfResponse(turn_id=turn_id, turn_revision=turn_revision)
 
     def on_session_end(self) -> None:
         logger.debug("OpenAI API language model session state reset")

--- a/src/speech_to_speech/LLM/responses_api_language_model.py
+++ b/src/speech_to_speech/LLM/responses_api_language_model.py
@@ -94,6 +94,9 @@ class ResponsesApiModelHandler(BaseHandler[LLMIn, LLMOut]):
     def _turn_is_latest(self, turn_id: str | None, turn_revision: int | None) -> bool:
         return self.speculative_turns is None or self.speculative_turns.is_latest(turn_id, turn_revision)
 
+    def _generation_is_stale(self, gen: int | None) -> bool:
+        return gen is not None and self.cancel_scope is not None and self.cancel_scope.is_stale(gen)
+
     def _turn_output_allowed(self, turn_id: str | None, turn_revision: int | None) -> bool:
         if self.speculative_turns is None:
             return True
@@ -257,7 +260,9 @@ class ResponsesApiModelHandler(BaseHandler[LLMIn, LLMOut]):
                         sentence_batch.append(printable_text.strip())
                     remaining = " ".join(sentence_batch)
                     if remaining or tools:
-                        if not self._turn_output_allowed(turn_id, turn_revision):
+                        if self._generation_is_stale(gen):
+                            logger.info("LLM generation cancelled (interruption)")
+                        elif not self._turn_output_allowed(turn_id, turn_revision):
                             logger.info("LLM generation cancelled (stale speculative turn)")
                         else:
                             logger.debug(f"Clean text: {clean_text}")
@@ -319,7 +324,9 @@ class ResponsesApiModelHandler(BaseHandler[LLMIn, LLMOut]):
                     logger.debug(f"Clean text: {clean_text}")
                     logger.info(f"Tools: {tools}")
                     if clean_text.strip() or tools:
-                        if not self._turn_output_allowed(turn_id, turn_revision):
+                        if self._generation_is_stale(gen):
+                            logger.info("LLM generation cancelled (interruption)")
+                        elif not self._turn_output_allowed(turn_id, turn_revision):
                             logger.info("LLM generation cancelled (stale speculative turn)")
                         else:
                             yield LLMResponseChunk(
@@ -338,7 +345,7 @@ class ResponsesApiModelHandler(BaseHandler[LLMIn, LLMOut]):
                 "OpenAI API read timed out after %.1fs; ending the current response",
                 self.request_timeout_s,
             )
-            if self._turn_output_allowed(turn_id, turn_revision):
+            if not self._generation_is_stale(gen) and self._turn_output_allowed(turn_id, turn_revision):
                 yield LLMResponseChunk(
                     text="Wow I'm a bit slow today, could you repeat that?",
                     runtime_config=runtime_config,
@@ -355,7 +362,7 @@ class ResponsesApiModelHandler(BaseHandler[LLMIn, LLMOut]):
                 except Exception:
                     pass
 
-        if self._turn_output_allowed(turn_id, turn_revision):
+        if not self._generation_is_stale(gen) and self._turn_output_allowed(turn_id, turn_revision):
             for item in pending_chat_items:
                 original_chat.add_item(item)
             original_chat.strip_images()

--- a/src/speech_to_speech/STT/base_stt_handler.py
+++ b/src/speech_to_speech/STT/base_stt_handler.py
@@ -17,7 +17,7 @@ class BaseSTTHandler(BaseHandler[STTIn, STTOut]):
     """Base STT handler with speculative-turn stale input filtering."""
 
     speculative_turns: SpeculativeTurnTracker | None = None
-    final_revision_settle_s: float = 0.6
+    final_revision_settle_s: float = 0.0
 
     def should_process_input(self, item: STTIn) -> bool:
         mode = getattr(item, "mode", None)

--- a/src/speech_to_speech/STT/base_stt_handler.py
+++ b/src/speech_to_speech/STT/base_stt_handler.py
@@ -1,9 +1,12 @@
 from __future__ import annotations
 
 import logging
+from collections import Counter
+from typing import Any
 
 from speech_to_speech.baseHandler import BaseHandler
 from speech_to_speech.pipeline.handler_types import STTIn, STTOut
+from speech_to_speech.pipeline.messages import VADAudio
 from speech_to_speech.pipeline.speculative_turns import SpeculativeTurnTracker
 
 logger = logging.getLogger(__name__)
@@ -13,14 +16,32 @@ class BaseSTTHandler(BaseHandler[STTIn, STTOut]):
     """Base STT handler with speculative-turn stale input filtering."""
 
     speculative_turns: SpeculativeTurnTracker | None = None
+    final_revision_settle_s: float = 0.6
 
     def should_process_input(self, item: STTIn) -> bool:
-        return self._is_latest_turn_item(item, wait_for_pending_reopen=True, stage="input")
+        if not self._is_latest_turn_item(
+            item,
+            wait_for_pending_reopen=True,
+            wait_for_stability=getattr(item, "mode", None) == "final",
+        ):
+            queued_drops = self._drop_stale_queued_inputs()
+            self._log_stale_turn_item(item, "input", queued_drops=queued_drops)
+            return False
+        return True
 
     def should_emit_output(self, output: STTOut) -> bool:
-        return self._is_latest_turn_item(output, wait_for_pending_reopen=True, stage="output")
+        if not self._is_latest_turn_item(output, wait_for_pending_reopen=True, wait_for_stability=False):
+            self._log_stale_turn_item(output, "output")
+            return False
+        return True
 
-    def _is_latest_turn_item(self, item: object, *, wait_for_pending_reopen: bool, stage: str) -> bool:
+    def _is_latest_turn_item(
+        self,
+        item: object,
+        *,
+        wait_for_pending_reopen: bool,
+        wait_for_stability: bool,
+    ) -> bool:
         if self.speculative_turns is None:
             return True
         turn_id = getattr(item, "turn_id", None)
@@ -28,17 +49,58 @@ class BaseSTTHandler(BaseHandler[STTIn, STTOut]):
         if turn_id is None or turn_revision is None:
             return True
 
-        if wait_for_pending_reopen:
+        if wait_for_stability:
+            is_latest = self.speculative_turns.is_latest_after_stability_window(
+                turn_id,
+                turn_revision,
+                self.final_revision_settle_s,
+            )
+        elif wait_for_pending_reopen:
             is_latest = self.speculative_turns.is_latest_after_pending_reopen(turn_id, turn_revision)
         else:
             is_latest = self.speculative_turns.is_latest(turn_id, turn_revision)
-
-        if not is_latest:
-            logger.info(
-                "%s: dropping stale STT %s for turn=%s rev=%s",
-                self.__class__.__name__,
-                stage,
-                turn_id,
-                turn_revision,
-            )
         return is_latest
+
+    def _drop_stale_queued_inputs(self) -> int:
+        if self.speculative_turns is None or not hasattr(self.queue_in, "mutex") or not hasattr(self.queue_in, "queue"):
+            return 0
+
+        dropped = 0
+        with self.queue_in.mutex:
+            kept: list[Any] = []
+            while self.queue_in.queue:
+                queued_item = self.queue_in.queue.popleft()
+                if isinstance(queued_item, VADAudio) and not self._is_latest_turn_item(
+                    queued_item,
+                    wait_for_pending_reopen=False,
+                    wait_for_stability=False,
+                ):
+                    dropped += 1
+                else:
+                    kept.append(queued_item)
+            self.queue_in.queue.extend(kept)
+            if dropped:
+                self.queue_in.not_full.notify_all()
+        return dropped
+
+    def _log_stale_turn_item(self, item: object, stage: str, *, queued_drops: int = 0) -> None:
+        turn_id = getattr(item, "turn_id", None)
+        turn_revision = getattr(item, "turn_revision", None)
+        if turn_id is None or turn_revision is None:
+            return
+
+        if not hasattr(self, "_stale_drop_counts"):
+            self._stale_drop_counts: Counter[tuple[str, str, int]] = Counter()
+        key = (stage, turn_id, turn_revision)
+        self._stale_drop_counts[key] += 1
+
+        message = "%s: dropping stale STT %s for turn=%s rev=%s"
+        args: tuple[object, ...] = (self.__class__.__name__, stage, turn_id, turn_revision)
+        if queued_drops:
+            message += " (+%d queued)"
+            args = (*args, queued_drops)
+
+        if self._stale_drop_counts[key] == 1:
+            logger.info(message, *args)
+        else:
+            logger.debug(message, *args)

--- a/src/speech_to_speech/STT/base_stt_handler.py
+++ b/src/speech_to_speech/STT/base_stt_handler.py
@@ -1,13 +1,13 @@
 from __future__ import annotations
 
 import logging
-from collections import Counter
+from collections import Counter, OrderedDict
 from time import perf_counter
 from typing import Any
 
 from speech_to_speech.baseHandler import BaseHandler
 from speech_to_speech.pipeline.handler_types import STTIn, STTOut
-from speech_to_speech.pipeline.messages import VADAudio
+from speech_to_speech.pipeline.messages import PartialTranscription, Transcription, VADAudio
 from speech_to_speech.pipeline.speculative_turns import SpeculativeTurnTracker
 
 logger = logging.getLogger(__name__)
@@ -16,6 +16,8 @@ logger = logging.getLogger(__name__)
 class BaseSTTHandler(BaseHandler[STTIn, STTOut]):
     """Base STT handler with speculative-turn stale input filtering."""
 
+    _MAX_COMPLETED_FINAL_REVISIONS = 2048
+
     speculative_turns: SpeculativeTurnTracker | None = None
     final_revision_settle_s: float = 0.0
 
@@ -23,6 +25,11 @@ class BaseSTTHandler(BaseHandler[STTIn, STTOut]):
         mode = getattr(item, "mode", None)
         turn_id = getattr(item, "turn_id", None)
         turn_revision = getattr(item, "turn_revision", None)
+        if self._is_completed_final_revision(item):
+            queued_drops = self._drop_stale_queued_inputs()
+            self._log_stale_turn_item(item, "input-after-final", queued_drops=queued_drops)
+            return False
+
         wait_for_stability = mode == "final"
         gate_start = perf_counter()
         is_latest = self._is_latest_turn_item(
@@ -51,10 +58,18 @@ class BaseSTTHandler(BaseHandler[STTIn, STTOut]):
         return True
 
     def should_emit_output(self, output: STTOut) -> bool:
+        if isinstance(output, PartialTranscription) and self._is_completed_final_revision(output):
+            self._log_stale_turn_item(output, "output-after-final")
+            return False
+
         if not self._is_latest_turn_item(output, wait_for_pending_reopen=True, wait_for_stability=False):
             self._log_stale_turn_item(output, "output")
             return False
         return True
+
+    def before_emit_output(self, output: STTOut) -> None:
+        if isinstance(output, Transcription):
+            self._mark_completed_final_revision(output)
 
     def _is_latest_turn_item(
         self,
@@ -91,10 +106,13 @@ class BaseSTTHandler(BaseHandler[STTIn, STTOut]):
             kept: list[Any] = []
             while self.queue_in.queue:
                 queued_item = self.queue_in.queue.popleft()
-                if isinstance(queued_item, VADAudio) and not self._is_latest_turn_item(
-                    queued_item,
-                    wait_for_pending_reopen=False,
-                    wait_for_stability=False,
+                if isinstance(queued_item, VADAudio) and (
+                    self._is_completed_final_revision(queued_item)
+                    or not self._is_latest_turn_item(
+                        queued_item,
+                        wait_for_pending_reopen=False,
+                        wait_for_stability=False,
+                    )
                 ):
                     dropped += 1
                 else:
@@ -143,3 +161,33 @@ class BaseSTTHandler(BaseHandler[STTIn, STTOut]):
             return self.queue_in.qsize()
         except NotImplementedError:
             return "unknown"
+
+    def _revision_key(self, item: object) -> tuple[str, int] | None:
+        turn_id = getattr(item, "turn_id", None)
+        turn_revision = getattr(item, "turn_revision", None)
+        if not isinstance(turn_id, str) or not isinstance(turn_revision, int):
+            return None
+        return (turn_id, turn_revision)
+
+    def _completed_final_revisions(self) -> OrderedDict[tuple[str, int], None]:
+        if not hasattr(self, "_completed_final_revision_keys"):
+            self._completed_final_revision_keys: OrderedDict[tuple[str, int], None] = OrderedDict()
+        return self._completed_final_revision_keys
+
+    def _is_completed_final_revision(self, item: object) -> bool:
+        key = self._revision_key(item)
+        return key is not None and key in self._completed_final_revisions()
+
+    def _mark_completed_final_revision(self, output: Transcription) -> None:
+        key = self._revision_key(output)
+        if key is None:
+            return
+        completed = self._completed_final_revisions()
+        completed[key] = None
+        completed.move_to_end(key)
+        while len(completed) > self._MAX_COMPLETED_FINAL_REVISIONS:
+            completed.popitem(last=False)
+
+    def on_session_end(self) -> None:
+        if hasattr(self, "_completed_final_revision_keys"):
+            self._completed_final_revision_keys.clear()

--- a/src/speech_to_speech/STT/base_stt_handler.py
+++ b/src/speech_to_speech/STT/base_stt_handler.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 import logging
 from collections import Counter
+from time import perf_counter
 from typing import Any
 
 from speech_to_speech.baseHandler import BaseHandler
@@ -19,11 +20,31 @@ class BaseSTTHandler(BaseHandler[STTIn, STTOut]):
     final_revision_settle_s: float = 0.6
 
     def should_process_input(self, item: STTIn) -> bool:
-        if not self._is_latest_turn_item(
+        mode = getattr(item, "mode", None)
+        turn_id = getattr(item, "turn_id", None)
+        turn_revision = getattr(item, "turn_revision", None)
+        wait_for_stability = mode == "final"
+        gate_start = perf_counter()
+        is_latest = self._is_latest_turn_item(
             item,
             wait_for_pending_reopen=True,
-            wait_for_stability=getattr(item, "mode", None) == "final",
-        ):
+            wait_for_stability=wait_for_stability,
+        )
+        gate_wait_s = perf_counter() - gate_start
+        if gate_wait_s >= 0.05:
+            logger.info(
+                "%s: STT input gate waited %.3fs for turn=%s rev=%s mode=%s latest=%s age=%.3fs queue=%s",
+                self.__class__.__name__,
+                gate_wait_s,
+                turn_id,
+                turn_revision,
+                mode,
+                is_latest,
+                self._item_age_s(item),
+                self._safe_qsize(),
+            )
+
+        if not is_latest:
             queued_drops = self._drop_stale_queued_inputs()
             self._log_stale_turn_item(item, "input", queued_drops=queued_drops)
             return False
@@ -94,8 +115,14 @@ class BaseSTTHandler(BaseHandler[STTIn, STTOut]):
         key = (stage, turn_id, turn_revision)
         self._stale_drop_counts[key] += 1
 
-        message = "%s: dropping stale STT %s for turn=%s rev=%s"
-        args: tuple[object, ...] = (self.__class__.__name__, stage, turn_id, turn_revision)
+        message = "%s: dropping stale STT %s for turn=%s rev=%s age=%.3fs"
+        args: tuple[object, ...] = (
+            self.__class__.__name__,
+            stage,
+            turn_id,
+            turn_revision,
+            self._item_age_s(item),
+        )
         if queued_drops:
             message += " (+%d queued)"
             args = (*args, queued_drops)
@@ -104,3 +131,15 @@ class BaseSTTHandler(BaseHandler[STTIn, STTOut]):
             logger.info(message, *args)
         else:
             logger.debug(message, *args)
+
+    def _item_age_s(self, item: object) -> float:
+        created_at_s = getattr(item, "created_at_s", None)
+        if not isinstance(created_at_s, float):
+            return 0.0
+        return max(0.0, perf_counter() - created_at_s)
+
+    def _safe_qsize(self) -> int | str:
+        try:
+            return self.queue_in.qsize()
+        except NotImplementedError:
+            return "unknown"

--- a/src/speech_to_speech/STT/base_stt_handler.py
+++ b/src/speech_to_speech/STT/base_stt_handler.py
@@ -1,0 +1,44 @@
+from __future__ import annotations
+
+import logging
+
+from speech_to_speech.baseHandler import BaseHandler
+from speech_to_speech.pipeline.handler_types import STTIn, STTOut
+from speech_to_speech.pipeline.speculative_turns import SpeculativeTurnTracker
+
+logger = logging.getLogger(__name__)
+
+
+class BaseSTTHandler(BaseHandler[STTIn, STTOut]):
+    """Base STT handler with speculative-turn stale input filtering."""
+
+    speculative_turns: SpeculativeTurnTracker | None = None
+
+    def should_process_input(self, item: STTIn) -> bool:
+        return self._is_latest_turn_item(item, wait_for_pending_reopen=True, stage="input")
+
+    def should_emit_output(self, output: STTOut) -> bool:
+        return self._is_latest_turn_item(output, wait_for_pending_reopen=True, stage="output")
+
+    def _is_latest_turn_item(self, item: object, *, wait_for_pending_reopen: bool, stage: str) -> bool:
+        if self.speculative_turns is None:
+            return True
+        turn_id = getattr(item, "turn_id", None)
+        turn_revision = getattr(item, "turn_revision", None)
+        if turn_id is None or turn_revision is None:
+            return True
+
+        if wait_for_pending_reopen:
+            is_latest = self.speculative_turns.is_latest_after_pending_reopen(turn_id, turn_revision)
+        else:
+            is_latest = self.speculative_turns.is_latest(turn_id, turn_revision)
+
+        if not is_latest:
+            logger.info(
+                "%s: dropping stale STT %s for turn=%s rev=%s",
+                self.__class__.__name__,
+                stage,
+                turn_id,
+                turn_revision,
+            )
+        return is_latest

--- a/src/speech_to_speech/STT/base_stt_handler.py
+++ b/src/speech_to_speech/STT/base_stt_handler.py
@@ -29,6 +29,9 @@ class BaseSTTHandler(BaseHandler[STTIn, STTOut]):
             queued_drops = self._drop_stale_queued_inputs()
             self._log_stale_turn_item(item, "input-after-final", queued_drops=queued_drops)
             return False
+        if mode == "progressive" and self._has_queued_final_for_revision(item):
+            self._log_stale_turn_item(item, "progressive-before-final")
+            return False
 
         wait_for_stability = mode == "final"
         gate_start = perf_counter()
@@ -108,6 +111,10 @@ class BaseSTTHandler(BaseHandler[STTIn, STTOut]):
                 queued_item = self.queue_in.queue.popleft()
                 if isinstance(queued_item, VADAudio) and (
                     self._is_completed_final_revision(queued_item)
+                    or (
+                        queued_item.mode == "progressive"
+                        and self._has_queued_final_for_revision_locked(queued_item)
+                    )
                     or not self._is_latest_turn_item(
                         queued_item,
                         wait_for_pending_reopen=False,
@@ -161,6 +168,23 @@ class BaseSTTHandler(BaseHandler[STTIn, STTOut]):
             return self.queue_in.qsize()
         except NotImplementedError:
             return "unknown"
+
+    def _has_queued_final_for_revision(self, item: object) -> bool:
+        if not hasattr(self.queue_in, "mutex") or not hasattr(self.queue_in, "queue"):
+            return False
+        with self.queue_in.mutex:
+            return self._has_queued_final_for_revision_locked(item)
+
+    def _has_queued_final_for_revision_locked(self, item: object) -> bool:
+        key = self._revision_key(item)
+        if key is None:
+            return False
+        return any(
+            isinstance(queued_item, VADAudio)
+            and queued_item.mode == "final"
+            and self._revision_key(queued_item) == key
+            for queued_item in self.queue_in.queue
+        )
 
     def _revision_key(self, item: object) -> tuple[str, int] | None:
         turn_id = getattr(item, "turn_id", None)

--- a/src/speech_to_speech/STT/base_stt_handler.py
+++ b/src/speech_to_speech/STT/base_stt_handler.py
@@ -111,10 +111,7 @@ class BaseSTTHandler(BaseHandler[STTIn, STTOut]):
                 queued_item = self.queue_in.queue.popleft()
                 if isinstance(queued_item, VADAudio) and (
                     self._is_completed_final_revision(queued_item)
-                    or (
-                        queued_item.mode == "progressive"
-                        and self._has_queued_final_for_revision_locked(queued_item)
-                    )
+                    or (queued_item.mode == "progressive" and self._has_queued_final_for_revision_locked(queued_item))
                     or not self._is_latest_turn_item(
                         queued_item,
                         wait_for_pending_reopen=False,
@@ -180,9 +177,7 @@ class BaseSTTHandler(BaseHandler[STTIn, STTOut]):
         if key is None:
             return False
         return any(
-            isinstance(queued_item, VADAudio)
-            and queued_item.mode == "final"
-            and self._revision_key(queued_item) == key
+            isinstance(queued_item, VADAudio) and queued_item.mode == "final" and self._revision_key(queued_item) == key
             for queued_item in self.queue_in.queue
         )
 

--- a/src/speech_to_speech/STT/faster_whisper_handler.py
+++ b/src/speech_to_speech/STT/faster_whisper_handler.py
@@ -7,16 +7,16 @@ from typing import Any, Iterator
 from faster_whisper import WhisperModel
 from rich.console import Console
 
-from speech_to_speech.baseHandler import BaseHandler
 from speech_to_speech.pipeline.handler_types import STTIn, STTOut
 from speech_to_speech.pipeline.messages import Transcription
+from speech_to_speech.STT.base_stt_handler import BaseSTTHandler
 
 console = Console()
 
 logger = logging.getLogger(__name__)
 
 
-class FasterWhisperSTTHandler(BaseHandler[STTIn, STTOut]):
+class FasterWhisperSTTHandler(BaseSTTHandler):
     """
     Handles the Speech To Text generation using a Whisper model.
     """

--- a/src/speech_to_speech/STT/faster_whisper_handler.py
+++ b/src/speech_to_speech/STT/faster_whisper_handler.py
@@ -49,7 +49,11 @@ class FasterWhisperSTTHandler(BaseHandler[STTIn, STTOut]):
         if pred_text:
             console.print(f"[yellow]USER: {pred_text}")
 
-            yield Transcription(text=pred_text)
+            yield Transcription(
+                text=pred_text,
+                turn_id=vad_audio.turn_id,
+                turn_revision=vad_audio.turn_revision,
+            )
         else:
             logger.debug("no text detected. skipping...")
 

--- a/src/speech_to_speech/STT/faster_whisper_handler.py
+++ b/src/speech_to_speech/STT/faster_whisper_handler.py
@@ -53,6 +53,7 @@ class FasterWhisperSTTHandler(BaseSTTHandler):
                 text=pred_text,
                 turn_id=vad_audio.turn_id,
                 turn_revision=vad_audio.turn_revision,
+                speech_stopped_at_s=vad_audio.created_at_s,
             )
         else:
             logger.debug("no text detected. skipping...")

--- a/src/speech_to_speech/STT/lightning_whisper_mlx_handler.py
+++ b/src/speech_to_speech/STT/lightning_whisper_mlx_handler.py
@@ -94,4 +94,9 @@ class LightningWhisperSTTHandler(BaseHandler[STTIn, STTOut]):
         if self.start_language == "auto":
             language_code += "-auto"
 
-        yield Transcription(text=pred_text, language_code=language_code)
+        yield Transcription(
+            text=pred_text,
+            language_code=language_code,
+            turn_id=vad_audio.turn_id,
+            turn_revision=vad_audio.turn_revision,
+        )

--- a/src/speech_to_speech/STT/lightning_whisper_mlx_handler.py
+++ b/src/speech_to_speech/STT/lightning_whisper_mlx_handler.py
@@ -8,9 +8,9 @@ import torch
 from lightning_whisper_mlx import LightningWhisperMLX
 from rich.console import Console
 
-from speech_to_speech.baseHandler import BaseHandler
 from speech_to_speech.pipeline.handler_types import STTIn, STTOut
 from speech_to_speech.pipeline.messages import Transcription
+from speech_to_speech.STT.base_stt_handler import BaseSTTHandler
 
 logger = logging.getLogger(__name__)
 
@@ -32,7 +32,7 @@ SUPPORTED_LANGUAGES = [
 ]
 
 
-class LightningWhisperSTTHandler(BaseHandler[STTIn, STTOut]):
+class LightningWhisperSTTHandler(BaseSTTHandler):
     """
     Handles the Speech To Text generation using a Whisper model.
     """

--- a/src/speech_to_speech/STT/lightning_whisper_mlx_handler.py
+++ b/src/speech_to_speech/STT/lightning_whisper_mlx_handler.py
@@ -99,4 +99,5 @@ class LightningWhisperSTTHandler(BaseSTTHandler):
             language_code=language_code,
             turn_id=vad_audio.turn_id,
             turn_revision=vad_audio.turn_revision,
+            speech_stopped_at_s=vad_audio.created_at_s,
         )

--- a/src/speech_to_speech/STT/mlx_audio_whisper_handler.py
+++ b/src/speech_to_speech/STT/mlx_audio_whisper_handler.py
@@ -146,4 +146,9 @@ class MLXAudioWhisperSTTHandler(BaseHandler[STTIn, STTOut]):
         if self.start_language == "auto":
             language_code += "-auto"
 
-        yield Transcription(text=pred_text, language_code=language_code)
+        yield Transcription(
+            text=pred_text,
+            language_code=language_code,
+            turn_id=vad_audio.turn_id,
+            turn_revision=vad_audio.turn_revision,
+        )

--- a/src/speech_to_speech/STT/mlx_audio_whisper_handler.py
+++ b/src/speech_to_speech/STT/mlx_audio_whisper_handler.py
@@ -151,4 +151,5 @@ class MLXAudioWhisperSTTHandler(BaseSTTHandler):
             language_code=language_code,
             turn_id=vad_audio.turn_id,
             turn_revision=vad_audio.turn_revision,
+            speech_stopped_at_s=vad_audio.created_at_s,
         )

--- a/src/speech_to_speech/STT/mlx_audio_whisper_handler.py
+++ b/src/speech_to_speech/STT/mlx_audio_whisper_handler.py
@@ -6,9 +6,9 @@ from typing import Any, Iterator, Optional
 import numpy as np
 from rich.console import Console
 
-from speech_to_speech.baseHandler import BaseHandler
 from speech_to_speech.pipeline.handler_types import STTIn, STTOut
 from speech_to_speech.pipeline.messages import Transcription
+from speech_to_speech.STT.base_stt_handler import BaseSTTHandler
 
 logger = logging.getLogger(__name__)
 
@@ -30,7 +30,7 @@ SUPPORTED_LANGUAGES = [
 ]
 
 
-class MLXAudioWhisperSTTHandler(BaseHandler[STTIn, STTOut]):
+class MLXAudioWhisperSTTHandler(BaseSTTHandler):
     """
     Handles the Speech To Text generation using MLX Audio's Whisper implementation.
     Optimized for Apple Silicon using the MLX framework.

--- a/src/speech_to_speech/STT/paraformer_handler.py
+++ b/src/speech_to_speech/STT/paraformer_handler.py
@@ -62,4 +62,5 @@ class ParaformerSTTHandler(BaseSTTHandler):
             text=pred_text,
             turn_id=vad_audio.turn_id,
             turn_revision=vad_audio.turn_revision,
+            speech_stopped_at_s=vad_audio.created_at_s,
         )

--- a/src/speech_to_speech/STT/paraformer_handler.py
+++ b/src/speech_to_speech/STT/paraformer_handler.py
@@ -58,4 +58,8 @@ class ParaformerSTTHandler(BaseHandler[STTIn, STTOut]):
         logger.debug("finished paraformer inference")
         console.print(f"[yellow]USER: {pred_text}")
 
-        yield Transcription(text=pred_text)
+        yield Transcription(
+            text=pred_text,
+            turn_id=vad_audio.turn_id,
+            turn_revision=vad_audio.turn_revision,
+        )

--- a/src/speech_to_speech/STT/paraformer_handler.py
+++ b/src/speech_to_speech/STT/paraformer_handler.py
@@ -8,9 +8,9 @@ import torch
 from funasr import AutoModel
 from rich.console import Console
 
-from speech_to_speech.baseHandler import BaseHandler
 from speech_to_speech.pipeline.handler_types import STTIn, STTOut
 from speech_to_speech.pipeline.messages import Transcription
+from speech_to_speech.STT.base_stt_handler import BaseSTTHandler
 
 logging.basicConfig(
     format="%(asctime)s - %(name)s - %(levelname)s - %(message)s",
@@ -20,7 +20,7 @@ logger = logging.getLogger(__name__)
 console = Console()
 
 
-class ParaformerSTTHandler(BaseHandler[STTIn, STTOut]):
+class ParaformerSTTHandler(BaseSTTHandler):
     """
     Handles the Speech To Text generation using a Paraformer model.
     The default for this model is set to Chinese.

--- a/src/speech_to_speech/STT/parakeet_tdt_handler.py
+++ b/src/speech_to_speech/STT/parakeet_tdt_handler.py
@@ -171,6 +171,7 @@ class ParakeetTDTSTTHandler(BaseHandler[STTIn, STTOut]):
             self.processing_final = False  # Track if we're processing final audio
             logger.info(f"Live transcription enabled for Parakeet TDT ({self.backend})")
         self._live_transcription_active = False
+        self._live_turn_key: tuple[str | None, int | None] | None = None
 
         self.warmup()
 
@@ -246,6 +247,8 @@ class ParakeetTDTSTTHandler(BaseHandler[STTIn, STTOut]):
         else:
             audio_input = audio_input.astype(np.float32)
 
+        self._prepare_live_transcription_turn(vad_audio.turn_id, vad_audio.turn_revision)
+
         # Handle progressive updates: yield tagged partial for TranscriptionNotifier
         if self.enable_live_transcription and is_progressive:
             # Ignore progressive updates if we're already processing final audio
@@ -311,8 +314,7 @@ class ParakeetTDTSTTHandler(BaseHandler[STTIn, STTOut]):
         # an utterance, and stale timing must not leak into the next turn.
         if self.enable_live_transcription:
             self.processing_final = False
-            if self.streaming_handler is not None:
-                self.streaming_handler.reset()
+            self._reset_live_transcription_state(clear_turn=True)
 
         yield Transcription(
             text=pred_text,
@@ -411,6 +413,23 @@ class ParakeetTDTSTTHandler(BaseHandler[STTIn, STTOut]):
         console.print("\r\033[2K", end="")
         self._live_transcription_active = False
 
+    def _prepare_live_transcription_turn(self, turn_id: str | None, turn_revision: int | None) -> None:
+        if not self.enable_live_transcription:
+            return
+        turn_key = (turn_id, turn_revision)
+        if getattr(self, "_live_turn_key", None) == turn_key:
+            return
+        self._reset_live_transcription_state(clear_turn=False)
+        self._live_turn_key = turn_key
+
+    def _reset_live_transcription_state(self, clear_turn: bool) -> None:
+        self._clear_live_transcription_line()
+        streaming_handler = getattr(self, "streaming_handler", None)
+        if streaming_handler is not None:
+            streaming_handler.reset()
+        if clear_turn:
+            self._live_turn_key = None
+
     def _build_progressive_text(self, result: ProgressiveStreamPartial) -> str:
         parts = []
         if result.fixed_text:
@@ -436,6 +455,14 @@ class ParakeetTDTSTTHandler(BaseHandler[STTIn, STTOut]):
             fixed_end_time = self.streaming_handler.fixed_end_time
             sample_rate = 16000
             fixed_end_sample = int(fixed_end_time * sample_rate)
+            if fixed_end_sample > len(audio_input):
+                logger.warning(
+                    "Ignoring stale progressive fixed text: fixed_end_sample=%d exceeds final audio samples=%d",
+                    fixed_end_sample,
+                    len(audio_input),
+                )
+                pred_text, language_code = self._process_mlx(audio_input)
+                return pred_text, language_code
 
             # Only transcribe the part after fixed sentences
             if fixed_end_sample < len(audio_input):
@@ -531,9 +558,7 @@ class ParakeetTDTSTTHandler(BaseHandler[STTIn, STTOut]):
 
     def on_session_end(self) -> None:
         self.last_language = self.start_language if self.start_language else "en"
-        self._clear_live_transcription_line()
         if self.enable_live_transcription:
             self.processing_final = False
-            if self.streaming_handler is not None:
-                self.streaming_handler.reset()
+            self._reset_live_transcription_state(clear_turn=True)
         logger.debug("Parakeet TDT session state reset")

--- a/src/speech_to_speech/STT/parakeet_tdt_handler.py
+++ b/src/speech_to_speech/STT/parakeet_tdt_handler.py
@@ -20,9 +20,9 @@ import numpy as np
 from rich.console import Console
 from rich.text import Text
 
-from speech_to_speech.baseHandler import BaseHandler
 from speech_to_speech.pipeline.handler_types import STTIn, STTOut
 from speech_to_speech.pipeline.messages import PartialTranscription, Transcription
+from speech_to_speech.STT.base_stt_handler import BaseSTTHandler
 from speech_to_speech.STT.smart_progressive_streaming import PartialTranscription as ProgressiveStreamPartial
 from speech_to_speech.utils.mlx_lock import MLXLockContext
 
@@ -87,7 +87,7 @@ if LINGUA_AVAILABLE:
     _lingua_detector = _build_lingua_detector()
 
 
-class ParakeetTDTSTTHandler(BaseHandler[STTIn, STTOut]):
+class ParakeetTDTSTTHandler(BaseSTTHandler):
     """
     Handles Speech-to-Text using NVIDIA Parakeet TDT model.
 

--- a/src/speech_to_speech/STT/parakeet_tdt_handler.py
+++ b/src/speech_to_speech/STT/parakeet_tdt_handler.py
@@ -107,7 +107,7 @@ class ParakeetTDTSTTHandler(BaseSTTHandler):
         language: Optional[str] = None,
         gen_kwargs: dict[str, Any] = {},
         enable_live_transcription: bool = False,
-        live_transcription_update_interval: float = 0.25,
+        live_transcription_update_interval: float = 0.5,
     ) -> None:
         """
         Initialize the Parakeet TDT model.

--- a/src/speech_to_speech/STT/parakeet_tdt_handler.py
+++ b/src/speech_to_speech/STT/parakeet_tdt_handler.py
@@ -14,6 +14,7 @@ import logging
 from contextlib import contextmanager
 from sys import platform
 from threading import Lock
+from time import perf_counter
 from typing import Any, Iterator, Optional
 
 import numpy as np
@@ -126,6 +127,7 @@ class ParakeetTDTSTTHandler(BaseSTTHandler):
         self.enable_live_transcription = enable_live_transcription
         self.live_transcription_update_interval = live_transcription_update_interval
         self.compute_lock = Lock()
+        self.sample_rate = 16000
 
         # Determine device
         if device == "auto":
@@ -238,6 +240,7 @@ class ParakeetTDTSTTHandler(BaseSTTHandler):
         Yields:
             :class:`PartialTranscription` or :class:`Transcription`
         """
+        process_start_s = perf_counter()
         is_progressive = vad_audio.mode == "progressive"
         audio_input = vad_audio.audio
 
@@ -246,6 +249,8 @@ class ParakeetTDTSTTHandler(BaseSTTHandler):
             audio_input = np.array(audio_input, dtype=np.float32)
         else:
             audio_input = audio_input.astype(np.float32)
+        audio_duration_s = len(audio_input) / getattr(self, "sample_rate", 16000)
+        item_age_s = self._item_age_s(vad_audio)
 
         self._prepare_live_transcription_turn(vad_audio.turn_id, vad_audio.turn_revision)
 
@@ -257,10 +262,25 @@ class ParakeetTDTSTTHandler(BaseSTTHandler):
                 return
 
             # Try to acquire lock with short timeout - skip if busy
+            lock_scope_start_s = perf_counter()
             with self._compute_lock_context(handler_name="ParakeetSTT-Progressive", timeout=0.01) as acquired:
                 if acquired:
                     try:
+                        inference_start_s = perf_counter()
                         progressive_text = self._show_progressive_transcription(audio_input)
+                        inference_s = perf_counter() - inference_start_s
+                        if inference_s >= 0.25:
+                            logger.info(
+                                "Parakeet progressive STT timing turn=%s rev=%s audio=%.3fs age=%.3fs "
+                                "lock_scope=%.3fs inference=%.3fs chars=%d",
+                                vad_audio.turn_id,
+                                vad_audio.turn_revision,
+                                audio_duration_s,
+                                item_age_s,
+                                perf_counter() - lock_scope_start_s,
+                                inference_s,
+                                len(progressive_text),
+                            )
                         if progressive_text:
                             yield PartialTranscription(
                                 text=progressive_text,
@@ -275,21 +295,36 @@ class ParakeetTDTSTTHandler(BaseSTTHandler):
             return
 
         # Handle final transcription (send to LLM)
+        logger.info(
+            "Parakeet final STT start turn=%s rev=%s audio=%.3fs age=%.3fs",
+            vad_audio.turn_id,
+            vad_audio.turn_revision,
+            audio_duration_s,
+            item_age_s,
+        )
+        inference_s = 0.0
+        lock_scope_s = 0.0
         try:
             if self.enable_live_transcription:
                 # Mark that we're processing final audio (ignore stale progressive updates)
                 self.processing_final = True
 
             # Acquire lock with longer timeout for final transcription
+            lock_scope_start_s = perf_counter()
             with self._compute_lock_context(handler_name="ParakeetSTT-Final", timeout=5.0) as acquired:
+                lock_scope_s = perf_counter() - lock_scope_start_s
                 if not acquired:
                     logger.error("Failed to acquire compute lock for final transcription")
                     pred_text = ""
                     language_code = self.last_language
-                elif self.backend == "mlx":
-                    pred_text, language_code = self._process_mlx_final(audio_input)
                 else:
-                    pred_text, language_code = self._process_nano_parakeet(audio_input)
+                    inference_start_s = perf_counter()
+                    if self.backend == "mlx":
+                        pred_text, language_code = self._process_mlx_final(audio_input)
+                    else:
+                        pred_text, language_code = self._process_nano_parakeet(audio_input)
+                    inference_s = perf_counter() - inference_start_s
+                    lock_scope_s = perf_counter() - lock_scope_start_s
 
             # Validate and update language
             if language_code and language_code in SUPPORTED_LANGUAGES:
@@ -302,6 +337,16 @@ class ParakeetTDTSTTHandler(BaseSTTHandler):
             pred_text = ""
             language_code = self.last_language
 
+        total_s = perf_counter() - process_start_s
+        logger.info(
+            "Parakeet final STT done turn=%s rev=%s total=%.3fs lock_scope=%.3fs inference=%.3fs chars=%d",
+            vad_audio.turn_id,
+            vad_audio.turn_revision,
+            total_s,
+            lock_scope_s,
+            inference_s,
+            len(pred_text),
+        )
         logger.debug("Finished Parakeet TDT inference")
         self._clear_live_transcription_line()
         if pred_text.strip():
@@ -363,12 +408,29 @@ class ParakeetTDTSTTHandler(BaseSTTHandler):
                 yield acquired
             return
 
+        lock_start_s = perf_counter()
         acquired = self.compute_lock.acquire(timeout=timeout)
+        wait_s = perf_counter() - lock_start_s
+        hold_start_s: float | None = None
+        if acquired:
+            if wait_s >= 0.25:
+                logger.info("%s: compute lock acquired after %.2fs", handler_name, wait_s)
+            else:
+                logger.debug("%s: compute lock acquired after %.3fs", handler_name, wait_s)
+            hold_start_s = perf_counter()
+        else:
+            logger.warning("%s: Failed to acquire compute lock after %.3fs (timeout=%s)", handler_name, wait_s, timeout)
         try:
             yield acquired
         finally:
             if acquired:
+                assert hold_start_s is not None
                 self.compute_lock.release()
+                hold_s = perf_counter() - hold_start_s
+                if hold_s >= 0.25:
+                    logger.info("%s: compute lock released after holding %.2fs", handler_name, hold_s)
+                else:
+                    logger.debug("%s: compute lock released after holding %.3fs", handler_name, hold_s)
 
     def _show_progressive_transcription(self, audio_input: np.ndarray) -> str:
         """Run progressive transcription, print to console, and return the text."""

--- a/src/speech_to_speech/STT/parakeet_tdt_handler.py
+++ b/src/speech_to_speech/STT/parakeet_tdt_handler.py
@@ -18,6 +18,7 @@ from typing import Any, Iterator, Optional
 
 import numpy as np
 from rich.console import Console
+from rich.text import Text
 
 from speech_to_speech.baseHandler import BaseHandler
 from speech_to_speech.pipeline.handler_types import STTIn, STTOut
@@ -169,6 +170,7 @@ class ParakeetTDTSTTHandler(BaseHandler[STTIn, STTOut]):
             )
             self.processing_final = False  # Track if we're processing final audio
             logger.info(f"Live transcription enabled for Parakeet TDT ({self.backend})")
+        self._live_transcription_active = False
 
         self.warmup()
 
@@ -298,6 +300,7 @@ class ParakeetTDTSTTHandler(BaseHandler[STTIn, STTOut]):
             language_code = self.last_language
 
         logger.debug("Finished Parakeet TDT inference")
+        self._clear_live_transcription_line()
         if pred_text.strip():
             console.print(f"[yellow]USER: {pred_text.strip()}")
             if language_code:
@@ -367,8 +370,6 @@ class ParakeetTDTSTTHandler(BaseHandler[STTIn, STTOut]):
 
     def _show_progressive_transcription(self, audio_input: np.ndarray) -> str:
         """Run progressive transcription, print to console, and return the text."""
-        from rich.text import Text
-
         result = self.streaming_handler.transcribe_incremental(audio_input)
         rich_text = Text()
         if result.fixed_text:
@@ -384,12 +385,31 @@ class ParakeetTDTSTTHandler(BaseHandler[STTIn, STTOut]):
 
         progressive_text = self._build_progressive_text(result)
         if progressive_text:
+            self._print_live_transcription(rich_text, progressive_text)
+
+        return progressive_text
+
+    def _print_live_transcription(self, rich_text: Text, progressive_text: str) -> None:
+        is_terminal = bool(getattr(console, "is_terminal", False))
+        if is_terminal:
+            console.print("\r\033[2K", end="")
             if rich_text:
                 console.print(rich_text, end="\r")
             else:
                 console.print(f"[dim]Live: [/dim]{progressive_text}", end="\r")
+            self._live_transcription_active = True
+            return
 
-        return progressive_text
+        if rich_text:
+            console.print(rich_text)
+        else:
+            console.print(f"[dim]Live: [/dim]{progressive_text}")
+
+    def _clear_live_transcription_line(self) -> None:
+        if not getattr(self, "_live_transcription_active", False):
+            return
+        console.print("\r\033[2K", end="")
+        self._live_transcription_active = False
 
     def _build_progressive_text(self, result: ProgressiveStreamPartial) -> str:
         parts = []
@@ -407,8 +427,7 @@ class ParakeetTDTSTTHandler(BaseHandler[STTIn, STTOut]):
             and hasattr(self.streaming_handler, "fixed_sentences")
             and self.streaming_handler.fixed_sentences
         ):
-            # Clear the live transcription line
-            console.print(" " * 100, end="\r")
+            self._clear_live_transcription_line()
 
             # Get fixed text from previous progressive updates
             fixed_text = " ".join(self.streaming_handler.fixed_sentences).strip()
@@ -512,6 +531,7 @@ class ParakeetTDTSTTHandler(BaseHandler[STTIn, STTOut]):
 
     def on_session_end(self) -> None:
         self.last_language = self.start_language if self.start_language else "en"
+        self._clear_live_transcription_line()
         if self.enable_live_transcription:
             self.processing_final = False
             if self.streaming_handler is not None:

--- a/src/speech_to_speech/STT/parakeet_tdt_handler.py
+++ b/src/speech_to_speech/STT/parakeet_tdt_handler.py
@@ -257,7 +257,11 @@ class ParakeetTDTSTTHandler(BaseHandler[STTIn, STTOut]):
                     try:
                         progressive_text = self._show_progressive_transcription(audio_input)
                         if progressive_text:
-                            yield PartialTranscription(text=progressive_text)
+                            yield PartialTranscription(
+                                text=progressive_text,
+                                turn_id=vad_audio.turn_id,
+                                turn_revision=vad_audio.turn_revision,
+                            )
                             return
                     except Exception as e:
                         logger.debug(f"Progressive transcription failed: {e}")
@@ -307,7 +311,12 @@ class ParakeetTDTSTTHandler(BaseHandler[STTIn, STTOut]):
             if self.streaming_handler is not None:
                 self.streaming_handler.reset()
 
-        yield Transcription(text=pred_text, language_code=language_code)
+        yield Transcription(
+            text=pred_text,
+            language_code=language_code,
+            turn_id=vad_audio.turn_id,
+            turn_revision=vad_audio.turn_revision,
+        )
 
     @property
     def timing_log_level(self) -> int:

--- a/src/speech_to_speech/STT/parakeet_tdt_handler.py
+++ b/src/speech_to_speech/STT/parakeet_tdt_handler.py
@@ -639,6 +639,7 @@ class ParakeetTDTSTTHandler(BaseSTTHandler):
             del self.model
 
     def on_session_end(self) -> None:
+        super().on_session_end()
         self.last_language = self.start_language if self.start_language else "en"
         if self.enable_live_transcription:
             self.processing_final = False

--- a/src/speech_to_speech/STT/parakeet_tdt_handler.py
+++ b/src/speech_to_speech/STT/parakeet_tdt_handler.py
@@ -366,6 +366,7 @@ class ParakeetTDTSTTHandler(BaseSTTHandler):
             language_code=language_code,
             turn_id=vad_audio.turn_id,
             turn_revision=vad_audio.turn_revision,
+            speech_stopped_at_s=vad_audio.created_at_s,
         )
 
     @property

--- a/src/speech_to_speech/STT/parakeet_tdt_handler.py
+++ b/src/speech_to_speech/STT/parakeet_tdt_handler.py
@@ -394,11 +394,14 @@ class ParakeetTDTSTTHandler(BaseHandler[STTIn, STTOut]):
     def _print_live_transcription(self, rich_text: Text, progressive_text: str) -> None:
         is_terminal = bool(getattr(console, "is_terminal", False))
         if is_terminal:
-            console.print("\r\033[2K", end="")
+            self._write_live_control("\r\x1b[2K")
             if rich_text:
-                console.print(rich_text, end="\r")
+                console.print(self._truncate_live_transcription(rich_text), end="")
             else:
-                console.print(f"[dim]Live: [/dim]{progressive_text}", end="\r")
+                fallback = Text("Live: ", style="dim")
+                fallback.append(progressive_text, style="cyan dim")
+                console.print(self._truncate_live_transcription(fallback), end="")
+            self._write_live_control("\r")
             self._live_transcription_active = True
             return
 
@@ -410,8 +413,25 @@ class ParakeetTDTSTTHandler(BaseHandler[STTIn, STTOut]):
     def _clear_live_transcription_line(self) -> None:
         if not getattr(self, "_live_transcription_active", False):
             return
-        console.print("\r\033[2K", end="")
+        self._write_live_control("\r\x1b[2K")
         self._live_transcription_active = False
+
+    def _write_live_control(self, sequence: str) -> None:
+        file = getattr(console, "file", None)
+        if file is None:
+            return
+        file.write(sequence)
+        file.flush()
+
+    def _truncate_live_transcription(self, text: Text) -> Text:
+        text = text.copy()
+        width = getattr(console, "width", 80)
+        try:
+            max_width = max(1, int(width) - 1)
+        except (TypeError, ValueError):
+            max_width = 79
+        text.truncate(max_width, overflow="ellipsis")
+        return text
 
     def _prepare_live_transcription_turn(self, turn_id: str | None, turn_revision: int | None) -> None:
         if not self.enable_live_transcription:

--- a/src/speech_to_speech/STT/smart_progressive_streaming.py
+++ b/src/speech_to_speech/STT/smart_progressive_streaming.py
@@ -2,7 +2,7 @@
 """
 Smart Progressive Streaming Handler
 
-Provides frequent partial transcriptions (every 250ms) with:
+Provides frequent partial transcriptions (every 500ms) with:
 - Growing window up to 15s for accuracy
 - Sentence-boundary-aware window sliding for audio > 15s
 - Fixed sentences + active transcription
@@ -30,7 +30,7 @@ class SmartProgressiveStreamingHandler:
     Smart progressive streaming with sentence-aware window management.
 
     Strategy:
-    1. Emit partial transcriptions every 250ms
+    1. Emit partial transcriptions every 500ms
     2. Use growing window (up to 15s) for better accuracy
     3. When audio > 15s, slide window using sentence boundaries:
        - Keep completed sentences as "fixed"
@@ -40,14 +40,14 @@ class SmartProgressiveStreamingHandler:
     def __init__(
         self,
         model: Any,
-        emission_interval: float = 0.25,
+        emission_interval: float = 0.5,
         max_window_size: float = 15.0,
         sentence_buffer: float = 2.0,
     ) -> None:
         """
         Args:
             model: Parakeet model with sentence alignment
-            emission_interval: Emit partial transcription every N seconds (default 250ms)
+            emission_interval: Emit partial transcription every N seconds (default 500ms)
             max_window_size: Maximum window size before sliding (default 15s)
             sentence_buffer: Keep last N seconds of sentences in active window (default 2s)
         """
@@ -251,7 +251,7 @@ def demo_smart_progressive() -> None:
     print("SMART PROGRESSIVE STREAMING DEMO")
     print("=" * 80)
     print("\nFeatures:")
-    print("  • Partial updates every 250ms")
+    print("  • Partial updates every 500ms")
     print("  • Growing window up to 15s")
     print("  • Sentence-aware window sliding for long audio")
     print()
@@ -286,7 +286,7 @@ def demo_smart_progressive() -> None:
 
         handler = SmartProgressiveStreamingHandler(
             model,
-            emission_interval=0.25,  # 250ms updates
+            emission_interval=0.5,  # 500ms updates
             max_window_size=15.0,  # Max 15s window
             sentence_buffer=2.0,  # Keep 2s of sentences in active window
         )
@@ -300,8 +300,8 @@ def demo_smart_progressive() -> None:
         for result in handler.transcribe_progressive(test_audio):
             update_count += 1
 
-            # Show every 4th update (every 1s) to keep output manageable
-            if update_count % 4 == 0 or result.is_final:
+            # Show every other update (every 1s) to keep output manageable
+            if update_count % 2 == 0 or result.is_final:
                 elapsed = time.perf_counter() - start_time
                 marker = "FINAL" if result.is_final else f"Update {update_count}"
 
@@ -320,7 +320,7 @@ def demo_smart_progressive() -> None:
     print("KEY INSIGHTS")
     print("=" * 80)
     print("""
-1. Frequent updates (250ms):
+1. Frequent updates (500ms):
    - User sees transcription building in real-time
    - Low latency feel
 

--- a/src/speech_to_speech/STT/transcription_notifier.py
+++ b/src/speech_to_speech/STT/transcription_notifier.py
@@ -57,11 +57,13 @@ class TranscriptionNotifier(BaseHandler[STTOut, Union[STTOut, LLMIn]]):
             language_code = transcription.language_code
             turn_id = transcription.turn_id
             turn_revision = transcription.turn_revision
+            speech_stopped_at_s = transcription.speech_stopped_at_s
         else:
             text = transcription
             language_code = None
             turn_id = None
             turn_revision = None
+            speech_stopped_at_s = None
 
         transcript = str(text)
         # Always close the client-visible transcription item. Empty final STT
@@ -74,6 +76,7 @@ class TranscriptionNotifier(BaseHandler[STTOut, Union[STTOut, LLMIn]]):
                     language_code=language_code,
                     turn_id=turn_id,
                     turn_revision=turn_revision,
+                    speech_stopped_at_s=speech_stopped_at_s,
                 )
             )
 
@@ -96,4 +99,5 @@ class TranscriptionNotifier(BaseHandler[STTOut, Union[STTOut, LLMIn]]):
                 language_code=language_code,
                 turn_id=turn_id,
                 turn_revision=turn_revision,
+                speech_stopped_at_s=speech_stopped_at_s,
             )

--- a/src/speech_to_speech/STT/transcription_notifier.py
+++ b/src/speech_to_speech/STT/transcription_notifier.py
@@ -42,23 +42,40 @@ class TranscriptionNotifier(BaseHandler[STTOut, Union[STTOut, LLMIn]]):
     def process(self, transcription: STTOut) -> Iterator[Union[STTOut, LLMIn]]:
         if isinstance(transcription, PartialTranscription):
             if self.text_output_queue and transcription.text:
-                self.text_output_queue.put(PartialTranscriptionEvent(delta=str(transcription.text)))
+                self.text_output_queue.put(
+                    PartialTranscriptionEvent(
+                        delta=str(transcription.text),
+                        turn_id=transcription.turn_id,
+                        turn_revision=transcription.turn_revision,
+                    )
+                )
                 logger.debug("Partial transcription: %s", str(transcription.text)[:80])
             return
 
         if isinstance(transcription, Transcription):
             text = transcription.text
             language_code = transcription.language_code
+            turn_id = transcription.turn_id
+            turn_revision = transcription.turn_revision
         else:
             text = transcription
             language_code = None
+            turn_id = None
+            turn_revision = None
 
         transcript = str(text)
         # Always close the client-visible transcription item. Empty final STT
         # results should not trigger the LLM, but clients may already have
         # received partial deltas and still need a completed event.
         if self.text_output_queue is not None:
-            self.text_output_queue.put(TranscriptionCompletedEvent(transcript=transcript, language_code=language_code))
+            self.text_output_queue.put(
+                TranscriptionCompletedEvent(
+                    transcript=transcript,
+                    language_code=language_code,
+                    turn_id=turn_id,
+                    turn_revision=turn_revision,
+                )
+            )
 
         if not transcript:
             logger.debug("Transcription completed with empty transcript")
@@ -73,8 +90,10 @@ class TranscriptionNotifier(BaseHandler[STTOut, Union[STTOut, LLMIn]]):
             logger.info("Transcription completed: %s", transcript)
 
         if self.runtime_config is not None:
-            self.runtime_config.chat.add_item(make_user_message(str(text)))
+            self.runtime_config.chat.add_item(make_user_message(transcript))
             yield GenerateResponseRequest(
                 runtime_config=self.runtime_config,
                 language_code=language_code,
+                turn_id=turn_id,
+                turn_revision=turn_revision,
             )

--- a/src/speech_to_speech/STT/whisper_stt_handler.py
+++ b/src/speech_to_speech/STT/whisper_stt_handler.py
@@ -138,4 +138,9 @@ class WhisperSTTHandler(BaseHandler[STTIn, STTOut]):
         if self.start_language == "auto":
             language_code += "-auto"
 
-        yield Transcription(text=pred_text, language_code=language_code)
+        yield Transcription(
+            text=pred_text,
+            language_code=language_code,
+            turn_id=vad_audio.turn_id,
+            turn_revision=vad_audio.turn_revision,
+        )

--- a/src/speech_to_speech/STT/whisper_stt_handler.py
+++ b/src/speech_to_speech/STT/whisper_stt_handler.py
@@ -143,4 +143,5 @@ class WhisperSTTHandler(BaseSTTHandler):
             language_code=language_code,
             turn_id=vad_audio.turn_id,
             turn_revision=vad_audio.turn_revision,
+            speech_stopped_at_s=vad_audio.created_at_s,
         )

--- a/src/speech_to_speech/STT/whisper_stt_handler.py
+++ b/src/speech_to_speech/STT/whisper_stt_handler.py
@@ -9,9 +9,9 @@ import torch
 from rich.console import Console
 from transformers import AutoModelForSpeechSeq2Seq, AutoProcessor
 
-from speech_to_speech.baseHandler import BaseHandler
 from speech_to_speech.pipeline.handler_types import STTIn, STTOut
 from speech_to_speech.pipeline.messages import Transcription
+from speech_to_speech.STT.base_stt_handler import BaseSTTHandler
 
 logger = logging.getLogger(__name__)
 console = Console()
@@ -32,7 +32,7 @@ SUPPORTED_LANGUAGES = [
 ]
 
 
-class WhisperSTTHandler(BaseHandler[STTIn, STTOut]):
+class WhisperSTTHandler(BaseSTTHandler):
     """
     Handles the Speech To Text generation using a Whisper model.
     """

--- a/src/speech_to_speech/TTS/chatTTS_handler.py
+++ b/src/speech_to_speech/TTS/chatTTS_handler.py
@@ -57,7 +57,7 @@ class ChatTTSHandler(BaseHandler[TTSIn, TTSOut]):
     def process(self, tts_input: TTSIn) -> Iterator[TTSOut]:
         speculative_turns = getattr(self, "speculative_turns", None)
         if isinstance(tts_input, EndOfResponse):
-            if speculative_turns and not speculative_turns.is_latest_after_pending_reopen(
+            if speculative_turns and not speculative_turns.is_latest_after_reopen_grace(
                 tts_input.turn_id,
                 tts_input.turn_revision,
             ):
@@ -65,7 +65,7 @@ class ChatTTSHandler(BaseHandler[TTSIn, TTSOut]):
             yield AUDIO_RESPONSE_DONE
             return
 
-        if speculative_turns and not speculative_turns.is_latest_after_pending_reopen(
+        if speculative_turns and not speculative_turns.is_latest_after_reopen_grace(
             tts_input.turn_id,
             tts_input.turn_revision,
         ):

--- a/src/speech_to_speech/TTS/chatTTS_handler.py
+++ b/src/speech_to_speech/TTS/chatTTS_handler.py
@@ -55,12 +55,17 @@ class ChatTTSHandler(BaseHandler[TTSIn, TTSOut]):
         _ = self.model.infer("text")
 
     def process(self, tts_input: TTSIn) -> Iterator[TTSOut]:
+        speculative_turns = getattr(self, "speculative_turns", None)
         if isinstance(tts_input, EndOfResponse):
+            if speculative_turns and not speculative_turns.is_latest_after_pending_reopen(
+                tts_input.turn_id,
+                tts_input.turn_revision,
+            ):
+                return
             yield AUDIO_RESPONSE_DONE
             return
 
-        speculative_turns = getattr(self, "speculative_turns", None)
-        if speculative_turns and not speculative_turns.is_latest(
+        if speculative_turns and not speculative_turns.is_latest_after_pending_reopen(
             tts_input.turn_id,
             tts_input.turn_revision,
         ):

--- a/src/speech_to_speech/TTS/chatTTS_handler.py
+++ b/src/speech_to_speech/TTS/chatTTS_handler.py
@@ -14,6 +14,7 @@ from speech_to_speech.baseHandler import BaseHandler
 from speech_to_speech.pipeline.cancel_scope import CancelScope
 from speech_to_speech.pipeline.handler_types import TTSIn, TTSOut
 from speech_to_speech.pipeline.messages import AUDIO_RESPONSE_DONE, EndOfResponse
+from speech_to_speech.pipeline.speculative_turns import SpeculativeTurnTracker
 
 logging.basicConfig(
     format="%(asctime)s - %(name)s - %(levelname)s - %(message)s",
@@ -33,9 +34,11 @@ class ChatTTSHandler(BaseHandler[TTSIn, TTSOut]):
         stream: bool = True,
         chunk_size: int = 512,
         cancel_scope: CancelScope | None = None,
+        speculative_turns: SpeculativeTurnTracker | None = None,
     ) -> None:
         self.should_listen = should_listen
         self.cancel_scope = cancel_scope
+        self.speculative_turns = speculative_turns
         self.device = device
         self.model = ChatTTS.Chat()
         self.model.load(compile=False)  # Doesn't work for me with True
@@ -54,6 +57,14 @@ class ChatTTSHandler(BaseHandler[TTSIn, TTSOut]):
     def process(self, tts_input: TTSIn) -> Iterator[TTSOut]:
         if isinstance(tts_input, EndOfResponse):
             yield AUDIO_RESPONSE_DONE
+            return
+
+        speculative_turns = getattr(self, "speculative_turns", None)
+        if speculative_turns and not speculative_turns.is_latest(
+            tts_input.turn_id,
+            tts_input.turn_revision,
+        ):
+            logger.debug("Dropping stale TTS input for turn=%s rev=%s", tts_input.turn_id, tts_input.turn_revision)
             return
 
         text = tts_input.text

--- a/src/speech_to_speech/TTS/chatTTS_handler.py
+++ b/src/speech_to_speech/TTS/chatTTS_handler.py
@@ -71,6 +71,8 @@ class ChatTTSHandler(BaseHandler[TTSIn, TTSOut]):
         ):
             logger.debug("Dropping stale TTS input for turn=%s rev=%s", tts_input.turn_id, tts_input.turn_revision)
             return
+        if speculative_turns:
+            speculative_turns.commit(tts_input.turn_id, tts_input.turn_revision)
 
         text = tts_input.text
 

--- a/src/speech_to_speech/TTS/facebookmms_handler.py
+++ b/src/speech_to_speech/TTS/facebookmms_handler.py
@@ -137,12 +137,17 @@ class FacebookMMSTTSHandler(BaseHandler[TTSIn, TTSOut]):
             return None
 
     def process(self, tts_input: TTSIn) -> Iterator[TTSOut]:
+        speculative_turns = getattr(self, "speculative_turns", None)
         if isinstance(tts_input, EndOfResponse):
+            if speculative_turns and not speculative_turns.is_latest_after_pending_reopen(
+                tts_input.turn_id,
+                tts_input.turn_revision,
+            ):
+                return
             yield AUDIO_RESPONSE_DONE
             return
 
-        speculative_turns = getattr(self, "speculative_turns", None)
-        if speculative_turns and not speculative_turns.is_latest(
+        if speculative_turns and not speculative_turns.is_latest_after_pending_reopen(
             tts_input.turn_id,
             tts_input.turn_revision,
         ):

--- a/src/speech_to_speech/TTS/facebookmms_handler.py
+++ b/src/speech_to_speech/TTS/facebookmms_handler.py
@@ -153,6 +153,8 @@ class FacebookMMSTTSHandler(BaseHandler[TTSIn, TTSOut]):
         ):
             logger.debug("Dropping stale TTS input for turn=%s rev=%s", tts_input.turn_id, tts_input.turn_revision)
             return
+        if speculative_turns:
+            speculative_turns.commit(tts_input.turn_id, tts_input.turn_revision)
 
         gen = self.cancel_scope.generation if self.cancel_scope else None
         language_code = tts_input.language_code

--- a/src/speech_to_speech/TTS/facebookmms_handler.py
+++ b/src/speech_to_speech/TTS/facebookmms_handler.py
@@ -139,7 +139,7 @@ class FacebookMMSTTSHandler(BaseHandler[TTSIn, TTSOut]):
     def process(self, tts_input: TTSIn) -> Iterator[TTSOut]:
         speculative_turns = getattr(self, "speculative_turns", None)
         if isinstance(tts_input, EndOfResponse):
-            if speculative_turns and not speculative_turns.is_latest_after_pending_reopen(
+            if speculative_turns and not speculative_turns.is_latest_after_reopen_grace(
                 tts_input.turn_id,
                 tts_input.turn_revision,
             ):
@@ -147,7 +147,7 @@ class FacebookMMSTTSHandler(BaseHandler[TTSIn, TTSOut]):
             yield AUDIO_RESPONSE_DONE
             return
 
-        if speculative_turns and not speculative_turns.is_latest_after_pending_reopen(
+        if speculative_turns and not speculative_turns.is_latest_after_reopen_grace(
             tts_input.turn_id,
             tts_input.turn_revision,
         ):

--- a/src/speech_to_speech/TTS/facebookmms_handler.py
+++ b/src/speech_to_speech/TTS/facebookmms_handler.py
@@ -14,6 +14,7 @@ from speech_to_speech.baseHandler import BaseHandler
 from speech_to_speech.pipeline.cancel_scope import CancelScope
 from speech_to_speech.pipeline.handler_types import TTSIn, TTSOut
 from speech_to_speech.pipeline.messages import AUDIO_RESPONSE_DONE, EndOfResponse
+from speech_to_speech.pipeline.speculative_turns import SpeculativeTurnTracker
 
 logging.basicConfig(format="%(asctime)s - %(name)s - %(levelname)s - %(message)s", level=logging.DEBUG)
 
@@ -73,10 +74,12 @@ class FacebookMMSTTSHandler(BaseHandler[TTSIn, TTSOut]):
         stream: bool = True,
         chunk_size: int = 512,
         cancel_scope: CancelScope | None = None,
+        speculative_turns: SpeculativeTurnTracker | None = None,
         **kwargs: Any,
     ) -> None:
         self.should_listen = should_listen
         self.cancel_scope = cancel_scope
+        self.speculative_turns = speculative_turns
         self.device = device
         self.torch_dtype = getattr(torch, torch_dtype)
         self.stream = stream
@@ -136,6 +139,14 @@ class FacebookMMSTTSHandler(BaseHandler[TTSIn, TTSOut]):
     def process(self, tts_input: TTSIn) -> Iterator[TTSOut]:
         if isinstance(tts_input, EndOfResponse):
             yield AUDIO_RESPONSE_DONE
+            return
+
+        speculative_turns = getattr(self, "speculative_turns", None)
+        if speculative_turns and not speculative_turns.is_latest(
+            tts_input.turn_id,
+            tts_input.turn_revision,
+        ):
+            logger.debug("Dropping stale TTS input for turn=%s rev=%s", tts_input.turn_id, tts_input.turn_revision)
             return
 
         gen = self.cancel_scope.generation if self.cancel_scope else None

--- a/src/speech_to_speech/TTS/kokoro_handler.py
+++ b/src/speech_to_speech/TTS/kokoro_handler.py
@@ -22,6 +22,7 @@ from speech_to_speech.baseHandler import BaseHandler
 from speech_to_speech.pipeline.cancel_scope import CancelScope
 from speech_to_speech.pipeline.handler_types import TTSIn, TTSOut
 from speech_to_speech.pipeline.messages import AUDIO_RESPONSE_DONE, EndOfResponse
+from speech_to_speech.pipeline.speculative_turns import SpeculativeTurnTracker
 from speech_to_speech.utils.mlx_lock import MLXLockContext
 
 logger = logging.getLogger(__name__)
@@ -94,6 +95,7 @@ class KokoroTTSHandler(BaseHandler[TTSIn, TTSOut]):
         blocksize: int = 512,
         gen_kwargs: dict[str, Any] | None = None,
         cancel_scope: CancelScope | None = None,
+        speculative_turns: SpeculativeTurnTracker | None = None,
     ) -> None:
         """
         Initialize the Kokoro TTS model.
@@ -115,6 +117,7 @@ class KokoroTTSHandler(BaseHandler[TTSIn, TTSOut]):
         self.speed = speed
         self.blocksize = blocksize
         self.cancel_scope = cancel_scope
+        self.speculative_turns = speculative_turns
 
         # Determine device
         if device == "auto":
@@ -237,6 +240,14 @@ class KokoroTTSHandler(BaseHandler[TTSIn, TTSOut]):
         """
         if isinstance(tts_input, EndOfResponse):
             yield AUDIO_RESPONSE_DONE
+            return
+
+        speculative_turns = getattr(self, "speculative_turns", None)
+        if speculative_turns and not speculative_turns.is_latest(
+            tts_input.turn_id,
+            tts_input.turn_revision,
+        ):
+            logger.debug("Dropping stale TTS input for turn=%s rev=%s", tts_input.turn_id, tts_input.turn_revision)
             return
 
         runtime_config = tts_input.runtime_config

--- a/src/speech_to_speech/TTS/kokoro_handler.py
+++ b/src/speech_to_speech/TTS/kokoro_handler.py
@@ -240,7 +240,7 @@ class KokoroTTSHandler(BaseHandler[TTSIn, TTSOut]):
         """
         speculative_turns = getattr(self, "speculative_turns", None)
         if isinstance(tts_input, EndOfResponse):
-            if speculative_turns and not speculative_turns.is_latest_after_pending_reopen(
+            if speculative_turns and not speculative_turns.is_latest_after_reopen_grace(
                 tts_input.turn_id,
                 tts_input.turn_revision,
             ):
@@ -248,7 +248,7 @@ class KokoroTTSHandler(BaseHandler[TTSIn, TTSOut]):
             yield AUDIO_RESPONSE_DONE
             return
 
-        if speculative_turns and not speculative_turns.is_latest_after_pending_reopen(
+        if speculative_turns and not speculative_turns.is_latest_after_reopen_grace(
             tts_input.turn_id,
             tts_input.turn_revision,
         ):

--- a/src/speech_to_speech/TTS/kokoro_handler.py
+++ b/src/speech_to_speech/TTS/kokoro_handler.py
@@ -238,12 +238,17 @@ class KokoroTTSHandler(BaseHandler[TTSIn, TTSOut]):
         Yields:
             Audio chunks as numpy int16 arrays
         """
+        speculative_turns = getattr(self, "speculative_turns", None)
         if isinstance(tts_input, EndOfResponse):
+            if speculative_turns and not speculative_turns.is_latest_after_pending_reopen(
+                tts_input.turn_id,
+                tts_input.turn_revision,
+            ):
+                return
             yield AUDIO_RESPONSE_DONE
             return
 
-        speculative_turns = getattr(self, "speculative_turns", None)
-        if speculative_turns and not speculative_turns.is_latest(
+        if speculative_turns and not speculative_turns.is_latest_after_pending_reopen(
             tts_input.turn_id,
             tts_input.turn_revision,
         ):

--- a/src/speech_to_speech/TTS/kokoro_handler.py
+++ b/src/speech_to_speech/TTS/kokoro_handler.py
@@ -254,6 +254,8 @@ class KokoroTTSHandler(BaseHandler[TTSIn, TTSOut]):
         ):
             logger.debug("Dropping stale TTS input for turn=%s rev=%s", tts_input.turn_id, tts_input.turn_revision)
             return
+        if speculative_turns:
+            speculative_turns.commit(tts_input.turn_id, tts_input.turn_revision)
 
         runtime_config = tts_input.runtime_config
         response = tts_input.response

--- a/src/speech_to_speech/TTS/pocket_tts_handler.py
+++ b/src/speech_to_speech/TTS/pocket_tts_handler.py
@@ -98,7 +98,7 @@ class PocketTTSHandler(BaseHandler[TTSIn, TTSOut]):
     def process(self, tts_input: TTSIn) -> Iterator[TTSOut]:
         speculative_turns = getattr(self, "speculative_turns", None)
         if isinstance(tts_input, EndOfResponse):
-            if speculative_turns and not speculative_turns.is_latest_after_pending_reopen(
+            if speculative_turns and not speculative_turns.is_latest_after_reopen_grace(
                 tts_input.turn_id,
                 tts_input.turn_revision,
             ):
@@ -106,7 +106,7 @@ class PocketTTSHandler(BaseHandler[TTSIn, TTSOut]):
             yield AUDIO_RESPONSE_DONE
             return
 
-        if speculative_turns and not speculative_turns.is_latest_after_pending_reopen(
+        if speculative_turns and not speculative_turns.is_latest_after_reopen_grace(
             tts_input.turn_id,
             tts_input.turn_revision,
         ):

--- a/src/speech_to_speech/TTS/pocket_tts_handler.py
+++ b/src/speech_to_speech/TTS/pocket_tts_handler.py
@@ -96,12 +96,17 @@ class PocketTTSHandler(BaseHandler[TTSIn, TTSOut]):
         return 0.1  # 100ms threshold
 
     def process(self, tts_input: TTSIn) -> Iterator[TTSOut]:
+        speculative_turns = getattr(self, "speculative_turns", None)
         if isinstance(tts_input, EndOfResponse):
+            if speculative_turns and not speculative_turns.is_latest_after_pending_reopen(
+                tts_input.turn_id,
+                tts_input.turn_revision,
+            ):
+                return
             yield AUDIO_RESPONSE_DONE
             return
 
-        speculative_turns = getattr(self, "speculative_turns", None)
-        if speculative_turns and not speculative_turns.is_latest(
+        if speculative_turns and not speculative_turns.is_latest_after_pending_reopen(
             tts_input.turn_id,
             tts_input.turn_revision,
         ):

--- a/src/speech_to_speech/TTS/pocket_tts_handler.py
+++ b/src/speech_to_speech/TTS/pocket_tts_handler.py
@@ -12,6 +12,7 @@ from speech_to_speech.baseHandler import BaseHandler
 from speech_to_speech.pipeline.cancel_scope import CancelScope
 from speech_to_speech.pipeline.handler_types import TTSIn, TTSOut
 from speech_to_speech.pipeline.messages import AUDIO_RESPONSE_DONE, EndOfResponse
+from speech_to_speech.pipeline.speculative_turns import SpeculativeTurnTracker
 
 logger = logging.getLogger(__name__)
 console = Console()
@@ -33,6 +34,7 @@ class PocketTTSHandler(BaseHandler[TTSIn, TTSOut]):
         max_tokens: int = 50,
         gen_kwargs: dict[str, Any] | None = None,  # For compatibility with pipeline, not used
         cancel_scope: CancelScope | None = None,
+        speculative_turns: SpeculativeTurnTracker | None = None,
     ) -> None:
         """
         Initialize Pocket TTS handler.
@@ -50,6 +52,7 @@ class PocketTTSHandler(BaseHandler[TTSIn, TTSOut]):
         """
         self.should_listen = should_listen
         self.cancel_scope = cancel_scope
+        self.speculative_turns = speculative_turns
         self.device = device
         self.voice = voice
         self.sample_rate = sample_rate
@@ -95,6 +98,14 @@ class PocketTTSHandler(BaseHandler[TTSIn, TTSOut]):
     def process(self, tts_input: TTSIn) -> Iterator[TTSOut]:
         if isinstance(tts_input, EndOfResponse):
             yield AUDIO_RESPONSE_DONE
+            return
+
+        speculative_turns = getattr(self, "speculative_turns", None)
+        if speculative_turns and not speculative_turns.is_latest(
+            tts_input.turn_id,
+            tts_input.turn_revision,
+        ):
+            logger.debug("Dropping stale TTS input for turn=%s rev=%s", tts_input.turn_id, tts_input.turn_revision)
             return
 
         gen = self.cancel_scope.generation if self.cancel_scope else None

--- a/src/speech_to_speech/TTS/pocket_tts_handler.py
+++ b/src/speech_to_speech/TTS/pocket_tts_handler.py
@@ -112,6 +112,8 @@ class PocketTTSHandler(BaseHandler[TTSIn, TTSOut]):
         ):
             logger.debug("Dropping stale TTS input for turn=%s rev=%s", tts_input.turn_id, tts_input.turn_revision)
             return
+        if speculative_turns:
+            speculative_turns.commit(tts_input.turn_id, tts_input.turn_revision)
 
         gen = self.cancel_scope.generation if self.cancel_scope else None
         language_code = tts_input.language_code

--- a/src/speech_to_speech/TTS/qwen3_tts_handler.py
+++ b/src/speech_to_speech/TTS/qwen3_tts_handler.py
@@ -638,12 +638,17 @@ class Qwen3TTSHandler(BaseHandler[TTSIn, TTSOut]):
         return combined_text, language_code, saw_end_of_response
 
     def process(self, tts_input: TTSIn) -> Iterator[TTSOut]:
+        speculative_turns = getattr(self, "speculative_turns", None)
         if isinstance(tts_input, EndOfResponse):
+            if speculative_turns and not speculative_turns.is_latest_after_pending_reopen(
+                tts_input.turn_id,
+                tts_input.turn_revision,
+            ):
+                return
             yield AUDIO_RESPONSE_DONE
             return
 
-        speculative_turns = getattr(self, "speculative_turns", None)
-        if speculative_turns and not speculative_turns.is_latest(
+        if speculative_turns and not speculative_turns.is_latest_after_pending_reopen(
             tts_input.turn_id,
             tts_input.turn_revision,
         ):

--- a/src/speech_to_speech/TTS/qwen3_tts_handler.py
+++ b/src/speech_to_speech/TTS/qwen3_tts_handler.py
@@ -30,6 +30,7 @@ from speech_to_speech.pipeline.cancel_scope import CancelScope
 from speech_to_speech.pipeline.control import SESSION_END, is_control_message
 from speech_to_speech.pipeline.handler_types import TTSIn, TTSOut
 from speech_to_speech.pipeline.messages import AUDIO_RESPONSE_DONE, PIPELINE_END, EndOfResponse, TTSInput
+from speech_to_speech.pipeline.speculative_turns import SpeculativeTurnTracker
 from speech_to_speech.utils.mlx_lock import MLXLockContext
 
 logger = logging.getLogger(__name__)
@@ -87,8 +88,10 @@ class Qwen3TTSHandler(BaseHandler[TTSIn, TTSOut]):
         blocksize: int = 512,
         gen_kwargs: dict[str, Any] | None = None,
         cancel_scope: CancelScope | None = None,
+        speculative_turns: SpeculativeTurnTracker | None = None,
     ) -> None:
         self.cancel_scope = cancel_scope
+        self.speculative_turns = speculative_turns
         self.should_listen = should_listen
         self.requested_device = device
         self.ref_audio = ref_audio
@@ -616,6 +619,8 @@ class Qwen3TTSHandler(BaseHandler[TTSIn, TTSOut]):
                     break
                 if not isinstance(next_item, TTSInput):
                     break
+                if current_input.turn_id != next_item.turn_id or current_input.turn_revision != next_item.turn_revision:
+                    break
                 if (
                     language_code is not None
                     and next_item.language_code is not None
@@ -635,6 +640,14 @@ class Qwen3TTSHandler(BaseHandler[TTSIn, TTSOut]):
     def process(self, tts_input: TTSIn) -> Iterator[TTSOut]:
         if isinstance(tts_input, EndOfResponse):
             yield AUDIO_RESPONSE_DONE
+            return
+
+        speculative_turns = getattr(self, "speculative_turns", None)
+        if speculative_turns and not speculative_turns.is_latest(
+            tts_input.turn_id,
+            tts_input.turn_revision,
+        ):
+            logger.debug("Dropping stale TTS input for turn=%s rev=%s", tts_input.turn_id, tts_input.turn_revision)
             return
 
         runtime_config = tts_input.runtime_config

--- a/src/speech_to_speech/TTS/qwen3_tts_handler.py
+++ b/src/speech_to_speech/TTS/qwen3_tts_handler.py
@@ -671,18 +671,37 @@ class Qwen3TTSHandler(BaseHandler[TTSIn, TTSOut]):
 
         try:
             if self.ref_audio:
-                yield from self._process_voice_clone(text)
+                audio_iter = self._process_voice_clone(text)
             elif model_type == "custom_voice":
-                yield from self._process_custom_voice(text)
+                audio_iter = self._process_custom_voice(text)
             elif model_type == "voice_design":
-                yield from self._process_voice_design(text)
+                audio_iter = self._process_voice_design(text)
             else:
                 raise ValueError(
                     "Qwen3-TTS Base model requires ref_audio for voice cloning. "
                     "Provide qwen3_tts_ref_audio or use a CustomVoice/VoiceDesign model."
                 )
+            first_audio = True
+            for audio_chunk in audio_iter:
+                if first_audio:
+                    self._log_first_audio_latency(tts_input)
+                    first_audio = False
+                yield audio_chunk
         except Exception as e:
             logger.error(f"Error during Qwen3-TTS generation: {e}", exc_info=True)
+
+    def _log_first_audio_latency(self, tts_input: TTSInput) -> None:
+        if tts_input.speech_stopped_at_s is None:
+            return
+        latency_s = perf_counter() - tts_input.speech_stopped_at_s
+        if latency_s < 0:
+            return
+        logger.info(
+            "Last speech detected to first speech out: %.3fs (turn=%s rev=%s)",
+            latency_s,
+            tts_input.turn_id,
+            tts_input.turn_revision,
+        )
 
     def _mlx_streaming_interval(self) -> float:
         return max(1, self.streaming_chunk_size) / MLX_STREAMING_TOKENS_PER_SECOND

--- a/src/speech_to_speech/TTS/qwen3_tts_handler.py
+++ b/src/speech_to_speech/TTS/qwen3_tts_handler.py
@@ -640,7 +640,7 @@ class Qwen3TTSHandler(BaseHandler[TTSIn, TTSOut]):
     def process(self, tts_input: TTSIn) -> Iterator[TTSOut]:
         speculative_turns = getattr(self, "speculative_turns", None)
         if isinstance(tts_input, EndOfResponse):
-            if speculative_turns and not speculative_turns.is_latest_after_pending_reopen(
+            if speculative_turns and not speculative_turns.is_latest_after_reopen_grace(
                 tts_input.turn_id,
                 tts_input.turn_revision,
             ):
@@ -648,7 +648,7 @@ class Qwen3TTSHandler(BaseHandler[TTSIn, TTSOut]):
             yield AUDIO_RESPONSE_DONE
             return
 
-        if speculative_turns and not speculative_turns.is_latest_after_pending_reopen(
+        if speculative_turns and not speculative_turns.is_latest_after_reopen_grace(
             tts_input.turn_id,
             tts_input.turn_revision,
         ):

--- a/src/speech_to_speech/TTS/qwen3_tts_handler.py
+++ b/src/speech_to_speech/TTS/qwen3_tts_handler.py
@@ -654,6 +654,8 @@ class Qwen3TTSHandler(BaseHandler[TTSIn, TTSOut]):
         ):
             logger.debug("Dropping stale TTS input for turn=%s rev=%s", tts_input.turn_id, tts_input.turn_revision)
             return
+        if speculative_turns:
+            speculative_turns.commit(tts_input.turn_id, tts_input.turn_revision)
 
         runtime_config = tts_input.runtime_config
         response = tts_input.response

--- a/src/speech_to_speech/VAD/vad_handler.py
+++ b/src/speech_to_speech/VAD/vad_handler.py
@@ -165,6 +165,14 @@ class VADHandler(BaseHandler[VADIn, VADOut]):
         buffer_samples = sum(len(t) for t in self.iterator.speech_buffer())
         return buffer_samples / self.sample_rate * 1000
 
+    def _current_voiced_duration_ms(self) -> float:
+        voiced_samples = getattr(self.iterator, "voiced_samples", 0)
+        return voiced_samples / self.sample_rate * 1000
+
+    def _last_utterance_voiced_duration_ms(self) -> float:
+        voiced_samples = getattr(self.iterator, "last_utterance_voiced_samples", 0)
+        return voiced_samples / self.sample_rate * 1000
+
     def _uses_realtime_turn_handling(self) -> bool:
         return self.enable_realtime_transcription or self.speculative_turns is not None
 
@@ -350,21 +358,23 @@ class VADHandler(BaseHandler[VADIn, VADOut]):
 
         vad_output = self.iterator(torch.from_numpy(audio_float32))
 
-        # Deferred speech_started: only emit once buffer >= min_speech_ms
+        # Deferred speech_started: only emit once voiced audio reaches the valid speech threshold.
         is_triggered_now = self.iterator.triggered
         if is_triggered_now and not self._speech_started_emitted:
-            buffer_samples = sum(len(t) for t in self.iterator.buffer)
-            buffer_duration_ms = buffer_samples / self.sample_rate * 1000
-            speech_buffer_duration_ms = self._speech_buffer_duration_ms()
-            start_ms = max(0, self._audio_ms - int(speech_buffer_duration_ms))
-            self._begin_pending_reopen_if_needed(start_ms)
-            if buffer_duration_ms >= self.min_speech_ms:
+            segment_samples = sum(len(t) for t in self.iterator.buffer)
+            segment_duration_ms = segment_samples / self.sample_rate * 1000
+            voiced_duration_ms = self._current_voiced_duration_ms()
+            if voiced_duration_ms >= self.min_speech_ms:
+                speech_buffer_duration_ms = self._speech_buffer_duration_ms()
+                start_ms = max(0, self._audio_ms - int(speech_buffer_duration_ms))
+                self._begin_pending_reopen_if_needed(start_ms)
                 turn_id, turn_revision, reopened = self._ensure_turn_for_speech_start(start_ms)
                 self._speech_started_emitted = True
                 self._log_speech_starts += 1
                 logger.info(
-                    "Speech started (confirmed, %.0fms buffered, turn=%s rev=%s)",
-                    buffer_duration_ms,
+                    "Speech started (confirmed, voiced=%.0fms, segment=%.0fms, turn=%s rev=%s)",
+                    voiced_duration_ms,
+                    segment_duration_ms,
                     turn_id,
                     turn_revision,
                 )
@@ -449,10 +459,15 @@ class VADHandler(BaseHandler[VADIn, VADOut]):
 
             array = torch.cat(vad_output).cpu().numpy()
             duration_ms = len(array) / self.sample_rate * 1000
+            voiced_duration_ms = self._last_utterance_voiced_duration_ms()
 
             if duration_ms < self.min_speech_ms or duration_ms > self.max_speech_ms:
                 logger.info(
-                    f"VAD: discarding {duration_ms:.0f}ms segment (bounds: {self.min_speech_ms}-{self.max_speech_ms}ms)"
+                    "VAD: discarding segment=%.0fms voiced=%.0fms (bounds: %s-%sms)",
+                    duration_ms,
+                    voiced_duration_ms,
+                    self.min_speech_ms,
+                    self.max_speech_ms,
                 )
                 if self._speech_started_emitted and self.text_output_queue:
                     turn_id, turn_revision = self._current_turn_metadata()
@@ -478,12 +493,19 @@ class VADHandler(BaseHandler[VADIn, VADOut]):
                                 turn_id=turn_id,
                                 turn_revision=turn_revision,
                                 reopened=reopened,
+                                interrupt_response=False,
                             )
                         )
                 else:
                     turn_id, turn_revision = self._current_turn_metadata()
                 self._log_speech_ends += 1
-                logger.info("Speech soft-ended (%.0fms, turn=%s rev=%s)", duration_ms, turn_id, turn_revision)
+                logger.info(
+                    "Speech soft-ended (segment=%.0fms, voiced=%.0fms, turn=%s rev=%s)",
+                    duration_ms,
+                    voiced_duration_ms,
+                    turn_id,
+                    turn_revision,
+                )
                 if self.audio_enhancement:
                     array = self._apply_audio_enhancement(array)
                 output_array = self._combined_turn_audio(array)
@@ -545,7 +567,12 @@ class VADHandler(BaseHandler[VADIn, VADOut]):
             else:
                 end_ms = self._audio_ms
                 if not self._speech_started_emitted and self.text_output_queue:
-                    self.text_output_queue.put(SpeechStartedEvent(audio_start_ms=max(0, end_ms - int(duration_ms))))
+                    self.text_output_queue.put(
+                        SpeechStartedEvent(
+                            audio_start_ms=max(0, end_ms - int(duration_ms)),
+                            interrupt_response=False,
+                        )
+                    )
                 self._log_speech_ends += 1
                 self.should_listen.clear()
                 logger.info(f"Speech ended ({duration_ms:.0f}ms), stop listening")

--- a/src/speech_to_speech/VAD/vad_handler.py
+++ b/src/speech_to_speech/VAD/vad_handler.py
@@ -45,7 +45,7 @@ class VADHandler(BaseHandler[VADIn, VADOut]):
         should_listen: Event,
         thresh: float = 0.6,
         sample_rate: int = 16000,
-        min_silence_ms: int = 1000,
+        min_silence_ms: int = 300,
         min_speech_ms: int = 500,
         max_speech_ms: float = float("inf"),
         speech_pad_ms: int = 30,
@@ -165,13 +165,13 @@ class VADHandler(BaseHandler[VADIn, VADOut]):
         buffer_samples = sum(len(t) for t in self.iterator.speech_buffer())
         return buffer_samples / self.sample_rate * 1000
 
-    def _current_voiced_duration_ms(self) -> float:
-        voiced_samples = getattr(self.iterator, "voiced_samples", 0)
-        return voiced_samples / self.sample_rate * 1000
+    def _current_active_speech_duration_ms(self) -> float:
+        active_speech_samples = getattr(self.iterator, "active_speech_samples", 0)
+        return active_speech_samples / self.sample_rate * 1000
 
-    def _last_utterance_voiced_duration_ms(self) -> float:
-        voiced_samples = getattr(self.iterator, "last_utterance_voiced_samples", 0)
-        return voiced_samples / self.sample_rate * 1000
+    def _last_utterance_active_speech_duration_ms(self) -> float:
+        active_speech_samples = getattr(self.iterator, "last_utterance_active_speech_samples", 0)
+        return active_speech_samples / self.sample_rate * 1000
 
     def _uses_realtime_turn_handling(self) -> bool:
         return self.enable_realtime_transcription or self.speculative_turns is not None
@@ -358,13 +358,13 @@ class VADHandler(BaseHandler[VADIn, VADOut]):
 
         vad_output = self.iterator(torch.from_numpy(audio_float32))
 
-        # Deferred speech_started: only emit once voiced audio reaches the valid speech threshold.
+        # Deferred speech_started: only emit once active VAD speech reaches the valid speech threshold.
         is_triggered_now = self.iterator.triggered
         if is_triggered_now and not self._speech_started_emitted:
             segment_samples = sum(len(t) for t in self.iterator.buffer)
             segment_duration_ms = segment_samples / self.sample_rate * 1000
-            voiced_duration_ms = self._current_voiced_duration_ms()
-            if voiced_duration_ms >= self.min_speech_ms:
+            active_speech_duration_ms = self._current_active_speech_duration_ms()
+            if active_speech_duration_ms >= self.min_speech_ms:
                 speech_buffer_duration_ms = self._speech_buffer_duration_ms()
                 start_ms = max(0, self._audio_ms - int(speech_buffer_duration_ms))
                 self._begin_pending_reopen_if_needed(start_ms)
@@ -372,8 +372,8 @@ class VADHandler(BaseHandler[VADIn, VADOut]):
                 self._speech_started_emitted = True
                 self._log_speech_starts += 1
                 logger.info(
-                    "Speech started (confirmed, voiced=%.0fms, segment=%.0fms, turn=%s rev=%s)",
-                    voiced_duration_ms,
+                    "Speech started (confirmed, active=%.0fms, segment=%.0fms, turn=%s rev=%s)",
+                    active_speech_duration_ms,
                     segment_duration_ms,
                     turn_id,
                     turn_revision,
@@ -459,13 +459,13 @@ class VADHandler(BaseHandler[VADIn, VADOut]):
 
             array = torch.cat(vad_output).cpu().numpy()
             duration_ms = len(array) / self.sample_rate * 1000
-            voiced_duration_ms = self._last_utterance_voiced_duration_ms()
+            active_speech_duration_ms = self._last_utterance_active_speech_duration_ms()
 
             if duration_ms < self.min_speech_ms or duration_ms > self.max_speech_ms:
                 logger.info(
-                    "VAD: discarding segment=%.0fms voiced=%.0fms (bounds: %s-%sms)",
+                    "VAD: discarding segment=%.0fms active=%.0fms (bounds: %s-%sms)",
                     duration_ms,
-                    voiced_duration_ms,
+                    active_speech_duration_ms,
                     self.min_speech_ms,
                     self.max_speech_ms,
                 )
@@ -500,9 +500,9 @@ class VADHandler(BaseHandler[VADIn, VADOut]):
                     turn_id, turn_revision = self._current_turn_metadata()
                 self._log_speech_ends += 1
                 logger.info(
-                    "Speech soft-ended (segment=%.0fms, voiced=%.0fms, turn=%s rev=%s)",
+                    "Speech soft-ended (segment=%.0fms, active=%.0fms, turn=%s rev=%s)",
                     duration_ms,
-                    voiced_duration_ms,
+                    active_speech_duration_ms,
                     turn_id,
                     turn_revision,
                 )

--- a/src/speech_to_speech/VAD/vad_handler.py
+++ b/src/speech_to_speech/VAD/vad_handler.py
@@ -54,7 +54,7 @@ class VADHandler(BaseHandler[VADIn, VADOut]):
         realtime_processing_pause: float = 0.25,
         text_output_queue: Queue[TextEventItem] | None = None,
         speculative_turns: SpeculativeTurnTracker | None = None,
-        speculative_reopen_ms: int = 1200,
+        speculative_reopen_ms: int = 1000,
     ) -> None:
         self.should_listen = should_listen
         self.sample_rate = sample_rate

--- a/src/speech_to_speech/VAD/vad_handler.py
+++ b/src/speech_to_speech/VAD/vad_handler.py
@@ -488,9 +488,15 @@ class VADHandler(BaseHandler[VADIn, VADOut]):
                         )
                     )
                 self._speculative_audio_prefix = output_array
-                yield VADAudio(audio=output_array, mode="final", turn_id=turn_id, turn_revision=turn_revision)
                 self._last_final_wall_time = time.time()
                 self._last_final_audio_ms = end_ms
+                if self.speculative_turns:
+                    self.speculative_turns.start_reopen_grace(
+                        turn_id,
+                        turn_revision,
+                        self.speculative_reopen_ms / 1000.0,
+                    )
+                yield VADAudio(audio=output_array, mode="final", turn_id=turn_id, turn_revision=turn_revision)
                 self.last_process_time = 0.0
                 self._speech_started_emitted = False
 

--- a/src/speech_to_speech/VAD/vad_handler.py
+++ b/src/speech_to_speech/VAD/vad_handler.py
@@ -46,7 +46,7 @@ class VADHandler(BaseHandler[VADIn, VADOut]):
         thresh: float = 0.6,
         sample_rate: int = 16000,
         min_silence_ms: int = 300,
-        min_speech_ms: int = 500,
+        min_speech_ms: int = 384,
         max_speech_ms: float = float("inf"),
         speech_pad_ms: int = 30,
         audio_enhancement: bool = False,

--- a/src/speech_to_speech/VAD/vad_handler.py
+++ b/src/speech_to_speech/VAD/vad_handler.py
@@ -364,10 +364,10 @@ class VADHandler(BaseHandler[VADIn, VADOut]):
             segment_samples = sum(len(t) for t in self.iterator.buffer)
             segment_duration_ms = segment_samples / self.sample_rate * 1000
             active_speech_duration_ms = self._current_active_speech_duration_ms()
+            speech_buffer_duration_ms = self._speech_buffer_duration_ms()
+            start_ms = max(0, self._audio_ms - int(speech_buffer_duration_ms))
+            self._begin_pending_reopen_if_needed(start_ms)
             if active_speech_duration_ms >= self.min_speech_ms:
-                speech_buffer_duration_ms = self._speech_buffer_duration_ms()
-                start_ms = max(0, self._audio_ms - int(speech_buffer_duration_ms))
-                self._begin_pending_reopen_if_needed(start_ms)
                 turn_id, turn_revision, reopened = self._ensure_turn_for_speech_start(start_ms)
                 self._speech_started_emitted = True
                 self._log_speech_starts += 1
@@ -530,6 +530,8 @@ class VADHandler(BaseHandler[VADIn, VADOut]):
                         turn_revision,
                         self.speculative_reopen_ms / 1000.0,
                     )
+                else:
+                    self.should_listen.clear()
                 yield VADAudio(audio=output_array, mode="final", turn_id=turn_id, turn_revision=turn_revision)
                 self.last_process_time = 0.0
                 self._speech_started_emitted = False

--- a/src/speech_to_speech/VAD/vad_handler.py
+++ b/src/speech_to_speech/VAD/vad_handler.py
@@ -401,15 +401,21 @@ class VADHandler(BaseHandler[VADIn, VADOut]):
         # Check if we're currently in a speech segment
         if hasattr(self.iterator, "buffer") and len(self.iterator.buffer) > 0:
             current_time = time.time()
+            duration_ms = self._speech_buffer_duration_ms()
+            progressive_pause = self._progressive_processing_pause(duration_ms)
 
             # Yield accumulated audio periodically while speaking
-            if (current_time - self.last_process_time) >= self.realtime_processing_pause:
+            if (current_time - self.last_process_time) >= progressive_pause:
                 array = torch.cat(self.iterator.speech_buffer()).cpu().numpy()
                 duration_ms = len(array) / self.sample_rate * 1000
 
                 if duration_ms >= self.min_speech_ms:
                     self._log_progressive_yields += 1
-                    logger.debug(f"VAD: yielding progressive audio ({duration_ms:.0f}ms)")
+                    logger.debug(
+                        "VAD: yielding progressive audio (%.0fms, interval=%.2fs)",
+                        duration_ms,
+                        progressive_pause,
+                    )
                     turn_id, turn_revision = self._current_turn_metadata()
                     yield VADAudio(
                         audio=self._combined_turn_audio(array),
@@ -499,6 +505,19 @@ class VADHandler(BaseHandler[VADIn, VADOut]):
                 yield VADAudio(audio=output_array, mode="final", turn_id=turn_id, turn_revision=turn_revision)
                 self.last_process_time = 0.0
                 self._speech_started_emitted = False
+
+    def _progressive_processing_pause(self, duration_ms: float) -> float:
+        base_pause = max(0.0, self.realtime_processing_pause)
+        duration_s = duration_ms / 1000.0
+        if duration_s < 8.0:
+            multiplier = 1.0
+        elif duration_s < 15.0:
+            multiplier = 2.0
+        elif duration_s < 30.0:
+            multiplier = 4.0
+        else:
+            multiplier = 6.0
+        return min(base_pause * multiplier, 2.0)
 
     def _process_normal(self, vad_output: list[torch.Tensor] | None) -> Iterator[VADOut]:
         """Original processing: yield only when speech ends."""

--- a/src/speech_to_speech/VAD/vad_handler.py
+++ b/src/speech_to_speech/VAD/vad_handler.py
@@ -5,7 +5,7 @@ import time
 from collections.abc import Iterator
 from queue import Queue
 from threading import Event
-from typing import TypeAlias
+from typing import Any, TypeAlias
 
 import numpy as np
 import torch
@@ -281,6 +281,54 @@ class VADHandler(BaseHandler[VADIn, VADOut]):
         if self._speculative_audio_prefix is None:
             return current_segment
         return np.concatenate((self._speculative_audio_prefix, current_segment))
+
+    def before_emit_output(self, output: VADOut) -> None:
+        if isinstance(output, VADAudio):
+            self._drop_superseded_vad_audio(output)
+
+    def _drop_superseded_vad_audio(self, latest: VADAudio) -> int:
+        if not hasattr(self.queue_out, "mutex") or not hasattr(self.queue_out, "queue"):
+            return 0
+
+        dropped = 0
+        with self.queue_out.mutex:
+            kept: list[Any] = []
+            while self.queue_out.queue:
+                queued_item = self.queue_out.queue.popleft()
+                if isinstance(queued_item, VADAudio) and self._vad_audio_is_superseded(
+                    queued_item,
+                    latest,
+                ):
+                    dropped += 1
+                else:
+                    kept.append(queued_item)
+            self.queue_out.queue.extend(kept)
+            if dropped:
+                self.queue_out.not_full.notify_all()
+
+        if dropped:
+            logger.debug(
+                "VAD: dropped %d superseded audio chunk(s) before enqueueing turn=%s rev=%s mode=%s",
+                dropped,
+                latest.turn_id,
+                latest.turn_revision,
+                latest.mode,
+            )
+        return dropped
+
+    def _vad_audio_is_superseded(self, queued_item: VADAudio, latest: VADAudio) -> bool:
+        if queued_item.turn_id is None or queued_item.turn_revision is None:
+            return False
+        if self.speculative_turns is not None and not self.speculative_turns.is_latest(
+            queued_item.turn_id,
+            queued_item.turn_revision,
+        ):
+            return True
+        return (
+            queued_item.mode == "progressive"
+            and queued_item.turn_id == latest.turn_id
+            and queued_item.turn_revision == latest.turn_revision
+        )
 
     def process(self, audio_chunk: VADIn) -> Iterator[VADOut]:
         runtime_config = None

--- a/src/speech_to_speech/VAD/vad_handler.py
+++ b/src/speech_to_speech/VAD/vad_handler.py
@@ -106,7 +106,7 @@ class VADHandler(BaseHandler[VADIn, VADOut]):
         self._turn_counter = 0
         self._current_turn_id: str | None = None
         self._current_turn_revision: int | None = None
-        self._speculative_segments: list[np.ndarray] = []
+        self._speculative_audio_prefix: np.ndarray | None = None
         self._last_final_wall_time: float | None = None
         self._last_final_audio_ms: int | None = None
         self._pending_reopen_candidate: tuple[str, int, int] | None = None
@@ -152,7 +152,7 @@ class VADHandler(BaseHandler[VADIn, VADOut]):
         self._turn_counter += 1
         self._current_turn_id = f"turn_{self._turn_counter}"
         self._current_turn_revision = 0
-        self._speculative_segments = []
+        self._speculative_audio_prefix = None
         self._last_final_wall_time = None
         self._last_final_audio_ms = None
         if self.speculative_turns:
@@ -226,6 +226,28 @@ class VADHandler(BaseHandler[VADIn, VADOut]):
         logger.info("VAD: reopened speculative turn %s revision %d", turn_id, candidate_revision)
         return turn_id, candidate_revision, True
 
+    def _reopen_current_turn(self) -> tuple[str, int, bool] | None:
+        if self._current_turn_id is None or self._current_turn_revision is None:
+            return None
+
+        turn_id = self._current_turn_id
+        base_revision = self._current_turn_revision
+        if self.speculative_turns is not None:
+            candidate_revision = self.speculative_turns.begin_reopen_candidate(turn_id, base_revision)
+            if candidate_revision is None or not self.speculative_turns.confirm_reopen_candidate(
+                turn_id,
+                base_revision,
+                candidate_revision,
+            ):
+                return None
+        else:
+            candidate_revision = base_revision + 1
+
+        self._current_turn_id = turn_id
+        self._current_turn_revision = candidate_revision
+        logger.info("VAD: reopened speculative turn %s revision %d", turn_id, candidate_revision)
+        return turn_id, candidate_revision, True
+
     def _ensure_turn_for_speech_start(self, audio_start_ms: int) -> tuple[str, int, bool]:
         if (
             self._speech_started_emitted
@@ -238,16 +260,16 @@ class VADHandler(BaseHandler[VADIn, VADOut]):
         if confirmed_reopen is not None:
             return confirmed_reopen
 
-        reopened = self._should_reopen_current_turn(audio_start_ms)
-        if reopened and self._current_turn_id is not None and self._current_turn_revision is not None:
-            self._current_turn_revision += 1
-            logger.info(
-                "VAD: reopened speculative turn %s revision %d", self._current_turn_id, self._current_turn_revision
-            )
-        else:
-            self._start_new_turn()
+        reopened = False
+        if self._should_reopen_current_turn(audio_start_ms):
+            reopened_turn = self._reopen_current_turn()
+            if reopened_turn is not None:
+                return reopened_turn
 
-        assert self._current_turn_id is not None and self._current_turn_revision is not None
+        self._start_new_turn()
+
+        if self._current_turn_id is None or self._current_turn_revision is None:
+            raise RuntimeError("VAD failed to allocate turn metadata")
         if self.speculative_turns:
             self.speculative_turns.observe(self._current_turn_id, self._current_turn_revision)
         return self._current_turn_id, self._current_turn_revision, reopened
@@ -256,9 +278,9 @@ class VADHandler(BaseHandler[VADIn, VADOut]):
         return self._current_turn_id, self._current_turn_revision
 
     def _combined_turn_audio(self, current_segment: np.ndarray) -> np.ndarray:
-        if not self._speculative_segments:
+        if self._speculative_audio_prefix is None:
             return current_segment
-        return np.concatenate([*self._speculative_segments, current_segment])
+        return np.concatenate((self._speculative_audio_prefix, current_segment))
 
     def process(self, audio_chunk: VADIn) -> Iterator[VADOut]:
         runtime_config = None
@@ -417,7 +439,7 @@ class VADHandler(BaseHandler[VADIn, VADOut]):
                             turn_revision=turn_revision,
                         )
                     )
-                self._speculative_segments.append(array)
+                self._speculative_audio_prefix = output_array
                 yield VADAudio(audio=output_array, mode="final", turn_id=turn_id, turn_revision=turn_revision)
                 self._last_final_wall_time = time.time()
                 self._last_final_audio_ms = end_ms
@@ -490,7 +512,7 @@ class VADHandler(BaseHandler[VADIn, VADOut]):
         self._turn_counter = 0
         self._current_turn_id = None
         self._current_turn_revision = None
-        self._speculative_segments = []
+        self._speculative_audio_prefix = None
         self._last_final_wall_time = None
         self._last_final_audio_ms = None
         self._pending_reopen_candidate = None

--- a/src/speech_to_speech/VAD/vad_handler.py
+++ b/src/speech_to_speech/VAD/vad_handler.py
@@ -16,6 +16,7 @@ from speech_to_speech.pipeline.events import SpeechStartedEvent, SpeechStoppedEv
 from speech_to_speech.pipeline.handler_types import VADIn, VADOut
 from speech_to_speech.pipeline.messages import VADAudio
 from speech_to_speech.pipeline.queue_types import TextEventItem
+from speech_to_speech.pipeline.speculative_turns import SpeculativeTurnTracker
 from speech_to_speech.utils.utils import int2float
 from speech_to_speech.VAD.vad_iterator import VADIterator
 
@@ -52,6 +53,8 @@ class VADHandler(BaseHandler[VADIn, VADOut]):
         enable_realtime_transcription: bool = False,
         realtime_processing_pause: float = 0.25,
         text_output_queue: Queue[TextEventItem] | None = None,
+        speculative_turns: SpeculativeTurnTracker | None = None,
+        speculative_reopen_ms: int = 1200,
     ) -> None:
         self.should_listen = should_listen
         self.sample_rate = sample_rate
@@ -61,6 +64,8 @@ class VADHandler(BaseHandler[VADIn, VADOut]):
         self.enable_realtime_transcription = enable_realtime_transcription
         self.realtime_processing_pause = realtime_processing_pause
         self.text_output_queue = text_output_queue
+        self.speculative_turns = speculative_turns
+        self.speculative_reopen_ms = speculative_reopen_ms
         self._last_turn_detection: dict | None = None
         self.model, _ = torch.hub.load(
             "snakers4/silero-vad",
@@ -98,6 +103,12 @@ class VADHandler(BaseHandler[VADIn, VADOut]):
         self._log_speech_ends = 0
         self._log_progressive_yields = 0
         self._speech_started_emitted = False
+        self._turn_counter = 0
+        self._current_turn_id: str | None = None
+        self._current_turn_revision: int | None = None
+        self._speculative_segments: list[np.ndarray] = []
+        self._last_final_wall_time: float | None = None
+        self._last_final_audio_ms: int | None = None
 
     @property
     def _audio_ms(self) -> int:
@@ -135,6 +146,62 @@ class VADHandler(BaseHandler[VADIn, VADOut]):
             self.iterator.min_silence_samples = self.sample_rate * td["silence_duration_ms"] / 1000
             logger.info(f"VAD silence duration updated to {td['silence_duration_ms']}ms")
 
+    def _start_new_turn(self) -> tuple[str, int]:
+        self._turn_counter += 1
+        self._current_turn_id = f"turn_{self._turn_counter}"
+        self._current_turn_revision = 0
+        self._speculative_segments = []
+        self._last_final_wall_time = None
+        self._last_final_audio_ms = None
+        if self.speculative_turns:
+            self.speculative_turns.observe(self._current_turn_id, self._current_turn_revision)
+        return self._current_turn_id, self._current_turn_revision
+
+    def _should_reopen_current_turn(self) -> bool:
+        if not self.enable_realtime_transcription:
+            return False
+        if self._current_turn_id is None or self._current_turn_revision is None or self._last_final_wall_time is None:
+            return False
+        elapsed_ms = (time.time() - self._last_final_wall_time) * 1000
+        if elapsed_ms > self.speculative_reopen_ms:
+            return False
+        if self.speculative_turns and self.speculative_turns.is_committed(
+            self._current_turn_id,
+            self._current_turn_revision,
+        ):
+            return False
+        return True
+
+    def _ensure_turn_for_speech_start(self) -> tuple[str, int, bool]:
+        if (
+            self._speech_started_emitted
+            and self._current_turn_id is not None
+            and self._current_turn_revision is not None
+        ):
+            return self._current_turn_id, self._current_turn_revision, False
+
+        reopened = self._should_reopen_current_turn()
+        if reopened and self._current_turn_id is not None and self._current_turn_revision is not None:
+            self._current_turn_revision += 1
+            logger.info(
+                "VAD: reopened speculative turn %s revision %d", self._current_turn_id, self._current_turn_revision
+            )
+        else:
+            self._start_new_turn()
+
+        assert self._current_turn_id is not None and self._current_turn_revision is not None
+        if self.speculative_turns:
+            self.speculative_turns.observe(self._current_turn_id, self._current_turn_revision)
+        return self._current_turn_id, self._current_turn_revision, reopened
+
+    def _current_turn_metadata(self) -> tuple[str | None, int | None]:
+        return self._current_turn_id, self._current_turn_revision
+
+    def _combined_turn_audio(self, current_segment: np.ndarray) -> np.ndarray:
+        if not self._speculative_segments:
+            return current_segment
+        return np.concatenate([*self._speculative_segments, current_segment])
+
     def process(self, audio_chunk: VADIn) -> Iterator[VADOut]:
         runtime_config = None
         if isinstance(audio_chunk, tuple):
@@ -158,12 +225,25 @@ class VADHandler(BaseHandler[VADIn, VADOut]):
             buffer_samples = sum(len(t) for t in self.iterator.buffer)
             buffer_duration_ms = buffer_samples / self.sample_rate * 1000
             if buffer_duration_ms >= self.min_speech_ms:
+                turn_id, turn_revision, reopened = self._ensure_turn_for_speech_start()
                 self._speech_started_emitted = True
                 self._log_speech_starts += 1
                 start_ms = max(0, self._audio_ms - int(buffer_duration_ms))
-                logger.info("Speech started (confirmed, %.0fms buffered)", buffer_duration_ms)
+                logger.info(
+                    "Speech started (confirmed, %.0fms buffered, turn=%s rev=%s)",
+                    buffer_duration_ms,
+                    turn_id,
+                    turn_revision,
+                )
                 if self.text_output_queue:
-                    self.text_output_queue.put(SpeechStartedEvent(audio_start_ms=start_ms))
+                    self.text_output_queue.put(
+                        SpeechStartedEvent(
+                            audio_start_ms=start_ms,
+                            turn_id=turn_id,
+                            turn_revision=turn_revision,
+                            reopened=reopened,
+                        )
+                    )
 
         # Log a summary once per second instead of every chunk
         now = time.time()
@@ -200,7 +280,13 @@ class VADHandler(BaseHandler[VADIn, VADOut]):
                 if duration_ms >= self.min_speech_ms:
                     self._log_progressive_yields += 1
                     logger.debug(f"VAD: yielding progressive audio ({duration_ms:.0f}ms)")
-                    yield VADAudio(audio=array, mode="progressive")
+                    turn_id, turn_revision = self._current_turn_metadata()
+                    yield VADAudio(
+                        audio=self._combined_turn_audio(array),
+                        mode="progressive",
+                        turn_id=turn_id,
+                        turn_revision=turn_revision,
+                    )
                     self.last_process_time = current_time
 
         # Handle end of speech
@@ -208,7 +294,14 @@ class VADHandler(BaseHandler[VADIn, VADOut]):
             if len(vad_output) == 0:
                 logger.info("VAD: phantom trigger (empty buffer), closing speech pair")
                 if self._speech_started_emitted and self.text_output_queue:
-                    self.text_output_queue.put(SpeechStoppedEvent(audio_end_ms=self._audio_ms))
+                    turn_id, turn_revision = self._current_turn_metadata()
+                    self.text_output_queue.put(
+                        SpeechStoppedEvent(
+                            audio_end_ms=self._audio_ms,
+                            turn_id=turn_id,
+                            turn_revision=turn_revision,
+                        )
+                    )
                 self._speech_started_emitted = False
                 return
 
@@ -220,20 +313,49 @@ class VADHandler(BaseHandler[VADIn, VADOut]):
                     f"VAD: discarding {duration_ms:.0f}ms segment (bounds: {self.min_speech_ms}-{self.max_speech_ms}ms)"
                 )
                 if self._speech_started_emitted and self.text_output_queue:
-                    self.text_output_queue.put(SpeechStoppedEvent(audio_end_ms=self._audio_ms))
+                    turn_id, turn_revision = self._current_turn_metadata()
+                    self.text_output_queue.put(
+                        SpeechStoppedEvent(
+                            audio_end_ms=self._audio_ms,
+                            turn_id=turn_id,
+                            turn_revision=turn_revision,
+                        )
+                    )
                 self._speech_started_emitted = False
             else:
                 end_ms = self._audio_ms
-                if not self._speech_started_emitted and self.text_output_queue:
-                    self.text_output_queue.put(SpeechStartedEvent(audio_start_ms=max(0, end_ms - int(duration_ms))))
+                if not self._speech_started_emitted:
+                    turn_id, turn_revision, reopened = self._ensure_turn_for_speech_start()
+                    if self.text_output_queue:
+                        self.text_output_queue.put(
+                            SpeechStartedEvent(
+                                audio_start_ms=max(0, end_ms - int(duration_ms)),
+                                turn_id=turn_id,
+                                turn_revision=turn_revision,
+                                reopened=reopened,
+                            )
+                        )
+                else:
+                    turn_id, turn_revision = self._current_turn_metadata()
                 self._log_speech_ends += 1
-                self.should_listen.clear()
-                logger.info(f"Speech ended ({duration_ms:.0f}ms), stop listening")
-                if self.text_output_queue:
-                    self.text_output_queue.put(SpeechStoppedEvent(duration_s=duration_ms / 1000.0, audio_end_ms=end_ms))
+                logger.info("Speech soft-ended (%.0fms, turn=%s rev=%s)", duration_ms, turn_id, turn_revision)
                 if self.audio_enhancement:
                     array = self._apply_audio_enhancement(array)
-                yield VADAudio(audio=array, mode="final")
+                output_array = self._combined_turn_audio(array)
+                combined_duration_s = len(output_array) / self.sample_rate
+                if self.text_output_queue:
+                    self.text_output_queue.put(
+                        SpeechStoppedEvent(
+                            duration_s=combined_duration_s,
+                            audio_end_ms=end_ms,
+                            turn_id=turn_id,
+                            turn_revision=turn_revision,
+                        )
+                    )
+                self._speculative_segments.append(array)
+                yield VADAudio(audio=output_array, mode="final", turn_id=turn_id, turn_revision=turn_revision)
+                self._last_final_wall_time = time.time()
+                self._last_final_audio_ms = end_ms
                 self.last_process_time = 0.0
                 self._speech_started_emitted = False
 
@@ -300,6 +422,14 @@ class VADHandler(BaseHandler[VADIn, VADOut]):
         self.last_process_time = 0.0
         self._total_samples = 0
         self._speech_started_emitted = False
+        self._turn_counter = 0
+        self._current_turn_id = None
+        self._current_turn_revision = None
+        self._speculative_segments = []
+        self._last_final_wall_time = None
+        self._last_final_audio_ms = None
+        if self.speculative_turns:
+            self.speculative_turns.reset()
         self.should_listen.set()
         logger.debug("VAD session state reset")
 

--- a/src/speech_to_speech/VAD/vad_handler.py
+++ b/src/speech_to_speech/VAD/vad_handler.py
@@ -51,7 +51,7 @@ class VADHandler(BaseHandler[VADIn, VADOut]):
         speech_pad_ms: int = 30,
         audio_enhancement: bool = False,
         enable_realtime_transcription: bool = False,
-        realtime_processing_pause: float = 0.25,
+        realtime_processing_pause: float = 0.5,
         text_output_queue: Queue[TextEventItem] | None = None,
         speculative_turns: SpeculativeTurnTracker | None = None,
         speculative_reopen_ms: int = 1000,

--- a/src/speech_to_speech/VAD/vad_handler.py
+++ b/src/speech_to_speech/VAD/vad_handler.py
@@ -165,8 +165,11 @@ class VADHandler(BaseHandler[VADIn, VADOut]):
         buffer_samples = sum(len(t) for t in self.iterator.speech_buffer())
         return buffer_samples / self.sample_rate * 1000
 
+    def _uses_realtime_turn_handling(self) -> bool:
+        return self.enable_realtime_transcription or self.speculative_turns is not None
+
     def _should_reopen_current_turn(self, audio_start_ms: int) -> bool:
-        if not self.enable_realtime_transcription:
+        if not self._uses_realtime_turn_handling():
             return False
         if self._current_turn_id is None or self._current_turn_revision is None or self._last_final_audio_ms is None:
             return False
@@ -389,8 +392,9 @@ class VADHandler(BaseHandler[VADIn, VADOut]):
             self._log_progressive_yields = 0
             self._last_log_time = now
 
-        if self.enable_realtime_transcription:
-            # Progressive mode: yield audio chunks while speaking
+        if self._uses_realtime_turn_handling():
+            # Realtime mode keeps turns reopenable; live transcription additionally
+            # emits progressive audio chunks while speaking.
             yield from self._process_realtime(vad_output)
         else:
             # Original mode: yield only when speech ends
@@ -398,8 +402,8 @@ class VADHandler(BaseHandler[VADIn, VADOut]):
 
     def _process_realtime(self, vad_output: list[torch.Tensor] | None) -> Iterator[VADOut]:
         """Process with real-time progressive audio release."""
-        # Check if we're currently in a speech segment
-        if hasattr(self.iterator, "buffer") and len(self.iterator.buffer) > 0:
+        # Check if we're currently in a speech segment.
+        if self.enable_realtime_transcription and hasattr(self.iterator, "buffer") and len(self.iterator.buffer) > 0:
             current_time = time.time()
             duration_ms = self._speech_buffer_duration_ms()
             progressive_pause = self._progressive_processing_pause(duration_ms)

--- a/src/speech_to_speech/VAD/vad_handler.py
+++ b/src/speech_to_speech/VAD/vad_handler.py
@@ -422,12 +422,14 @@ class VADHandler(BaseHandler[VADIn, VADOut]):
             if (current_time - self.last_process_time) >= progressive_pause:
                 array = torch.cat(self.iterator.speech_buffer()).cpu().numpy()
                 duration_ms = len(array) / self.sample_rate * 1000
+                active_speech_duration_ms = self._current_active_speech_duration_ms()
 
-                if duration_ms >= self.min_speech_ms:
+                if active_speech_duration_ms >= self.min_speech_ms:
                     self._log_progressive_yields += 1
                     logger.debug(
-                        "VAD: yielding progressive audio (%.0fms, interval=%.2fs)",
+                        "VAD: yielding progressive audio (segment=%.0fms, active=%.0fms, interval=%.2fs)",
                         duration_ms,
+                        active_speech_duration_ms,
                         progressive_pause,
                     )
                     turn_id, turn_revision = self._current_turn_metadata()
@@ -461,9 +463,9 @@ class VADHandler(BaseHandler[VADIn, VADOut]):
             duration_ms = len(array) / self.sample_rate * 1000
             active_speech_duration_ms = self._last_utterance_active_speech_duration_ms()
 
-            if duration_ms < self.min_speech_ms or duration_ms > self.max_speech_ms:
+            if active_speech_duration_ms < self.min_speech_ms or duration_ms > self.max_speech_ms:
                 logger.info(
-                    "VAD: discarding segment=%.0fms active=%.0fms (bounds: %s-%sms)",
+                    "VAD: discarding segment=%.0fms active=%.0fms (active_min=%sms, segment_max=%sms)",
                     duration_ms,
                     active_speech_duration_ms,
                     self.min_speech_ms,
@@ -557,9 +559,14 @@ class VADHandler(BaseHandler[VADIn, VADOut]):
 
             array = torch.cat(vad_output).cpu().numpy()
             duration_ms = len(array) / self.sample_rate * 1000
-            if duration_ms < self.min_speech_ms or duration_ms > self.max_speech_ms:
+            active_speech_duration_ms = self._last_utterance_active_speech_duration_ms()
+            if active_speech_duration_ms < self.min_speech_ms or duration_ms > self.max_speech_ms:
                 logger.info(
-                    f"VAD: discarding {duration_ms:.0f}ms segment (bounds: {self.min_speech_ms}-{self.max_speech_ms}ms)"
+                    "VAD: discarding segment=%.0fms active=%.0fms (active_min=%sms, segment_max=%sms)",
+                    duration_ms,
+                    active_speech_duration_ms,
+                    self.min_speech_ms,
+                    self.max_speech_ms,
                 )
                 if self._speech_started_emitted and self.text_output_queue:
                     self.text_output_queue.put(SpeechStoppedEvent(audio_end_ms=self._audio_ms))

--- a/src/speech_to_speech/VAD/vad_handler.py
+++ b/src/speech_to_speech/VAD/vad_handler.py
@@ -109,6 +109,7 @@ class VADHandler(BaseHandler[VADIn, VADOut]):
         self._speculative_segments: list[np.ndarray] = []
         self._last_final_wall_time: float | None = None
         self._last_final_audio_ms: int | None = None
+        self._pending_reopen_candidate: tuple[str, int, int] | None = None
 
     @property
     def _audio_ms(self) -> int:
@@ -147,6 +148,7 @@ class VADHandler(BaseHandler[VADIn, VADOut]):
             logger.info(f"VAD silence duration updated to {td['silence_duration_ms']}ms")
 
     def _start_new_turn(self) -> tuple[str, int]:
+        self._cancel_pending_reopen()
         self._turn_counter += 1
         self._current_turn_id = f"turn_{self._turn_counter}"
         self._current_turn_revision = 0
@@ -157,12 +159,18 @@ class VADHandler(BaseHandler[VADIn, VADOut]):
             self.speculative_turns.observe(self._current_turn_id, self._current_turn_revision)
         return self._current_turn_id, self._current_turn_revision
 
-    def _should_reopen_current_turn(self) -> bool:
+    def _speech_buffer_duration_ms(self) -> float:
+        if not hasattr(self.iterator, "speech_buffer"):
+            return 0.0
+        buffer_samples = sum(len(t) for t in self.iterator.speech_buffer())
+        return buffer_samples / self.sample_rate * 1000
+
+    def _should_reopen_current_turn(self, audio_start_ms: int) -> bool:
         if not self.enable_realtime_transcription:
             return False
-        if self._current_turn_id is None or self._current_turn_revision is None or self._last_final_wall_time is None:
+        if self._current_turn_id is None or self._current_turn_revision is None or self._last_final_audio_ms is None:
             return False
-        elapsed_ms = (time.time() - self._last_final_wall_time) * 1000
+        elapsed_ms = max(0, audio_start_ms - self._last_final_audio_ms)
         if elapsed_ms > self.speculative_reopen_ms:
             return False
         if self.speculative_turns and self.speculative_turns.is_committed(
@@ -172,7 +180,53 @@ class VADHandler(BaseHandler[VADIn, VADOut]):
             return False
         return True
 
-    def _ensure_turn_for_speech_start(self) -> tuple[str, int, bool]:
+    def _begin_pending_reopen_if_needed(self, audio_start_ms: int) -> None:
+        if self._pending_reopen_candidate is not None or not self._should_reopen_current_turn(audio_start_ms):
+            return
+        if self.speculative_turns is None:
+            return
+        candidate_revision = self.speculative_turns.begin_reopen_candidate(
+            self._current_turn_id,
+            self._current_turn_revision,
+        )
+        if candidate_revision is None or self._current_turn_id is None or self._current_turn_revision is None:
+            return
+        self._pending_reopen_candidate = (
+            self._current_turn_id,
+            self._current_turn_revision,
+            candidate_revision,
+        )
+        logger.info(
+            "VAD: pending reopen candidate for speculative turn %s revision %d",
+            self._current_turn_id,
+            candidate_revision,
+        )
+
+    def _cancel_pending_reopen(self) -> None:
+        if self._pending_reopen_candidate is None:
+            return
+        turn_id, _base_revision, candidate_revision = self._pending_reopen_candidate
+        if self.speculative_turns:
+            self.speculative_turns.cancel_reopen_candidate(turn_id, candidate_revision)
+        self._pending_reopen_candidate = None
+
+    def _confirm_pending_reopen(self) -> tuple[str, int, bool] | None:
+        if self._pending_reopen_candidate is None:
+            return None
+        turn_id, base_revision, candidate_revision = self._pending_reopen_candidate
+        self._pending_reopen_candidate = None
+        if self.speculative_turns and not self.speculative_turns.confirm_reopen_candidate(
+            turn_id,
+            base_revision,
+            candidate_revision,
+        ):
+            return None
+        self._current_turn_id = turn_id
+        self._current_turn_revision = candidate_revision
+        logger.info("VAD: reopened speculative turn %s revision %d", turn_id, candidate_revision)
+        return turn_id, candidate_revision, True
+
+    def _ensure_turn_for_speech_start(self, audio_start_ms: int) -> tuple[str, int, bool]:
         if (
             self._speech_started_emitted
             and self._current_turn_id is not None
@@ -180,7 +234,11 @@ class VADHandler(BaseHandler[VADIn, VADOut]):
         ):
             return self._current_turn_id, self._current_turn_revision, False
 
-        reopened = self._should_reopen_current_turn()
+        confirmed_reopen = self._confirm_pending_reopen()
+        if confirmed_reopen is not None:
+            return confirmed_reopen
+
+        reopened = self._should_reopen_current_turn(audio_start_ms)
         if reopened and self._current_turn_id is not None and self._current_turn_revision is not None:
             self._current_turn_revision += 1
             logger.info(
@@ -224,11 +282,13 @@ class VADHandler(BaseHandler[VADIn, VADOut]):
         if is_triggered_now and not self._speech_started_emitted:
             buffer_samples = sum(len(t) for t in self.iterator.buffer)
             buffer_duration_ms = buffer_samples / self.sample_rate * 1000
+            speech_buffer_duration_ms = self._speech_buffer_duration_ms()
+            start_ms = max(0, self._audio_ms - int(speech_buffer_duration_ms))
+            self._begin_pending_reopen_if_needed(start_ms)
             if buffer_duration_ms >= self.min_speech_ms:
-                turn_id, turn_revision, reopened = self._ensure_turn_for_speech_start()
+                turn_id, turn_revision, reopened = self._ensure_turn_for_speech_start(start_ms)
                 self._speech_started_emitted = True
                 self._log_speech_starts += 1
-                start_ms = max(0, self._audio_ms - int(buffer_duration_ms))
                 logger.info(
                     "Speech started (confirmed, %.0fms buffered, turn=%s rev=%s)",
                     buffer_duration_ms,
@@ -302,6 +362,8 @@ class VADHandler(BaseHandler[VADIn, VADOut]):
                             turn_revision=turn_revision,
                         )
                     )
+                if not self._speech_started_emitted:
+                    self._cancel_pending_reopen()
                 self._speech_started_emitted = False
                 return
 
@@ -321,15 +383,18 @@ class VADHandler(BaseHandler[VADIn, VADOut]):
                             turn_revision=turn_revision,
                         )
                     )
+                if not self._speech_started_emitted:
+                    self._cancel_pending_reopen()
                 self._speech_started_emitted = False
             else:
                 end_ms = self._audio_ms
                 if not self._speech_started_emitted:
-                    turn_id, turn_revision, reopened = self._ensure_turn_for_speech_start()
+                    start_ms = max(0, end_ms - int(duration_ms))
+                    turn_id, turn_revision, reopened = self._ensure_turn_for_speech_start(start_ms)
                     if self.text_output_queue:
                         self.text_output_queue.put(
                             SpeechStartedEvent(
-                                audio_start_ms=max(0, end_ms - int(duration_ms)),
+                                audio_start_ms=start_ms,
                                 turn_id=turn_id,
                                 turn_revision=turn_revision,
                                 reopened=reopened,
@@ -428,6 +493,7 @@ class VADHandler(BaseHandler[VADIn, VADOut]):
         self._speculative_segments = []
         self._last_final_wall_time = None
         self._last_final_audio_ms = None
+        self._pending_reopen_candidate = None
         if self.speculative_turns:
             self.speculative_turns.reset()
         self.should_listen.set()

--- a/src/speech_to_speech/VAD/vad_iterator.py
+++ b/src/speech_to_speech/VAD/vad_iterator.py
@@ -9,7 +9,7 @@ class VADIterator:
         model,
         threshold: float = 0.5,
         sampling_rate: int = 16000,
-        min_silence_duration_ms: int = 100,
+        min_silence_duration_ms: int = 300,
         speech_pad_ms: int = 30,
     ) -> None:
         """
@@ -27,7 +27,7 @@ class VADIterator:
         sampling_rate: int (default - 16000)
             Currently silero VAD models support 8000 and 16000 sample rates
 
-        min_silence_duration_ms: int (default - 100 milliseconds)
+        min_silence_duration_ms: int (default - 300 milliseconds)
             In the end of each speech chunk wait for min_silence_duration_ms before separating it
 
         speech_pad_ms: int (default - 30 milliseconds)
@@ -41,8 +41,8 @@ class VADIterator:
         self.is_speaking = False
         self.buffer: list[torch.Tensor] = []
         self.prefix_buffer: list[torch.Tensor] = []
-        self.voiced_samples = 0
-        self.last_utterance_voiced_samples = 0
+        self.active_speech_samples = 0
+        self.last_utterance_active_speech_samples = 0
         self._pre_speech_buffer: deque[torch.Tensor] = deque()
         self._pre_speech_samples = 0
 
@@ -60,8 +60,8 @@ class VADIterator:
         self.current_sample = 0
         self.buffer = []
         self.prefix_buffer = []
-        self.voiced_samples = 0
-        self.last_utterance_voiced_samples = 0
+        self.active_speech_samples = 0
+        self.last_utterance_active_speech_samples = 0
         self._pre_speech_buffer.clear()
         self._pre_speech_samples = 0
 
@@ -134,8 +134,8 @@ class VADIterator:
             self._pre_speech_buffer.clear()
             self._pre_speech_samples = 0
             self.buffer.append(x)
-            self.voiced_samples = window_size_samples
-            self.last_utterance_voiced_samples = 0
+            self.active_speech_samples = window_size_samples
+            self.last_utterance_active_speech_samples = 0
             return None
 
         if not self.triggered:
@@ -144,8 +144,8 @@ class VADIterator:
 
         if self.triggered:
             self.buffer.append(x)
-            if speech_prob >= self.threshold:
-                self.voiced_samples += window_size_samples
+            if speech_prob >= self.threshold - 0.15:
+                self.active_speech_samples += window_size_samples
                 if self.temp_end:
                     self.temp_end = 0
                     return None
@@ -161,8 +161,8 @@ class VADIterator:
                 self.temp_end = 0
                 self.triggered = False
                 spoken_utterance = self.speech_buffer()
-                self.last_utterance_voiced_samples = self.voiced_samples
-                self.voiced_samples = 0
+                self.last_utterance_active_speech_samples = self.active_speech_samples
+                self.active_speech_samples = 0
                 self.buffer = []
                 self.prefix_buffer = []
                 return spoken_utterance

--- a/src/speech_to_speech/VAD/vad_iterator.py
+++ b/src/speech_to_speech/VAD/vad_iterator.py
@@ -41,6 +41,8 @@ class VADIterator:
         self.is_speaking = False
         self.buffer: list[torch.Tensor] = []
         self.prefix_buffer: list[torch.Tensor] = []
+        self.voiced_samples = 0
+        self.last_utterance_voiced_samples = 0
         self._pre_speech_buffer: deque[torch.Tensor] = deque()
         self._pre_speech_samples = 0
 
@@ -58,6 +60,8 @@ class VADIterator:
         self.current_sample = 0
         self.buffer = []
         self.prefix_buffer = []
+        self.voiced_samples = 0
+        self.last_utterance_voiced_samples = 0
         self._pre_speech_buffer.clear()
         self._pre_speech_samples = 0
 
@@ -130,6 +134,8 @@ class VADIterator:
             self._pre_speech_buffer.clear()
             self._pre_speech_samples = 0
             self.buffer.append(x)
+            self.voiced_samples = window_size_samples
+            self.last_utterance_voiced_samples = 0
             return None
 
         if not self.triggered:
@@ -138,9 +144,11 @@ class VADIterator:
 
         if self.triggered:
             self.buffer.append(x)
-            if (speech_prob >= self.threshold) and self.temp_end:
-                self.temp_end = 0
-                return None
+            if speech_prob >= self.threshold:
+                self.voiced_samples += window_size_samples
+                if self.temp_end:
+                    self.temp_end = 0
+                    return None
 
             if speech_prob < self.threshold - 0.15:
                 if not self.temp_end:
@@ -153,6 +161,8 @@ class VADIterator:
                 self.temp_end = 0
                 self.triggered = False
                 spoken_utterance = self.speech_buffer()
+                self.last_utterance_voiced_samples = self.voiced_samples
+                self.voiced_samples = 0
                 self.buffer = []
                 self.prefix_buffer = []
                 return spoken_utterance

--- a/src/speech_to_speech/api/openai_realtime/README.md
+++ b/src/speech_to_speech/api/openai_realtime/README.md
@@ -77,6 +77,7 @@ flowchart LR
 | `response.created` | Emitted on the first outbound audio chunk (response is `in_progress`). |
 | `response.output_audio.delta` | Base64 PCM audio chunk from TTS. |
 | `response.output_audio.done` | Audio stream complete for the current output item. |
+| `output_audio_buffer.cleared` | Server-side VAD interruption cleared already-buffered assistant audio. |
 | `response.output_audio_transcript.done` | Full assistant text transcript for the turn. |
 | `response.function_call_arguments.done` | Tool call with `call_id`, `name`, and JSON `arguments`. |
 | `response.done` | Response finished (`completed`, `cancelled` with reason `turn_detected` or `client_cancelled`). |
@@ -143,8 +144,10 @@ sequenceDiagram
     Note over TTS,Client: Assistant audio is playing (response_playing=set)
     User->>VAD: speaks
     VAD->>SendLoop: speech_started on text_output_queue
-    SendLoop->>Client: input_audio_buffer.speech_started
+    SendLoop->>Client: response.output_audio.done
+    SendLoop->>Client: output_audio_buffer.cleared
     SendLoop->>Client: response.done (status=cancelled, reason=turn_detected)
+    SendLoop->>Client: input_audio_buffer.speech_started
     SendLoop->>SendLoop: cancel_scope.cancel() (gen++ & discarding=True)
     SendLoop->>SendLoop: flush output_queue + text_output_queue
     SendLoop->>SendLoop: response_playing.clear()
@@ -158,7 +161,7 @@ sequenceDiagram
 **Step by step:**
 
 1. **VAD detects speech**: puts `{"type": "speech_started"}` on `text_output_queue`.
-2. **`_send_loop` processes text events first** (priority over audio): translates `speech_started` into protocol events. If an active response was in progress, `RealtimeService.dispatch_pipeline_event` emits `response.output_audio.done` + `response.done` with `status="cancelled"` and `reason="turn_detected"`.
+2. **`_send_loop` processes text events first** (priority over audio): translates `speech_started` into protocol events. If an active response was in progress, `RealtimeService.dispatch_pipeline_event` emits `response.output_audio.done`, `output_audio_buffer.cleared`, and `response.done` with `status="cancelled"` and `reason="turn_detected"`, followed by `input_audio_buffer.speech_started` for the new user turn.
 3. **Cancel + queue flush**: if `response_playing` is set, the send loop calls `cancel_scope.cancel()` (increments generation, enables discard), drains both `output_queue` (preserving `__RESPONSE_DONE__` sentinels) and `text_output_queue`, then clears `response_playing`.
 4. **LLM/TTS cancellation**: handlers capture `gen = cancel_scope.generation` at the start of each response and check `cancel_scope.is_stale(gen)` on every streaming token, aborting early when stale.
 5. **Discard guard**: while `cancel_scope.discarding` is True, the send loop silently drops stale audio chunks and assistant text. The guard clears when `__RESPONSE_DONE__` arrives (via `cancel_scope.response_done()`).

--- a/src/speech_to_speech/api/openai_realtime/README.md
+++ b/src/speech_to_speech/api/openai_realtime/README.md
@@ -77,7 +77,6 @@ flowchart LR
 | `response.created` | Emitted on the first outbound audio chunk (response is `in_progress`). |
 | `response.output_audio.delta` | Base64 PCM audio chunk from TTS. |
 | `response.output_audio.done` | Audio stream complete for the current output item. |
-| `output_audio_buffer.cleared` | Server-side VAD interruption cleared already-buffered assistant audio. |
 | `response.output_audio_transcript.done` | Full assistant text transcript for the turn. |
 | `response.function_call_arguments.done` | Tool call with `call_id`, `name`, and JSON `arguments`. |
 | `response.done` | Response finished (`completed`, `cancelled` with reason `turn_detected` or `client_cancelled`). |
@@ -144,10 +143,8 @@ sequenceDiagram
     Note over TTS,Client: Assistant audio is playing (response_playing=set)
     User->>VAD: speaks
     VAD->>SendLoop: speech_started on text_output_queue
-    SendLoop->>Client: response.output_audio.done
-    SendLoop->>Client: output_audio_buffer.cleared
-    SendLoop->>Client: response.done (status=cancelled, reason=turn_detected)
     SendLoop->>Client: input_audio_buffer.speech_started
+    SendLoop->>Client: response.done (status=cancelled, reason=turn_detected)
     SendLoop->>SendLoop: cancel_scope.cancel() (gen++ & discarding=True)
     SendLoop->>SendLoop: flush output_queue + text_output_queue
     SendLoop->>SendLoop: response_playing.clear()
@@ -161,7 +158,7 @@ sequenceDiagram
 **Step by step:**
 
 1. **VAD detects speech**: puts `{"type": "speech_started"}` on `text_output_queue`.
-2. **`_send_loop` processes text events first** (priority over audio): translates `speech_started` into protocol events. If an active response was in progress, `RealtimeService.dispatch_pipeline_event` emits `response.output_audio.done`, `output_audio_buffer.cleared`, and `response.done` with `status="cancelled"` and `reason="turn_detected"`, followed by `input_audio_buffer.speech_started` for the new user turn.
+2. **`_send_loop` processes text events first** (priority over audio): translates `speech_started` into protocol events. If an active response was in progress, `RealtimeService.dispatch_pipeline_event` emits `response.output_audio.done` + `response.done` with `status="cancelled"` and `reason="turn_detected"`.
 3. **Cancel + queue flush**: if `response_playing` is set, the send loop calls `cancel_scope.cancel()` (increments generation, enables discard), drains both `output_queue` (preserving `__RESPONSE_DONE__` sentinels) and `text_output_queue`, then clears `response_playing`.
 4. **LLM/TTS cancellation**: handlers capture `gen = cancel_scope.generation` at the start of each response and check `cancel_scope.is_stale(gen)` on every streaming token, aborting early when stale.
 5. **Discard guard**: while `cancel_scope.discarding` is True, the send loop silently drops stale audio chunks and assistant text. The guard clears when `__RESPONSE_DONE__` arrives (via `cancel_scope.response_done()`).

--- a/src/speech_to_speech/api/openai_realtime/handlers/audio.py
+++ b/src/speech_to_speech/api/openai_realtime/handlers/audio.py
@@ -84,7 +84,7 @@ class AudioHandler(RealtimeBaseHandler):
         response = self._service.response
         events: list[ServerEvent] = []
         st = self._state(conn_id)
-        if st.in_response and st.runtime_config.interrupt_response_enabled:
+        if st.in_response and event.interrupt_response and st.runtime_config.interrupt_response_enabled:
             events.extend(response.finish_audio_response(conn_id, status="cancelled", reason="turn_detected"))
         is_reopen = bool(event.reopened and event.turn_id is not None and event.turn_id == st.speculative_turn_id)
         if is_reopen:

--- a/src/speech_to_speech/api/openai_realtime/handlers/audio.py
+++ b/src/speech_to_speech/api/openai_realtime/handlers/audio.py
@@ -86,9 +86,19 @@ class AudioHandler(RealtimeBaseHandler):
         st = self._state(conn_id)
         if st.in_response and st.runtime_config.interrupt_response_enabled:
             events.extend(response.finish_audio_response(conn_id, status="cancelled", reason="turn_detected"))
-        input_item_id = response._start_item(conn_id)
+        is_reopen = bool(event.reopened and event.turn_id is not None and event.turn_id == st.speculative_turn_id)
+        if is_reopen:
+            input_item_id = st.speculative_input_item_id or response._current_item_id(conn_id)
+            st.current_item_id = input_item_id
+            st.content_index = 0
+            st.input_audio_duration_s = 0.0
+        else:
+            input_item_id = response._start_item(conn_id)
+            st.speculative_input_item_id = input_item_id
+            st.response_usage.turns += 1
+        st.speculative_turn_id = event.turn_id
+        st.speculative_turn_revision = event.turn_revision
         st.last_item_id = input_item_id
-        st.response_usage.turns += 1
         events.append(
             InputAudioBufferSpeechStartedEvent(
                 type="input_audio_buffer.speech_started",

--- a/src/speech_to_speech/api/openai_realtime/handlers/audio.py
+++ b/src/speech_to_speech/api/openai_realtime/handlers/audio.py
@@ -31,6 +31,20 @@ CHUNK_SIZE_BYTES = CHUNK_SAMPLES * BYTES_PER_SAMPLE
 class AudioHandler(RealtimeBaseHandler):
     """Owns inbound audio decoding/chunking and outbound audio encoding."""
 
+    def _start_input_item(self, conn_id: str, *, preserve_active_response: bool = False) -> str:
+        response = self._service.response
+        st = self._state(conn_id)
+        if not preserve_active_response:
+            item_id = response._start_item(conn_id)
+        else:
+            response_item_id = st.current_item_id
+            response_content_index = st.content_index
+            item_id = response._start_item(conn_id)
+            st.current_item_id = response_item_id
+            st.content_index = response_content_index
+        st.input_content_index = 0
+        return item_id
+
     def handle_audio_append(self, conn_id: str, event: InputAudioBufferAppendEvent) -> list[bytes]:
         """Decode base64 audio, resample to pipeline rate, and split into 512-sample PCM16 chunks for the VAD."""
         try:
@@ -87,13 +101,25 @@ class AudioHandler(RealtimeBaseHandler):
         if st.in_response and event.interrupt_response and st.runtime_config.interrupt_response_enabled:
             events.extend(response.finish_audio_response(conn_id, status="cancelled", reason="turn_detected"))
         is_reopen = bool(event.reopened and event.turn_id is not None and event.turn_id == st.speculative_turn_id)
+        preserve_active_response = st.in_response
         if is_reopen:
-            input_item_id = st.speculative_input_item_id or response._current_item_id(conn_id)
-            st.current_item_id = input_item_id
-            st.content_index = 0
+            input_item_id = st.speculative_input_item_id
+            if input_item_id is None:
+                input_item_id = self._start_input_item(
+                    conn_id,
+                    preserve_active_response=preserve_active_response,
+                )
+                st.speculative_input_item_id = input_item_id
+            elif not preserve_active_response:
+                st.current_item_id = input_item_id
+                st.content_index = 0
             st.input_audio_duration_s = 0.0
+            st.input_content_index = 0
         else:
-            input_item_id = response._start_item(conn_id)
+            input_item_id = self._start_input_item(
+                conn_id,
+                preserve_active_response=preserve_active_response,
+            )
             st.speculative_input_item_id = input_item_id
             st.response_usage.turns += 1
         st.speculative_turn_id = event.turn_id
@@ -111,7 +137,6 @@ class AudioHandler(RealtimeBaseHandler):
 
     def on_speech_stopped(self, conn_id: str, event: SpeechStoppedEvent) -> list[ServerEvent]:
         """Handle VAD speech_stopped: record duration and emit stopped event."""
-        response = self._service.response
         if event.duration_s:
             self._state(conn_id).input_audio_duration_s = event.duration_s
         return [
@@ -119,7 +144,7 @@ class AudioHandler(RealtimeBaseHandler):
                 type="input_audio_buffer.speech_stopped",
                 event_id=self._next_event_id(),
                 audio_end_ms=event.audio_end_ms,
-                item_id=response._current_item_id(conn_id),
+                item_id=self._input_item_id(conn_id),
             )
         ]
 

--- a/src/speech_to_speech/api/openai_realtime/handlers/base.py
+++ b/src/speech_to_speech/api/openai_realtime/handlers/base.py
@@ -39,6 +39,16 @@ class RealtimeBaseHandler:
     def _state(self, conn_id: str) -> ConnState:
         return self._service._state(conn_id)
 
+    def _input_item_id(self, conn_id: str) -> str:
+        st = self._state(conn_id)
+        return st.speculative_input_item_id or self._service.response._current_item_id(conn_id)
+
+    def _next_input_content_index(self, conn_id: str) -> int:
+        st = self._state(conn_id)
+        idx = st.input_content_index
+        st.input_content_index += 1
+        return idx
+
     @staticmethod
     def _next_event_id() -> str:
         return _generate_id("event")

--- a/src/speech_to_speech/api/openai_realtime/handlers/conversation.py
+++ b/src/speech_to_speech/api/openai_realtime/handlers/conversation.py
@@ -100,20 +100,18 @@ class ConversationHandler(RealtimeBaseHandler):
 
     def on_partial_transcription(self, conn_id: str, event: PartialTranscriptionEvent) -> list[ServerEvent]:
         """Handle partial_transcription: emit transcription delta event."""
-        response = self._service.response
         return [
             ConversationItemInputAudioTranscriptionDeltaEvent(
                 type="conversation.item.input_audio_transcription.delta",
                 event_id=self._next_event_id(),
-                content_index=response._next_content_index(conn_id),
-                item_id=response._current_item_id(conn_id),
+                content_index=self._next_input_content_index(conn_id),
+                item_id=self._input_item_id(conn_id),
                 delta=event.delta,
             )
         ]
 
     def on_transcription_completed(self, conn_id: str, event: TranscriptionCompletedEvent) -> list[ServerEvent]:
         """Handle transcription_completed: accumulate duration and emit completed event."""
-        response = self._service.response
         st = self._state(conn_id)
         st.response_usage.audio_duration_s += st.input_audio_duration_s
         return [
@@ -121,7 +119,7 @@ class ConversationHandler(RealtimeBaseHandler):
                 type="conversation.item.input_audio_transcription.completed",
                 event_id=self._next_event_id(),
                 content_index=0,
-                item_id=response._current_item_id(conn_id),
+                item_id=self._input_item_id(conn_id),
                 transcript=event.transcript,
                 usage=UsageTranscriptTextUsageDuration(
                     seconds=st.input_audio_duration_s,

--- a/src/speech_to_speech/api/openai_realtime/handlers/response.py
+++ b/src/speech_to_speech/api/openai_realtime/handlers/response.py
@@ -15,6 +15,7 @@ from openai.types.realtime import (
 from openai.types.realtime.realtime_response import Audio, AudioOutput
 from openai.types.realtime.realtime_response_status import RealtimeResponseStatus
 from openai.types.realtime.realtime_response_usage import RealtimeResponseUsage
+from openai.types.realtime.realtime_server_event import OutputAudioBufferCleared
 
 from speech_to_speech.api.openai_realtime.handlers.base import RealtimeBaseHandler
 from speech_to_speech.LLM.chat import ChatItemError
@@ -210,6 +211,14 @@ class ResponseHandler(RealtimeBaseHandler):
                     response_id=resp_id,
                 )
             )
+            if status == "cancelled" and reason == "turn_detected":
+                events.append(
+                    OutputAudioBufferCleared(
+                        type="output_audio_buffer.cleared",
+                        event_id=self._next_event_id(),
+                        response_id=resp_id,
+                    )
+                )
             events.append(
                 ResponseDoneEvent(
                     type="response.done",

--- a/src/speech_to_speech/api/openai_realtime/handlers/response.py
+++ b/src/speech_to_speech/api/openai_realtime/handlers/response.py
@@ -165,6 +165,9 @@ class ResponseHandler(RealtimeBaseHandler):
                 GenerateResponseRequest(
                     runtime_config=cfg,
                     response=event.response,
+                    turn_id=st.speculative_user_turn_id,
+                    turn_revision=st.speculative_user_turn_revision,
+                    speech_stopped_at_s=st.speculative_user_speech_stopped_at_s,
                 )
             )
         logger.debug("response.create received, LLM generation triggered")

--- a/src/speech_to_speech/api/openai_realtime/handlers/response.py
+++ b/src/speech_to_speech/api/openai_realtime/handlers/response.py
@@ -218,6 +218,8 @@ class ResponseHandler(RealtimeBaseHandler):
 
     def on_assistant_text(self, conn_id: str, event: AssistantTextEvent) -> list[ServerEvent]:
         """Handle assistant_text: emit transcript and/or tool-call events."""
+        if self._service.speculative_turns:
+            self._service.speculative_turns.commit(event.turn_id, event.turn_revision)
         st = self._state(conn_id)
         events: list[ServerEvent] = []
         resp_id, item_id = self._ensure_response(conn_id)

--- a/src/speech_to_speech/api/openai_realtime/handlers/response.py
+++ b/src/speech_to_speech/api/openai_realtime/handlers/response.py
@@ -40,6 +40,7 @@ class ResponseHandler(RealtimeBaseHandler):
             st.current_response_id = _generate_id("resp")
             self._start_item(conn_id)
             st.in_response = True
+        st.response_pending = False
         return st.current_response_id, self._current_item_id(conn_id)
 
     def _end_response(self, conn_id: str, status: _ResponseStatus = "completed") -> None:
@@ -65,6 +66,7 @@ class ResponseHandler(RealtimeBaseHandler):
         st.current_item_id = None
         st.content_index = 0
         st.in_response = False
+        st.response_pending = False
         st.current_response_params = None
 
     def _start_item(self, conn_id: str) -> str:
@@ -153,6 +155,7 @@ class ResponseHandler(RealtimeBaseHandler):
                     return self.make_error(message=str(exc), _type="invalid_input_item")
 
         st.in_response = True
+        st.response_pending = False
 
         st.current_response_params = event.response
         st.current_response_id = _generate_id("resp")

--- a/src/speech_to_speech/api/openai_realtime/handlers/response.py
+++ b/src/speech_to_speech/api/openai_realtime/handlers/response.py
@@ -218,8 +218,15 @@ class ResponseHandler(RealtimeBaseHandler):
 
     def on_assistant_text(self, conn_id: str, event: AssistantTextEvent) -> list[ServerEvent]:
         """Handle assistant_text: emit transcript and/or tool-call events."""
-        if self._service.speculative_turns:
-            self._service.speculative_turns.commit(event.turn_id, event.turn_revision)
+        if (
+            self._service.speculative_turns
+            and not self._service.speculative_turns.commit_if_latest_after_pending_reopen(
+                event.turn_id,
+                event.turn_revision,
+            )
+        ):
+            logger.debug("Dropping stale assistant text for turn=%s rev=%s", event.turn_id, event.turn_revision)
+            return []
         st = self._state(conn_id)
         events: list[ServerEvent] = []
         resp_id, item_id = self._ensure_response(conn_id)

--- a/src/speech_to_speech/api/openai_realtime/handlers/response.py
+++ b/src/speech_to_speech/api/openai_realtime/handlers/response.py
@@ -225,6 +225,7 @@ class ResponseHandler(RealtimeBaseHandler):
     ) -> list[ServerEvent] | None:
         """Handle assistant_text: emit transcript and/or tool-call events."""
         if self._service.speculative_turns:
+            commit_result: bool | None
             if wait_for_pending_reopen:
                 commit_result = self._service.speculative_turns.commit_if_latest_after_pending_reopen(
                     event.turn_id,

--- a/src/speech_to_speech/api/openai_realtime/handlers/response.py
+++ b/src/speech_to_speech/api/openai_realtime/handlers/response.py
@@ -227,12 +227,12 @@ class ResponseHandler(RealtimeBaseHandler):
         if self._service.speculative_turns:
             commit_result: bool | None
             if wait_for_pending_reopen:
-                commit_result = self._service.speculative_turns.commit_if_latest_after_pending_reopen(
+                commit_result = self._service.speculative_turns.commit_if_latest_after_reopen_grace(
                     event.turn_id,
                     event.turn_revision,
                 )
             else:
-                commit_result = self._service.speculative_turns.try_commit_if_latest_after_pending_reopen(
+                commit_result = self._service.speculative_turns.try_commit_if_latest_after_reopen_grace(
                     event.turn_id,
                     event.turn_revision,
                 )

--- a/src/speech_to_speech/api/openai_realtime/handlers/response.py
+++ b/src/speech_to_speech/api/openai_realtime/handlers/response.py
@@ -15,7 +15,6 @@ from openai.types.realtime import (
 from openai.types.realtime.realtime_response import Audio, AudioOutput
 from openai.types.realtime.realtime_response_status import RealtimeResponseStatus
 from openai.types.realtime.realtime_response_usage import RealtimeResponseUsage
-from openai.types.realtime.realtime_server_event import OutputAudioBufferCleared
 
 from speech_to_speech.api.openai_realtime.handlers.base import RealtimeBaseHandler
 from speech_to_speech.LLM.chat import ChatItemError
@@ -211,14 +210,6 @@ class ResponseHandler(RealtimeBaseHandler):
                     response_id=resp_id,
                 )
             )
-            if status == "cancelled" and reason == "turn_detected":
-                events.append(
-                    OutputAudioBufferCleared(
-                        type="output_audio_buffer.cleared",
-                        event_id=self._next_event_id(),
-                        response_id=resp_id,
-                    )
-                )
             events.append(
                 ResponseDoneEvent(
                     type="response.done",

--- a/src/speech_to_speech/api/openai_realtime/handlers/response.py
+++ b/src/speech_to_speech/api/openai_realtime/handlers/response.py
@@ -216,17 +216,30 @@ class ResponseHandler(RealtimeBaseHandler):
 
     # ── Pipeline event handlers ───────────────────
 
-    def on_assistant_text(self, conn_id: str, event: AssistantTextEvent) -> list[ServerEvent]:
+    def on_assistant_text(
+        self,
+        conn_id: str,
+        event: AssistantTextEvent,
+        *,
+        wait_for_pending_reopen: bool = True,
+    ) -> list[ServerEvent] | None:
         """Handle assistant_text: emit transcript and/or tool-call events."""
-        if (
-            self._service.speculative_turns
-            and not self._service.speculative_turns.commit_if_latest_after_pending_reopen(
-                event.turn_id,
-                event.turn_revision,
-            )
-        ):
-            logger.debug("Dropping stale assistant text for turn=%s rev=%s", event.turn_id, event.turn_revision)
-            return []
+        if self._service.speculative_turns:
+            if wait_for_pending_reopen:
+                commit_result = self._service.speculative_turns.commit_if_latest_after_pending_reopen(
+                    event.turn_id,
+                    event.turn_revision,
+                )
+            else:
+                commit_result = self._service.speculative_turns.try_commit_if_latest_after_pending_reopen(
+                    event.turn_id,
+                    event.turn_revision,
+                )
+            if commit_result is None:
+                return None
+            if not commit_result:
+                logger.debug("Dropping stale assistant text for turn=%s rev=%s", event.turn_id, event.turn_revision)
+                return []
         st = self._state(conn_id)
         events: list[ServerEvent] = []
         resp_id, item_id = self._ensure_response(conn_id)

--- a/src/speech_to_speech/api/openai_realtime/server.py
+++ b/src/speech_to_speech/api/openai_realtime/server.py
@@ -10,6 +10,7 @@ from speech_to_speech.api.openai_realtime.service import RealtimeService
 from speech_to_speech.api.openai_realtime.websocket_router import create_app
 from speech_to_speech.pipeline.cancel_scope import CancelScope
 from speech_to_speech.pipeline.queue_types import AudioInItem, AudioOutItem, TextEventItem, TextPromptItem
+from speech_to_speech.pipeline.speculative_turns import SpeculativeTurnTracker
 
 logger = logging.getLogger(__name__)
 
@@ -32,6 +33,7 @@ class RealtimeServer:
         cancel_scope: CancelScope | None = None,
         text_output_queue: Queue[TextEventItem] | None = None,
         text_prompt_queue: Queue[TextPromptItem] | None = None,
+        speculative_turns: SpeculativeTurnTracker | None = None,
         host: str = "0.0.0.0",
         port: int = 8765,
         chat_size: int = 10,
@@ -41,6 +43,7 @@ class RealtimeServer:
         self.output_queue = output_queue
         self.text_output_queue = text_output_queue
         self.text_prompt_queue = text_prompt_queue
+        self.speculative_turns = speculative_turns
         self.should_listen = should_listen
         self.response_playing = response_playing
         self.cancel_scope = cancel_scope
@@ -54,6 +57,7 @@ class RealtimeServer:
             text_prompt_queue=self.text_prompt_queue,
             should_listen=self.should_listen,
             chat_size=self.chat_size,
+            speculative_turns=self.speculative_turns,
         )
         app = create_app(
             service=service,

--- a/src/speech_to_speech/api/openai_realtime/service.py
+++ b/src/speech_to_speech/api/openai_realtime/service.py
@@ -330,7 +330,8 @@ class RealtimeService:
     def _on_transcription_completed(self, conn_id: str, event: TranscriptionCompletedEvent) -> list[ServerEvent]:
         """Handle a final STT transcription: emit protocol event, append to chat, trigger LM."""
         st = self._state(conn_id)
-        if event.turn_id is not None and event.turn_id == st.speculative_user_turn_id:
+        same_speculative_turn = event.turn_id is not None and event.turn_id == st.speculative_user_turn_id
+        if same_speculative_turn:
             st.response_usage.audio_duration_s -= st.speculative_audio_duration_s
         else:
             st.speculative_audio_duration_s = 0.0
@@ -342,7 +343,6 @@ class RealtimeService:
         cfg = st.runtime_config
         transcript = event.transcript
         if transcript:
-            same_speculative_turn = event.turn_id is not None and event.turn_id == st.speculative_user_turn_id
             if same_speculative_turn and st.speculative_user_item_id:
                 replaced = cfg.chat.replace_user_message_text(st.speculative_user_item_id, transcript)
                 if not replaced:
@@ -351,6 +351,13 @@ class RealtimeService:
             else:
                 item = cfg.chat.add_item(make_user_message(transcript))
                 st.speculative_user_item_id = item.id
+        elif same_speculative_turn and st.speculative_user_item_id:
+            cfg.chat.remove_user_message(st.speculative_user_item_id)
+            st.speculative_user_item_id = None
+        elif event.turn_id is not None and event.turn_id != st.speculative_user_turn_id:
+            st.speculative_user_item_id = None
+
+        if event.turn_id is not None:
             st.speculative_user_turn_id = event.turn_id
             st.speculative_user_turn_revision = event.turn_revision
 

--- a/src/speech_to_speech/api/openai_realtime/service.py
+++ b/src/speech_to_speech/api/openai_realtime/service.py
@@ -194,7 +194,6 @@ class RealtimeService:
         self._pipeline_dispatch: dict[type[PipelineEvent], Callable[..., list[ServerEvent]]] = {
             SpeechStartedEvent: self.audio.on_speech_started,
             SpeechStoppedEvent: self.audio.on_speech_stopped,
-            AssistantTextEvent: self.response.on_assistant_text,
             TokenUsageEvent: self._on_token_usage,
             PartialTranscriptionEvent: self.conversation.on_partial_transcription,
             TranscriptionCompletedEvent: self._on_transcription_completed,
@@ -288,7 +287,36 @@ class RealtimeService:
 
     def dispatch_pipeline_event(self, conn_id: str, event: PipelineEvent) -> list[ServerEvent]:
         """Route a pipeline text_output_queue event to the appropriate handler."""
-        if self._is_stale_turn_event(event):
+        events = self._dispatch_pipeline_event(conn_id, event, wait_for_pending_reopen=True)
+        return [] if events is None else events
+
+    def try_dispatch_pipeline_event(self, conn_id: str, event: PipelineEvent) -> list[ServerEvent] | None:
+        """Non-blocking dispatch.
+
+        Returns ``None`` when dispatch must be retried after a speculative
+        reopen candidate resolves.
+        """
+        return self._dispatch_pipeline_event(conn_id, event, wait_for_pending_reopen=False)
+
+    def should_defer_pipeline_event(self, event: PipelineEvent) -> bool:
+        if self.speculative_turns is None or not isinstance(event, (AssistantTextEvent, TokenUsageEvent)):
+            return False
+        return self.speculative_turns.has_pending_reopen(
+            getattr(event, "turn_id", None),
+            getattr(event, "turn_revision", None),
+        )
+
+    def _dispatch_pipeline_event(
+        self,
+        conn_id: str,
+        event: PipelineEvent,
+        *,
+        wait_for_pending_reopen: bool,
+    ) -> list[ServerEvent] | None:
+        is_stale = self._is_stale_turn_event(event, wait_for_pending_reopen=wait_for_pending_reopen)
+        if is_stale is None:
+            return None
+        if is_stale:
             logger.info(
                 "Ignoring stale %s for turn=%s rev=%s",
                 event.type,
@@ -298,13 +326,19 @@ class RealtimeService:
             return []
 
         self._observe_turn_event(event)
+        if isinstance(event, AssistantTextEvent):
+            return self.response.on_assistant_text(
+                conn_id,
+                event,
+                wait_for_pending_reopen=wait_for_pending_reopen,
+            )
         handler = self._pipeline_dispatch.get(type(event))
         if handler is None:
             logger.debug("Unhandled pipeline event type: %s", type(event).__name__)
             return []
         return handler(conn_id, event)
 
-    def _is_stale_turn_event(self, event: PipelineEvent) -> bool:
+    def _is_stale_turn_event(self, event: PipelineEvent, *, wait_for_pending_reopen: bool = True) -> bool | None:
         if self.speculative_turns is None:
             return False
         if not isinstance(
@@ -315,7 +349,13 @@ class RealtimeService:
         turn_id = getattr(event, "turn_id", None)
         turn_revision = getattr(event, "turn_revision", None)
         if isinstance(event, (AssistantTextEvent, TokenUsageEvent)):
-            return not self.speculative_turns.is_latest_after_pending_reopen(turn_id, turn_revision)
+            if wait_for_pending_reopen:
+                is_latest = self.speculative_turns.is_latest_after_pending_reopen(turn_id, turn_revision)
+            else:
+                is_latest = self.speculative_turns.try_is_latest_after_pending_reopen(turn_id, turn_revision)
+            if is_latest is None:
+                return None
+            return not is_latest
         return not self.speculative_turns.is_latest(turn_id, turn_revision)
 
     def _observe_turn_event(self, event: PipelineEvent) -> None:
@@ -379,7 +419,7 @@ class RealtimeService:
 
     def _on_token_usage(self, conn_id: str, event: TokenUsageEvent) -> list[ServerEvent]:
         """Accumulate input/output token counts on the connection's usage metrics."""
-        if self.speculative_turns and not self.speculative_turns.is_latest_after_pending_reopen(
+        if self.speculative_turns and not self.speculative_turns.is_latest(
             event.turn_id,
             event.turn_revision,
         ):

--- a/src/speech_to_speech/api/openai_realtime/service.py
+++ b/src/speech_to_speech/api/openai_realtime/service.py
@@ -349,6 +349,7 @@ class RealtimeService:
         turn_id = getattr(event, "turn_id", None)
         turn_revision = getattr(event, "turn_revision", None)
         if isinstance(event, (AssistantTextEvent, TokenUsageEvent)):
+            is_latest: bool | None
             if wait_for_pending_reopen:
                 is_latest = self.speculative_turns.is_latest_after_pending_reopen(turn_id, turn_revision)
             else:

--- a/src/speech_to_speech/api/openai_realtime/service.py
+++ b/src/speech_to_speech/api/openai_realtime/service.py
@@ -162,6 +162,7 @@ class ConnState(BaseModel):
     speculative_turn_revision: Optional[int] = None
     speculative_user_turn_id: Optional[str] = None
     speculative_user_turn_revision: Optional[int] = None
+    speculative_user_speech_stopped_at_s: Optional[float] = None
     speculative_user_item_id: Optional[str] = None
     speculative_input_item_id: Optional[str] = None
     speculative_audio_duration_s: float = 0.0
@@ -409,6 +410,7 @@ class RealtimeService:
         if event.turn_id is not None:
             st.speculative_user_turn_id = event.turn_id
             st.speculative_user_turn_revision = event.turn_revision
+            st.speculative_user_speech_stopped_at_s = event.speech_stopped_at_s
 
         queue = self.text_prompt_queue
         if queue and transcript:

--- a/src/speech_to_speech/api/openai_realtime/service.py
+++ b/src/speech_to_speech/api/openai_realtime/service.py
@@ -312,10 +312,11 @@ class RealtimeService:
             (PartialTranscriptionEvent, TranscriptionCompletedEvent, AssistantTextEvent, TokenUsageEvent),
         ):
             return False
-        return not self.speculative_turns.is_latest(
-            getattr(event, "turn_id", None),
-            getattr(event, "turn_revision", None),
-        )
+        turn_id = getattr(event, "turn_id", None)
+        turn_revision = getattr(event, "turn_revision", None)
+        if isinstance(event, (AssistantTextEvent, TokenUsageEvent)):
+            return not self.speculative_turns.is_latest_after_pending_reopen(turn_id, turn_revision)
+        return not self.speculative_turns.is_latest(turn_id, turn_revision)
 
     def _observe_turn_event(self, event: PipelineEvent) -> None:
         if self.speculative_turns is None:
@@ -378,6 +379,12 @@ class RealtimeService:
 
     def _on_token_usage(self, conn_id: str, event: TokenUsageEvent) -> list[ServerEvent]:
         """Accumulate input/output token counts on the connection's usage metrics."""
+        if self.speculative_turns and not self.speculative_turns.is_latest_after_pending_reopen(
+            event.turn_id,
+            event.turn_revision,
+        ):
+            logger.debug("Dropping stale token usage for turn=%s rev=%s", event.turn_id, event.turn_revision)
+            return []
         st = self._state(conn_id)
         st.response_usage.input_tokens += event.input_tokens
         st.response_usage.output_tokens += event.output_tokens

--- a/src/speech_to_speech/api/openai_realtime/service.py
+++ b/src/speech_to_speech/api/openai_realtime/service.py
@@ -26,7 +26,6 @@ from openai.types.realtime import (
     SessionUpdateEvent,
 )
 from openai.types.realtime.realtime_response_create_params import RealtimeResponseCreateParams
-from openai.types.realtime.realtime_server_event import OutputAudioBufferCleared
 from pydantic import BaseModel, ConfigDict, Field, ValidationError
 
 from speech_to_speech.api.openai_realtime.handlers import (
@@ -89,7 +88,6 @@ ServerEvent = Union[
     ResponseDoneEvent,
     ResponseAudioDeltaEvent,
     ResponseAudioDoneEvent,
-    OutputAudioBufferCleared,
     ResponseAudioTranscriptDoneEvent,
     ResponseFunctionCallArgumentsDoneEvent,
 ]

--- a/src/speech_to_speech/api/openai_realtime/service.py
+++ b/src/speech_to_speech/api/openai_realtime/service.py
@@ -149,6 +149,7 @@ class ConnState(BaseModel):
     conversation_id: str = Field(default_factory=lambda: _generate_id("conv"))
     runtime_config: RuntimeConfig = Field(default_factory=RuntimeConfig)
     in_response: bool = False
+    response_pending: bool = False
     audio_buffer_has_data: bool = False
     audio_remainder: bytes = b""
     current_response_id: Optional[str] = None
@@ -414,6 +415,7 @@ class RealtimeService:
 
         queue = self.text_prompt_queue
         if queue and transcript:
+            st.response_pending = True
             queue.put(
                 GenerateResponseRequest(
                     runtime_config=cfg,

--- a/src/speech_to_speech/api/openai_realtime/service.py
+++ b/src/speech_to_speech/api/openai_realtime/service.py
@@ -47,6 +47,7 @@ from speech_to_speech.pipeline.events import (
 )
 from speech_to_speech.pipeline.messages import GenerateResponseRequest
 from speech_to_speech.pipeline.queue_types import TextPromptItem
+from speech_to_speech.pipeline.speculative_turns import SpeculativeTurnTracker
 from speech_to_speech.utils.utils import _generate_id
 
 logger = logging.getLogger(__name__)
@@ -154,6 +155,13 @@ class ConnState(BaseModel):
     last_item_id: Optional[str] = None
     current_response_params: RealtimeResponseCreateParams | None = None
     response_usage: UsageMetrics = Field(default_factory=UsageMetrics)
+    speculative_turn_id: Optional[str] = None
+    speculative_turn_revision: Optional[int] = None
+    speculative_user_turn_id: Optional[str] = None
+    speculative_user_turn_revision: Optional[int] = None
+    speculative_user_item_id: Optional[str] = None
+    speculative_input_item_id: Optional[str] = None
+    speculative_audio_duration_s: float = 0.0
 
 
 class RealtimeService:
@@ -169,10 +177,12 @@ class RealtimeService:
         text_prompt_queue: Queue[TextPromptItem] | None = None,
         should_listen: ThreadingEvent | None = None,
         chat_size: int = 10,
+        speculative_turns: SpeculativeTurnTracker | None = None,
     ) -> None:
         self.text_prompt_queue = text_prompt_queue
         self.should_listen = should_listen
         self._chat_size = chat_size
+        self.speculative_turns = speculative_turns
         self._conns: dict[str, ConnState] = {}
         self.total_usage = GlobalUsageMetrics()
 
@@ -194,6 +204,8 @@ class RealtimeService:
 
     def register(self) -> str:
         """Register a new connection and return its session_id."""
+        if self.speculative_turns:
+            self.speculative_turns.reset()
         state = ConnState(runtime_config=RuntimeConfig(chat=Chat(self._chat_size)))
         self._conns[state.session_id] = state
         self.total_usage.connections += 1
@@ -276,23 +288,71 @@ class RealtimeService:
 
     def dispatch_pipeline_event(self, conn_id: str, event: PipelineEvent) -> list[ServerEvent]:
         """Route a pipeline text_output_queue event to the appropriate handler."""
+        if self._is_stale_turn_event(event):
+            logger.info(
+                "Ignoring stale %s for turn=%s rev=%s",
+                event.type,
+                getattr(event, "turn_id", None),
+                getattr(event, "turn_revision", None),
+            )
+            return []
+
+        self._observe_turn_event(event)
         handler = self._pipeline_dispatch.get(type(event))
         if handler is None:
             logger.debug("Unhandled pipeline event type: %s", type(event).__name__)
             return []
         return handler(conn_id, event)
 
+    def _is_stale_turn_event(self, event: PipelineEvent) -> bool:
+        if self.speculative_turns is None:
+            return False
+        if not isinstance(
+            event,
+            (PartialTranscriptionEvent, TranscriptionCompletedEvent, AssistantTextEvent, TokenUsageEvent),
+        ):
+            return False
+        return not self.speculative_turns.is_latest(
+            getattr(event, "turn_id", None),
+            getattr(event, "turn_revision", None),
+        )
+
+    def _observe_turn_event(self, event: PipelineEvent) -> None:
+        if self.speculative_turns is None:
+            return
+        self.speculative_turns.observe(
+            getattr(event, "turn_id", None),
+            getattr(event, "turn_revision", None),
+        )
+
     # ── STT → LM bridge ────────────────────────────
 
     def _on_transcription_completed(self, conn_id: str, event: TranscriptionCompletedEvent) -> list[ServerEvent]:
         """Handle a final STT transcription: emit protocol event, append to chat, trigger LM."""
-        events = self.conversation.on_transcription_completed(conn_id, event)
-
         st = self._state(conn_id)
+        if event.turn_id is not None and event.turn_id == st.speculative_user_turn_id:
+            st.response_usage.audio_duration_s -= st.speculative_audio_duration_s
+        else:
+            st.speculative_audio_duration_s = 0.0
+
+        events = self.conversation.on_transcription_completed(conn_id, event)
+        if event.turn_id is not None:
+            st.speculative_audio_duration_s = st.input_audio_duration_s
+
         cfg = st.runtime_config
         transcript = event.transcript
         if transcript:
-            cfg.chat.add_item(make_user_message(transcript))
+            same_speculative_turn = event.turn_id is not None and event.turn_id == st.speculative_user_turn_id
+            if same_speculative_turn and st.speculative_user_item_id:
+                replaced = cfg.chat.replace_user_message_text(st.speculative_user_item_id, transcript)
+                if not replaced:
+                    item = cfg.chat.add_item(make_user_message(transcript))
+                    st.speculative_user_item_id = item.id
+            else:
+                item = cfg.chat.add_item(make_user_message(transcript))
+                st.speculative_user_item_id = item.id
+            st.speculative_user_turn_id = event.turn_id
+            st.speculative_user_turn_revision = event.turn_revision
 
         queue = self.text_prompt_queue
         if queue and transcript:
@@ -300,6 +360,8 @@ class RealtimeService:
                 GenerateResponseRequest(
                     runtime_config=cfg,
                     language_code=event.language_code,
+                    turn_id=event.turn_id,
+                    turn_revision=event.turn_revision,
                 )
             )
 

--- a/src/speech_to_speech/api/openai_realtime/service.py
+++ b/src/speech_to_speech/api/openai_realtime/service.py
@@ -26,6 +26,7 @@ from openai.types.realtime import (
     SessionUpdateEvent,
 )
 from openai.types.realtime.realtime_response_create_params import RealtimeResponseCreateParams
+from openai.types.realtime.realtime_server_event import OutputAudioBufferCleared
 from pydantic import BaseModel, ConfigDict, Field, ValidationError
 
 from speech_to_speech.api.openai_realtime.handlers import (
@@ -88,6 +89,7 @@ ServerEvent = Union[
     ResponseDoneEvent,
     ResponseAudioDeltaEvent,
     ResponseAudioDoneEvent,
+    OutputAudioBufferCleared,
     ResponseAudioTranscriptDoneEvent,
     ResponseFunctionCallArgumentsDoneEvent,
 ]

--- a/src/speech_to_speech/api/openai_realtime/service.py
+++ b/src/speech_to_speech/api/openai_realtime/service.py
@@ -411,6 +411,7 @@ class RealtimeService:
                     language_code=event.language_code,
                     turn_id=event.turn_id,
                     turn_revision=event.turn_revision,
+                    speech_stopped_at_s=event.speech_stopped_at_s,
                 )
             )
 

--- a/src/speech_to_speech/api/openai_realtime/service.py
+++ b/src/speech_to_speech/api/openai_realtime/service.py
@@ -301,7 +301,7 @@ class RealtimeService:
     def should_defer_pipeline_event(self, event: PipelineEvent) -> bool:
         if self.speculative_turns is None or not isinstance(event, (AssistantTextEvent, TokenUsageEvent)):
             return False
-        return self.speculative_turns.has_pending_reopen(
+        return self.speculative_turns.has_pending_reopen_or_grace(
             getattr(event, "turn_id", None),
             getattr(event, "turn_revision", None),
         )
@@ -351,9 +351,9 @@ class RealtimeService:
         if isinstance(event, (AssistantTextEvent, TokenUsageEvent)):
             is_latest: bool | None
             if wait_for_pending_reopen:
-                is_latest = self.speculative_turns.is_latest_after_pending_reopen(turn_id, turn_revision)
+                is_latest = self.speculative_turns.is_latest_after_reopen_grace(turn_id, turn_revision)
             else:
-                is_latest = self.speculative_turns.try_is_latest_after_pending_reopen(turn_id, turn_revision)
+                is_latest = self.speculative_turns.try_is_latest_after_reopen_grace(turn_id, turn_revision)
             if is_latest is None:
                 return None
             return not is_latest

--- a/src/speech_to_speech/api/openai_realtime/service.py
+++ b/src/speech_to_speech/api/openai_realtime/service.py
@@ -155,6 +155,7 @@ class ConnState(BaseModel):
     current_response_id: Optional[str] = None
     current_item_id: Optional[str] = None
     content_index: int = 0
+    input_content_index: int = 0
     input_audio_duration_s: float = 0.0
     last_item_id: Optional[str] = None
     current_response_params: RealtimeResponseCreateParams | None = None

--- a/src/speech_to_speech/api/openai_realtime/websocket_router.py
+++ b/src/speech_to_speech/api/openai_realtime/websocket_router.py
@@ -22,10 +22,12 @@ from speech_to_speech.pipeline.cancel_scope import CancelScope
 from speech_to_speech.pipeline.control import SESSION_END, PipelineControlMessage, is_control_message
 from speech_to_speech.pipeline.events import (
     AssistantTextEvent,
+    PartialTranscriptionEvent,
     PipelineEvent,
     SpeechStartedEvent,
     SpeechStoppedEvent,
     TokenUsageEvent,
+    TranscriptionCompletedEvent,
 )
 from speech_to_speech.pipeline.messages import AUDIO_RESPONSE_DONE, PIPELINE_END
 from speech_to_speech.pipeline.queue_types import AudioInItem, AudioOutItem, TextEventItem
@@ -52,7 +54,10 @@ def _keep_audio_sentinel(item: Any) -> bool:
 
 
 def _keep_user_text_event(item: Any) -> bool:
-    return isinstance(item, (SpeechStoppedEvent, TokenUsageEvent))
+    return isinstance(
+        item,
+        (SpeechStoppedEvent, PartialTranscriptionEvent, TranscriptionCompletedEvent, TokenUsageEvent),
+    )
 
 
 def create_app(
@@ -100,6 +105,15 @@ def create_app(
         if cancel_scope:
             cancel_scope.reset()
         should_listen.set()
+
+    def _is_latest_turn_event(item: Any) -> bool:
+        if service.speculative_turns is None or not isinstance(item, PipelineEvent):
+            return False
+        turn_id = getattr(item, "turn_id", None)
+        turn_revision = getattr(item, "turn_revision", None)
+        if turn_id is None or turn_revision is None:
+            return False
+        return service.speculative_turns.is_latest(turn_id, turn_revision)
 
     def _to_audio_bytes(chunk: AudioOutItem) -> bytes:
         if isinstance(chunk, PipelineControlMessage):
@@ -242,9 +256,14 @@ def create_app(
                         if is_speech_start and app.state.active_session:
                             was_in_response = service._state(app.state.active_session).in_response
 
+                        drop_text_msg = False
                         if cancel_scope and cancel_scope.discarding and isinstance(text_msg, AssistantTextEvent):
-                            pass
-                        else:
+                            if _is_latest_turn_event(text_msg):
+                                cancel_scope.response_done()
+                            else:
+                                drop_text_msg = True
+
+                        if not drop_text_msg:
                             for cid in service.connection_ids:
                                 ws = app.state.websockets.get(cid)
                                 if ws and isinstance(text_msg, PipelineEvent):

--- a/src/speech_to_speech/api/openai_realtime/websocket_router.py
+++ b/src/speech_to_speech/api/openai_realtime/websocket_router.py
@@ -406,8 +406,11 @@ def create_app(pool: list[PipelineUnit], stop_event: ThreadingEvent) -> FastAPI:
                     is_speech_start = isinstance(text_msg, SpeechStartedEvent)
 
                     was_in_response = False
+                    was_response_pending = False
                     if is_speech_start and session_id:
-                        was_in_response = unit.service._state(session_id).in_response
+                        st = unit.service._state(session_id)
+                        was_in_response = st.in_response
+                        was_response_pending = st.response_pending
 
                     if unit.cancel_scope.discarding and isinstance(text_msg, AssistantTextEvent):
                         pass
@@ -416,15 +419,23 @@ def create_app(pool: list[PipelineUnit], stop_event: ThreadingEvent) -> FastAPI:
                         if events:
                             await _send_events(ws, events)
 
-                    if is_speech_start and was_in_response:
+                    if is_speech_start and (was_in_response or was_response_pending):
                         active_cfg = unit.service._state(session_id).runtime_config if session_id else None
-                        if active_cfg is None or active_cfg.interrupt_response_enabled:
+                        if text_msg.interrupt_response and (
+                            active_cfg is None or active_cfg.interrupt_response_enabled
+                        ):
                             unit.cancel_scope.cancel()
+                            if session_id:
+                                unit.service._state(session_id).response_pending = False
                             _flush_queue(unit.output_queue, preserve=_keep_audio_sentinel)
                             _flush_queue(unit.text_output_queue, preserve=_keep_user_text_event)
                             if unit.response_playing.is_set():
                                 unit.response_playing.clear()
-                            logger.info(f"Pipeline {unit.index}: speech during response: cancelled, queue flushed")
+                            logger.info(
+                                "Pipeline %d: speech during %s: cancelled, queue flushed",
+                                unit.index,
+                                "response" if was_in_response else "pending response",
+                            )
                         else:
                             logger.info(
                                 f"Pipeline {unit.index}: speech during response: interrupt_response disabled, ignoring"
@@ -447,12 +458,16 @@ def create_app(pool: list[PipelineUnit], stop_event: ThreadingEvent) -> FastAPI:
                     if _is_audio_done(audio_chunk):
                         audio_generation = _audio_generation(audio_chunk)
                         if audio_generation is not None and unit.cancel_scope.is_stale(audio_generation):
+                            if session_id:
+                                unit.service._state(session_id).response_pending = False
                             unit.cancel_scope.response_done(audio_generation)
                             unit.should_listen.set()
                             logger.info(f"Pipeline {unit.index}: stale response complete, listening re-enabled")
                             continue
                         if ws is not None and session_id:
                             await _send_events(ws, unit.service.finish_audio_response(session_id))
+                        if session_id:
+                            unit.service._state(session_id).response_pending = False
                         unit.response_playing.clear()
                         unit.cancel_scope.response_done(audio_generation)
                         unit.should_listen.set()

--- a/src/speech_to_speech/api/openai_realtime/websocket_router.py
+++ b/src/speech_to_speech/api/openai_realtime/websocket_router.py
@@ -29,7 +29,7 @@ from speech_to_speech.pipeline.events import (
     TokenUsageEvent,
     TranscriptionCompletedEvent,
 )
-from speech_to_speech.pipeline.messages import AUDIO_RESPONSE_DONE, PIPELINE_END
+from speech_to_speech.pipeline.messages import AUDIO_RESPONSE_DONE, PIPELINE_END, AudioOutput
 from speech_to_speech.pipeline.queue_types import AudioInItem, AudioOutItem, TextEventItem
 
 logger = logging.getLogger(__name__)
@@ -50,7 +50,7 @@ async def _send_events(ws: WebSocket, events: list[ServerEvent]) -> None:
 
 
 def _keep_audio_sentinel(item: Any) -> bool:
-    return isinstance(item, bytes) and item == AUDIO_RESPONSE_DONE
+    return _audio_payload(item) == AUDIO_RESPONSE_DONE
 
 
 def _keep_user_text_event(item: Any) -> bool:
@@ -58,6 +58,14 @@ def _keep_user_text_event(item: Any) -> bool:
         item,
         (SpeechStoppedEvent, PartialTranscriptionEvent, TranscriptionCompletedEvent, TokenUsageEvent),
     )
+
+
+def _audio_payload(item: Any) -> Any:
+    return item.audio if isinstance(item, AudioOutput) else item
+
+
+def _audio_generation(item: Any) -> int | None:
+    return item.cancel_generation if isinstance(item, AudioOutput) else None
 
 
 def create_app(
@@ -116,11 +124,28 @@ def create_app(
         return service.speculative_turns.is_latest(turn_id, turn_revision)
 
     def _to_audio_bytes(chunk: AudioOutItem) -> bytes:
+        chunk = _audio_payload(chunk)
         if isinstance(chunk, PipelineControlMessage):
             raise TypeError(f"unexpected control message on audio output queue: {chunk!r}")
         if isinstance(chunk, np.ndarray) or hasattr(chunk, "tobytes"):
             return chunk.tobytes()
         return chunk
+
+    def _is_audio_done(item: Any) -> bool:
+        return _audio_payload(item) == AUDIO_RESPONSE_DONE
+
+    def _is_pipeline_end(item: Any) -> bool:
+        return isinstance(item, bytes) and item == PIPELINE_END
+
+    def _should_discard_audio(item: Any) -> bool:
+        if cancel_scope is None:
+            return False
+        generation = _audio_generation(item)
+        if generation is not None and cancel_scope.is_stale(generation):
+            return True
+        if cancel_scope.discarding and generation != cancel_scope.generation:
+            return True
+        return False
 
     @asynccontextmanager
     async def lifespan(app: FastAPI) -> AsyncIterator[None]:
@@ -326,14 +351,20 @@ def create_app(
                     else:
                         audio_chunk = output_queue.get_nowait()
 
-                    if isinstance(audio_chunk, bytes) and audio_chunk == PIPELINE_END:
+                    if _is_pipeline_end(audio_chunk):
                         for cid in service.connection_ids:
                             ws = app.state.websockets.get(cid)
                             if ws:
                                 await _send_events(ws, service.finish_audio_response(cid))
                         break
 
-                    if isinstance(audio_chunk, bytes) and audio_chunk == AUDIO_RESPONSE_DONE:
+                    if _is_audio_done(audio_chunk):
+                        audio_generation = _audio_generation(audio_chunk)
+                        if cancel_scope and audio_generation is not None and cancel_scope.is_stale(audio_generation):
+                            cancel_scope.response_done(audio_generation)
+                            should_listen.set()
+                            logger.info("Stale response complete, listening re-enabled")
+                            continue
                         for cid in service.connection_ids:
                             ws = app.state.websockets.get(cid)
                             if ws:
@@ -341,7 +372,7 @@ def create_app(
                         if response_playing:
                             response_playing.clear()
                         if cancel_scope:
-                            cancel_scope.response_done()
+                            cancel_scope.response_done(audio_generation)
                         should_listen.set()
                         logger.info("Response complete, listening re-enabled")
                         continue
@@ -349,7 +380,7 @@ def create_app(
                     if is_control_message(audio_chunk):
                         continue
 
-                    if cancel_scope and cancel_scope.discarding:
+                    if _should_discard_audio(audio_chunk):
                         continue
 
                     audio_chunk = _to_audio_bytes(audio_chunk)
@@ -361,11 +392,14 @@ def create_app(
                         except Empty:
                             break
 
-                        if (
-                            isinstance(next_chunk, bytes) and next_chunk in {PIPELINE_END, AUDIO_RESPONSE_DONE}
-                        ) or is_control_message(next_chunk, SESSION_END.kind):
+                        if _is_pipeline_end(next_chunk) or _is_audio_done(next_chunk) or is_control_message(
+                            next_chunk, SESSION_END.kind
+                        ):
                             pending_output_item = next_chunk
                             break
+
+                        if _should_discard_audio(next_chunk):
+                            continue
 
                         next_audio = _to_audio_bytes(next_chunk)
                         if len(audio_batch) + len(next_audio) > MAX_AUDIO_BATCH_BYTES:

--- a/src/speech_to_speech/api/openai_realtime/websocket_router.py
+++ b/src/speech_to_speech/api/openai_realtime/websocket_router.py
@@ -252,13 +252,17 @@ def create_app(
                                     if events:
                                         await _send_events(ws, events)
 
-                        if is_speech_start and was_in_response:
+                        if is_speech_start and (was_in_response or getattr(text_msg, "reopened", False)):
                             active_cfg = (
                                 service._state(app.state.active_session).runtime_config
                                 if app.state.active_session
                                 else None
                             )
-                            if active_cfg is None or active_cfg.interrupt_response_enabled:
+                            if (
+                                active_cfg is None
+                                or active_cfg.interrupt_response_enabled
+                                or getattr(text_msg, "reopened", False)
+                            ):
                                 if cancel_scope:
                                     cancel_scope.cancel()
                                 _flush_queue(output_queue, preserve=_keep_audio_sentinel)

--- a/src/speech_to_speech/api/openai_realtime/websocket_router.py
+++ b/src/speech_to_speech/api/openai_realtime/websocket_router.py
@@ -483,8 +483,10 @@ def create_app(pool: list[PipelineUnit], stop_event: ThreadingEvent) -> FastAPI:
                         except Empty:
                             break
 
-                        if _is_pipeline_end(next_chunk) or _is_audio_done(next_chunk) or is_control_message(
-                            next_chunk, SESSION_END.kind
+                        if (
+                            _is_pipeline_end(next_chunk)
+                            or _is_audio_done(next_chunk)
+                            or is_control_message(next_chunk, SESSION_END.kind)
                         ):
                             # Only stash if we still have a session; otherwise drop it.
                             if session is not None:

--- a/src/speech_to_speech/api/openai_realtime/websocket_router.py
+++ b/src/speech_to_speech/api/openai_realtime/websocket_router.py
@@ -262,6 +262,7 @@ def create_app(
                             defer_text_msg = True
 
                         is_speech_start = isinstance(text_msg, SpeechStartedEvent)
+                        speech_can_interrupt = is_speech_start and getattr(text_msg, "interrupt_response", True)
 
                         was_in_response = False
                         if is_speech_start and app.state.active_session:
@@ -295,7 +296,7 @@ def create_app(
                             pending_text_item = text_msg
                         elif complete_discard_after_dispatch and cancel_scope:
                             cancel_scope.response_done()
-                        elif is_speech_start and (was_in_response or getattr(text_msg, "reopened", False)):
+                        elif speech_can_interrupt and (was_in_response or getattr(text_msg, "reopened", False)):
                             active_cfg = (
                                 service._state(app.state.active_session).runtime_config
                                 if app.state.active_session

--- a/src/speech_to_speech/api/openai_realtime/websocket_router.py
+++ b/src/speech_to_speech/api/openai_realtime/websocket_router.py
@@ -244,12 +244,23 @@ def create_app(
     async def _send_loop() -> None:
         """Poll pipeline output queues and send to each connected client."""
         pending_output_item = None
+        pending_text_item: PipelineEvent | None = None
         while not stop_event.is_set():
             try:
                 # Process text events first (speech_started cancels active response)
-                if text_output_queue:
+                if text_output_queue or pending_text_item is not None:
                     try:
-                        text_msg = text_output_queue.get_nowait()
+                        if pending_text_item is not None:
+                            text_msg = pending_text_item
+                            pending_text_item = None
+                        else:
+                            text_msg = text_output_queue.get_nowait()
+
+                        defer_text_msg = False
+                        if isinstance(text_msg, PipelineEvent) and service.should_defer_pipeline_event(text_msg):
+                            pending_text_item = text_msg
+                            defer_text_msg = True
+
                         is_speech_start = isinstance(text_msg, SpeechStartedEvent)
 
                         was_in_response = False
@@ -257,21 +268,34 @@ def create_app(
                             was_in_response = service._state(app.state.active_session).in_response
 
                         drop_text_msg = False
-                        if cancel_scope and cancel_scope.discarding and isinstance(text_msg, AssistantTextEvent):
+                        complete_discard_after_dispatch = False
+                        if (
+                            not defer_text_msg
+                            and cancel_scope
+                            and cancel_scope.discarding
+                            and isinstance(text_msg, AssistantTextEvent)
+                        ):
                             if _is_latest_turn_event(text_msg):
-                                cancel_scope.response_done()
+                                complete_discard_after_dispatch = True
                             else:
                                 drop_text_msg = True
 
-                        if not drop_text_msg:
+                        if not drop_text_msg and not defer_text_msg:
                             for cid in service.connection_ids:
                                 ws = app.state.websockets.get(cid)
                                 if ws and isinstance(text_msg, PipelineEvent):
-                                    events = service.dispatch_pipeline_event(cid, text_msg)
+                                    events = service.try_dispatch_pipeline_event(cid, text_msg)
+                                    if events is None:
+                                        defer_text_msg = True
+                                        break
                                     if events:
                                         await _send_events(ws, events)
 
-                        if is_speech_start and (was_in_response or getattr(text_msg, "reopened", False)):
+                        if defer_text_msg:
+                            pending_text_item = text_msg
+                        elif complete_discard_after_dispatch and cancel_scope:
+                            cancel_scope.response_done()
+                        elif is_speech_start and (was_in_response or getattr(text_msg, "reopened", False)):
                             active_cfg = (
                                 service._state(app.state.active_session).runtime_config
                                 if app.state.active_session

--- a/src/speech_to_speech/api/openai_realtime/websocket_router.py
+++ b/src/speech_to_speech/api/openai_realtime/websocket_router.py
@@ -113,6 +113,33 @@ def _flush_queue(q: Queue[QItem], *, preserve: Callable[[QItem], bool] | None = 
             q.not_empty.notify(len(preserved))
 
 
+def _drain_pending_token_usage(unit: PipelineUnit, session_id: str | None) -> None:
+    if session_id is None:
+        return
+
+    preserved: list[Any] = []
+    drained = 0
+    while True:
+        try:
+            item = unit.text_output_queue.get_nowait()
+        except Empty:
+            break
+        if isinstance(item, TokenUsageEvent):
+            unit.service.dispatch_pipeline_event(session_id, item)
+            drained += 1
+        else:
+            preserved.append(item)
+
+    if preserved:
+        with unit.text_output_queue.mutex:
+            for item in reversed(preserved):
+                unit.text_output_queue.queue.appendleft(item)
+            unit.text_output_queue.not_empty.notify(len(preserved))
+
+    if drained:
+        logger.debug("Pipeline %d: drained %d token usage event(s) before response completion", unit.index, drained)
+
+
 def _clean_unit(unit: PipelineUnit, preserve: Callable[[Any], bool] | None = None) -> None:
     """Cancel in-flight work and flush queues for a single pipeline unit.
 
@@ -464,6 +491,7 @@ def create_app(pool: list[PipelineUnit], stop_event: ThreadingEvent) -> FastAPI:
                             unit.should_listen.set()
                             logger.info(f"Pipeline {unit.index}: stale response complete, listening re-enabled")
                             continue
+                        _drain_pending_token_usage(unit, session_id)
                         if ws is not None and session_id:
                             await _send_events(ws, unit.service.finish_audio_response(session_id))
                         if session_id:

--- a/src/speech_to_speech/api/openai_realtime/websocket_router.py
+++ b/src/speech_to_speech/api/openai_realtime/websocket_router.py
@@ -251,7 +251,7 @@ def create_app(
                 if text_output_queue or pending_text_item is not None:
                     try:
                         if pending_text_item is not None:
-                            text_msg = pending_text_item
+                            text_msg: TextEventItem = pending_text_item
                             pending_text_item = None
                         else:
                             text_msg = text_output_queue.get_nowait()
@@ -291,7 +291,7 @@ def create_app(
                                     if events:
                                         await _send_events(ws, events)
 
-                        if defer_text_msg:
+                        if defer_text_msg and isinstance(text_msg, PipelineEvent):
                             pending_text_item = text_msg
                         elif complete_discard_after_dispatch and cancel_scope:
                             cancel_scope.response_done()

--- a/src/speech_to_speech/arguments_classes/module_arguments.py
+++ b/src/speech_to_speech/arguments_classes/module_arguments.py
@@ -51,8 +51,8 @@ class ModuleArguments:
         },
     )
     live_transcription_update_interval: float = field(
-        default=0.25,
-        metadata={"help": "Update interval for live transcription in seconds (default: 0.25s = 250ms)"},
+        default=0.5,
+        metadata={"help": "Update interval for live transcription in seconds (default: 0.5s = 500ms)"},
     )
     live_transcription_min_silence_ms: int = field(
         default=500,

--- a/src/speech_to_speech/arguments_classes/vad_arguments.py
+++ b/src/speech_to_speech/arguments_classes/vad_arguments.py
@@ -56,7 +56,7 @@ class VADHandlerArguments:
         },
     )
     speculative_reopen_ms: int = field(
-        default=1200,
+        default=1000,
         metadata={
             "help": "In realtime mode, keep a soft-ended turn reopenable for this many milliseconds unless a response commits it."
         },

--- a/src/speech_to_speech/arguments_classes/vad_arguments.py
+++ b/src/speech_to_speech/arguments_classes/vad_arguments.py
@@ -50,9 +50,9 @@ class VADHandlerArguments:
         metadata={"help": "Enable progressive audio release for live transcription during speech. Default is False."},
     )
     realtime_processing_pause: float = field(
-        default=0.2,
+        default=0.5,
         metadata={
-            "help": "Interval (in seconds) for releasing progressive audio chunks during speech. Default is 0.2s."
+            "help": "Interval (in seconds) for releasing progressive audio chunks during speech. Default is 0.5s."
         },
     )
     speculative_reopen_ms: int = field(

--- a/src/speech_to_speech/arguments_classes/vad_arguments.py
+++ b/src/speech_to_speech/arguments_classes/vad_arguments.py
@@ -18,7 +18,7 @@ class VADHandlerArguments:
     min_silence_ms: int = field(
         default=300,
         metadata={
-            "help": "Minimum length of silence intervals to be used for segmenting speech. Measured in milliseconds. Default is 250 ms."
+            "help": "Minimum length of silence intervals to be used for segmenting speech. Measured in milliseconds. Default is 300 ms."
         },
     )
     min_speech_ms: int = field(

--- a/src/speech_to_speech/arguments_classes/vad_arguments.py
+++ b/src/speech_to_speech/arguments_classes/vad_arguments.py
@@ -55,3 +55,9 @@ class VADHandlerArguments:
             "help": "Interval (in seconds) for releasing progressive audio chunks during speech. Default is 0.2s."
         },
     )
+    speculative_reopen_ms: int = field(
+        default=1200,
+        metadata={
+            "help": "In realtime mode, keep a soft-ended turn reopenable for this many milliseconds unless a response commits it."
+        },
+    )

--- a/src/speech_to_speech/arguments_classes/vad_arguments.py
+++ b/src/speech_to_speech/arguments_classes/vad_arguments.py
@@ -22,9 +22,9 @@ class VADHandlerArguments:
         },
     )
     min_speech_ms: int = field(
-        default=500,
+        default=384,
         metadata={
-            "help": "Minimum length of speech segments to be considered valid speech. Measured in milliseconds. Default is 500 ms."
+            "help": "Minimum length of speech segments to be considered valid speech. Measured in milliseconds. Default is 384 ms."
         },
     )
     max_speech_ms: float = field(

--- a/src/speech_to_speech/baseHandler.py
+++ b/src/speech_to_speech/baseHandler.py
@@ -47,6 +47,12 @@ class BaseHandler(Generic[InT, OutT]):
     def process(self, input: InT) -> Iterator[OutT]:
         raise NotImplementedError
 
+    def should_process_input(self, item: InT) -> bool:
+        return True
+
+    def should_emit_output(self, output: OutT) -> bool:
+        return True
+
     def run(self) -> None:
         logger.debug(f"{self.__class__.__name__}: Handler thread started")
         while not self.stop_event.is_set():
@@ -77,9 +83,16 @@ class BaseHandler(Generic[InT, OutT]):
                 logger.warning("%s: unexpected control message kind: %s", self.__class__.__name__, item.kind)
                 continue
 
+            typed_item = cast(InT, item)
+            if not self.should_process_input(typed_item):
+                continue
+
             start_time = perf_counter()
             try:
-                for output in self.process(cast(InT, item)):
+                for output in self.process(typed_item):
+                    if not self.should_emit_output(output):
+                        start_time = perf_counter()
+                        continue
                     self._times.append(perf_counter() - start_time)
                     if self.should_log_timing(output):
                         logger.log(self.timing_log_level, "%s: %.3f s", self.__class__.__name__, self.last_time)

--- a/src/speech_to_speech/baseHandler.py
+++ b/src/speech_to_speech/baseHandler.py
@@ -8,6 +8,8 @@ from threading import Event
 from time import perf_counter
 from typing import Any, Generic, Iterator, TypeVar, cast
 
+import numpy as np
+
 from speech_to_speech.pipeline.control import PipelineControlMessage, is_control_message, SESSION_END
 from speech_to_speech.pipeline.log_context import pipeline_log_ctx
 from speech_to_speech.pipeline.messages import PIPELINE_END, AudioOutput, EndOfResponse
@@ -75,7 +77,8 @@ class BaseHandler(Generic[InT, OutT]):
     def output_for_queue(self, output: OutT, source_input: InT) -> OutT | AudioOutput:
         cancel_generation = getattr(source_input, "cancel_generation", None)
         if cancel_generation is not None and (isinstance(output, bytes) or hasattr(output, "tobytes")):
-            return AudioOutput(audio=output, cancel_generation=cancel_generation)
+            audio = cast(bytes | np.ndarray, output)
+            return AudioOutput(audio=audio, cancel_generation=cancel_generation)
         return output
 
     def run(self) -> None:
@@ -124,7 +127,11 @@ class BaseHandler(Generic[InT, OutT]):
                     if self.should_log_timing(output):
                         logger.log(self.timing_log_level, "%s: %.3f s", self.__class__.__name__, self.last_time)
                     self.before_emit_output(output)
-                    self.queue_out.put(self.output_for_queue(output, typed_item))
+                    queued_output = cast(
+                        OutT | PipelineControlMessage | bytes,
+                        self.output_for_queue(output, typed_item),
+                    )
+                    self.queue_out.put(queued_output)
                     start_time = perf_counter()
             except Exception as e:
                 logger.error(f"{self.__class__.__name__}: Error in process(): {type(e).__name__}: {e}", exc_info=True)

--- a/src/speech_to_speech/baseHandler.py
+++ b/src/speech_to_speech/baseHandler.py
@@ -53,6 +53,9 @@ class BaseHandler(Generic[InT, OutT]):
     def should_emit_output(self, output: OutT) -> bool:
         return True
 
+    def before_emit_output(self, output: OutT) -> None:
+        pass
+
     def run(self) -> None:
         logger.debug(f"{self.__class__.__name__}: Handler thread started")
         while not self.stop_event.is_set():
@@ -96,6 +99,7 @@ class BaseHandler(Generic[InT, OutT]):
                     self._times.append(perf_counter() - start_time)
                     if self.should_log_timing(output):
                         logger.log(self.timing_log_level, "%s: %.3f s", self.__class__.__name__, self.last_time)
+                    self.before_emit_output(output)
                     self.queue_out.put(output)
                     start_time = perf_counter()
             except Exception as e:

--- a/src/speech_to_speech/baseHandler.py
+++ b/src/speech_to_speech/baseHandler.py
@@ -9,7 +9,7 @@ from time import perf_counter
 from typing import Any, Generic, Iterator, TypeVar, cast
 
 from speech_to_speech.pipeline.control import PipelineControlMessage, is_control_message, SESSION_END
-from speech_to_speech.pipeline.messages import PIPELINE_END
+from speech_to_speech.pipeline.messages import PIPELINE_END, AudioOutput, EndOfResponse
 
 logger = logging.getLogger(__name__)
 
@@ -48,6 +48,20 @@ class BaseHandler(Generic[InT, OutT]):
         raise NotImplementedError
 
     def should_process_input(self, item: InT) -> bool:
+        cancel_scope = getattr(self, "cancel_scope", None)
+        cancel_generation = getattr(item, "cancel_generation", None)
+        if (
+            cancel_scope is not None
+            and cancel_generation is not None
+            and not isinstance(item, EndOfResponse)
+            and cancel_scope.is_stale(cancel_generation)
+        ):
+            logger.debug(
+                "%s: dropping stale input for cancel generation %s",
+                self.__class__.__name__,
+                cancel_generation,
+            )
+            return False
         return True
 
     def should_emit_output(self, output: OutT) -> bool:
@@ -55,6 +69,12 @@ class BaseHandler(Generic[InT, OutT]):
 
     def before_emit_output(self, output: OutT) -> None:
         pass
+
+    def output_for_queue(self, output: OutT, source_input: InT) -> OutT | AudioOutput:
+        cancel_generation = getattr(source_input, "cancel_generation", None)
+        if cancel_generation is not None and (isinstance(output, bytes) or hasattr(output, "tobytes")):
+            return AudioOutput(audio=output, cancel_generation=cancel_generation)
+        return output
 
     def run(self) -> None:
         logger.debug(f"{self.__class__.__name__}: Handler thread started")
@@ -100,7 +120,7 @@ class BaseHandler(Generic[InT, OutT]):
                     if self.should_log_timing(output):
                         logger.log(self.timing_log_level, "%s: %.3f s", self.__class__.__name__, self.last_time)
                     self.before_emit_output(output)
-                    self.queue_out.put(output)
+                    self.queue_out.put(self.output_for_queue(output, typed_item))
                     start_time = perf_counter()
             except Exception as e:
                 logger.error(f"{self.__class__.__name__}: Error in process(): {type(e).__name__}: {e}", exc_info=True)

--- a/src/speech_to_speech/pipeline/cancel_scope.py
+++ b/src/speech_to_speech/pipeline/cancel_scope.py
@@ -13,6 +13,7 @@ class CancelScope:
     def __init__(self) -> None:
         self._gen: int = 0
         self._discarding: bool = False
+        self._discarded_generation: int | None = None
 
     @property
     def generation(self) -> int:
@@ -27,17 +28,26 @@ class CancelScope:
         generation as stale) and enables the send-loop discard guard.
         """
         # prevent overflow... after 4 billion generations, we'll wrap around xD...
+        self._discarded_generation = self._gen
         self._gen = (self._gen + 1) & 0xFFFFFFFF
         self._discarding = True
 
-    def response_done(self) -> None:
+    def response_done(self, generation: int | None = None) -> None:
         """Pipeline acknowledged completion.  Clears the discard guard."""
+        if (
+            generation is not None
+            and self._discarded_generation is not None
+            and generation not in {self._discarded_generation, self._gen}
+        ):
+            return
         self._discarding = False
+        self._discarded_generation = None
 
     def new_response(self) -> None:
         """An explicit ``response.create`` starts a new response.
         Clears the discard guard."""
         self._discarding = False
+        self._discarded_generation = None
 
     def is_stale(self, gen: int) -> bool:
         """Return True if *gen* has been superseded by a ``cancel`` call."""
@@ -51,3 +61,4 @@ class CancelScope:
     def reset(self) -> None:
         """Clear discard state (e.g. on new session connect)."""
         self._discarding = False
+        self._discarded_generation = None

--- a/src/speech_to_speech/pipeline/events.py
+++ b/src/speech_to_speech/pipeline/events.py
@@ -30,12 +30,17 @@ class PipelineEvent(BaseModel):
 class SpeechStartedEvent(PipelineEvent):
     type: Literal["speech_started"] = "speech_started"
     audio_start_ms: int = 0
+    turn_id: str | None = None
+    turn_revision: int | None = None
+    reopened: bool = False
 
 
 class SpeechStoppedEvent(PipelineEvent):
     type: Literal["speech_stopped"] = "speech_stopped"
     duration_s: float = 0.0
     audio_end_ms: int = 0
+    turn_id: str | None = None
+    turn_revision: int | None = None
 
 
 # ── Transcription events (TranscriptionNotifier) ─────────────────────
@@ -44,12 +49,16 @@ class SpeechStoppedEvent(PipelineEvent):
 class PartialTranscriptionEvent(PipelineEvent):
     type: Literal["partial_transcription"] = "partial_transcription"
     delta: str
+    turn_id: str | None = None
+    turn_revision: int | None = None
 
 
 class TranscriptionCompletedEvent(PipelineEvent):
     type: Literal["transcription_completed"] = "transcription_completed"
     transcript: str
     language_code: Optional[str] = None
+    turn_id: str | None = None
+    turn_revision: int | None = None
 
 
 # ── LLM output events (LMOutputProcessor) ────────────────────────────
@@ -59,9 +68,13 @@ class AssistantTextEvent(PipelineEvent):
     type: Literal["assistant_text"] = "assistant_text"
     text: str
     tools: list[ResponseFunctionToolCall] = Field(default_factory=list)
+    turn_id: str | None = None
+    turn_revision: int | None = None
 
 
 class TokenUsageEvent(PipelineEvent):
     type: Literal["token_usage"] = "token_usage"
     input_tokens: int = 0
     output_tokens: int = 0
+    turn_id: str | None = None
+    turn_revision: int | None = None

--- a/src/speech_to_speech/pipeline/events.py
+++ b/src/speech_to_speech/pipeline/events.py
@@ -33,6 +33,7 @@ class SpeechStartedEvent(PipelineEvent):
     turn_id: str | None = None
     turn_revision: int | None = None
     reopened: bool = False
+    interrupt_response: bool = Field(default=True, exclude=True)
 
 
 class SpeechStoppedEvent(PipelineEvent):

--- a/src/speech_to_speech/pipeline/events.py
+++ b/src/speech_to_speech/pipeline/events.py
@@ -60,6 +60,7 @@ class TranscriptionCompletedEvent(PipelineEvent):
     language_code: Optional[str] = None
     turn_id: str | None = None
     turn_revision: int | None = None
+    speech_stopped_at_s: float | None = Field(default=None, exclude=True)
 
 
 # ── LLM output events (LMOutputProcessor) ────────────────────────────

--- a/src/speech_to_speech/pipeline/handler_types.py
+++ b/src/speech_to_speech/pipeline/handler_types.py
@@ -14,6 +14,7 @@ from typing import TypeAlias
 import numpy as np
 
 from speech_to_speech.pipeline.messages import (
+    AudioOutput,
     EndOfResponse,
     GenerateResponseRequest,
     LLMResponseChunk,
@@ -40,4 +41,4 @@ LLMOut: TypeAlias = LLMResponseChunk | TokenUsage | EndOfResponse
 
 # ── TTS stage ─────────────────────────────────────────────────────────
 TTSIn: TypeAlias = TTSInput | EndOfResponse
-TTSOut: TypeAlias = bytes | np.ndarray
+TTSOut: TypeAlias = bytes | np.ndarray | AudioOutput

--- a/src/speech_to_speech/pipeline/messages.py
+++ b/src/speech_to_speech/pipeline/messages.py
@@ -85,6 +85,7 @@ class LLMResponseChunk(PipelineMessage):
     turn_id: str | None = None
     turn_revision: int | None = None
     speech_stopped_at_s: float | None = None
+    cancel_generation: int | None = None
 
 
 class TokenUsage(PipelineMessage):
@@ -103,6 +104,7 @@ class EndOfResponse(PipelineMessage):
     tag: Literal["end_of_response"] = "end_of_response"
     turn_id: str | None = None
     turn_revision: int | None = None
+    cancel_generation: int | None = None
 
 
 # ── LMOutputProcessor → TTS ──────────────────────────────────────────
@@ -119,6 +121,15 @@ class TTSInput(PipelineMessage):
     turn_id: str | None = None
     turn_revision: int | None = None
     speech_stopped_at_s: float | None = None
+    cancel_generation: int | None = None
+
+
+class AudioOutput(PipelineMessage):
+    """Audio queue item tagged with the response generation that produced it."""
+
+    tag: Literal["audio_output"] = "audio_output"
+    audio: bytes | np.ndarray
+    cancel_generation: int | None = None
 
 
 # ── Realtime service → LLM ────────────────────────────────────────────

--- a/src/speech_to_speech/pipeline/messages.py
+++ b/src/speech_to_speech/pipeline/messages.py
@@ -67,6 +67,7 @@ class Transcription(PipelineMessage):
     language_code: Optional[str] = None
     turn_id: str | None = None
     turn_revision: int | None = None
+    speech_stopped_at_s: float | None = None
 
 
 # ── LLM → LMOutputProcessor ──────────────────────────────────────────
@@ -83,6 +84,7 @@ class LLMResponseChunk(PipelineMessage):
     response: RealtimeResponseCreateParams | None = None
     turn_id: str | None = None
     turn_revision: int | None = None
+    speech_stopped_at_s: float | None = None
 
 
 class TokenUsage(PipelineMessage):
@@ -116,6 +118,7 @@ class TTSInput(PipelineMessage):
     response: RealtimeResponseCreateParams | None = None
     turn_id: str | None = None
     turn_revision: int | None = None
+    speech_stopped_at_s: float | None = None
 
 
 # ── Realtime service → LLM ────────────────────────────────────────────
@@ -138,6 +141,7 @@ class GenerateResponseRequest(PipelineMessage):
     language_code: Optional[str] = None
     turn_id: str | None = None
     turn_revision: int | None = None
+    speech_stopped_at_s: float | None = None
 
 
 # ── Binary sentinels (audio/output queue) ─────────────────────────────

--- a/src/speech_to_speech/pipeline/messages.py
+++ b/src/speech_to_speech/pipeline/messages.py
@@ -41,6 +41,8 @@ class VADAudio(PipelineMessage):
     tag: Literal["vad_audio"] = "vad_audio"
     audio: np.ndarray
     mode: Literal["progressive", "final"] | None = None
+    turn_id: str | None = None
+    turn_revision: int | None = None
 
 
 # ── STT → TranscriptionNotifier → LLM ────────────────────────────────
@@ -51,6 +53,8 @@ class PartialTranscription(PipelineMessage):
 
     tag: Literal["partial_transcription"] = "partial_transcription"
     text: str
+    turn_id: str | None = None
+    turn_revision: int | None = None
 
 
 class Transcription(PipelineMessage):
@@ -59,6 +63,8 @@ class Transcription(PipelineMessage):
     tag: Literal["transcription"] = "transcription"
     text: str
     language_code: Optional[str] = None
+    turn_id: str | None = None
+    turn_revision: int | None = None
 
 
 # ── LLM → LMOutputProcessor ──────────────────────────────────────────
@@ -73,6 +79,8 @@ class LLMResponseChunk(PipelineMessage):
     tools: list[ResponseFunctionToolCall] = Field(default_factory=list)
     runtime_config: RuntimeConfig | None = None
     response: RealtimeResponseCreateParams | None = None
+    turn_id: str | None = None
+    turn_revision: int | None = None
 
 
 class TokenUsage(PipelineMessage):
@@ -81,12 +89,16 @@ class TokenUsage(PipelineMessage):
     tag: Literal["token_usage"] = "token_usage"
     input_tokens: int
     output_tokens: int
+    turn_id: str | None = None
+    turn_revision: int | None = None
 
 
 class EndOfResponse(PipelineMessage):
     """Sentinel marking the end of a response."""
 
     tag: Literal["end_of_response"] = "end_of_response"
+    turn_id: str | None = None
+    turn_revision: int | None = None
 
 
 # ── LMOutputProcessor → TTS ──────────────────────────────────────────
@@ -100,6 +112,8 @@ class TTSInput(PipelineMessage):
     language_code: Optional[str] = None
     runtime_config: RuntimeConfig | None = None
     response: RealtimeResponseCreateParams | None = None
+    turn_id: str | None = None
+    turn_revision: int | None = None
 
 
 # ── Realtime service → LLM ────────────────────────────────────────────
@@ -120,6 +134,8 @@ class GenerateResponseRequest(PipelineMessage):
     runtime_config: RuntimeConfig
     response: RealtimeResponseCreateParams | None = None
     language_code: Optional[str] = None
+    turn_id: str | None = None
+    turn_revision: int | None = None
 
 
 # ── Binary sentinels (audio/output queue) ─────────────────────────────

--- a/src/speech_to_speech/pipeline/messages.py
+++ b/src/speech_to_speech/pipeline/messages.py
@@ -8,6 +8,7 @@ constants.
 
 from __future__ import annotations
 
+from time import perf_counter
 from typing import Final, Literal, Optional, TypeAlias
 
 import numpy as np
@@ -43,6 +44,7 @@ class VADAudio(PipelineMessage):
     mode: Literal["progressive", "final"] | None = None
     turn_id: str | None = None
     turn_revision: int | None = None
+    created_at_s: float = Field(default_factory=perf_counter)
 
 
 # ── STT → TranscriptionNotifier → LLM ────────────────────────────────

--- a/src/speech_to_speech/pipeline/queue_types.py
+++ b/src/speech_to_speech/pipeline/queue_types.py
@@ -15,6 +15,7 @@ import numpy as np
 from speech_to_speech.pipeline.control import PipelineControlMessage
 from speech_to_speech.pipeline.events import PipelineEvent
 from speech_to_speech.pipeline.handler_types import LLMIn, LLMOut, STTOut, TTSIn, VADIn, VADOut
+from speech_to_speech.pipeline.messages import AudioOutput
 
 # Use plain ``bytes`` for sentinel values on queues (``PIPELINE_END``, ``AUDIO_RESPONSE_DONE``).
 # ``Queue`` is invariant; ``Literal[b"END"]`` is not accepted where ``bytes`` is required.
@@ -39,7 +40,7 @@ LMOutItem: TypeAlias = LLMOut | PipelineInternalItem
 TTSInItem: TypeAlias = TTSIn | PipelineInternalItem
 
 # Audio outputs flowing to speakers / client (includes sentinels as bytes).
-AudioOutItem: TypeAlias = bytes | np.ndarray | PipelineControlMessage
+AudioOutItem: TypeAlias = bytes | np.ndarray | AudioOutput | PipelineControlMessage
 
 # Side-channel text events sent to websocket/realtime clients.
 TextEventItem: TypeAlias = PipelineEvent | PipelineInternalItem

--- a/src/speech_to_speech/pipeline/speculative_turns.py
+++ b/src/speech_to_speech/pipeline/speculative_turns.py
@@ -1,0 +1,53 @@
+from __future__ import annotations
+
+import logging
+from threading import Lock
+
+logger = logging.getLogger(__name__)
+
+
+class SpeculativeTurnTracker:
+    """Thread-safe revision tracker for raw-audio speculative turns."""
+
+    def __init__(self) -> None:
+        self._lock = Lock()
+        self._latest_revision: dict[str, int] = {}
+        self._committed_revision: dict[str, int] = {}
+
+    def observe(self, turn_id: str | None, revision: int | None) -> None:
+        if turn_id is None or revision is None:
+            return
+        with self._lock:
+            current = self._latest_revision.get(turn_id, -1)
+            if revision > current:
+                self._latest_revision[turn_id] = revision
+                logger.debug("Observed speculative turn %s revision %d", turn_id, revision)
+
+    def is_latest(self, turn_id: str | None, revision: int | None) -> bool:
+        if turn_id is None or revision is None:
+            return True
+        with self._lock:
+            return self._latest_revision.get(turn_id, revision) == revision
+
+    def commit(self, turn_id: str | None, revision: int | None) -> None:
+        if turn_id is None or revision is None:
+            return
+        with self._lock:
+            latest = self._latest_revision.get(turn_id, revision)
+            if revision == latest:
+                self._committed_revision[turn_id] = revision
+                logger.debug("Committed speculative turn %s revision %d", turn_id, revision)
+
+    def is_committed(self, turn_id: str | None, revision: int | None = None) -> bool:
+        if turn_id is None:
+            return False
+        with self._lock:
+            committed = self._committed_revision.get(turn_id)
+            if committed is None:
+                return False
+            return revision is None or committed >= revision
+
+    def reset(self) -> None:
+        with self._lock:
+            self._latest_revision.clear()
+            self._committed_revision.clear()

--- a/src/speech_to_speech/pipeline/speculative_turns.py
+++ b/src/speech_to_speech/pipeline/speculative_turns.py
@@ -1,53 +1,171 @@
 from __future__ import annotations
 
 import logging
-from threading import Lock
+import time
+from dataclasses import dataclass
+from threading import Condition
 
 logger = logging.getLogger(__name__)
+
+
+@dataclass(frozen=True)
+class _PendingReopen:
+    base_revision: int
+    candidate_revision: int
 
 
 class SpeculativeTurnTracker:
     """Thread-safe revision tracker for raw-audio speculative turns."""
 
+    _PENDING_REOPEN_WAIT_TIMEOUT_S = 2.0
+
     def __init__(self) -> None:
-        self._lock = Lock()
+        self._condition = Condition()
         self._latest_revision: dict[str, int] = {}
         self._committed_revision: dict[str, int] = {}
+        self._pending_reopen: dict[str, _PendingReopen] = {}
 
     def observe(self, turn_id: str | None, revision: int | None) -> None:
         if turn_id is None or revision is None:
             return
-        with self._lock:
+        with self._condition:
             current = self._latest_revision.get(turn_id, -1)
             if revision > current:
                 self._latest_revision[turn_id] = revision
                 logger.debug("Observed speculative turn %s revision %d", turn_id, revision)
+                self._condition.notify_all()
 
     def is_latest(self, turn_id: str | None, revision: int | None) -> bool:
         if turn_id is None or revision is None:
             return True
-        with self._lock:
+        with self._condition:
             return self._latest_revision.get(turn_id, revision) == revision
 
     def commit(self, turn_id: str | None, revision: int | None) -> None:
         if turn_id is None or revision is None:
             return
-        with self._lock:
+        with self._condition:
+            pending = self._pending_reopen.get(turn_id)
+            if pending is not None and pending.base_revision == revision:
+                logger.debug("Deferring speculative turn %s revision %d commit while reopen is pending", turn_id, revision)
+                return
             latest = self._latest_revision.get(turn_id, revision)
             if revision == latest:
                 self._committed_revision[turn_id] = revision
                 logger.debug("Committed speculative turn %s revision %d", turn_id, revision)
+                self._condition.notify_all()
 
     def is_committed(self, turn_id: str | None, revision: int | None = None) -> bool:
         if turn_id is None:
             return False
-        with self._lock:
+        with self._condition:
             committed = self._committed_revision.get(turn_id)
             if committed is None:
                 return False
             return revision is None or committed >= revision
 
+    def begin_reopen_candidate(self, turn_id: str | None, revision: int | None) -> int | None:
+        if turn_id is None or revision is None:
+            return None
+        with self._condition:
+            if self._committed_revision.get(turn_id, -1) >= revision:
+                return None
+            if self._latest_revision.get(turn_id, revision) != revision:
+                return None
+
+            pending = self._pending_reopen.get(turn_id)
+            if pending is not None:
+                if pending.base_revision == revision:
+                    return pending.candidate_revision
+                return None
+
+            candidate_revision = revision + 1
+            self._pending_reopen[turn_id] = _PendingReopen(
+                base_revision=revision,
+                candidate_revision=candidate_revision,
+            )
+            logger.debug(
+                "Started speculative reopen candidate for turn %s revision %d -> %d",
+                turn_id,
+                revision,
+                candidate_revision,
+            )
+            self._condition.notify_all()
+            return candidate_revision
+
+    def confirm_reopen_candidate(
+        self,
+        turn_id: str | None,
+        base_revision: int | None,
+        candidate_revision: int | None,
+    ) -> bool:
+        if turn_id is None or base_revision is None or candidate_revision is None:
+            return False
+        with self._condition:
+            pending = self._pending_reopen.get(turn_id)
+            if (
+                pending is None
+                or pending.base_revision != base_revision
+                or pending.candidate_revision != candidate_revision
+            ):
+                return False
+            if self._committed_revision.get(turn_id, -1) >= base_revision:
+                del self._pending_reopen[turn_id]
+                self._condition.notify_all()
+                return False
+            if self._latest_revision.get(turn_id, base_revision) != base_revision:
+                del self._pending_reopen[turn_id]
+                self._condition.notify_all()
+                return False
+
+            self._latest_revision[turn_id] = candidate_revision
+            del self._pending_reopen[turn_id]
+            logger.debug(
+                "Confirmed speculative reopen candidate for turn %s revision %d",
+                turn_id,
+                candidate_revision,
+            )
+            self._condition.notify_all()
+            return True
+
+    def cancel_reopen_candidate(self, turn_id: str | None, candidate_revision: int | None = None) -> None:
+        if turn_id is None:
+            return
+        with self._condition:
+            pending = self._pending_reopen.get(turn_id)
+            if pending is None:
+                return
+            if candidate_revision is not None and pending.candidate_revision != candidate_revision:
+                return
+            del self._pending_reopen[turn_id]
+            logger.debug("Cancelled speculative reopen candidate for turn %s", turn_id)
+            self._condition.notify_all()
+
+    def wait_for_pending_reopen(
+        self,
+        turn_id: str | None,
+        revision: int | None,
+        timeout_s: float = _PENDING_REOPEN_WAIT_TIMEOUT_S,
+    ) -> None:
+        if turn_id is None or revision is None:
+            return
+        deadline = time.monotonic() + timeout_s
+        with self._condition:
+            pending = self._pending_reopen.get(turn_id)
+            if pending is None or pending.base_revision != revision:
+                return
+            logger.debug("Waiting for pending speculative reopen turn=%s rev=%s", turn_id, revision)
+            while pending is not None and pending.base_revision == revision:
+                remaining = deadline - time.monotonic()
+                if remaining <= 0:
+                    logger.warning("Timed out waiting for pending speculative reopen turn=%s rev=%s", turn_id, revision)
+                    return
+                self._condition.wait(remaining)
+                pending = self._pending_reopen.get(turn_id)
+
     def reset(self) -> None:
-        with self._lock:
+        with self._condition:
             self._latest_revision.clear()
             self._committed_revision.clear()
+            self._pending_reopen.clear()
+            self._condition.notify_all()

--- a/src/speech_to_speech/pipeline/speculative_turns.py
+++ b/src/speech_to_speech/pipeline/speculative_turns.py
@@ -46,6 +46,26 @@ class SpeculativeTurnTracker:
         with self._condition:
             return self._latest_revision.get(turn_id, revision) == revision
 
+    def is_latest_after_pending_reopen(self, turn_id: str | None, revision: int | None) -> bool:
+        if turn_id is None or revision is None:
+            return True
+        with self._condition:
+            self._wait_for_pending_reopen_locked(turn_id, revision, self._PENDING_REOPEN_WAIT_TIMEOUT_S)
+            return self._latest_revision.get(turn_id, revision) == revision
+
+    def commit_if_latest_after_pending_reopen(self, turn_id: str | None, revision: int | None) -> bool:
+        if turn_id is None or revision is None:
+            return True
+        with self._condition:
+            self._wait_for_pending_reopen_locked(turn_id, revision, self._PENDING_REOPEN_WAIT_TIMEOUT_S)
+            latest = self._latest_revision.get(turn_id, revision)
+            if revision != latest:
+                return False
+            self._committed_revision[turn_id] = revision
+            logger.debug("Committed speculative turn %s revision %d", turn_id, revision)
+            self._condition.notify_all()
+            return True
+
     def commit(self, turn_id: str | None, revision: int | None) -> None:
         if turn_id is None or revision is None:
             return
@@ -161,23 +181,26 @@ class SpeculativeTurnTracker:
     ) -> None:
         if turn_id is None or revision is None:
             return
-        deadline = time.monotonic() + timeout_s
         with self._condition:
-            pending = self._pending_reopen.get(turn_id)
-            if pending is None or pending.base_revision != revision:
+            self._wait_for_pending_reopen_locked(turn_id, revision, timeout_s)
+
+    def _wait_for_pending_reopen_locked(self, turn_id: str, revision: int, timeout_s: float) -> None:
+        deadline = time.monotonic() + timeout_s
+        pending = self._pending_reopen.get(turn_id)
+        if pending is None or pending.base_revision != revision:
+            return
+        logger.debug("Waiting for pending speculative reopen turn=%s rev=%s", turn_id, revision)
+        while pending is not None and pending.base_revision == revision:
+            remaining = deadline - time.monotonic()
+            if remaining <= 0:
+                logger.warning("Timed out waiting for pending speculative reopen turn=%s rev=%s", turn_id, revision)
+                if self._pending_reopen.get(turn_id) == pending:
+                    del self._pending_reopen[turn_id]
+                    self._prune_tracked_turns()
+                    self._condition.notify_all()
                 return
-            logger.debug("Waiting for pending speculative reopen turn=%s rev=%s", turn_id, revision)
-            while pending is not None and pending.base_revision == revision:
-                remaining = deadline - time.monotonic()
-                if remaining <= 0:
-                    logger.warning("Timed out waiting for pending speculative reopen turn=%s rev=%s", turn_id, revision)
-                    if self._pending_reopen.get(turn_id) == pending:
-                        del self._pending_reopen[turn_id]
-                        self._prune_tracked_turns()
-                        self._condition.notify_all()
-                    return
-                self._condition.wait(remaining)
-                pending = self._pending_reopen.get(turn_id)
+            self._condition.wait(remaining)
+            pending = self._pending_reopen.get(turn_id)
 
     def _prune_tracked_turns(self) -> None:
         if self._max_tracked_turns <= 0:

--- a/src/speech_to_speech/pipeline/speculative_turns.py
+++ b/src/speech_to_speech/pipeline/speculative_turns.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 import logging
 import time
+from collections import OrderedDict
 from dataclasses import dataclass
 from threading import Condition
 
@@ -18,10 +19,12 @@ class SpeculativeTurnTracker:
     """Thread-safe revision tracker for raw-audio speculative turns."""
 
     _PENDING_REOPEN_WAIT_TIMEOUT_S = 2.0
+    _MAX_TRACKED_TURNS = 2048
 
-    def __init__(self) -> None:
+    def __init__(self, max_tracked_turns: int = _MAX_TRACKED_TURNS) -> None:
         self._condition = Condition()
-        self._latest_revision: dict[str, int] = {}
+        self._max_tracked_turns = max_tracked_turns
+        self._latest_revision: OrderedDict[str, int] = OrderedDict()
         self._committed_revision: dict[str, int] = {}
         self._pending_reopen: dict[str, _PendingReopen] = {}
 
@@ -32,6 +35,8 @@ class SpeculativeTurnTracker:
             current = self._latest_revision.get(turn_id, -1)
             if revision > current:
                 self._latest_revision[turn_id] = revision
+                self._latest_revision.move_to_end(turn_id)
+                self._prune_tracked_turns()
                 logger.debug("Observed speculative turn %s revision %d", turn_id, revision)
                 self._condition.notify_all()
 
@@ -113,15 +118,19 @@ class SpeculativeTurnTracker:
                 return False
             if self._committed_revision.get(turn_id, -1) >= base_revision:
                 del self._pending_reopen[turn_id]
+                self._prune_tracked_turns()
                 self._condition.notify_all()
                 return False
             if self._latest_revision.get(turn_id, base_revision) != base_revision:
                 del self._pending_reopen[turn_id]
+                self._prune_tracked_turns()
                 self._condition.notify_all()
                 return False
 
             self._latest_revision[turn_id] = candidate_revision
+            self._latest_revision.move_to_end(turn_id)
             del self._pending_reopen[turn_id]
+            self._prune_tracked_turns()
             logger.debug(
                 "Confirmed speculative reopen candidate for turn %s revision %d",
                 turn_id,
@@ -140,6 +149,7 @@ class SpeculativeTurnTracker:
             if candidate_revision is not None and pending.candidate_revision != candidate_revision:
                 return
             del self._pending_reopen[turn_id]
+            self._prune_tracked_turns()
             logger.debug("Cancelled speculative reopen candidate for turn %s", turn_id)
             self._condition.notify_all()
 
@@ -161,9 +171,23 @@ class SpeculativeTurnTracker:
                 remaining = deadline - time.monotonic()
                 if remaining <= 0:
                     logger.warning("Timed out waiting for pending speculative reopen turn=%s rev=%s", turn_id, revision)
+                    if self._pending_reopen.get(turn_id) == pending:
+                        del self._pending_reopen[turn_id]
+                        self._prune_tracked_turns()
+                        self._condition.notify_all()
                     return
                 self._condition.wait(remaining)
                 pending = self._pending_reopen.get(turn_id)
+
+    def _prune_tracked_turns(self) -> None:
+        if self._max_tracked_turns <= 0:
+            return
+
+        prunable_turn_ids = [turn_id for turn_id in self._latest_revision if turn_id not in self._pending_reopen]
+        while len(prunable_turn_ids) > self._max_tracked_turns:
+            turn_id = prunable_turn_ids.pop(0)
+            self._latest_revision.pop(turn_id, None)
+            self._committed_revision.pop(turn_id, None)
 
     def reset(self) -> None:
         with self._condition:

--- a/src/speech_to_speech/pipeline/speculative_turns.py
+++ b/src/speech_to_speech/pipeline/speculative_turns.py
@@ -104,6 +104,28 @@ class SpeculativeTurnTracker:
         with self._condition:
             return self._has_pending_reopen_locked(turn_id, revision)
 
+    def is_latest_after_stability_window(
+        self,
+        turn_id: str | None,
+        revision: int | None,
+        settle_s: float,
+    ) -> bool:
+        if turn_id is None or revision is None:
+            return True
+        if settle_s <= 0:
+            return self.is_latest_after_pending_reopen(turn_id, revision)
+        with self._condition:
+            deadline = time.monotonic() + settle_s
+            while self._latest_revision.get(turn_id, revision) == revision:
+                if self._has_pending_reopen_locked(turn_id, revision):
+                    break
+                remaining = deadline - time.monotonic()
+                if remaining <= 0:
+                    break
+                self._condition.wait(remaining)
+            self._wait_for_pending_reopen_locked(turn_id, revision, self._PENDING_REOPEN_WAIT_TIMEOUT_S)
+            return self._latest_revision.get(turn_id, revision) == revision
+
     def commit(self, turn_id: str | None, revision: int | None) -> None:
         if turn_id is None or revision is None:
             return

--- a/src/speech_to_speech/pipeline/speculative_turns.py
+++ b/src/speech_to_speech/pipeline/speculative_turns.py
@@ -47,7 +47,9 @@ class SpeculativeTurnTracker:
         with self._condition:
             pending = self._pending_reopen.get(turn_id)
             if pending is not None and pending.base_revision == revision:
-                logger.debug("Deferring speculative turn %s revision %d commit while reopen is pending", turn_id, revision)
+                logger.debug(
+                    "Deferring speculative turn %s revision %d commit while reopen is pending", turn_id, revision
+                )
                 return
             latest = self._latest_revision.get(turn_id, revision)
             if revision == latest:

--- a/src/speech_to_speech/pipeline/speculative_turns.py
+++ b/src/speech_to_speech/pipeline/speculative_turns.py
@@ -53,6 +53,19 @@ class SpeculativeTurnTracker:
             self._wait_for_pending_reopen_locked(turn_id, revision, self._PENDING_REOPEN_WAIT_TIMEOUT_S)
             return self._latest_revision.get(turn_id, revision) == revision
 
+    def try_is_latest_after_pending_reopen(self, turn_id: str | None, revision: int | None) -> bool | None:
+        """Non-blocking variant of ``is_latest_after_pending_reopen``.
+
+        Returns ``None`` when a matching reopen candidate is still pending and
+        the caller should retry after it resolves.
+        """
+        if turn_id is None or revision is None:
+            return True
+        with self._condition:
+            if self._has_pending_reopen_locked(turn_id, revision):
+                return None
+            return self._latest_revision.get(turn_id, revision) == revision
+
     def commit_if_latest_after_pending_reopen(self, turn_id: str | None, revision: int | None) -> bool:
         if turn_id is None or revision is None:
             return True
@@ -65,6 +78,31 @@ class SpeculativeTurnTracker:
             logger.debug("Committed speculative turn %s revision %d", turn_id, revision)
             self._condition.notify_all()
             return True
+
+    def try_commit_if_latest_after_pending_reopen(self, turn_id: str | None, revision: int | None) -> bool | None:
+        """Non-blocking variant of ``commit_if_latest_after_pending_reopen``.
+
+        Returns ``None`` when a matching reopen candidate is still pending and
+        the caller should retry after it resolves.
+        """
+        if turn_id is None or revision is None:
+            return True
+        with self._condition:
+            if self._has_pending_reopen_locked(turn_id, revision):
+                return None
+            latest = self._latest_revision.get(turn_id, revision)
+            if revision != latest:
+                return False
+            self._committed_revision[turn_id] = revision
+            logger.debug("Committed speculative turn %s revision %d", turn_id, revision)
+            self._condition.notify_all()
+            return True
+
+    def has_pending_reopen(self, turn_id: str | None, revision: int | None) -> bool:
+        if turn_id is None or revision is None:
+            return False
+        with self._condition:
+            return self._has_pending_reopen_locked(turn_id, revision)
 
     def commit(self, turn_id: str | None, revision: int | None) -> None:
         if turn_id is None or revision is None:
@@ -183,6 +221,10 @@ class SpeculativeTurnTracker:
             return
         with self._condition:
             self._wait_for_pending_reopen_locked(turn_id, revision, timeout_s)
+
+    def _has_pending_reopen_locked(self, turn_id: str, revision: int) -> bool:
+        pending = self._pending_reopen.get(turn_id)
+        return pending is not None and pending.base_revision == revision
 
     def _wait_for_pending_reopen_locked(self, turn_id: str, revision: int, timeout_s: float) -> None:
         deadline = time.monotonic() + timeout_s

--- a/src/speech_to_speech/pipeline/speculative_turns.py
+++ b/src/speech_to_speech/pipeline/speculative_turns.py
@@ -15,6 +15,12 @@ class _PendingReopen:
     candidate_revision: int
 
 
+@dataclass(frozen=True)
+class _ReopenGrace:
+    revision: int
+    deadline: float
+
+
 class SpeculativeTurnTracker:
     """Thread-safe revision tracker for raw-audio speculative turns."""
 
@@ -27,6 +33,7 @@ class SpeculativeTurnTracker:
         self._latest_revision: OrderedDict[str, int] = OrderedDict()
         self._committed_revision: dict[str, int] = {}
         self._pending_reopen: dict[str, _PendingReopen] = {}
+        self._reopen_grace: dict[str, _ReopenGrace] = {}
 
     def observe(self, turn_id: str | None, revision: int | None) -> None:
         if turn_id is None or revision is None:
@@ -66,11 +73,46 @@ class SpeculativeTurnTracker:
                 return None
             return self._latest_revision.get(turn_id, revision) == revision
 
+    def is_latest_after_reopen_grace(self, turn_id: str | None, revision: int | None) -> bool:
+        if turn_id is None or revision is None:
+            return True
+        with self._condition:
+            self._wait_for_reopen_gate_locked(turn_id, revision)
+            return self._latest_revision.get(turn_id, revision) == revision
+
+    def try_is_latest_after_reopen_grace(self, turn_id: str | None, revision: int | None) -> bool | None:
+        if turn_id is None or revision is None:
+            return True
+        with self._condition:
+            if (
+                self._has_pending_reopen_locked(turn_id, revision)
+                or self._reopen_grace_remaining_locked(
+                    turn_id,
+                    revision,
+                )
+                > 0
+            ):
+                return None
+            return self._latest_revision.get(turn_id, revision) == revision
+
     def commit_if_latest_after_pending_reopen(self, turn_id: str | None, revision: int | None) -> bool:
         if turn_id is None or revision is None:
             return True
         with self._condition:
             self._wait_for_pending_reopen_locked(turn_id, revision, self._PENDING_REOPEN_WAIT_TIMEOUT_S)
+            latest = self._latest_revision.get(turn_id, revision)
+            if revision != latest:
+                return False
+            self._committed_revision[turn_id] = revision
+            logger.debug("Committed speculative turn %s revision %d", turn_id, revision)
+            self._condition.notify_all()
+            return True
+
+    def commit_if_latest_after_reopen_grace(self, turn_id: str | None, revision: int | None) -> bool:
+        if turn_id is None or revision is None:
+            return True
+        with self._condition:
+            self._wait_for_reopen_gate_locked(turn_id, revision)
             latest = self._latest_revision.get(turn_id, revision)
             if revision != latest:
                 return False
@@ -98,11 +140,65 @@ class SpeculativeTurnTracker:
             self._condition.notify_all()
             return True
 
+    def try_commit_if_latest_after_reopen_grace(self, turn_id: str | None, revision: int | None) -> bool | None:
+        if turn_id is None or revision is None:
+            return True
+        with self._condition:
+            if (
+                self._has_pending_reopen_locked(turn_id, revision)
+                or self._reopen_grace_remaining_locked(
+                    turn_id,
+                    revision,
+                )
+                > 0
+            ):
+                return None
+            latest = self._latest_revision.get(turn_id, revision)
+            if revision != latest:
+                return False
+            self._committed_revision[turn_id] = revision
+            logger.debug("Committed speculative turn %s revision %d", turn_id, revision)
+            self._condition.notify_all()
+            return True
+
     def has_pending_reopen(self, turn_id: str | None, revision: int | None) -> bool:
         if turn_id is None or revision is None:
             return False
         with self._condition:
             return self._has_pending_reopen_locked(turn_id, revision)
+
+    def has_pending_reopen_or_grace(self, turn_id: str | None, revision: int | None) -> bool:
+        if turn_id is None or revision is None:
+            return False
+        with self._condition:
+            return (
+                self._has_pending_reopen_locked(turn_id, revision)
+                or self._reopen_grace_remaining_locked(
+                    turn_id,
+                    revision,
+                )
+                > 0
+            )
+
+    def start_reopen_grace(self, turn_id: str | None, revision: int | None, grace_s: float) -> None:
+        if turn_id is None or revision is None or grace_s <= 0:
+            return
+        with self._condition:
+            if self._latest_revision.get(turn_id, revision) != revision:
+                return
+            if self._committed_revision.get(turn_id, -1) >= revision:
+                return
+            deadline = time.monotonic() + grace_s
+            existing = self._reopen_grace.get(turn_id)
+            if existing is None or existing.revision != revision or deadline > existing.deadline:
+                self._reopen_grace[turn_id] = _ReopenGrace(revision=revision, deadline=deadline)
+                logger.debug(
+                    "Started speculative reopen grace for turn %s revision %d: %.0fms",
+                    turn_id,
+                    revision,
+                    grace_s * 1000,
+                )
+                self._condition.notify_all()
 
     def is_latest_after_stability_window(
         self,
@@ -248,6 +344,31 @@ class SpeculativeTurnTracker:
         pending = self._pending_reopen.get(turn_id)
         return pending is not None and pending.base_revision == revision
 
+    def _reopen_grace_remaining_locked(self, turn_id: str, revision: int) -> float:
+        grace = self._reopen_grace.get(turn_id)
+        if grace is None or grace.revision != revision:
+            return 0.0
+        if self._latest_revision.get(turn_id, revision) != revision:
+            del self._reopen_grace[turn_id]
+            return 0.0
+        remaining = grace.deadline - time.monotonic()
+        if remaining <= 0:
+            del self._reopen_grace[turn_id]
+            self._prune_tracked_turns()
+            return 0.0
+        return remaining
+
+    def _wait_for_reopen_gate_locked(self, turn_id: str, revision: int) -> None:
+        while self._latest_revision.get(turn_id, revision) == revision:
+            self._wait_for_pending_reopen_locked(turn_id, revision, self._PENDING_REOPEN_WAIT_TIMEOUT_S)
+            if self._latest_revision.get(turn_id, revision) != revision:
+                return
+            remaining = self._reopen_grace_remaining_locked(turn_id, revision)
+            if remaining <= 0:
+                return
+            logger.debug("Waiting for speculative reopen grace turn=%s rev=%s", turn_id, revision)
+            self._condition.wait(remaining)
+
     def _wait_for_pending_reopen_locked(self, turn_id: str, revision: int, timeout_s: float) -> None:
         deadline = time.monotonic() + timeout_s
         pending = self._pending_reopen.get(turn_id)
@@ -270,15 +391,28 @@ class SpeculativeTurnTracker:
         if self._max_tracked_turns <= 0:
             return
 
-        prunable_turn_ids = [turn_id for turn_id in self._latest_revision if turn_id not in self._pending_reopen]
+        self._drop_expired_reopen_graces_locked()
+        prunable_turn_ids = [
+            turn_id
+            for turn_id in self._latest_revision
+            if turn_id not in self._pending_reopen and turn_id not in self._reopen_grace
+        ]
         while len(prunable_turn_ids) > self._max_tracked_turns:
             turn_id = prunable_turn_ids.pop(0)
             self._latest_revision.pop(turn_id, None)
             self._committed_revision.pop(turn_id, None)
+            self._reopen_grace.pop(turn_id, None)
+
+    def _drop_expired_reopen_graces_locked(self) -> None:
+        now = time.monotonic()
+        for turn_id, grace in list(self._reopen_grace.items()):
+            if self._latest_revision.get(turn_id, grace.revision) != grace.revision or grace.deadline <= now:
+                del self._reopen_grace[turn_id]
 
     def reset(self) -> None:
         with self._condition:
             self._latest_revision.clear()
             self._committed_revision.clear()
             self._pending_reopen.clear()
+            self._reopen_grace.clear()
             self._condition.notify_all()

--- a/src/speech_to_speech/s2s_pipeline.py
+++ b/src/speech_to_speech/s2s_pipeline.py
@@ -382,6 +382,7 @@ def build_pipeline(
     response_playing = queues_and_events["response_playing"]
     cancel_scope = queues_and_events["cancel_scope"]
     speculative_turns = queues_and_events["speculative_turns"]
+    active_speculative_turns = speculative_turns if module_kwargs.mode == "realtime" else None
     recv_audio_chunks_queue = queues_and_events["recv_audio_chunks_queue"]
     send_audio_chunks_queue = queues_and_events["send_audio_chunks_queue"]
     spoken_prompt_queue = queues_and_events["spoken_prompt_queue"]
@@ -393,18 +394,19 @@ def build_pipeline(
         None  # Only set for websocket/realtime modes; kept None otherwise to avoid unbounded queue growth
     )
 
-    _wire_speculative_turn_dependencies(
-        cancel_scope,
-        speculative_turns,
-        vad_handler_kwargs,
-        language_model_handler_kwargs,
-        responses_api_language_model_handler_kwargs,
-        chat_tts_handler_kwargs,
-        facebook_mms_tts_handler_kwargs,
-        pocket_tts_handler_kwargs,
-        kokoro_tts_handler_kwargs,
-        qwen3_tts_handler_kwargs,
-    )
+    if active_speculative_turns is not None:
+        _wire_speculative_turn_dependencies(
+            cancel_scope,
+            active_speculative_turns,
+            vad_handler_kwargs,
+            language_model_handler_kwargs,
+            responses_api_language_model_handler_kwargs,
+            chat_tts_handler_kwargs,
+            facebook_mms_tts_handler_kwargs,
+            pocket_tts_handler_kwargs,
+            kokoro_tts_handler_kwargs,
+            qwen3_tts_handler_kwargs,
+        )
 
     comms_handlers: list[Any] = []
     if module_kwargs.mode == "local":
@@ -529,7 +531,7 @@ def build_pipeline(
         stop_event,
         spoken_prompt_queue,
         stt_output_queue,
-        speculative_turns,
+        active_speculative_turns,
         whisper_stt_handler_kwargs,
         faster_whisper_stt_handler_kwargs,
         paraformer_stt_handler_kwargs,
@@ -553,7 +555,7 @@ def build_pipeline(
         stop_event,
         queue_in=lm_response_queue,
         queue_out=lm_processed_queue,
-        setup_kwargs={"text_output_queue": text_output_queue, "speculative_turns": speculative_turns},
+        setup_kwargs={"text_output_queue": text_output_queue, "speculative_turns": active_speculative_turns},
     )
 
     tts = get_tts_handler(

--- a/src/speech_to_speech/s2s_pipeline.py
+++ b/src/speech_to_speech/s2s_pipeline.py
@@ -748,7 +748,9 @@ def get_stt_handler(
     mlx_audio_whisper_stt_handler_kwargs: MLXAudioWhisperSTTHandlerArguments,
     parakeet_tdt_stt_handler_kwargs: ParakeetTDTSTTHandlerArguments,
 ) -> BaseHandler[STTIn, STTOut]:
-    def with_speculative_turns(handler: BaseHandler[STTIn, STTOut]) -> BaseHandler[STTIn, STTOut]:
+    from speech_to_speech.STT.base_stt_handler import BaseSTTHandler
+
+    def with_speculative_turns(handler: BaseSTTHandler) -> BaseSTTHandler:
         if speculative_turns is not None:
             handler.speculative_turns = speculative_turns
         return handler

--- a/src/speech_to_speech/s2s_pipeline.py
+++ b/src/speech_to_speech/s2s_pipeline.py
@@ -330,6 +330,33 @@ def initialize_queues_and_events() -> dict[str, Any]:
     }
 
 
+def _wire_speculative_turn_dependencies(
+    cancel_scope: CancelScope,
+    speculative_turns: SpeculativeTurnTracker,
+    vad_handler_kwargs: VADHandlerArguments,
+    language_model_handler_kwargs: LanguageModelHandlerArguments,
+    responses_api_language_model_handler_kwargs: ResponsesApiLanguageModelHandlerArguments,
+    chat_tts_handler_kwargs: ChatTTSHandlerArguments,
+    facebook_mms_tts_handler_kwargs: FacebookMMSTTSHandlerArguments,
+    pocket_tts_handler_kwargs: PocketTTSHandlerArguments,
+    kokoro_tts_handler_kwargs: KokoroTTSHandlerArguments,
+    qwen3_tts_handler_kwargs: Qwen3TTSHandlerArguments,
+) -> None:
+    vars(vad_handler_kwargs)["speculative_turns"] = speculative_turns
+
+    for kw in (
+        language_model_handler_kwargs,
+        responses_api_language_model_handler_kwargs,
+        kokoro_tts_handler_kwargs,
+        qwen3_tts_handler_kwargs,
+        pocket_tts_handler_kwargs,
+        chat_tts_handler_kwargs,
+        facebook_mms_tts_handler_kwargs,
+    ):
+        vars(kw)["cancel_scope"] = cancel_scope
+        vars(kw)["speculative_turns"] = speculative_turns
+
+
 def build_pipeline(
     module_kwargs: ModuleArguments,
     socket_receiver_kwargs: SocketReceiverArguments,
@@ -366,6 +393,19 @@ def build_pipeline(
         None  # Only set for websocket/realtime modes; kept None otherwise to avoid unbounded queue growth
     )
 
+    _wire_speculative_turn_dependencies(
+        cancel_scope,
+        speculative_turns,
+        vad_handler_kwargs,
+        language_model_handler_kwargs,
+        responses_api_language_model_handler_kwargs,
+        chat_tts_handler_kwargs,
+        facebook_mms_tts_handler_kwargs,
+        pocket_tts_handler_kwargs,
+        kokoro_tts_handler_kwargs,
+        qwen3_tts_handler_kwargs,
+    )
+
     comms_handlers: list[Any] = []
     if module_kwargs.mode == "local":
         from speech_to_speech.connections.local_audio_streamer import LocalAudioStreamer
@@ -397,19 +437,6 @@ def build_pipeline(
         text_output_queue = queues_and_events["text_output_queue"]
 
         vars(vad_handler_kwargs)["text_output_queue"] = text_output_queue
-        vars(vad_handler_kwargs)["speculative_turns"] = speculative_turns
-
-        for kw in (
-            language_model_handler_kwargs,
-            responses_api_language_model_handler_kwargs,
-            kokoro_tts_handler_kwargs,
-            qwen3_tts_handler_kwargs,
-            pocket_tts_handler_kwargs,
-            chat_tts_handler_kwargs,
-            facebook_mms_tts_handler_kwargs,
-        ):
-            vars(kw)["cancel_scope"] = cancel_scope
-            vars(kw)["speculative_turns"] = speculative_turns
 
         if module_kwargs.llm_backend == "responses-api":
             chat_size = vars(responses_api_language_model_handler_kwargs).get("chat_size", 10)

--- a/src/speech_to_speech/s2s_pipeline.py
+++ b/src/speech_to_speech/s2s_pipeline.py
@@ -60,6 +60,7 @@ from speech_to_speech.pipeline.queue_types import (
     VADOutItem,
 )
 from speech_to_speech.pipeline.speculative_turns import SpeculativeTurnTracker
+from speech_to_speech.STT.base_stt_handler import BaseSTTHandler
 from speech_to_speech.STT.transcription_notifier import TranscriptionNotifier
 from speech_to_speech.utils.thread_manager import ThreadManager
 from speech_to_speech.VAD.vad_handler import VADHandler
@@ -501,6 +502,7 @@ def build_pipeline(
         stop_event,
         spoken_prompt_queue,
         stt_output_queue,
+        speculative_turns,
         whisper_stt_handler_kwargs,
         faster_whisper_stt_handler_kwargs,
         paraformer_stt_handler_kwargs,
@@ -551,58 +553,73 @@ def get_stt_handler(
     stop_event: Event,
     spoken_prompt_queue: Queue[VADOutItem],
     text_prompt_queue: Queue[STTOutItem],
+    speculative_turns: SpeculativeTurnTracker | None,
     whisper_stt_handler_kwargs: WhisperSTTHandlerArguments,
     faster_whisper_stt_handler_kwargs: FasterWhisperSTTHandlerArguments,
     paraformer_stt_handler_kwargs: ParaformerSTTHandlerArguments,
     mlx_audio_whisper_stt_handler_kwargs: MLXAudioWhisperSTTHandlerArguments,
     parakeet_tdt_stt_handler_kwargs: ParakeetTDTSTTHandlerArguments,
 ) -> BaseHandler[STTIn, STTOut]:
+    def with_speculative_turns(handler: BaseSTTHandler) -> BaseSTTHandler:
+        handler.speculative_turns = speculative_turns
+        return handler
+
     if module_kwargs.stt == "whisper":
         from speech_to_speech.STT.whisper_stt_handler import WhisperSTTHandler
 
-        return WhisperSTTHandler(
-            stop_event,
-            queue_in=spoken_prompt_queue,
-            queue_out=text_prompt_queue,
-            setup_kwargs=vars(whisper_stt_handler_kwargs),
+        return with_speculative_turns(
+            WhisperSTTHandler(
+                stop_event,
+                queue_in=spoken_prompt_queue,
+                queue_out=text_prompt_queue,
+                setup_kwargs=vars(whisper_stt_handler_kwargs),
+            )
         )
     elif module_kwargs.stt == "whisper-mlx":
         from speech_to_speech.STT.lightning_whisper_mlx_handler import LightningWhisperSTTHandler
 
-        return LightningWhisperSTTHandler(
-            stop_event,
-            queue_in=spoken_prompt_queue,
-            queue_out=text_prompt_queue,
-            setup_kwargs=vars(whisper_stt_handler_kwargs),
+        return with_speculative_turns(
+            LightningWhisperSTTHandler(
+                stop_event,
+                queue_in=spoken_prompt_queue,
+                queue_out=text_prompt_queue,
+                setup_kwargs=vars(whisper_stt_handler_kwargs),
+            )
         )
     elif module_kwargs.stt == "mlx-audio-whisper":
         from speech_to_speech.STT.mlx_audio_whisper_handler import MLXAudioWhisperSTTHandler
 
         # Merge MLX Audio Whisper kwargs with shared language parameter from Whisper kwargs
         setup_kwargs = {**vars(mlx_audio_whisper_stt_handler_kwargs), "language": whisper_stt_handler_kwargs.language}
-        return MLXAudioWhisperSTTHandler(
-            stop_event,
-            queue_in=spoken_prompt_queue,
-            queue_out=text_prompt_queue,
-            setup_kwargs=setup_kwargs,
+        return with_speculative_turns(
+            MLXAudioWhisperSTTHandler(
+                stop_event,
+                queue_in=spoken_prompt_queue,
+                queue_out=text_prompt_queue,
+                setup_kwargs=setup_kwargs,
+            )
         )
     elif module_kwargs.stt == "paraformer":
         from speech_to_speech.STT.paraformer_handler import ParaformerSTTHandler
 
-        return ParaformerSTTHandler(
-            stop_event,
-            queue_in=spoken_prompt_queue,
-            queue_out=text_prompt_queue,
-            setup_kwargs=vars(paraformer_stt_handler_kwargs),
+        return with_speculative_turns(
+            ParaformerSTTHandler(
+                stop_event,
+                queue_in=spoken_prompt_queue,
+                queue_out=text_prompt_queue,
+                setup_kwargs=vars(paraformer_stt_handler_kwargs),
+            )
         )
     elif module_kwargs.stt == "faster-whisper":
         from speech_to_speech.STT.faster_whisper_handler import FasterWhisperSTTHandler
 
-        return FasterWhisperSTTHandler(
-            stop_event,
-            queue_in=spoken_prompt_queue,
-            queue_out=text_prompt_queue,
-            setup_kwargs=vars(faster_whisper_stt_handler_kwargs),
+        return with_speculative_turns(
+            FasterWhisperSTTHandler(
+                stop_event,
+                queue_in=spoken_prompt_queue,
+                queue_out=text_prompt_queue,
+                setup_kwargs=vars(faster_whisper_stt_handler_kwargs),
+            )
         )
     elif module_kwargs.stt == "parakeet-tdt":
         from speech_to_speech.STT.parakeet_tdt_handler import ParakeetTDTSTTHandler
@@ -614,11 +631,13 @@ def get_stt_handler(
             "live_transcription_update_interval": module_kwargs.live_transcription_update_interval,
         }
 
-        return ParakeetTDTSTTHandler(
-            stop_event,
-            queue_in=spoken_prompt_queue,
-            queue_out=text_prompt_queue,
-            setup_kwargs=setup_kwargs,
+        return with_speculative_turns(
+            ParakeetTDTSTTHandler(
+                stop_event,
+                queue_in=spoken_prompt_queue,
+                queue_out=text_prompt_queue,
+                setup_kwargs=setup_kwargs,
+            )
         )
     else:
         raise ValueError(

--- a/src/speech_to_speech/s2s_pipeline.py
+++ b/src/speech_to_speech/s2s_pipeline.py
@@ -59,6 +59,7 @@ from speech_to_speech.pipeline.queue_types import (
     TTSInItem,
     VADOutItem,
 )
+from speech_to_speech.pipeline.speculative_turns import SpeculativeTurnTracker
 from speech_to_speech.STT.transcription_notifier import TranscriptionNotifier
 from speech_to_speech.utils.thread_manager import ThreadManager
 from speech_to_speech.VAD.vad_handler import VADHandler
@@ -316,6 +317,7 @@ def initialize_queues_and_events() -> dict[str, Any]:
         "should_listen": Event(),
         "response_playing": Event(),
         "cancel_scope": CancelScope(),
+        "speculative_turns": SpeculativeTurnTracker(),
         "recv_audio_chunks_queue": Queue[AudioInItem](),
         "send_audio_chunks_queue": Queue[AudioOutItem](),
         "spoken_prompt_queue": Queue[VADOutItem](),
@@ -351,6 +353,7 @@ def build_pipeline(
     should_listen = queues_and_events["should_listen"]
     response_playing = queues_and_events["response_playing"]
     cancel_scope = queues_and_events["cancel_scope"]
+    speculative_turns = queues_and_events["speculative_turns"]
     recv_audio_chunks_queue = queues_and_events["recv_audio_chunks_queue"]
     send_audio_chunks_queue = queues_and_events["send_audio_chunks_queue"]
     spoken_prompt_queue = queues_and_events["spoken_prompt_queue"]
@@ -393,6 +396,7 @@ def build_pipeline(
         text_output_queue = queues_and_events["text_output_queue"]
 
         vars(vad_handler_kwargs)["text_output_queue"] = text_output_queue
+        vars(vad_handler_kwargs)["speculative_turns"] = speculative_turns
 
         for kw in (
             language_model_handler_kwargs,
@@ -404,6 +408,7 @@ def build_pipeline(
             facebook_mms_tts_handler_kwargs,
         ):
             vars(kw)["cancel_scope"] = cancel_scope
+            vars(kw)["speculative_turns"] = speculative_turns
 
         if module_kwargs.llm_backend == "responses-api":
             chat_size = vars(responses_api_language_model_handler_kwargs).get("chat_size", 10)
@@ -419,6 +424,7 @@ def build_pipeline(
             cancel_scope=cancel_scope,
             text_output_queue=text_output_queue,
             text_prompt_queue=text_prompt_queue,
+            speculative_turns=speculative_turns,
             host=websocket_streamer_kwargs.ws_host,
             port=websocket_streamer_kwargs.ws_port,
             chat_size=chat_size,
@@ -518,7 +524,7 @@ def build_pipeline(
         stop_event,
         queue_in=lm_response_queue,
         queue_out=lm_processed_queue,
-        setup_kwargs={"text_output_queue": text_output_queue},
+        setup_kwargs={"text_output_queue": text_output_queue, "speculative_turns": speculative_turns},
     )
 
     tts = get_tts_handler(

--- a/src/speech_to_speech/utils/mlx_lock.py
+++ b/src/speech_to_speech/utils/mlx_lock.py
@@ -9,6 +9,7 @@ a global lock that all MLX handlers should acquire before using their models.
 import logging
 import types
 from threading import RLock
+from time import perf_counter
 from typing import Literal
 
 logger = logging.getLogger(__name__)
@@ -30,10 +31,15 @@ def acquire_mlx_lock(timeout: float | None = None, handler_name: str = "Unknown"
         True if lock was acquired, False if timeout occurred
     """
     logger.debug(f"{handler_name}: Attempting to acquire MLX lock")
+    start = perf_counter()
     acquired = _mlx_lock.acquire(timeout=timeout) if timeout else _mlx_lock.acquire(blocking=True)
+    wait_s = perf_counter() - start
 
     if acquired:
-        logger.debug(f"{handler_name}: MLX lock acquired")
+        if wait_s >= 0.25:
+            logger.info("%s: MLX lock acquired after %.2fs", handler_name, wait_s)
+        else:
+            logger.debug("%s: MLX lock acquired after %.3fs", handler_name, wait_s)
     else:
         logger.warning(f"{handler_name}: Failed to acquire MLX lock (timeout)")
 

--- a/src/speech_to_speech/utils/mlx_lock.py
+++ b/src/speech_to_speech/utils/mlx_lock.py
@@ -8,7 +8,7 @@ a global lock that all MLX handlers should acquire before using their models.
 
 import logging
 import types
-from threading import RLock
+from threading import Lock, RLock, current_thread, get_ident
 from time import perf_counter
 from typing import Literal
 
@@ -17,6 +17,63 @@ logger = logging.getLogger(__name__)
 # Global reentrant lock for MLX model access
 # Using RLock (reentrant lock) so the same thread can acquire it multiple times
 _mlx_lock = RLock()
+_mlx_lock_state = Lock()
+_lock_owner_ident: int | None = None
+_lock_owner_thread: str | None = None
+_lock_owner_handler: str | None = None
+_lock_acquired_at: float | None = None
+_lock_depth = 0
+
+
+def _owner_snapshot(now: float | None = None) -> str:
+    if _lock_owner_ident is None:
+        return "none"
+    elapsed = ""
+    if _lock_acquired_at is not None:
+        elapsed = f" for {(now or perf_counter()) - _lock_acquired_at:.3f}s"
+    return f"{_lock_owner_handler} on {_lock_owner_thread}{elapsed}"
+
+
+def _record_lock_acquired(handler_name: str) -> int:
+    global _lock_acquired_at, _lock_depth, _lock_owner_handler, _lock_owner_ident, _lock_owner_thread
+    ident = get_ident()
+    thread_name = current_thread().name
+    now = perf_counter()
+    with _mlx_lock_state:
+        if _lock_owner_ident == ident:
+            _lock_depth += 1
+        else:
+            _lock_owner_ident = ident
+            _lock_owner_thread = thread_name
+            _lock_owner_handler = handler_name
+            _lock_acquired_at = now
+            _lock_depth = 1
+        return _lock_depth
+
+
+def _record_lock_released(handler_name: str) -> tuple[int, float | None]:
+    global _lock_acquired_at, _lock_depth, _lock_owner_handler, _lock_owner_ident, _lock_owner_thread
+    ident = get_ident()
+    now = perf_counter()
+    with _mlx_lock_state:
+        if _lock_owner_ident != ident:
+            logger.warning(
+                "%s: MLX lock release requested by non-owner thread; owner=%s",
+                handler_name,
+                _owner_snapshot(now),
+            )
+            return _lock_depth, None
+
+        hold_s = None if _lock_acquired_at is None else now - _lock_acquired_at
+        _lock_depth -= 1
+        depth = _lock_depth
+        if _lock_depth <= 0:
+            _lock_owner_ident = None
+            _lock_owner_thread = None
+            _lock_owner_handler = None
+            _lock_acquired_at = None
+            _lock_depth = 0
+        return depth, hold_s
 
 
 def acquire_mlx_lock(timeout: float | None = None, handler_name: str = "Unknown") -> bool:
@@ -30,18 +87,41 @@ def acquire_mlx_lock(timeout: float | None = None, handler_name: str = "Unknown"
     Returns:
         True if lock was acquired, False if timeout occurred
     """
-    logger.debug(f"{handler_name}: Attempting to acquire MLX lock")
+    with _mlx_lock_state:
+        owner_before = _owner_snapshot()
+    logger.debug("%s: Attempting to acquire MLX lock (owner=%s)", handler_name, owner_before)
     start = perf_counter()
     acquired = _mlx_lock.acquire(timeout=timeout) if timeout else _mlx_lock.acquire(blocking=True)
     wait_s = perf_counter() - start
 
     if acquired:
+        depth = _record_lock_acquired(handler_name)
         if wait_s >= 0.25:
-            logger.info("%s: MLX lock acquired after %.2fs", handler_name, wait_s)
+            logger.info(
+                "%s: MLX lock acquired after %.2fs (previous_owner=%s, depth=%d)",
+                handler_name,
+                wait_s,
+                owner_before,
+                depth,
+            )
         else:
-            logger.debug("%s: MLX lock acquired after %.3fs", handler_name, wait_s)
+            logger.debug(
+                "%s: MLX lock acquired after %.3fs (previous_owner=%s, depth=%d)",
+                handler_name,
+                wait_s,
+                owner_before,
+                depth,
+            )
     else:
-        logger.warning(f"{handler_name}: Failed to acquire MLX lock (timeout)")
+        with _mlx_lock_state:
+            owner_after = _owner_snapshot()
+        logger.warning(
+            "%s: Failed to acquire MLX lock after %.3fs (timeout=%s, owner=%s)",
+            handler_name,
+            wait_s,
+            timeout,
+            owner_after,
+        )
 
     return acquired
 
@@ -54,8 +134,16 @@ def release_mlx_lock(handler_name: str = "Unknown") -> None:
         handler_name: Name of the handler releasing the lock (for logging)
     """
     try:
+        depth, hold_s = _record_lock_released(handler_name)
         _mlx_lock.release()
-        logger.debug(f"{handler_name}: MLX lock released")
+        if hold_s is not None and depth == 0 and hold_s >= 0.25:
+            logger.info("%s: MLX lock released after holding %.2fs", handler_name, hold_s)
+        else:
+            logger.debug(
+                "%s: MLX lock released%s",
+                handler_name,
+                "" if hold_s is None else f" after holding {hold_s:.3f}s (depth={depth})",
+            )
     except RuntimeError as e:
         logger.error(f"{handler_name}: Failed to release MLX lock: {e}")
 

--- a/tests/install_smoke.py
+++ b/tests/install_smoke.py
@@ -61,6 +61,7 @@ def _validate_package_defaults() -> None:
     assert qwen3_args.qwen3_tts_ref_audio is None
     assert qwen3_args.qwen3_tts_mlx_quantization == "6bit"
     assert vad_args.thresh == 0.6
+    assert vad_args.min_silence_ms == 300
     assert vad_args.min_speech_ms == 500
     assert vad_args.realtime_processing_pause == 0.5
 

--- a/tests/install_smoke.py
+++ b/tests/install_smoke.py
@@ -51,6 +51,7 @@ def _validate_package_defaults() -> None:
     assert module_args.tts == "qwen3"
     assert module_args.log_level == "info"
     assert module_args.enable_live_transcription is True
+    assert module_args.live_transcription_update_interval == 0.5
     assert responses_api_args.model_name == "gpt-5.4-mini"
     assert responses_api_args.responses_api_stream is True
     assert qwen3_args.qwen3_tts_model_name == "Qwen/Qwen3-TTS-12Hz-1.7B-CustomVoice"
@@ -60,6 +61,7 @@ def _validate_package_defaults() -> None:
     assert qwen3_args.qwen3_tts_ref_audio is None
     assert qwen3_args.qwen3_tts_mlx_quantization == "6bit"
     assert vad_args.thresh == 0.6
+    assert vad_args.realtime_processing_pause == 0.5
 
     package_root = Path(speech_to_speech.__file__).resolve().parent
     ref_audio = package_root / "TTS" / "ref_audio.wav"

--- a/tests/install_smoke.py
+++ b/tests/install_smoke.py
@@ -62,7 +62,7 @@ def _validate_package_defaults() -> None:
     assert qwen3_args.qwen3_tts_mlx_quantization == "6bit"
     assert vad_args.thresh == 0.6
     assert vad_args.min_silence_ms == 300
-    assert vad_args.min_speech_ms == 500
+    assert vad_args.min_speech_ms == 384
     assert vad_args.realtime_processing_pause == 0.5
 
     package_root = Path(speech_to_speech.__file__).resolve().parent

--- a/tests/install_smoke.py
+++ b/tests/install_smoke.py
@@ -61,6 +61,7 @@ def _validate_package_defaults() -> None:
     assert qwen3_args.qwen3_tts_ref_audio is None
     assert qwen3_args.qwen3_tts_mlx_quantization == "6bit"
     assert vad_args.thresh == 0.6
+    assert vad_args.min_speech_ms == 500
     assert vad_args.realtime_processing_pause == 0.5
 
     package_root = Path(speech_to_speech.__file__).resolve().parent

--- a/tests/openai_realtime/test_openai_client.py
+++ b/tests/openai_realtime/test_openai_client.py
@@ -148,7 +148,6 @@ RESPONSE_CREATED = "response.created"
 RESPONSE_DONE = "response.done"
 AUDIO_DELTA = "response.output_audio.delta"
 AUDIO_DONE = "response.output_audio.done"
-OUTPUT_AUDIO_BUFFER_CLEARED = "output_audio_buffer.cleared"
 TRANSCRIPT_DONE = "response.output_audio_transcript.done"
 FUNCTION_CALL_DONE = "response.function_call_arguments.done"
 ERROR = "error"
@@ -309,12 +308,11 @@ class TestSDKBargeIn:
             server_env.text_output_queue.put(SpeechStartedEvent())
 
             events = []
-            for _ in range(4):
+            for _ in range(3):
                 events.append(await _recv(conn))
 
             types = [e.type for e in events]
             assert AUDIO_DONE in types
-            assert OUTPUT_AUDIO_BUFFER_CLEARED in types
             assert RESPONSE_DONE in types
             assert SPEECH_STARTED in types
 
@@ -338,12 +336,11 @@ class TestSDKBargeIn:
             server_env.text_output_queue.put(AssistantTextEvent(text="stale response text"))
 
             events = []
-            for _ in range(4):
+            for _ in range(3):
                 events.append(await _recv(conn))
 
             types = [e.type for e in events]
             assert AUDIO_DONE in types
-            assert OUTPUT_AUDIO_BUFFER_CLEARED in types
             assert RESPONSE_DONE in types
             assert SPEECH_STARTED in types
 
@@ -415,12 +412,11 @@ class TestSDKInterruptionState:
 
             server_env.text_output_queue.put(SpeechStartedEvent())
             events = []
-            for _ in range(4):
+            for _ in range(3):
                 events.append(await _recv(conn))
 
             types = [e.type for e in events]
             assert SPEECH_STARTED in types
-            assert OUTPUT_AUDIO_BUFFER_CLEARED in types
             assert RESPONSE_DONE in types
 
             await asyncio.sleep(0.1)
@@ -651,10 +647,9 @@ class TestSDKMultiTurn:
             # Barge-in
             server_env.text_output_queue.put(SpeechStartedEvent())
             events = []
-            for _ in range(4):
+            for _ in range(3):
                 events.append(await _recv(conn))
 
-            assert OUTPUT_AUDIO_BUFFER_CLEARED in [e.type for e in events]
             t1_done = next(e for e in events if e.type == RESPONSE_DONE)
 
             # Simulate pipeline acknowledging cancellation so discard guard clears

--- a/tests/openai_realtime/test_openai_client.py
+++ b/tests/openai_realtime/test_openai_client.py
@@ -148,6 +148,7 @@ RESPONSE_CREATED = "response.created"
 RESPONSE_DONE = "response.done"
 AUDIO_DELTA = "response.output_audio.delta"
 AUDIO_DONE = "response.output_audio.done"
+OUTPUT_AUDIO_BUFFER_CLEARED = "output_audio_buffer.cleared"
 TRANSCRIPT_DONE = "response.output_audio_transcript.done"
 FUNCTION_CALL_DONE = "response.function_call_arguments.done"
 ERROR = "error"
@@ -308,11 +309,12 @@ class TestSDKBargeIn:
             server_env.text_output_queue.put(SpeechStartedEvent())
 
             events = []
-            for _ in range(3):
+            for _ in range(4):
                 events.append(await _recv(conn))
 
             types = [e.type for e in events]
             assert AUDIO_DONE in types
+            assert OUTPUT_AUDIO_BUFFER_CLEARED in types
             assert RESPONSE_DONE in types
             assert SPEECH_STARTED in types
 
@@ -336,11 +338,12 @@ class TestSDKBargeIn:
             server_env.text_output_queue.put(AssistantTextEvent(text="stale response text"))
 
             events = []
-            for _ in range(3):
+            for _ in range(4):
                 events.append(await _recv(conn))
 
             types = [e.type for e in events]
             assert AUDIO_DONE in types
+            assert OUTPUT_AUDIO_BUFFER_CLEARED in types
             assert RESPONSE_DONE in types
             assert SPEECH_STARTED in types
 
@@ -412,11 +415,12 @@ class TestSDKInterruptionState:
 
             server_env.text_output_queue.put(SpeechStartedEvent())
             events = []
-            for _ in range(3):
+            for _ in range(4):
                 events.append(await _recv(conn))
 
             types = [e.type for e in events]
             assert SPEECH_STARTED in types
+            assert OUTPUT_AUDIO_BUFFER_CLEARED in types
             assert RESPONSE_DONE in types
 
             await asyncio.sleep(0.1)
@@ -647,9 +651,10 @@ class TestSDKMultiTurn:
             # Barge-in
             server_env.text_output_queue.put(SpeechStartedEvent())
             events = []
-            for _ in range(3):
+            for _ in range(4):
                 events.append(await _recv(conn))
 
+            assert OUTPUT_AUDIO_BUFFER_CLEARED in [e.type for e in events]
             t1_done = next(e for e in events if e.type == RESPONSE_DONE)
 
             # Simulate pipeline acknowledging cancellation so discard guard clears

--- a/tests/openai_realtime/test_realtime_service.py
+++ b/tests/openai_realtime/test_realtime_service.py
@@ -434,6 +434,32 @@ class TestHandleResponseCreate:
         assert req.response.tool_choice == "auto"
         assert req.runtime_config is runtime_config
 
+    def test_response_create_preserves_latest_user_turn_timing(self, service, conn_id, text_prompt_queue):
+        service.dispatch_pipeline_event(
+            conn_id,
+            TranscriptionCompletedEvent(
+                transcript="hello",
+                language_code="en",
+                turn_id="turn_1",
+                turn_revision=2,
+                speech_stopped_at_s=123.0,
+            ),
+        )
+        initial_req = text_prompt_queue.get()
+        assert isinstance(initial_req, GenerateResponseRequest)
+        assert initial_req.turn_id == "turn_1"
+        assert initial_req.turn_revision == 2
+        assert initial_req.speech_stopped_at_s == 123.0
+
+        result = service.handle_response_create(conn_id, ResponseCreateEvent(type="response.create"))
+
+        assert isinstance(result, ResponseCreatedEvent)
+        followup_req = text_prompt_queue.get()
+        assert isinstance(followup_req, GenerateResponseRequest)
+        assert followup_req.turn_id == "turn_1"
+        assert followup_req.turn_revision == 2
+        assert followup_req.speech_stopped_at_s == 123.0
+
     def test_response_create_rejects_complex_tool_choice(self, service, conn_id, runtime_config):
         evt = ResponseCreateEvent(
             type="response.create",

--- a/tests/openai_realtime/test_realtime_service.py
+++ b/tests/openai_realtime/test_realtime_service.py
@@ -660,6 +660,17 @@ class TestDispatchPipelineEvent:
         assert isinstance(events[0], InputAudioBufferSpeechStartedEvent)
         assert service._state(conn_id).in_response is True
 
+    def test_speech_started_internal_non_interrupt_does_not_cancel(self, service, conn_id):
+        service.response._ensure_response(conn_id)
+        events = service.dispatch_pipeline_event(
+            conn_id,
+            SpeechStartedEvent(interrupt_response=False),
+        )
+
+        assert len(events) == 1
+        assert isinstance(events[0], InputAudioBufferSpeechStartedEvent)
+        assert service._state(conn_id).in_response is True
+
     def test_consecutive_speech_cycles_get_distinct_item_ids(self, service, conn_id):
         """Each speech_started/stopped cycle generates a new unique item_id."""
         started_1 = service.dispatch_pipeline_event(conn_id, SpeechStartedEvent())

--- a/tests/openai_realtime/test_realtime_service.py
+++ b/tests/openai_realtime/test_realtime_service.py
@@ -7,6 +7,7 @@ validated for correct type, attributes, and state transitions.
 import base64
 import json
 from queue import Queue
+from threading import Event, Thread
 
 import pytest
 from openai.types.realtime import (
@@ -762,6 +763,108 @@ class TestDispatchPipelineEvent:
         assert len(events) == 1
         assert isinstance(events[0], ResponseFunctionCallArgumentsDoneEvent)
         assert events[0].output_index == 0
+
+    def test_assistant_text_waits_for_pending_reopen_and_drops_confirmed_stale_turn(
+        self,
+        runtime_config,
+        should_listen,
+    ):
+        tracker = SpeculativeTurnTracker()
+        service = RealtimeService(should_listen=should_listen, speculative_turns=tracker)
+        conn_id = service.register()
+        service._state(conn_id).runtime_config = runtime_config
+        tracker.observe("turn_1", 0)
+        candidate_revision = tracker.begin_reopen_candidate("turn_1", 0)
+        done = Event()
+        result = {}
+
+        def dispatch():
+            result["events"] = service.dispatch_pipeline_event(
+                conn_id,
+                AssistantTextEvent(text="stale", turn_id="turn_1", turn_revision=0),
+            )
+            done.set()
+
+        thread = Thread(target=dispatch)
+        thread.start()
+
+        assert not done.wait(0.05)
+        assert tracker.confirm_reopen_candidate("turn_1", 0, candidate_revision)
+        assert done.wait(1.0)
+        thread.join(timeout=1.0)
+
+        assert result["events"] == []
+        assert service._state(conn_id).current_response_id is None
+        service.unregister(conn_id)
+
+    def test_assistant_text_waits_for_pending_reopen_and_emits_cancelled_reopen(
+        self,
+        runtime_config,
+        should_listen,
+    ):
+        tracker = SpeculativeTurnTracker()
+        service = RealtimeService(should_listen=should_listen, speculative_turns=tracker)
+        conn_id = service.register()
+        service._state(conn_id).runtime_config = runtime_config
+        tracker.observe("turn_1", 0)
+        candidate_revision = tracker.begin_reopen_candidate("turn_1", 0)
+        done = Event()
+        result = {}
+
+        def dispatch():
+            result["events"] = service.dispatch_pipeline_event(
+                conn_id,
+                AssistantTextEvent(text="latest", turn_id="turn_1", turn_revision=0),
+            )
+            done.set()
+
+        thread = Thread(target=dispatch)
+        thread.start()
+
+        assert not done.wait(0.05)
+        tracker.cancel_reopen_candidate("turn_1", candidate_revision)
+        assert done.wait(1.0)
+        thread.join(timeout=1.0)
+
+        assert len(result["events"]) == 1
+        assert isinstance(result["events"][0], ResponseAudioTranscriptDoneEvent)
+        assert result["events"][0].transcript == "latest"
+        assert tracker.is_committed("turn_1", 0)
+        service.unregister(conn_id)
+
+    def test_token_usage_waits_for_pending_reopen_and_drops_confirmed_stale_turn(
+        self,
+        runtime_config,
+        should_listen,
+    ):
+        tracker = SpeculativeTurnTracker()
+        service = RealtimeService(should_listen=should_listen, speculative_turns=tracker)
+        conn_id = service.register()
+        service._state(conn_id).runtime_config = runtime_config
+        tracker.observe("turn_1", 0)
+        candidate_revision = tracker.begin_reopen_candidate("turn_1", 0)
+        done = Event()
+        result = {}
+
+        def dispatch():
+            result["events"] = service.dispatch_pipeline_event(
+                conn_id,
+                TokenUsageEvent(input_tokens=10, output_tokens=5, turn_id="turn_1", turn_revision=0),
+            )
+            done.set()
+
+        thread = Thread(target=dispatch)
+        thread.start()
+
+        assert not done.wait(0.05)
+        assert tracker.confirm_reopen_candidate("turn_1", 0, candidate_revision)
+        assert done.wait(1.0)
+        thread.join(timeout=1.0)
+
+        assert result["events"] == []
+        assert service._state(conn_id).response_usage.input_tokens == 0
+        assert service._state(conn_id).response_usage.output_tokens == 0
+        service.unregister(conn_id)
 
     # -- partial_transcription --
 

--- a/tests/openai_realtime/test_realtime_service.py
+++ b/tests/openai_realtime/test_realtime_service.py
@@ -31,7 +31,6 @@ from openai.types.realtime import (
     SessionCreatedEvent,
     SessionUpdateEvent,
 )
-from openai.types.realtime.realtime_server_event import OutputAudioBufferCleared
 
 from speech_to_speech.api.openai_realtime.service import (
     CHUNK_SIZE_BYTES,
@@ -609,9 +608,7 @@ class TestFinishAudioResponse:
     def test_finish_with_cancel_status(self, service, conn_id):
         service.response._ensure_response(conn_id)
         events = service.finish_audio_response(conn_id, status="cancelled", reason="turn_detected")
-        assert len(events) == 3
-        assert isinstance(events[1], OutputAudioBufferCleared)
-        done = events[2]
+        done = events[1]
         assert done.response.status == "cancelled"
         assert done.response.status_details.reason == "turn_detected"
 
@@ -657,7 +654,6 @@ class TestDispatchPipelineEvent:
         )
         cancel_events = [e for e in events if isinstance(e, (ResponseAudioDoneEvent, ResponseDoneEvent))]
         assert len(cancel_events) == 2
-        assert any(isinstance(e, OutputAudioBufferCleared) for e in events)
         done = [e for e in cancel_events if isinstance(e, ResponseDoneEvent)][0]
         assert done.response.status == "cancelled"
         assert done.response.status_details.reason == "turn_detected"

--- a/tests/openai_realtime/test_realtime_service.py
+++ b/tests/openai_realtime/test_realtime_service.py
@@ -874,6 +874,99 @@ class TestDispatchPipelineEvent:
         assert service._state(conn_id).response_usage.audio_duration_s == 2.0
         service.unregister(conn_id)
 
+    def test_empty_revised_transcription_removes_speculative_user_message(self, runtime_config, should_listen):
+        text_prompt_queue = Queue()
+        tracker = SpeculativeTurnTracker()
+        service = RealtimeService(
+            text_prompt_queue=text_prompt_queue,
+            should_listen=should_listen,
+            speculative_turns=tracker,
+        )
+        conn_id = service.register()
+        service._state(conn_id).runtime_config = runtime_config
+
+        service.dispatch_pipeline_event(
+            conn_id,
+            SpeechStartedEvent(turn_id="turn_1", turn_revision=0),
+        )
+        service.dispatch_pipeline_event(
+            conn_id,
+            SpeechStoppedEvent(duration_s=1.0, turn_id="turn_1", turn_revision=0),
+        )
+        service.dispatch_pipeline_event(
+            conn_id,
+            TranscriptionCompletedEvent(transcript="hello", turn_id="turn_1", turn_revision=0),
+        )
+
+        tracker.observe("turn_1", 1)
+        service.dispatch_pipeline_event(
+            conn_id,
+            SpeechStartedEvent(turn_id="turn_1", turn_revision=1, reopened=True),
+        )
+        service.dispatch_pipeline_event(
+            conn_id,
+            SpeechStoppedEvent(duration_s=2.0, turn_id="turn_1", turn_revision=1),
+        )
+        service.dispatch_pipeline_event(
+            conn_id,
+            TranscriptionCompletedEvent(transcript="", turn_id="turn_1", turn_revision=1),
+        )
+
+        user_items = [item for item in runtime_config.chat.buffer if getattr(item, "role", None) == "user"]
+        assert user_items == []
+        first_req = text_prompt_queue.get_nowait()
+        assert first_req.turn_revision == 0
+        assert text_prompt_queue.empty()
+        assert service._state(conn_id).response_usage.audio_duration_s == 2.0
+        service.unregister(conn_id)
+
+    def test_empty_first_revision_tracks_audio_for_later_nonempty_reopen(self, runtime_config, should_listen):
+        text_prompt_queue = Queue()
+        tracker = SpeculativeTurnTracker()
+        service = RealtimeService(
+            text_prompt_queue=text_prompt_queue,
+            should_listen=should_listen,
+            speculative_turns=tracker,
+        )
+        conn_id = service.register()
+        service._state(conn_id).runtime_config = runtime_config
+
+        service.dispatch_pipeline_event(
+            conn_id,
+            SpeechStartedEvent(turn_id="turn_1", turn_revision=0),
+        )
+        service.dispatch_pipeline_event(
+            conn_id,
+            SpeechStoppedEvent(duration_s=1.0, turn_id="turn_1", turn_revision=0),
+        )
+        service.dispatch_pipeline_event(
+            conn_id,
+            TranscriptionCompletedEvent(transcript="", turn_id="turn_1", turn_revision=0),
+        )
+
+        tracker.observe("turn_1", 1)
+        service.dispatch_pipeline_event(
+            conn_id,
+            SpeechStartedEvent(turn_id="turn_1", turn_revision=1, reopened=True),
+        )
+        service.dispatch_pipeline_event(
+            conn_id,
+            SpeechStoppedEvent(duration_s=2.0, turn_id="turn_1", turn_revision=1),
+        )
+        service.dispatch_pipeline_event(
+            conn_id,
+            TranscriptionCompletedEvent(transcript="hello again", turn_id="turn_1", turn_revision=1),
+        )
+
+        user_items = [item for item in runtime_config.chat.buffer if getattr(item, "role", None) == "user"]
+        assert len(user_items) == 1
+        assert user_items[0].content[0].text == "hello again"
+        req = text_prompt_queue.get_nowait()
+        assert req.turn_revision == 1
+        assert text_prompt_queue.empty()
+        assert service._state(conn_id).response_usage.audio_duration_s == 2.0
+        service.unregister(conn_id)
+
     def test_stale_transcription_revision_is_ignored(self, runtime_config, should_listen):
         text_prompt_queue = Queue()
         tracker = SpeculativeTurnTracker()

--- a/tests/openai_realtime/test_realtime_service.py
+++ b/tests/openai_realtime/test_realtime_service.py
@@ -677,7 +677,7 @@ class TestDispatchPipelineEvent:
             type="server_vad",
             interrupt_response=False,
         )
-        service.response._ensure_response(conn_id)
+        _, response_item_id = service.response._ensure_response(conn_id)
         events = service.dispatch_pipeline_event(
             conn_id,
             SpeechStartedEvent(),
@@ -685,9 +685,10 @@ class TestDispatchPipelineEvent:
         assert len(events) == 1
         assert isinstance(events[0], InputAudioBufferSpeechStartedEvent)
         assert service._state(conn_id).in_response is True
+        assert service._state(conn_id).current_item_id == response_item_id
 
     def test_speech_started_internal_non_interrupt_does_not_cancel(self, service, conn_id):
-        service.response._ensure_response(conn_id)
+        _, response_item_id = service.response._ensure_response(conn_id)
         events = service.dispatch_pipeline_event(
             conn_id,
             SpeechStartedEvent(interrupt_response=False),
@@ -696,6 +697,9 @@ class TestDispatchPipelineEvent:
         assert len(events) == 1
         assert isinstance(events[0], InputAudioBufferSpeechStartedEvent)
         assert service._state(conn_id).in_response is True
+        assert service._state(conn_id).current_item_id == response_item_id
+        done_events = service.finish_audio_response(conn_id)
+        assert done_events[0].item_id == response_item_id
 
     def test_consecutive_speech_cycles_get_distinct_item_ids(self, service, conn_id):
         """Each speech_started/stopped cycle generates a new unique item_id."""

--- a/tests/openai_realtime/test_realtime_service.py
+++ b/tests/openai_realtime/test_realtime_service.py
@@ -1007,6 +1007,7 @@ class TestDispatchPipelineEvent:
         assert evt.transcript == "hello world"
         assert evt.usage.seconds == 3.2
         assert evt.usage.type == "duration"
+        assert service._state(conn_id).response_pending is True
 
     def test_empty_transcription_completed_emits_event_without_response(
         self,
@@ -1032,6 +1033,7 @@ class TestDispatchPipelineEvent:
         assert evt.usage.seconds == 1.1
         assert text_prompt_queue.empty()
         assert runtime_config.chat.buffer == []
+        assert service._state(conn_id).response_pending is False
 
     def test_revised_transcription_replaces_speculative_user_message(self, runtime_config, should_listen):
         text_prompt_queue = Queue()

--- a/tests/openai_realtime/test_realtime_service.py
+++ b/tests/openai_realtime/test_realtime_service.py
@@ -866,6 +866,48 @@ class TestDispatchPipelineEvent:
         assert service._state(conn_id).response_usage.output_tokens == 0
         service.unregister(conn_id)
 
+    def test_try_dispatch_assistant_text_defers_pending_reopen(self, runtime_config, should_listen):
+        tracker = SpeculativeTurnTracker()
+        service = RealtimeService(should_listen=should_listen, speculative_turns=tracker)
+        conn_id = service.register()
+        service._state(conn_id).runtime_config = runtime_config
+        tracker.observe("turn_1", 0)
+        candidate_revision = tracker.begin_reopen_candidate("turn_1", 0)
+
+        event = AssistantTextEvent(text="latest", turn_id="turn_1", turn_revision=0)
+
+        assert service.try_dispatch_pipeline_event(conn_id, event) is None
+        assert service._state(conn_id).current_response_id is None
+
+        tracker.cancel_reopen_candidate("turn_1", candidate_revision)
+        events = service.try_dispatch_pipeline_event(conn_id, event)
+
+        assert events is not None
+        assert len(events) == 1
+        assert isinstance(events[0], ResponseAudioTranscriptDoneEvent)
+        assert events[0].transcript == "latest"
+        assert tracker.is_committed("turn_1", 0)
+        service.unregister(conn_id)
+
+    def test_try_dispatch_token_usage_defers_pending_reopen(self, runtime_config, should_listen):
+        tracker = SpeculativeTurnTracker()
+        service = RealtimeService(should_listen=should_listen, speculative_turns=tracker)
+        conn_id = service.register()
+        service._state(conn_id).runtime_config = runtime_config
+        tracker.observe("turn_1", 0)
+        candidate_revision = tracker.begin_reopen_candidate("turn_1", 0)
+
+        event = TokenUsageEvent(input_tokens=10, output_tokens=5, turn_id="turn_1", turn_revision=0)
+
+        assert service.try_dispatch_pipeline_event(conn_id, event) is None
+        assert service._state(conn_id).response_usage.input_tokens == 0
+
+        assert tracker.confirm_reopen_candidate("turn_1", 0, candidate_revision)
+        assert service.try_dispatch_pipeline_event(conn_id, event) == []
+        assert service._state(conn_id).response_usage.input_tokens == 0
+        assert service._state(conn_id).response_usage.output_tokens == 0
+        service.unregister(conn_id)
+
     # -- partial_transcription --
 
     def test_partial_transcription_emits_delta(self, service, conn_id):

--- a/tests/openai_realtime/test_realtime_service.py
+++ b/tests/openai_realtime/test_realtime_service.py
@@ -8,6 +8,7 @@ import base64
 import json
 from queue import Queue
 from threading import Event, Thread
+from time import sleep
 
 import pytest
 from openai.types.realtime import (
@@ -880,6 +881,30 @@ class TestDispatchPipelineEvent:
         assert service._state(conn_id).current_response_id is None
 
         tracker.cancel_reopen_candidate("turn_1", candidate_revision)
+        events = service.try_dispatch_pipeline_event(conn_id, event)
+
+        assert events is not None
+        assert len(events) == 1
+        assert isinstance(events[0], ResponseAudioTranscriptDoneEvent)
+        assert events[0].transcript == "latest"
+        assert tracker.is_committed("turn_1", 0)
+        service.unregister(conn_id)
+
+    def test_try_dispatch_assistant_text_defers_reopen_grace(self, runtime_config, should_listen):
+        tracker = SpeculativeTurnTracker()
+        service = RealtimeService(should_listen=should_listen, speculative_turns=tracker)
+        conn_id = service.register()
+        service._state(conn_id).runtime_config = runtime_config
+        tracker.observe("turn_1", 0)
+        tracker.start_reopen_grace("turn_1", 0, grace_s=0.05)
+
+        event = AssistantTextEvent(text="latest", turn_id="turn_1", turn_revision=0)
+
+        assert service.should_defer_pipeline_event(event)
+        assert service.try_dispatch_pipeline_event(conn_id, event) is None
+        assert service._state(conn_id).current_response_id is None
+
+        sleep(0.06)
         events = service.try_dispatch_pipeline_event(conn_id, event)
 
         assert events is not None

--- a/tests/openai_realtime/test_realtime_service.py
+++ b/tests/openai_realtime/test_realtime_service.py
@@ -31,6 +31,7 @@ from openai.types.realtime import (
     SessionCreatedEvent,
     SessionUpdateEvent,
 )
+from openai.types.realtime.realtime_server_event import OutputAudioBufferCleared
 
 from speech_to_speech.api.openai_realtime.service import (
     CHUNK_SIZE_BYTES,
@@ -608,7 +609,9 @@ class TestFinishAudioResponse:
     def test_finish_with_cancel_status(self, service, conn_id):
         service.response._ensure_response(conn_id)
         events = service.finish_audio_response(conn_id, status="cancelled", reason="turn_detected")
-        done = events[1]
+        assert len(events) == 3
+        assert isinstance(events[1], OutputAudioBufferCleared)
+        done = events[2]
         assert done.response.status == "cancelled"
         assert done.response.status_details.reason == "turn_detected"
 
@@ -654,6 +657,7 @@ class TestDispatchPipelineEvent:
         )
         cancel_events = [e for e in events if isinstance(e, (ResponseAudioDoneEvent, ResponseDoneEvent))]
         assert len(cancel_events) == 2
+        assert any(isinstance(e, OutputAudioBufferCleared) for e in events)
         done = [e for e in cancel_events if isinstance(e, ResponseDoneEvent)][0]
         assert done.response.status == "cancelled"
         assert done.response.status_details.reason == "turn_detected"

--- a/tests/openai_realtime/test_realtime_service.py
+++ b/tests/openai_realtime/test_realtime_service.py
@@ -6,6 +6,7 @@ validated for correct type, attributes, and state transitions.
 
 import base64
 import json
+from queue import Queue
 
 import pytest
 from openai.types.realtime import (
@@ -31,6 +32,7 @@ from openai.types.realtime import (
 
 from speech_to_speech.api.openai_realtime.service import (
     CHUNK_SIZE_BYTES,
+    RealtimeService,
 )
 from speech_to_speech.pipeline.events import (
     AssistantTextEvent,
@@ -41,6 +43,7 @@ from speech_to_speech.pipeline.events import (
     TranscriptionCompletedEvent,
 )
 from speech_to_speech.pipeline.messages import GenerateResponseRequest
+from speech_to_speech.pipeline.speculative_turns import SpeculativeTurnTracker
 
 # ---------------------------------------------------------------------------
 # Helpers
@@ -822,6 +825,76 @@ class TestDispatchPipelineEvent:
         assert evt.usage.seconds == 1.1
         assert text_prompt_queue.empty()
         assert runtime_config.chat.buffer == []
+
+    def test_revised_transcription_replaces_speculative_user_message(self, runtime_config, should_listen):
+        text_prompt_queue = Queue()
+        tracker = SpeculativeTurnTracker()
+        service = RealtimeService(
+            text_prompt_queue=text_prompt_queue,
+            should_listen=should_listen,
+            speculative_turns=tracker,
+        )
+        conn_id = service.register()
+        service._state(conn_id).runtime_config = runtime_config
+
+        service.dispatch_pipeline_event(
+            conn_id,
+            SpeechStartedEvent(turn_id="turn_1", turn_revision=0),
+        )
+        service.dispatch_pipeline_event(
+            conn_id,
+            SpeechStoppedEvent(duration_s=1.0, turn_id="turn_1", turn_revision=0),
+        )
+        service.dispatch_pipeline_event(
+            conn_id,
+            TranscriptionCompletedEvent(transcript="hello", turn_id="turn_1", turn_revision=0),
+        )
+
+        tracker.observe("turn_1", 1)
+        service.dispatch_pipeline_event(
+            conn_id,
+            SpeechStartedEvent(turn_id="turn_1", turn_revision=1, reopened=True),
+        )
+        service.dispatch_pipeline_event(
+            conn_id,
+            SpeechStoppedEvent(duration_s=2.0, turn_id="turn_1", turn_revision=1),
+        )
+        service.dispatch_pipeline_event(
+            conn_id,
+            TranscriptionCompletedEvent(transcript="hello again", turn_id="turn_1", turn_revision=1),
+        )
+
+        user_items = [item for item in runtime_config.chat.buffer if getattr(item, "role", None) == "user"]
+        assert len(user_items) == 1
+        assert user_items[0].content[0].text == "hello again"
+        first_req = text_prompt_queue.get_nowait()
+        second_req = text_prompt_queue.get_nowait()
+        assert first_req.turn_revision == 0
+        assert second_req.turn_revision == 1
+        assert service._state(conn_id).response_usage.audio_duration_s == 2.0
+        service.unregister(conn_id)
+
+    def test_stale_transcription_revision_is_ignored(self, runtime_config, should_listen):
+        text_prompt_queue = Queue()
+        tracker = SpeculativeTurnTracker()
+        service = RealtimeService(
+            text_prompt_queue=text_prompt_queue,
+            should_listen=should_listen,
+            speculative_turns=tracker,
+        )
+        conn_id = service.register()
+        service._state(conn_id).runtime_config = runtime_config
+        tracker.observe("turn_1", 1)
+
+        events = service.dispatch_pipeline_event(
+            conn_id,
+            TranscriptionCompletedEvent(transcript="stale", turn_id="turn_1", turn_revision=0),
+        )
+
+        assert events == []
+        assert runtime_config.chat.buffer == []
+        assert text_prompt_queue.empty()
+        service.unregister(conn_id)
 
     # -- unknown --
 

--- a/tests/openai_realtime/test_websocket_router.py
+++ b/tests/openai_realtime/test_websocket_router.py
@@ -14,10 +14,15 @@ import pytest
 from starlette.testclient import TestClient
 
 from speech_to_speech.api.openai_realtime.service import CHUNK_SIZE_BYTES, RealtimeService
-from speech_to_speech.api.openai_realtime.websocket_router import create_app
+from speech_to_speech.api.openai_realtime.websocket_router import _keep_user_text_event, create_app
 from speech_to_speech.pipeline.cancel_scope import CancelScope
 from speech_to_speech.pipeline.control import SESSION_END, is_control_message
-from speech_to_speech.pipeline.events import AssistantTextEvent, SpeechStartedEvent
+from speech_to_speech.pipeline.events import (
+    AssistantTextEvent,
+    PartialTranscriptionEvent,
+    SpeechStartedEvent,
+    TranscriptionCompletedEvent,
+)
 from speech_to_speech.pipeline.messages import AUDIO_RESPONSE_DONE, PIPELINE_END
 
 # ---------------------------------------------------------------------------
@@ -244,6 +249,11 @@ class TestClientEventDispatch:
 
 
 class TestSendLoop:
+    def test_cancel_flush_preserves_pending_user_transcription_events(self):
+        assert _keep_user_text_event(TranscriptionCompletedEvent(transcript="hello"))
+        assert _keep_user_text_event(PartialTranscriptionEvent(delta="hel"))
+        assert not _keep_user_text_event(AssistantTextEvent(text="stale"))
+
     def test_audio_output_ignores_session_end_control_message(self, setup):
         app, _, _, output_queue, *_ = setup
         with TestClient(app) as client:

--- a/tests/openai_realtime/test_websocket_router.py
+++ b/tests/openai_realtime/test_websocket_router.py
@@ -23,7 +23,7 @@ from speech_to_speech.pipeline.events import (
     SpeechStartedEvent,
     TranscriptionCompletedEvent,
 )
-from speech_to_speech.pipeline.messages import AUDIO_RESPONSE_DONE, PIPELINE_END
+from speech_to_speech.pipeline.messages import AUDIO_RESPONSE_DONE, PIPELINE_END, AudioOutput
 from speech_to_speech.pipeline.speculative_turns import SpeculativeTurnTracker
 
 # ---------------------------------------------------------------------------
@@ -369,6 +369,42 @@ class TestSendLoop:
                 output_queue.put(AUDIO_RESPONSE_DONE)
                 time.sleep(0.15)
                 assert not cancel_scope.discarding
+
+    def test_stale_tagged_audio_is_dropped_after_interruption(self, setup):
+        app, _, _, output_queue, _, _, _, _, cancel_scope = setup
+        with TestClient(app) as client:
+            with client.websocket_connect("/v1/realtime") as ws:
+                ws.receive_json()  # session.created
+                stale_generation = cancel_scope.generation
+                cancel_scope.cancel()
+                current_generation = cancel_scope.generation
+                output_queue.put(AudioOutput(audio=_pcm_bytes(64), cancel_generation=stale_generation))
+                output_queue.put(AudioOutput(audio=_pcm_bytes(512), cancel_generation=current_generation))
+
+                assert ws.receive_json()["type"] == "response.created"
+                delta = ws.receive_json()
+
+                assert delta["type"] == "response.output_audio.delta"
+                assert len(base64.b64decode(delta["delta"])) == len(_pcm_bytes(512))
+
+    def test_stale_tagged_response_done_does_not_finish_current_response(self, setup):
+        app, service, _, output_queue, _, _, _, _, cancel_scope = setup
+        with TestClient(app) as client:
+            with client.websocket_connect("/v1/realtime") as ws:
+                ws.receive_json()  # session.created
+                conn_id = list(service._conns.keys())[0]
+                stale_generation = cancel_scope.generation
+                service.response._ensure_response(conn_id)
+                service.finish_audio_response(conn_id, status="cancelled")
+                cancel_scope.cancel()
+                current_response_id, _ = service.response._ensure_response(conn_id)
+
+                output_queue.put(AudioOutput(audio=AUDIO_RESPONSE_DONE, cancel_generation=stale_generation))
+                time.sleep(0.15)
+
+                state = service._state(conn_id)
+                assert state.in_response
+                assert state.current_response_id == current_response_id
 
     def test_speech_started_does_not_cancel_when_interrupt_disabled(self, setup):
         """With interrupt_response=False, speech during playback should NOT cancel or flush."""

--- a/tests/openai_realtime/test_websocket_router.py
+++ b/tests/openai_realtime/test_websocket_router.py
@@ -20,7 +20,7 @@ from speech_to_speech.api.openai_realtime.service import CHUNK_SIZE_BYTES, Realt
 from speech_to_speech.api.openai_realtime.websocket_router import create_app
 from speech_to_speech.pipeline.cancel_scope import CancelScope
 from speech_to_speech.pipeline.control import SESSION_END, PipelineControlMessage, is_control_message
-from speech_to_speech.pipeline.events import AssistantTextEvent, SpeechStartedEvent
+from speech_to_speech.pipeline.events import AssistantTextEvent, SpeechStartedEvent, TokenUsageEvent
 from speech_to_speech.pipeline.messages import AUDIO_RESPONSE_DONE, PIPELINE_END, AudioOutput
 
 # ---------------------------------------------------------------------------
@@ -467,6 +467,32 @@ class TestSendLoop:
                 assert state.in_response
                 assert state.current_response_id == current_response_id
 
+    def test_response_done_drains_pending_token_usage_before_finish(self, setup):
+        app, service, _, output_queue, text_output_queue, *_ = setup
+        with TestClient(app) as client:
+            with client.websocket_connect("/v1/realtime") as ws:
+                ws.receive_json()  # session.created
+                conn_id = list(service._conns.keys())[0]
+
+                text_output_queue.put(
+                    AssistantTextEvent(
+                        text="",
+                        tools=[{"type": "function_call", "call_id": "c1", "name": "f1", "arguments": "{}"}],
+                    )
+                )
+                text_output_queue.put(TokenUsageEvent(input_tokens=10, output_tokens=5))
+                output_queue.put(AUDIO_RESPONSE_DONE)
+
+                assert ws.receive_json()["type"] == "response.function_call_arguments.done"
+                msg1 = ws.receive_json()
+                msg2 = ws.receive_json()
+                assert {msg1["type"], msg2["type"]} == {"response.output_audio.done", "response.done"}
+
+                assert service.total_usage.input_tokens == 10
+                assert service.total_usage.output_tokens == 5
+                assert service._state(conn_id).response_usage.input_tokens == 0
+                assert service._state(conn_id).response_usage.output_tokens == 0
+
     def test_speech_started_does_not_cancel_when_interrupt_disabled(self, setup):
         """With interrupt_response=False, speech during playback should NOT cancel or flush."""
         from openai.types.realtime.realtime_audio_input_turn_detection import ServerVad
@@ -480,7 +506,7 @@ class TestSendLoop:
                     type="server_vad",
                     interrupt_response=False,
                 )
-                service.response._ensure_response(conn_id)
+                _, response_item_id = service.response._ensure_response(conn_id)
                 response_playing.set()
                 text_output_queue.put(SpeechStartedEvent())
                 msg = ws.receive_json()
@@ -489,6 +515,7 @@ class TestSendLoop:
                 assert response_playing.is_set(), "response_playing should remain set"
                 assert not cancel_scope.discarding, "cancel_scope should not be discarding"
                 assert service._state(conn_id).in_response, "response should still be active"
+                assert service._state(conn_id).current_item_id == response_item_id
 
 
 # ===================================================================

--- a/tests/openai_realtime/test_websocket_router.py
+++ b/tests/openai_realtime/test_websocket_router.py
@@ -382,11 +382,9 @@ class TestSendLoop:
                 response_playing.set()
                 # Trigger barge-in
                 text_output_queue.put(SpeechStartedEvent())
-                ws.receive_json()  # response.output_audio.done
-                clear_event = ws.receive_json()
-                assert clear_event["type"] == "output_audio_buffer.cleared"
-                ws.receive_json()  # response.done
                 ws.receive_json()  # input_audio_buffer.speech_started
+                ws.receive_json()  # response.output_audio.done
+                ws.receive_json()  # response.done
                 time.sleep(0.1)
                 assert cancel_scope.discarding
                 output_queue.put(AUDIO_RESPONSE_DONE)

--- a/tests/openai_realtime/test_websocket_router.py
+++ b/tests/openai_realtime/test_websocket_router.py
@@ -382,9 +382,11 @@ class TestSendLoop:
                 response_playing.set()
                 # Trigger barge-in
                 text_output_queue.put(SpeechStartedEvent())
-                ws.receive_json()  # input_audio_buffer.speech_started
                 ws.receive_json()  # response.output_audio.done
+                clear_event = ws.receive_json()
+                assert clear_event["type"] == "output_audio_buffer.cleared"
                 ws.receive_json()  # response.done
+                ws.receive_json()  # input_audio_buffer.speech_started
                 time.sleep(0.1)
                 assert cancel_scope.discarding
                 output_queue.put(AUDIO_RESPONSE_DONE)

--- a/tests/openai_realtime/test_websocket_router.py
+++ b/tests/openai_realtime/test_websocket_router.py
@@ -391,6 +391,46 @@ class TestSendLoop:
                 time.sleep(0.15)
                 assert not cancel_scope.discarding
 
+    def test_speech_started_cancels_pending_implicit_response(self, setup):
+        app, service, _, output_queue, text_output_queue, _, _, response_playing, cancel_scope = setup
+        with TestClient(app) as client:
+            with client.websocket_connect("/v1/realtime") as ws:
+                ws.receive_json()  # session.created
+                conn_id = list(service._conns.keys())[0]
+                stale_generation = cancel_scope.generation
+                service._state(conn_id).response_pending = True
+
+                text_output_queue.put(SpeechStartedEvent())
+                msg = ws.receive_json()
+
+                assert msg["type"] == "input_audio_buffer.speech_started"
+                time.sleep(0.15)
+                assert cancel_scope.discarding
+                assert cancel_scope.generation == stale_generation + 1
+                assert service._state(conn_id).response_pending is False
+                assert service._state(conn_id).in_response is False
+                assert not response_playing.is_set()
+
+                output_queue.put(AudioOutput(audio=AUDIO_RESPONSE_DONE, cancel_generation=stale_generation))
+                time.sleep(0.15)
+                assert not cancel_scope.discarding
+
+    def test_speech_started_does_not_cancel_pending_when_internal_non_interrupt(self, setup):
+        app, service, _, _, text_output_queue, _, _, _, cancel_scope = setup
+        with TestClient(app) as client:
+            with client.websocket_connect("/v1/realtime") as ws:
+                ws.receive_json()  # session.created
+                conn_id = list(service._conns.keys())[0]
+                service._state(conn_id).response_pending = True
+
+                text_output_queue.put(SpeechStartedEvent(interrupt_response=False))
+                msg = ws.receive_json()
+
+                assert msg["type"] == "input_audio_buffer.speech_started"
+                time.sleep(0.15)
+                assert not cancel_scope.discarding
+                assert service._state(conn_id).response_pending is True
+
     def test_stale_tagged_audio_is_dropped_after_interruption(self, setup):
         app, _, _, output_queue, _, _, _, _, cancel_scope = setup
         with TestClient(app) as client:

--- a/tests/openai_realtime/test_websocket_router.py
+++ b/tests/openai_realtime/test_websocket_router.py
@@ -24,6 +24,7 @@ from speech_to_speech.pipeline.events import (
     TranscriptionCompletedEvent,
 )
 from speech_to_speech.pipeline.messages import AUDIO_RESPONSE_DONE, PIPELINE_END
+from speech_to_speech.pipeline.speculative_turns import SpeculativeTurnTracker
 
 # ---------------------------------------------------------------------------
 # Fixtures
@@ -327,6 +328,27 @@ class TestSendLoop:
                 msg = ws.receive_json()
                 assert msg["type"] == "input_audio_buffer.speech_started"
                 assert msg["audio_start_ms"] == 0
+
+    def test_pending_reopen_text_does_not_block_audio_send_loop(self, setup):
+        app, service, _, output_queue, text_output_queue, *_ = setup
+        tracker = SpeculativeTurnTracker()
+        service.speculative_turns = tracker
+        with TestClient(app) as client:
+            with client.websocket_connect("/v1/realtime") as ws:
+                ws.receive_json()
+                tracker.observe("turn_1", 0)
+                candidate_revision = tracker.begin_reopen_candidate("turn_1", 0)
+                text_output_queue.put(AssistantTextEvent(text="deferred", turn_id="turn_1", turn_revision=0))
+                output_queue.put(_pcm_bytes(256))
+
+                started_at = time.monotonic()
+                msg = ws.receive_json()
+                elapsed_s = time.monotonic() - started_at
+
+                assert elapsed_s < 0.5
+                assert msg["type"] == "response.created"
+                assert ws.receive_json()["type"] == "response.output_audio.delta"
+                assert tracker.confirm_reopen_candidate("turn_1", 0, candidate_revision)
 
     def test_barge_in_discard_clears_after_response_done(self, setup):
         """After barge-in sets discarding=True, __RESPONSE_DONE__ must clear it back to False."""

--- a/tests/openai_realtime/test_websocket_router.py
+++ b/tests/openai_realtime/test_websocket_router.py
@@ -393,6 +393,24 @@ class TestSendLoop:
                 assert not cancel_scope.discarding, "cancel_scope should not be discarding"
                 assert service._state(conn_id).in_response, "response should still be active"
 
+    def test_speech_started_internal_non_interrupt_does_not_cancel_or_flush(self, setup):
+        app, service, _, _, text_output_queue, _, _, response_playing, cancel_scope = setup
+        with TestClient(app) as client:
+            with client.websocket_connect("/v1/realtime") as ws:
+                ws.receive_json()  # session.created
+                conn_id = list(service._conns.keys())[0]
+                service.response._ensure_response(conn_id)
+                response_playing.set()
+                text_output_queue.put(SpeechStartedEvent(interrupt_response=False))
+
+                msg = ws.receive_json()
+
+                assert msg["type"] == "input_audio_buffer.speech_started"
+                time.sleep(0.15)
+                assert response_playing.is_set(), "response_playing should remain set"
+                assert not cancel_scope.discarding, "cancel_scope should not be discarding"
+                assert service._state(conn_id).in_response, "response should still be active"
+
 
 # ===================================================================
 # Cleanup

--- a/tests/test_cli_defaults.py
+++ b/tests/test_cli_defaults.py
@@ -38,6 +38,7 @@ def test_release_defaults_match_responses_api_parakeet_qwen3_realtime_profile():
     assert module_args.live_transcription_update_interval == 0.5
 
     assert vad_args.thresh == 0.6
+    assert vad_args.min_silence_ms == 300
     assert vad_args.min_speech_ms == 500
     assert vad_args.realtime_processing_pause == 0.5
     assert responses_api_args.model_name == "gpt-5.4-mini"

--- a/tests/test_cli_defaults.py
+++ b/tests/test_cli_defaults.py
@@ -35,8 +35,10 @@ def test_release_defaults_match_responses_api_parakeet_qwen3_realtime_profile():
     assert module_args.tts == "qwen3"
     assert module_args.log_level == "info"
     assert module_args.enable_live_transcription is True
+    assert module_args.live_transcription_update_interval == 0.5
 
     assert vad_args.thresh == 0.6
+    assert vad_args.realtime_processing_pause == 0.5
     assert responses_api_args.model_name == "gpt-5.4-mini"
     assert responses_api_args.chat_size == 30
     assert responses_api_args.responses_api_stream is True

--- a/tests/test_cli_defaults.py
+++ b/tests/test_cli_defaults.py
@@ -38,6 +38,7 @@ def test_release_defaults_match_responses_api_parakeet_qwen3_realtime_profile():
     assert module_args.live_transcription_update_interval == 0.5
 
     assert vad_args.thresh == 0.6
+    assert vad_args.min_speech_ms == 500
     assert vad_args.realtime_processing_pause == 0.5
     assert responses_api_args.model_name == "gpt-5.4-mini"
     assert responses_api_args.chat_size == 30

--- a/tests/test_cli_defaults.py
+++ b/tests/test_cli_defaults.py
@@ -20,7 +20,9 @@ from speech_to_speech.arguments_classes.socket_sender_arguments import SocketSen
 from speech_to_speech.arguments_classes.vad_arguments import VADHandlerArguments
 from speech_to_speech.arguments_classes.websocket_streamer_arguments import WebSocketStreamerArguments
 from speech_to_speech.arguments_classes.whisper_stt_arguments import WhisperSTTHandlerArguments
-from speech_to_speech.s2s_pipeline import ParsedArguments, parse_arguments
+from speech_to_speech.pipeline.cancel_scope import CancelScope
+from speech_to_speech.pipeline.speculative_turns import SpeculativeTurnTracker
+from speech_to_speech.s2s_pipeline import ParsedArguments, _wire_speculative_turn_dependencies, parse_arguments
 
 
 def test_release_defaults_match_responses_api_parakeet_qwen3_realtime_profile():
@@ -50,6 +52,46 @@ def test_release_defaults_match_responses_api_parakeet_qwen3_realtime_profile():
     assert qwen3_args.qwen3_tts_non_streaming_mode is True
     assert qwen3_args.qwen3_tts_ref_audio is None
     assert qwen3_args.qwen3_tts_mlx_quantization == "6bit"
+
+
+def test_speculative_turn_state_is_wired_to_all_turn_generating_handlers():
+    cancel_scope = CancelScope()
+    speculative_turns = SpeculativeTurnTracker()
+    vad_args = VADHandlerArguments()
+    language_model_args = LanguageModelHandlerArguments()
+    responses_api_args = ResponsesApiLanguageModelHandlerArguments()
+    chat_tts_args = ChatTTSHandlerArguments()
+    facebook_mms_args = FacebookMMSTTSHandlerArguments()
+    pocket_tts_args = PocketTTSHandlerArguments()
+    kokoro_args = KokoroTTSHandlerArguments()
+    qwen3_args = Qwen3TTSHandlerArguments()
+
+    _wire_speculative_turn_dependencies(
+        cancel_scope,
+        speculative_turns,
+        vad_args,
+        language_model_args,
+        responses_api_args,
+        chat_tts_args,
+        facebook_mms_args,
+        pocket_tts_args,
+        kokoro_args,
+        qwen3_args,
+    )
+
+    assert vars(vad_args)["speculative_turns"] is speculative_turns
+
+    for args in (
+        language_model_args,
+        responses_api_args,
+        chat_tts_args,
+        facebook_mms_args,
+        pocket_tts_args,
+        kokoro_args,
+        qwen3_args,
+    ):
+        assert vars(args)["cancel_scope"] is cancel_scope
+        assert vars(args)["speculative_turns"] is speculative_turns
 
 
 # -- ParsedArguments dataclass tests ------------------------------------------

--- a/tests/test_cli_defaults.py
+++ b/tests/test_cli_defaults.py
@@ -41,7 +41,7 @@ def test_release_defaults_match_responses_api_parakeet_qwen3_realtime_profile():
 
     assert vad_args.thresh == 0.6
     assert vad_args.min_silence_ms == 300
-    assert vad_args.min_speech_ms == 500
+    assert vad_args.min_speech_ms == 384
     assert vad_args.realtime_processing_pause == 0.5
     assert responses_api_args.model_name == "gpt-5.4-mini"
     assert responses_api_args.chat_size == 30

--- a/tests/test_lm_output_processor.py
+++ b/tests/test_lm_output_processor.py
@@ -1,0 +1,33 @@
+from queue import Queue
+
+from speech_to_speech.LLM.lm_output_processor import LMOutputProcessor
+from speech_to_speech.pipeline.messages import EndOfResponse
+from speech_to_speech.pipeline.speculative_turns import SpeculativeTurnTracker
+
+
+def _processor(tracker: SpeculativeTurnTracker) -> LMOutputProcessor:
+    processor = LMOutputProcessor.__new__(LMOutputProcessor)
+    processor.setup(text_output_queue=Queue(), speculative_turns=tracker)
+    return processor
+
+
+def test_stale_end_of_response_is_not_forwarded_to_tts():
+    tracker = SpeculativeTurnTracker()
+    tracker.observe("turn_1", 1)
+    processor = _processor(tracker)
+
+    outputs = list(processor.process(EndOfResponse(turn_id="turn_1", turn_revision=0)))
+
+    assert outputs == []
+
+
+def test_latest_end_of_response_is_forwarded_to_tts():
+    tracker = SpeculativeTurnTracker()
+    tracker.observe("turn_1", 1)
+    processor = _processor(tracker)
+
+    outputs = list(processor.process(EndOfResponse(turn_id="turn_1", turn_revision=1)))
+
+    assert len(outputs) == 1
+    assert outputs[0].turn_id == "turn_1"
+    assert outputs[0].turn_revision == 1

--- a/tests/test_lm_output_processor.py
+++ b/tests/test_lm_output_processor.py
@@ -1,7 +1,8 @@
 from queue import Queue
+from threading import Event, Thread
 
 from speech_to_speech.LLM.lm_output_processor import LMOutputProcessor
-from speech_to_speech.pipeline.messages import EndOfResponse
+from speech_to_speech.pipeline.messages import EndOfResponse, LLMResponseChunk
 from speech_to_speech.pipeline.speculative_turns import SpeculativeTurnTracker
 
 
@@ -31,3 +32,69 @@ def test_latest_end_of_response_is_forwarded_to_tts():
     assert len(outputs) == 1
     assert outputs[0].turn_id == "turn_1"
     assert outputs[0].turn_revision == 1
+
+
+def test_pending_reopen_holds_assistant_chunk_until_cancelled():
+    tracker = SpeculativeTurnTracker()
+    tracker.observe("turn_1", 0)
+    candidate_revision = tracker.begin_reopen_candidate("turn_1", 0)
+    processor = _processor(tracker)
+    done = Event()
+    outputs = []
+
+    def run_processor():
+        outputs.extend(
+            processor.process(
+                LLMResponseChunk(
+                    text="hello",
+                    turn_id="turn_1",
+                    turn_revision=0,
+                )
+            )
+        )
+        done.set()
+
+    thread = Thread(target=run_processor)
+    thread.start()
+
+    assert not done.wait(0.05)
+    tracker.cancel_reopen_candidate("turn_1", candidate_revision)
+    assert done.wait(1.0)
+    thread.join(timeout=1.0)
+
+    assert len(outputs) == 1
+    assert outputs[0].text == "hello"
+    event = processor.text_output_queue.get_nowait()
+    assert event.text == "hello"
+
+
+def test_confirmed_reopen_drops_held_assistant_chunk():
+    tracker = SpeculativeTurnTracker()
+    tracker.observe("turn_1", 0)
+    candidate_revision = tracker.begin_reopen_candidate("turn_1", 0)
+    processor = _processor(tracker)
+    done = Event()
+    outputs = []
+
+    def run_processor():
+        outputs.extend(
+            processor.process(
+                LLMResponseChunk(
+                    text="hello",
+                    turn_id="turn_1",
+                    turn_revision=0,
+                )
+            )
+        )
+        done.set()
+
+    thread = Thread(target=run_processor)
+    thread.start()
+
+    assert not done.wait(0.05)
+    assert tracker.confirm_reopen_candidate("turn_1", 0, candidate_revision)
+    assert done.wait(1.0)
+    thread.join(timeout=1.0)
+
+    assert outputs == []
+    assert processor.text_output_queue.empty()

--- a/tests/test_lm_output_processor.py
+++ b/tests/test_lm_output_processor.py
@@ -34,6 +34,26 @@ def test_latest_end_of_response_is_forwarded_to_tts():
     assert outputs[0].turn_revision == 1
 
 
+def test_cancel_generation_is_forwarded_to_tts():
+    tracker = SpeculativeTurnTracker()
+    tracker.observe("turn_1", 0)
+    processor = _processor(tracker)
+
+    outputs = list(
+        processor.process(
+            LLMResponseChunk(
+                text="hello",
+                turn_id="turn_1",
+                turn_revision=0,
+                cancel_generation=7,
+            )
+        )
+    )
+
+    assert len(outputs) == 1
+    assert outputs[0].cancel_generation == 7
+
+
 def test_pending_reopen_holds_assistant_chunk_until_cancelled():
     tracker = SpeculativeTurnTracker()
     tracker.observe("turn_1", 0)

--- a/tests/test_lm_output_processor.py
+++ b/tests/test_lm_output_processor.py
@@ -68,6 +68,39 @@ def test_pending_reopen_holds_assistant_chunk_until_cancelled():
     assert event.text == "hello"
 
 
+def test_reopen_grace_holds_assistant_chunk_until_elapsed():
+    tracker = SpeculativeTurnTracker()
+    tracker.observe("turn_1", 0)
+    tracker.start_reopen_grace("turn_1", 0, grace_s=0.08)
+    processor = _processor(tracker)
+    done = Event()
+    outputs = []
+
+    def run_processor():
+        outputs.extend(
+            processor.process(
+                LLMResponseChunk(
+                    text="hello",
+                    turn_id="turn_1",
+                    turn_revision=0,
+                )
+            )
+        )
+        done.set()
+
+    thread = Thread(target=run_processor)
+    thread.start()
+
+    assert not done.wait(0.02)
+    assert done.wait(1.0)
+    thread.join(timeout=1.0)
+
+    assert len(outputs) == 1
+    assert outputs[0].text == "hello"
+    event = processor.text_output_queue.get_nowait()
+    assert event.text == "hello"
+
+
 def test_confirmed_reopen_drops_held_assistant_chunk():
     tracker = SpeculativeTurnTracker()
     tracker.observe("turn_1", 0)

--- a/tests/test_parakeet_transcription_events.py
+++ b/tests/test_parakeet_transcription_events.py
@@ -129,6 +129,7 @@ def test_final_transcription_resets_live_streaming_state(monkeypatch):
     handler.last_language = "en"
     handler.start_language = None
     handler.processing_final = False
+    handler._live_turn_key = (None, None)
     reset_calls = []
     handler.streaming_handler = SimpleNamespace(reset=lambda: reset_calls.append(True))
 
@@ -146,6 +147,77 @@ def test_final_transcription_resets_live_streaming_state(monkeypatch):
     assert isinstance(result[0], Transcription)
     assert handler.processing_final is False
     assert reset_calls == [True]
+
+
+def test_turn_change_resets_live_streaming_state_before_progressive(monkeypatch):
+    handler = object.__new__(ParakeetTDTSTTHandler)
+    handler.enable_live_transcription = True
+    handler.processing_final = False
+    handler._live_turn_key = ("turn_1", 0)
+    reset_calls = []
+    handler.streaming_handler = SimpleNamespace(reset=lambda: reset_calls.append(True))
+
+    @contextmanager
+    def fake_lock(*args, **kwargs):
+        yield True
+
+    handler._compute_lock_context = fake_lock
+    handler._show_progressive_transcription = lambda audio: "new partial"
+    monkeypatch.setattr(parakeet_tdt_handler.console, "print", lambda *args, **kwargs: None)
+
+    result = list(
+        handler.process(
+            VADAudio(
+                audio=np.zeros(16000, dtype=np.float32),
+                mode="progressive",
+                turn_id="turn_2",
+                turn_revision=0,
+            )
+        )
+    )
+
+    assert reset_calls == [True]
+    assert len(result) == 1
+    assert isinstance(result[0], PartialTranscription)
+    assert result[0].text == "new partial"
+
+
+def test_mlx_final_ignores_fixed_text_that_exceeds_current_audio(monkeypatch):
+    handler = object.__new__(ParakeetTDTSTTHandler)
+    handler.enable_live_transcription = True
+    handler.backend = "mlx"
+    handler.last_language = "en"
+    handler.start_language = None
+    handler.processing_final = False
+    handler._live_turn_key = ("turn_3", 0)
+    handler.streaming_handler = SimpleNamespace(
+        fixed_sentences=["stale previous transcript"],
+        fixed_end_time=10.0,
+        reset=lambda: None,
+    )
+
+    @contextmanager
+    def fake_lock(*args, **kwargs):
+        yield True
+
+    handler._compute_lock_context = fake_lock
+    handler._process_mlx = lambda audio_input: ("new short turn", "en")
+    monkeypatch.setattr(parakeet_tdt_handler.console, "print", lambda *args, **kwargs: None)
+
+    result = list(
+        handler.process(
+            VADAudio(
+                audio=np.zeros(16000, dtype=np.float32),
+                mode="final",
+                turn_id="turn_3",
+                turn_revision=0,
+            )
+        )
+    )
+
+    assert len(result) == 1
+    assert isinstance(result[0], Transcription)
+    assert result[0].text == "new short turn"
 
 
 def test_final_transcription_prevents_stale_fixed_window_on_next_progressive(monkeypatch):

--- a/tests/test_parakeet_transcription_events.py
+++ b/tests/test_parakeet_transcription_events.py
@@ -3,6 +3,7 @@ from contextlib import contextmanager
 from types import SimpleNamespace
 
 import numpy as np
+from rich.text import Text
 
 from speech_to_speech.pipeline.messages import PartialTranscription, Transcription, VADAudio
 from speech_to_speech.STT import parakeet_tdt_handler
@@ -23,6 +24,50 @@ def test_show_progressive_transcription_returns_combined_text(monkeypatch):
     result = handler._show_progressive_transcription(np.zeros(16000, dtype=np.float32))
 
     assert result == "I just wanted to check in"
+
+
+def test_live_transcription_clears_terminal_line_before_each_update(monkeypatch):
+    calls = []
+
+    class FakeConsole:
+        is_terminal = True
+
+        def print(self, *args, **kwargs):
+            calls.append((args, kwargs))
+
+    handler = object.__new__(ParakeetTDTSTTHandler)
+    handler._live_transcription_active = False
+    monkeypatch.setattr(parakeet_tdt_handler, "console", FakeConsole())
+
+    handler._print_live_transcription(Text("Live: first"), "first")
+    handler._print_live_transcription(Text("Live: second"), "second")
+    handler._clear_live_transcription_line()
+
+    assert calls[0] == (("\r\x1b[2K",), {"end": ""})
+    assert calls[1] == ((Text("Live: first"),), {"end": "\r"})
+    assert calls[2] == (("\r\x1b[2K",), {"end": ""})
+    assert calls[3] == ((Text("Live: second"),), {"end": "\r"})
+    assert calls[4] == (("\r\x1b[2K",), {"end": ""})
+    assert handler._live_transcription_active is False
+
+
+def test_live_transcription_uses_lines_for_non_terminal_logs(monkeypatch):
+    calls = []
+
+    class FakeConsole:
+        is_terminal = False
+
+        def print(self, *args, **kwargs):
+            calls.append((args, kwargs))
+
+    handler = object.__new__(ParakeetTDTSTTHandler)
+    handler._live_transcription_active = False
+    monkeypatch.setattr(parakeet_tdt_handler, "console", FakeConsole())
+
+    handler._print_live_transcription(Text("Live: first"), "first")
+
+    assert calls == [((Text("Live: first"),), {})]
+    assert handler._live_transcription_active is False
 
 
 def test_process_yields_partial_tagged_tuple(monkeypatch):

--- a/tests/test_parakeet_transcription_events.py
+++ b/tests/test_parakeet_transcription_events.py
@@ -1,3 +1,4 @@
+import io
 import logging
 from contextlib import contextmanager
 from types import SimpleNamespace
@@ -31,6 +32,38 @@ def test_live_transcription_clears_terminal_line_before_each_update(monkeypatch)
 
     class FakeConsole:
         is_terminal = True
+        width = 80
+
+        def __init__(self):
+            self.file = io.StringIO()
+
+        def print(self, *args, **kwargs):
+            calls.append((args, kwargs))
+
+    handler = object.__new__(ParakeetTDTSTTHandler)
+    handler._live_transcription_active = False
+    fake_console = FakeConsole()
+    monkeypatch.setattr(parakeet_tdt_handler, "console", fake_console)
+
+    handler._print_live_transcription(Text("Live: first"), "first")
+    handler._print_live_transcription(Text("Live: second"), "second")
+    handler._clear_live_transcription_line()
+
+    assert [args[0].plain for args, _ in calls] == ["Live: first", "Live: second"]
+    assert [kwargs for _, kwargs in calls] == [{"end": ""}, {"end": ""}]
+    assert fake_console.file.getvalue() == "\r\x1b[2K\r\r\x1b[2K\r\r\x1b[2K"
+    assert handler._live_transcription_active is False
+
+
+def test_live_transcription_truncates_terminal_updates(monkeypatch):
+    calls = []
+
+    class FakeConsole:
+        is_terminal = True
+        width = 14
+
+        def __init__(self):
+            self.file = io.StringIO()
 
         def print(self, *args, **kwargs):
             calls.append((args, kwargs))
@@ -39,16 +72,11 @@ def test_live_transcription_clears_terminal_line_before_each_update(monkeypatch)
     handler._live_transcription_active = False
     monkeypatch.setattr(parakeet_tdt_handler, "console", FakeConsole())
 
-    handler._print_live_transcription(Text("Live: first"), "first")
-    handler._print_live_transcription(Text("Live: second"), "second")
-    handler._clear_live_transcription_line()
+    handler._print_live_transcription(Text("Live: abcdefghijklmnopqrstuvwxyz"), "abcdefghijklmnopqrstuvwxyz")
 
-    assert calls[0] == (("\r\x1b[2K",), {"end": ""})
-    assert calls[1] == ((Text("Live: first"),), {"end": "\r"})
-    assert calls[2] == (("\r\x1b[2K",), {"end": ""})
-    assert calls[3] == ((Text("Live: second"),), {"end": "\r"})
-    assert calls[4] == (("\r\x1b[2K",), {"end": ""})
-    assert handler._live_transcription_active is False
+    printed_text = calls[0][0][0]
+    assert printed_text.plain == "Live: abcdef\u2026"
+    assert len(printed_text.plain) == 13
 
 
 def test_live_transcription_uses_lines_for_non_terminal_logs(monkeypatch):

--- a/tests/test_qwen3_tts_handler_backend.py
+++ b/tests/test_qwen3_tts_handler_backend.py
@@ -1,7 +1,7 @@
 import sys
 from pathlib import Path
 from queue import Queue
-from threading import Event
+from threading import Event, Thread
 from types import SimpleNamespace
 
 import numpy as np
@@ -10,6 +10,7 @@ import pytest
 import speech_to_speech.TTS.qwen3_tts_handler as qwen3_tts_module
 from speech_to_speech.api.openai_realtime.runtime_config import RuntimeConfig
 from speech_to_speech.pipeline.messages import AUDIO_RESPONSE_DONE, EndOfResponse, TTSInput
+from speech_to_speech.pipeline.speculative_turns import SpeculativeTurnTracker
 from speech_to_speech.TTS.qwen3_tts_handler import Qwen3TTSHandler
 
 
@@ -322,6 +323,62 @@ def test_process_only_reenables_listening_after_end_of_response(monkeypatch):
     end_outputs = list(handler.process(EndOfResponse()))
 
     assert end_outputs == [AUDIO_RESPONSE_DONE]
+
+
+def test_process_waits_for_pending_reopen_and_drops_stale_tts_input():
+    tracker = SpeculativeTurnTracker()
+    tracker.observe("turn_1", 0)
+    candidate_revision = tracker.begin_reopen_candidate("turn_1", 0)
+    handler = object.__new__(Qwen3TTSHandler)
+    handler.speculative_turns = tracker
+    done = Event()
+    outputs = []
+
+    def run_process():
+        outputs.extend(
+            handler.process(
+                TTSInput(
+                    text="stale",
+                    turn_id="turn_1",
+                    turn_revision=0,
+                )
+            )
+        )
+        done.set()
+
+    thread = Thread(target=run_process)
+    thread.start()
+
+    assert not done.wait(0.05)
+    assert tracker.confirm_reopen_candidate("turn_1", 0, candidate_revision)
+    assert done.wait(1.0)
+    thread.join(timeout=1.0)
+
+    assert outputs == []
+
+
+def test_process_waits_for_pending_reopen_and_drops_stale_end_of_response():
+    tracker = SpeculativeTurnTracker()
+    tracker.observe("turn_1", 0)
+    candidate_revision = tracker.begin_reopen_candidate("turn_1", 0)
+    handler = object.__new__(Qwen3TTSHandler)
+    handler.speculative_turns = tracker
+    done = Event()
+    outputs = []
+
+    def run_process():
+        outputs.extend(handler.process(EndOfResponse(turn_id="turn_1", turn_revision=0)))
+        done.set()
+
+    thread = Thread(target=run_process)
+    thread.start()
+
+    assert not done.wait(0.05)
+    assert tracker.confirm_reopen_candidate("turn_1", 0, candidate_revision)
+    assert done.wait(1.0)
+    thread.join(timeout=1.0)
+
+    assert outputs == []
 
 
 def test_process_does_not_set_should_listen_when_generation_fails(monkeypatch):

--- a/tests/test_qwen3_tts_handler_backend.py
+++ b/tests/test_qwen3_tts_handler_backend.py
@@ -381,6 +381,64 @@ def test_process_waits_for_pending_reopen_and_drops_stale_end_of_response():
     assert outputs == []
 
 
+def test_process_waits_for_reopen_grace_and_drops_stale_tts_input():
+    tracker = SpeculativeTurnTracker()
+    tracker.observe("turn_1", 0)
+    tracker.start_reopen_grace("turn_1", 0, grace_s=0.5)
+    handler = object.__new__(Qwen3TTSHandler)
+    handler.speculative_turns = tracker
+    done = Event()
+    outputs = []
+
+    def run_process():
+        outputs.extend(
+            handler.process(
+                TTSInput(
+                    text="stale",
+                    turn_id="turn_1",
+                    turn_revision=0,
+                )
+            )
+        )
+        done.set()
+
+    thread = Thread(target=run_process)
+    thread.start()
+
+    assert not done.wait(0.05)
+    candidate_revision = tracker.begin_reopen_candidate("turn_1", 0)
+    assert tracker.confirm_reopen_candidate("turn_1", 0, candidate_revision)
+    assert done.wait(1.0)
+    thread.join(timeout=1.0)
+
+    assert outputs == []
+
+
+def test_process_waits_for_reopen_grace_and_drops_stale_end_of_response():
+    tracker = SpeculativeTurnTracker()
+    tracker.observe("turn_1", 0)
+    tracker.start_reopen_grace("turn_1", 0, grace_s=0.5)
+    handler = object.__new__(Qwen3TTSHandler)
+    handler.speculative_turns = tracker
+    done = Event()
+    outputs = []
+
+    def run_process():
+        outputs.extend(handler.process(EndOfResponse(turn_id="turn_1", turn_revision=0)))
+        done.set()
+
+    thread = Thread(target=run_process)
+    thread.start()
+
+    assert not done.wait(0.05)
+    candidate_revision = tracker.begin_reopen_candidate("turn_1", 0)
+    assert tracker.confirm_reopen_candidate("turn_1", 0, candidate_revision)
+    assert done.wait(1.0)
+    thread.join(timeout=1.0)
+
+    assert outputs == []
+
+
 def test_process_does_not_set_should_listen_when_generation_fails(monkeypatch):
     """TTS no longer manages should_listen; the I/O streamer does via AUDIO_RESPONSE_DONE."""
     handler = object.__new__(Qwen3TTSHandler)

--- a/tests/test_qwen3_tts_handler_backend.py
+++ b/tests/test_qwen3_tts_handler_backend.py
@@ -1,3 +1,4 @@
+import logging
 import sys
 from pathlib import Path
 from queue import Queue
@@ -439,7 +440,7 @@ def test_process_waits_for_reopen_grace_and_drops_stale_end_of_response():
     assert outputs == []
 
 
-def test_process_commits_turn_before_generating_audio(monkeypatch):
+def test_process_commits_turn_before_generating_audio(monkeypatch, caplog):
     tracker = SpeculativeTurnTracker()
     tracker.observe("turn_1", 0)
     handler = object.__new__(Qwen3TTSHandler)
@@ -463,18 +464,21 @@ def test_process_commits_turn_before_generating_audio(monkeypatch):
 
     monkeypatch.setattr(qwen3_tts_module.console, "print", lambda *args, **kwargs: None)
 
-    outputs = list(
-        handler.process(
-            TTSInput(
-                text="Hello there.",
-                turn_id="turn_1",
-                turn_revision=0,
+    with caplog.at_level(logging.INFO, logger="speech_to_speech.TTS.qwen3_tts_handler"):
+        outputs = list(
+            handler.process(
+                TTSInput(
+                    text="Hello there.",
+                    turn_id="turn_1",
+                    turn_revision=0,
+                    speech_stopped_at_s=qwen3_tts_module.perf_counter() - 1.0,
+                )
             )
         )
-    )
 
     assert len(outputs) == 1
     assert tracker.is_committed("turn_1", 0)
+    assert "Last speech detected to first speech out:" in caplog.text
 
 
 def test_process_does_not_set_should_listen_when_generation_fails(monkeypatch):

--- a/tests/test_qwen3_tts_handler_backend.py
+++ b/tests/test_qwen3_tts_handler_backend.py
@@ -439,6 +439,44 @@ def test_process_waits_for_reopen_grace_and_drops_stale_end_of_response():
     assert outputs == []
 
 
+def test_process_commits_turn_before_generating_audio(monkeypatch):
+    tracker = SpeculativeTurnTracker()
+    tracker.observe("turn_1", 0)
+    handler = object.__new__(Qwen3TTSHandler)
+    handler.should_listen = Event()
+    handler.cancel_scope = None
+    handler.speculative_turns = tracker
+    handler.ref_audio = "TTS/ref_audio.wav"
+    handler.speaker = None
+    handler.instruct = None
+    handler.language = "English"
+    handler.backend = "mlx"
+    handler.queue_in = Queue()
+    handler.model = SimpleNamespace(config=SimpleNamespace(tts_model_type="base"))
+    handler._apply_session_voice_override = lambda model_type, runtime_config=None, response=None: None
+
+    def _process_voice_clone(text):
+        assert tracker.is_committed("turn_1", 0)
+        yield np.zeros(512, dtype=np.int16)
+
+    handler._process_voice_clone = _process_voice_clone
+
+    monkeypatch.setattr(qwen3_tts_module.console, "print", lambda *args, **kwargs: None)
+
+    outputs = list(
+        handler.process(
+            TTSInput(
+                text="Hello there.",
+                turn_id="turn_1",
+                turn_revision=0,
+            )
+        )
+    )
+
+    assert len(outputs) == 1
+    assert tracker.is_committed("turn_1", 0)
+
+
 def test_process_does_not_set_should_listen_when_generation_fails(monkeypatch):
     """TTS no longer manages should_listen; the I/O streamer does via AUDIO_RESPONSE_DONE."""
     handler = object.__new__(Qwen3TTSHandler)

--- a/tests/test_responses_api_language_model.py
+++ b/tests/test_responses_api_language_model.py
@@ -83,6 +83,7 @@ def _make_handler(*, disable_thinking=False, stream=True, cancel_scope=None):
     handler._extra_body = {"chat_template_kwargs": {"enable_thinking": False}} if disable_thinking else None
     handler.user_role = "user"
     handler.cancel_scope = cancel_scope
+    handler.speculative_turns = None
     handler.tools = None
     handler.tools_choice = None
     return handler

--- a/tests/test_speculative_turns.py
+++ b/tests/test_speculative_turns.py
@@ -1,3 +1,6 @@
+import time
+from threading import Thread
+
 import numpy as np
 
 from speech_to_speech.pipeline.speculative_turns import SpeculativeTurnTracker
@@ -101,6 +104,22 @@ def test_try_is_latest_after_pending_reopen_reports_pending_without_blocking():
     assert tracker.try_is_latest_after_pending_reopen("turn_1", 0) is True
     assert tracker.try_commit_if_latest_after_pending_reopen("turn_1", 0) is True
     assert tracker.is_committed("turn_1", 0)
+
+
+def test_is_latest_after_stability_window_catches_reopen_started_during_wait():
+    tracker = SpeculativeTurnTracker()
+    tracker.observe("turn_1", 0)
+
+    def reopen_turn():
+        time.sleep(0.02)
+        candidate_revision = tracker.begin_reopen_candidate("turn_1", 0)
+        assert tracker.confirm_reopen_candidate("turn_1", 0, candidate_revision)
+
+    thread = Thread(target=reopen_turn)
+    thread.start()
+
+    assert not tracker.is_latest_after_stability_window("turn_1", 0, settle_s=0.2)
+    thread.join(timeout=1.0)
 
 
 def test_vad_direct_reopen_path_uses_tracker_candidate_protocol():

--- a/tests/test_speculative_turns.py
+++ b/tests/test_speculative_turns.py
@@ -1,10 +1,12 @@
 import time
 from queue import Queue
-from threading import Thread
+from threading import Event, Thread
 from typing import Literal
 
 import numpy as np
+import torch
 
+from speech_to_speech.pipeline.events import SpeechStartedEvent, SpeechStoppedEvent
 from speech_to_speech.pipeline.messages import VADAudio
 from speech_to_speech.pipeline.speculative_turns import SpeculativeTurnTracker
 from speech_to_speech.VAD.vad_handler import VADHandler
@@ -211,6 +213,124 @@ def test_vad_realtime_path_does_not_emit_progressive_when_live_transcription_dis
     handler.iterator = FakeIterator()
 
     assert list(handler._process_realtime(None)) == []
+
+
+class _StaticVADIterator:
+    def __init__(
+        self,
+        *,
+        triggered: bool,
+        vad_output: list[torch.Tensor] | None,
+        buffer_chunks: list[torch.Tensor] | None = None,
+        speech_chunks: list[torch.Tensor] | None = None,
+        voiced_samples: int = 0,
+        last_utterance_voiced_samples: int = 0,
+    ) -> None:
+        self.triggered = triggered
+        self._vad_output = vad_output
+        self.buffer = buffer_chunks or []
+        self._speech_chunks = speech_chunks or self.buffer
+        self.voiced_samples = voiced_samples
+        self.last_utterance_voiced_samples = last_utterance_voiced_samples
+
+    def __call__(self, _chunk: torch.Tensor) -> list[torch.Tensor] | None:
+        return self._vad_output
+
+    def speech_buffer(self) -> list[torch.Tensor]:
+        return self._speech_chunks
+
+
+def _vad_handler_for_iterator(iterator: _StaticVADIterator) -> VADHandler:
+    handler = object.__new__(VADHandler)
+    handler.should_listen = Event()
+    handler.should_listen.set()
+    handler.sample_rate = 16000
+    handler.min_silence_ms = 300
+    handler.min_speech_ms = 500
+    handler.max_speech_ms = float("inf")
+    handler.enable_realtime_transcription = False
+    handler.realtime_processing_pause = 0.5
+    handler.text_output_queue = Queue()
+    handler.speculative_turns = SpeculativeTurnTracker()
+    handler.speculative_reopen_ms = 1000
+    handler._last_turn_detection = None
+    handler.iterator = iterator
+    handler.audio_enhancement = False
+    handler.last_process_time = 0.0
+    handler._total_samples = 0
+    handler._last_log_time = time.time()
+    handler._log_chunks = 0
+    handler._log_speech_starts = 0
+    handler._log_speech_ends = 0
+    handler._log_progressive_yields = 0
+    handler._speech_started_emitted = False
+    handler._turn_counter = 0
+    handler._current_turn_id = None
+    handler._current_turn_revision = None
+    handler._speculative_audio_prefix = None
+    handler._last_final_wall_time = None
+    handler._last_final_audio_ms = None
+    handler._pending_reopen_candidate = None
+    return handler
+
+
+def _audio_bytes(samples: int = 512) -> bytes:
+    return np.zeros(samples, dtype=np.int16).tobytes()
+
+
+def test_vad_interruption_uses_voiced_duration_not_padded_segment():
+    chunks = [torch.zeros(512) for _ in range(20)]
+    iterator = _StaticVADIterator(
+        triggered=True,
+        vad_output=None,
+        buffer_chunks=chunks,
+        speech_chunks=chunks,
+        voiced_samples=10 * 512,
+    )
+    handler = _vad_handler_for_iterator(iterator)
+
+    assert list(handler.process(_audio_bytes())) == []
+
+    assert handler.text_output_queue.empty()
+    assert handler._speech_started_emitted is False
+
+
+def test_vad_interruption_emits_after_voiced_threshold():
+    chunks = [torch.zeros(512) for _ in range(20)]
+    iterator = _StaticVADIterator(
+        triggered=True,
+        vad_output=None,
+        buffer_chunks=chunks,
+        speech_chunks=chunks,
+        voiced_samples=16 * 512,
+    )
+    handler = _vad_handler_for_iterator(iterator)
+
+    assert list(handler.process(_audio_bytes())) == []
+
+    event = handler.text_output_queue.get_nowait()
+    assert isinstance(event, SpeechStartedEvent)
+    assert event.interrupt_response is True
+    assert handler._speech_started_emitted is True
+
+
+def test_vad_final_synthetic_start_does_not_interrupt_response():
+    final_chunks = [torch.zeros(512) for _ in range(31)]
+    iterator = _StaticVADIterator(
+        triggered=False,
+        vad_output=final_chunks,
+        last_utterance_voiced_samples=2 * 512,
+    )
+    handler = _vad_handler_for_iterator(iterator)
+
+    outputs = list(handler.process(_audio_bytes()))
+
+    assert len(outputs) == 1
+    started = handler.text_output_queue.get_nowait()
+    stopped = handler.text_output_queue.get_nowait()
+    assert isinstance(started, SpeechStartedEvent)
+    assert started.interrupt_response is False
+    assert isinstance(stopped, SpeechStoppedEvent)
 
 
 def test_vad_keeps_single_speculative_audio_prefix():

--- a/tests/test_speculative_turns.py
+++ b/tests/test_speculative_turns.py
@@ -223,15 +223,15 @@ class _StaticVADIterator:
         vad_output: list[torch.Tensor] | None,
         buffer_chunks: list[torch.Tensor] | None = None,
         speech_chunks: list[torch.Tensor] | None = None,
-        voiced_samples: int = 0,
-        last_utterance_voiced_samples: int = 0,
+        active_speech_samples: int = 0,
+        last_utterance_active_speech_samples: int = 0,
     ) -> None:
         self.triggered = triggered
         self._vad_output = vad_output
         self.buffer = buffer_chunks or []
         self._speech_chunks = speech_chunks or self.buffer
-        self.voiced_samples = voiced_samples
-        self.last_utterance_voiced_samples = last_utterance_voiced_samples
+        self.active_speech_samples = active_speech_samples
+        self.last_utterance_active_speech_samples = last_utterance_active_speech_samples
 
     def __call__(self, _chunk: torch.Tensor) -> list[torch.Tensor] | None:
         return self._vad_output
@@ -278,14 +278,14 @@ def _audio_bytes(samples: int = 512) -> bytes:
     return np.zeros(samples, dtype=np.int16).tobytes()
 
 
-def test_vad_interruption_uses_voiced_duration_not_padded_segment():
+def test_vad_interruption_uses_active_speech_duration_not_padded_segment():
     chunks = [torch.zeros(512) for _ in range(20)]
     iterator = _StaticVADIterator(
         triggered=True,
         vad_output=None,
         buffer_chunks=chunks,
         speech_chunks=chunks,
-        voiced_samples=10 * 512,
+        active_speech_samples=10 * 512,
     )
     handler = _vad_handler_for_iterator(iterator)
 
@@ -295,14 +295,14 @@ def test_vad_interruption_uses_voiced_duration_not_padded_segment():
     assert handler._speech_started_emitted is False
 
 
-def test_vad_interruption_emits_after_voiced_threshold():
+def test_vad_interruption_emits_after_active_speech_threshold():
     chunks = [torch.zeros(512) for _ in range(20)]
     iterator = _StaticVADIterator(
         triggered=True,
         vad_output=None,
         buffer_chunks=chunks,
         speech_chunks=chunks,
-        voiced_samples=16 * 512,
+        active_speech_samples=16 * 512,
     )
     handler = _vad_handler_for_iterator(iterator)
 
@@ -319,7 +319,7 @@ def test_vad_final_synthetic_start_does_not_interrupt_response():
     iterator = _StaticVADIterator(
         triggered=False,
         vad_output=final_chunks,
-        last_utterance_voiced_samples=2 * 512,
+        last_utterance_active_speech_samples=2 * 512,
     )
     handler = _vad_handler_for_iterator(iterator)
 

--- a/tests/test_speculative_turns.py
+++ b/tests/test_speculative_turns.py
@@ -66,6 +66,27 @@ def test_pending_reopen_wait_timeout_clears_candidate():
     assert tracker._pending_reopen == {}
 
 
+def test_commit_if_latest_waits_for_pending_reopen_and_drops_confirmed_reopen():
+    tracker = SpeculativeTurnTracker()
+    tracker.observe("turn_1", 0)
+    candidate_revision = tracker.begin_reopen_candidate("turn_1", 0)
+
+    assert tracker.confirm_reopen_candidate("turn_1", 0, candidate_revision)
+    assert not tracker.commit_if_latest_after_pending_reopen("turn_1", 0)
+    assert not tracker.is_committed("turn_1", 0)
+
+
+def test_commit_if_latest_commits_after_pending_reopen_is_cancelled():
+    tracker = SpeculativeTurnTracker()
+    tracker.observe("turn_1", 0)
+    candidate_revision = tracker.begin_reopen_candidate("turn_1", 0)
+
+    tracker.cancel_reopen_candidate("turn_1", candidate_revision)
+
+    assert tracker.commit_if_latest_after_pending_reopen("turn_1", 0)
+    assert tracker.is_committed("turn_1", 0)
+
+
 def test_vad_direct_reopen_path_uses_tracker_candidate_protocol():
     tracker = SpeculativeTurnTracker()
     tracker.observe("turn_1", 0)

--- a/tests/test_speculative_turns.py
+++ b/tests/test_speculative_turns.py
@@ -108,6 +108,42 @@ def test_try_is_latest_after_pending_reopen_reports_pending_without_blocking():
     assert tracker.is_committed("turn_1", 0)
 
 
+def test_try_is_latest_after_reopen_grace_reports_pending_without_blocking():
+    tracker = SpeculativeTurnTracker()
+    tracker.observe("turn_1", 0)
+    tracker.start_reopen_grace("turn_1", 0, grace_s=0.05)
+
+    assert tracker.try_is_latest_after_reopen_grace("turn_1", 0) is None
+    assert tracker.try_commit_if_latest_after_reopen_grace("turn_1", 0) is None
+
+    time.sleep(0.06)
+
+    assert tracker.try_is_latest_after_reopen_grace("turn_1", 0) is True
+    assert tracker.try_commit_if_latest_after_reopen_grace("turn_1", 0) is True
+    assert tracker.is_committed("turn_1", 0)
+
+
+def test_reopen_grace_wait_drops_confirmed_reopen():
+    tracker = SpeculativeTurnTracker()
+    tracker.observe("turn_1", 0)
+    tracker.start_reopen_grace("turn_1", 0, grace_s=0.2)
+    result: dict[str, bool] = {}
+
+    def wait_for_grace():
+        result["is_latest"] = tracker.is_latest_after_reopen_grace("turn_1", 0)
+
+    thread = Thread(target=wait_for_grace)
+    thread.start()
+
+    time.sleep(0.02)
+    candidate_revision = tracker.begin_reopen_candidate("turn_1", 0)
+    assert tracker.confirm_reopen_candidate("turn_1", 0, candidate_revision)
+    thread.join(timeout=1.0)
+
+    assert not thread.is_alive()
+    assert result == {"is_latest": False}
+
+
 def test_is_latest_after_stability_window_catches_reopen_started_during_wait():
     tracker = SpeculativeTurnTracker()
     tracker.observe("turn_1", 0)

--- a/tests/test_speculative_turns.py
+++ b/tests/test_speculative_turns.py
@@ -1,6 +1,7 @@
 import time
 from queue import Queue
 from threading import Thread
+from typing import Literal
 
 import numpy as np
 
@@ -199,7 +200,11 @@ def test_vad_keeps_single_speculative_audio_prefix():
     np.testing.assert_array_equal(third_output, np.array([1.0, 2.0, 3.0, 4.0], dtype=np.float32))
 
 
-def _vad_audio(turn_id: str = "turn_1", revision: int = 0, mode: str | None = "progressive") -> VADAudio:
+def _vad_audio(
+    turn_id: str = "turn_1",
+    revision: int = 0,
+    mode: Literal["progressive", "final"] | None = "progressive",
+) -> VADAudio:
     return VADAudio(audio=np.zeros(512, dtype=np.float32), mode=mode, turn_id=turn_id, turn_revision=revision)
 
 
@@ -256,3 +261,20 @@ def test_vad_final_audio_replaces_queued_progressive_audio_for_same_revision():
 
     queued_items = list(handler.queue_out.queue)
     assert queued_items == [other_turn_progressive]
+
+
+def test_vad_progressive_processing_pause_increases_with_speech_duration():
+    handler = object.__new__(VADHandler)
+    handler.realtime_processing_pause = 0.25
+
+    assert handler._progressive_processing_pause(7_999) == 0.25
+    assert handler._progressive_processing_pause(8_000) == 0.5
+    assert handler._progressive_processing_pause(15_000) == 1.0
+    assert handler._progressive_processing_pause(30_000) == 1.5
+
+
+def test_vad_progressive_processing_pause_is_capped():
+    handler = object.__new__(VADHandler)
+    handler.realtime_processing_pause = 0.5
+
+    assert handler._progressive_processing_pause(30_000) == 2.0

--- a/tests/test_speculative_turns.py
+++ b/tests/test_speculative_turns.py
@@ -318,6 +318,31 @@ def test_vad_interruption_uses_active_speech_duration_not_padded_segment():
     assert handler._speech_started_emitted is False
 
 
+def test_vad_pending_reopen_starts_before_active_speech_threshold():
+    chunks = [torch.zeros(512) for _ in range(12)]
+    iterator = _StaticVADIterator(
+        triggered=True,
+        vad_output=None,
+        buffer_chunks=chunks,
+        speech_chunks=chunks,
+        active_speech_samples=8 * 512,
+    )
+    handler = _vad_handler_for_iterator(iterator)
+    tracker = handler.speculative_turns
+    tracker.observe("turn_1", 0)
+    handler._current_turn_id = "turn_1"
+    handler._current_turn_revision = 0
+    handler._last_final_audio_ms = 0
+
+    assert list(handler.process(_audio_bytes())) == []
+
+    assert tracker.has_pending_reopen("turn_1", 0)
+    tracker.commit("turn_1", 0)
+    assert not tracker.is_committed("turn_1", 0)
+    assert handler.text_output_queue.empty()
+    assert handler._speech_started_emitted is False
+
+
 def test_vad_interruption_emits_after_active_speech_threshold():
     chunks = [torch.zeros(512) for _ in range(20)]
     iterator = _StaticVADIterator(
@@ -335,6 +360,23 @@ def test_vad_interruption_emits_after_active_speech_threshold():
     assert isinstance(event, SpeechStartedEvent)
     assert event.interrupt_response is True
     assert handler._speech_started_emitted is True
+
+
+def test_vad_live_transcription_without_speculative_turns_stops_listening_on_final():
+    final_chunks = [torch.zeros(512) for _ in range(31)]
+    iterator = _StaticVADIterator(
+        triggered=False,
+        vad_output=final_chunks,
+        last_utterance_active_speech_samples=12 * 512,
+    )
+    handler = _vad_handler_for_iterator(iterator)
+    handler.enable_realtime_transcription = True
+    handler.speculative_turns = None
+
+    outputs = list(handler.process(_audio_bytes()))
+
+    assert len(outputs) == 1
+    assert not handler.should_listen.is_set()
 
 
 def test_vad_discards_final_segment_when_active_speech_is_short():

--- a/tests/test_speculative_turns.py
+++ b/tests/test_speculative_turns.py
@@ -1,8 +1,10 @@
 import time
+from queue import Queue
 from threading import Thread
 
 import numpy as np
 
+from speech_to_speech.pipeline.messages import VADAudio
 from speech_to_speech.pipeline.speculative_turns import SpeculativeTurnTracker
 from speech_to_speech.VAD.vad_handler import VADHandler
 
@@ -159,3 +161,62 @@ def test_vad_keeps_single_speculative_audio_prefix():
     assert first_output is first_segment
     np.testing.assert_array_equal(second_output, np.array([1.0, 2.0, 3.0], dtype=np.float32))
     np.testing.assert_array_equal(third_output, np.array([1.0, 2.0, 3.0, 4.0], dtype=np.float32))
+
+
+def _vad_audio(turn_id: str = "turn_1", revision: int = 0, mode: str | None = "progressive") -> VADAudio:
+    return VADAudio(audio=np.zeros(512, dtype=np.float32), mode=mode, turn_id=turn_id, turn_revision=revision)
+
+
+def test_vad_drops_superseded_progressive_audio_from_output_queue():
+    handler = object.__new__(VADHandler)
+    handler.queue_out = Queue()
+    handler.speculative_turns = None
+    first_progressive = _vad_audio()
+    final_audio = _vad_audio(mode="final")
+    second_progressive = _vad_audio()
+    other_turn_progressive = _vad_audio(turn_id="turn_2")
+
+    handler.queue_out.put(first_progressive)
+    handler.queue_out.put(final_audio)
+    handler.queue_out.put(second_progressive)
+    handler.queue_out.put(other_turn_progressive)
+
+    dropped = handler._drop_superseded_vad_audio(_vad_audio())
+
+    assert dropped == 2
+    queued_items = list(handler.queue_out.queue)
+    assert queued_items == [final_audio, other_turn_progressive]
+
+
+def test_vad_drops_stale_progressive_revisions_from_output_queue():
+    tracker = SpeculativeTurnTracker()
+    tracker.observe("turn_1", 1)
+    handler = object.__new__(VADHandler)
+    handler.queue_out = Queue()
+    handler.speculative_turns = tracker
+    stale_progressive = _vad_audio(revision=0)
+    current_progressive = _vad_audio(revision=1)
+
+    handler.queue_out.put(stale_progressive)
+    handler.queue_out.put(current_progressive)
+
+    handler.before_emit_output(_vad_audio(revision=1))
+
+    assert handler.queue_out.empty()
+
+
+def test_vad_final_audio_replaces_queued_progressive_audio_for_same_revision():
+    handler = object.__new__(VADHandler)
+    handler.queue_out = Queue()
+    handler.speculative_turns = None
+    progressive_audio = _vad_audio()
+    final_audio = _vad_audio(mode="final")
+    other_turn_progressive = _vad_audio(turn_id="turn_2")
+
+    handler.queue_out.put(progressive_audio)
+    handler.queue_out.put(other_turn_progressive)
+
+    handler.before_emit_output(final_audio)
+
+    queued_items = list(handler.queue_out.queue)
+    assert queued_items == [other_turn_progressive]

--- a/tests/test_speculative_turns.py
+++ b/tests/test_speculative_turns.py
@@ -87,6 +87,22 @@ def test_commit_if_latest_commits_after_pending_reopen_is_cancelled():
     assert tracker.is_committed("turn_1", 0)
 
 
+def test_try_is_latest_after_pending_reopen_reports_pending_without_blocking():
+    tracker = SpeculativeTurnTracker()
+    tracker.observe("turn_1", 0)
+    candidate_revision = tracker.begin_reopen_candidate("turn_1", 0)
+
+    assert tracker.has_pending_reopen("turn_1", 0)
+    assert tracker.try_is_latest_after_pending_reopen("turn_1", 0) is None
+    assert tracker.try_commit_if_latest_after_pending_reopen("turn_1", 0) is None
+
+    tracker.cancel_reopen_candidate("turn_1", candidate_revision)
+
+    assert tracker.try_is_latest_after_pending_reopen("turn_1", 0) is True
+    assert tracker.try_commit_if_latest_after_pending_reopen("turn_1", 0) is True
+    assert tracker.is_committed("turn_1", 0)
+
+
 def test_vad_direct_reopen_path_uses_tracker_candidate_protocol():
     tracker = SpeculativeTurnTracker()
     tracker.observe("turn_1", 0)

--- a/tests/test_speculative_turns.py
+++ b/tests/test_speculative_turns.py
@@ -1,0 +1,28 @@
+from speech_to_speech.pipeline.speculative_turns import SpeculativeTurnTracker
+
+
+def test_pending_reopen_defers_commit_until_cancelled():
+    tracker = SpeculativeTurnTracker()
+    tracker.observe("turn_1", 0)
+    candidate_revision = tracker.begin_reopen_candidate("turn_1", 0)
+
+    tracker.commit("turn_1", 0)
+
+    assert candidate_revision == 1
+    assert not tracker.is_committed("turn_1", 0)
+
+    tracker.cancel_reopen_candidate("turn_1", candidate_revision)
+    tracker.commit("turn_1", 0)
+
+    assert tracker.is_committed("turn_1", 0)
+
+
+def test_confirmed_reopen_makes_previous_revision_stale():
+    tracker = SpeculativeTurnTracker()
+    tracker.observe("turn_1", 0)
+    candidate_revision = tracker.begin_reopen_candidate("turn_1", 0)
+
+    assert tracker.confirm_reopen_candidate("turn_1", 0, candidate_revision)
+
+    assert not tracker.is_latest("turn_1", 0)
+    assert tracker.is_latest("turn_1", 1)

--- a/tests/test_speculative_turns.py
+++ b/tests/test_speculative_turns.py
@@ -182,6 +182,37 @@ def test_vad_direct_reopen_path_uses_tracker_candidate_protocol():
     assert tracker._pending_reopen == {}
 
 
+def test_vad_reopens_speculative_turn_when_live_transcription_disabled():
+    tracker = SpeculativeTurnTracker()
+    tracker.observe("turn_1", 0)
+    handler = object.__new__(VADHandler)
+    handler.enable_realtime_transcription = False
+    handler._speech_started_emitted = False
+    handler._current_turn_id = "turn_1"
+    handler._current_turn_revision = 0
+    handler._last_final_audio_ms = 1000
+    handler.speculative_reopen_ms = 1200
+    handler.speculative_turns = tracker
+    handler._pending_reopen_candidate = None
+
+    turn_id, revision, reopened = handler._ensure_turn_for_speech_start(1100)
+
+    assert (turn_id, revision, reopened) == ("turn_1", 1, True)
+    assert not tracker.is_latest("turn_1", 0)
+    assert tracker.is_latest("turn_1", 1)
+
+
+def test_vad_realtime_path_does_not_emit_progressive_when_live_transcription_disabled():
+    class FakeIterator:
+        buffer = [object()]
+
+    handler = object.__new__(VADHandler)
+    handler.enable_realtime_transcription = False
+    handler.iterator = FakeIterator()
+
+    assert list(handler._process_realtime(None)) == []
+
+
 def test_vad_keeps_single_speculative_audio_prefix():
     handler = object.__new__(VADHandler)
     handler._speculative_audio_prefix = None

--- a/tests/test_speculative_turns.py
+++ b/tests/test_speculative_turns.py
@@ -268,7 +268,7 @@ def _vad_handler_for_iterator(iterator: _StaticVADIterator) -> VADHandler:
     handler.should_listen.set()
     handler.sample_rate = 16000
     handler.min_silence_ms = 300
-    handler.min_speech_ms = 500
+    handler.min_speech_ms = 384
     handler.max_speech_ms = float("inf")
     handler.enable_realtime_transcription = False
     handler.realtime_processing_pause = 0.5
@@ -325,7 +325,7 @@ def test_vad_interruption_emits_after_active_speech_threshold():
         vad_output=None,
         buffer_chunks=chunks,
         speech_chunks=chunks,
-        active_speech_samples=16 * 512,
+        active_speech_samples=12 * 512,
     )
     handler = _vad_handler_for_iterator(iterator)
 
@@ -342,7 +342,7 @@ def test_vad_discards_final_segment_when_active_speech_is_short():
     iterator = _StaticVADIterator(
         triggered=False,
         vad_output=final_chunks,
-        last_utterance_active_speech_samples=15 * 512,
+        last_utterance_active_speech_samples=11 * 512,
     )
     handler = _vad_handler_for_iterator(iterator)
 
@@ -357,7 +357,7 @@ def test_vad_final_synthetic_start_does_not_interrupt_response():
     iterator = _StaticVADIterator(
         triggered=False,
         vad_output=final_chunks,
-        last_utterance_active_speech_samples=16 * 512,
+        last_utterance_active_speech_samples=12 * 512,
     )
     handler = _vad_handler_for_iterator(iterator)
 

--- a/tests/test_speculative_turns.py
+++ b/tests/test_speculative_turns.py
@@ -1,4 +1,7 @@
+import numpy as np
+
 from speech_to_speech.pipeline.speculative_turns import SpeculativeTurnTracker
+from speech_to_speech.VAD.vad_handler import VADHandler
 
 
 def test_pending_reopen_defers_commit_until_cancelled():
@@ -26,3 +29,77 @@ def test_confirmed_reopen_makes_previous_revision_stale():
 
     assert not tracker.is_latest("turn_1", 0)
     assert tracker.is_latest("turn_1", 1)
+
+
+def test_tracker_prunes_old_turn_revisions():
+    tracker = SpeculativeTurnTracker(max_tracked_turns=2)
+    tracker.observe("turn_1", 0)
+    tracker.commit("turn_1", 0)
+    tracker.observe("turn_2", 0)
+    tracker.observe("turn_3", 0)
+
+    assert list(tracker._latest_revision) == ["turn_2", "turn_3"]
+    assert "turn_1" not in tracker._committed_revision
+
+
+def test_tracker_keeps_pending_reopen_while_pruning():
+    tracker = SpeculativeTurnTracker(max_tracked_turns=1)
+    tracker.observe("turn_1", 0)
+    candidate_revision = tracker.begin_reopen_candidate("turn_1", 0)
+
+    tracker.observe("turn_2", 0)
+
+    assert candidate_revision == 1
+    assert "turn_1" in tracker._latest_revision
+    assert "turn_1" in tracker._pending_reopen
+    assert "turn_2" in tracker._latest_revision
+
+
+def test_pending_reopen_wait_timeout_clears_candidate():
+    tracker = SpeculativeTurnTracker()
+    tracker.observe("turn_1", 0)
+    candidate_revision = tracker.begin_reopen_candidate("turn_1", 0)
+
+    tracker.wait_for_pending_reopen("turn_1", 0, timeout_s=0)
+
+    assert candidate_revision == 1
+    assert tracker._pending_reopen == {}
+
+
+def test_vad_direct_reopen_path_uses_tracker_candidate_protocol():
+    tracker = SpeculativeTurnTracker()
+    tracker.observe("turn_1", 0)
+    handler = object.__new__(VADHandler)
+    handler.enable_realtime_transcription = True
+    handler._speech_started_emitted = False
+    handler._current_turn_id = "turn_1"
+    handler._current_turn_revision = 0
+    handler._last_final_audio_ms = 1000
+    handler.speculative_reopen_ms = 1200
+    handler.speculative_turns = tracker
+    handler._pending_reopen_candidate = None
+
+    turn_id, revision, reopened = handler._ensure_turn_for_speech_start(1100)
+
+    assert (turn_id, revision, reopened) == ("turn_1", 1, True)
+    assert not tracker.is_latest("turn_1", 0)
+    assert tracker.is_latest("turn_1", 1)
+    assert tracker._pending_reopen == {}
+
+
+def test_vad_keeps_single_speculative_audio_prefix():
+    handler = object.__new__(VADHandler)
+    handler._speculative_audio_prefix = None
+    first_segment = np.array([1.0, 2.0], dtype=np.float32)
+    second_segment = np.array([3.0], dtype=np.float32)
+    third_segment = np.array([4.0], dtype=np.float32)
+
+    first_output = handler._combined_turn_audio(first_segment)
+    handler._speculative_audio_prefix = first_output
+    second_output = handler._combined_turn_audio(second_segment)
+    handler._speculative_audio_prefix = second_output
+    third_output = handler._combined_turn_audio(third_segment)
+
+    assert first_output is first_segment
+    np.testing.assert_array_equal(second_output, np.array([1.0, 2.0, 3.0], dtype=np.float32))
+    np.testing.assert_array_equal(third_output, np.array([1.0, 2.0, 3.0, 4.0], dtype=np.float32))

--- a/tests/test_speculative_turns.py
+++ b/tests/test_speculative_turns.py
@@ -288,6 +288,7 @@ def test_vad_interruption_uses_active_speech_duration_not_padded_segment():
         active_speech_samples=10 * 512,
     )
     handler = _vad_handler_for_iterator(iterator)
+    handler.enable_realtime_transcription = True
 
     assert list(handler.process(_audio_bytes())) == []
 
@@ -314,12 +315,27 @@ def test_vad_interruption_emits_after_active_speech_threshold():
     assert handler._speech_started_emitted is True
 
 
+def test_vad_discards_final_segment_when_active_speech_is_short():
+    final_chunks = [torch.zeros(512) for _ in range(31)]
+    iterator = _StaticVADIterator(
+        triggered=False,
+        vad_output=final_chunks,
+        last_utterance_active_speech_samples=15 * 512,
+    )
+    handler = _vad_handler_for_iterator(iterator)
+
+    outputs = list(handler.process(_audio_bytes()))
+
+    assert outputs == []
+    assert handler.text_output_queue.empty()
+
+
 def test_vad_final_synthetic_start_does_not_interrupt_response():
     final_chunks = [torch.zeros(512) for _ in range(31)]
     iterator = _StaticVADIterator(
         triggered=False,
         vad_output=final_chunks,
-        last_utterance_active_speech_samples=2 * 512,
+        last_utterance_active_speech_samples=16 * 512,
     )
     handler = _vad_handler_for_iterator(iterator)
 

--- a/tests/test_speculative_turns.py
+++ b/tests/test_speculative_turns.py
@@ -204,6 +204,28 @@ def test_vad_reopens_speculative_turn_when_live_transcription_disabled():
     assert tracker.is_latest("turn_1", 1)
 
 
+def test_vad_starts_new_turn_after_committed_turn_would_have_reopened():
+    tracker = SpeculativeTurnTracker()
+    tracker.observe("turn_1", 0)
+    tracker.commit("turn_1", 0)
+    handler = object.__new__(VADHandler)
+    handler.enable_realtime_transcription = False
+    handler._speech_started_emitted = False
+    handler._current_turn_id = "turn_1"
+    handler._current_turn_revision = 0
+    handler._turn_counter = 1
+    handler._last_final_audio_ms = 1000
+    handler.speculative_reopen_ms = 1200
+    handler.speculative_turns = tracker
+    handler._pending_reopen_candidate = None
+
+    turn_id, revision, reopened = handler._ensure_turn_for_speech_start(1100)
+
+    assert (turn_id, revision, reopened) == ("turn_2", 0, False)
+    assert tracker.is_committed("turn_1", 0)
+    assert tracker.is_latest("turn_2", 0)
+
+
 def test_vad_realtime_path_does_not_emit_progressive_when_live_transcription_disabled():
     class FakeIterator:
         buffer = [object()]

--- a/tests/test_stt_stale_filter.py
+++ b/tests/test_stt_stale_filter.py
@@ -1,0 +1,118 @@
+from __future__ import annotations
+
+from queue import Empty, Queue
+from threading import Event, Thread
+from time import sleep
+from typing import Iterator
+
+import numpy as np
+
+from speech_to_speech.pipeline.messages import PIPELINE_END, Transcription, VADAudio
+from speech_to_speech.pipeline.speculative_turns import SpeculativeTurnTracker
+from speech_to_speech.STT.base_stt_handler import BaseSTTHandler
+
+
+class RecordingSTTHandler(BaseSTTHandler):
+    def setup(
+        self,
+        speculative_turns: SpeculativeTurnTracker | None = None,
+        mark_stale_during_process: bool = False,
+    ) -> None:
+        self.speculative_turns = speculative_turns
+        self.mark_stale_during_process = mark_stale_during_process
+        self.processed: list[tuple[str | None, int | None]] = []
+
+    def process(self, vad_audio: VADAudio) -> Iterator[Transcription]:
+        self.processed.append((vad_audio.turn_id, vad_audio.turn_revision))
+        if self.mark_stale_during_process and vad_audio.turn_id is not None and vad_audio.turn_revision is not None:
+            self.speculative_turns.observe(vad_audio.turn_id, vad_audio.turn_revision + 1)
+        yield Transcription(
+            text="hello",
+            turn_id=vad_audio.turn_id,
+            turn_revision=vad_audio.turn_revision,
+        )
+
+
+def _vad_audio(turn_id: str = "turn_1", revision: int = 0) -> VADAudio:
+    return VADAudio(audio=np.zeros(512, dtype=np.float32), turn_id=turn_id, turn_revision=revision)
+
+
+def _handler(
+    tracker: SpeculativeTurnTracker,
+    queue_in: Queue,
+    queue_out: Queue,
+    *,
+    mark_stale_during_process: bool = False,
+) -> RecordingSTTHandler:
+    return RecordingSTTHandler(
+        Event(),
+        queue_in=queue_in,
+        queue_out=queue_out,
+        setup_kwargs={
+            "speculative_turns": tracker,
+            "mark_stale_during_process": mark_stale_during_process,
+        },
+    )
+
+
+def test_stt_handler_drops_stale_queued_audio_without_processing():
+    tracker = SpeculativeTurnTracker()
+    tracker.observe("turn_1", 1)
+    queue_in = Queue()
+    queue_out = Queue()
+    handler = _handler(tracker, queue_in, queue_out)
+
+    queue_in.put(_vad_audio(revision=0))
+    queue_in.put(PIPELINE_END)
+
+    handler.run()
+
+    assert handler.processed == []
+    assert queue_out.get_nowait() == PIPELINE_END
+
+
+def test_stt_handler_waits_for_pending_reopen_before_processing():
+    tracker = SpeculativeTurnTracker()
+    tracker.observe("turn_1", 0)
+    candidate_revision = tracker.begin_reopen_candidate("turn_1", 0)
+    queue_in = Queue()
+    queue_out = Queue()
+    handler = _handler(tracker, queue_in, queue_out)
+
+    queue_in.put(_vad_audio(revision=0))
+    queue_in.put(PIPELINE_END)
+    thread = Thread(target=handler.run)
+    thread.start()
+
+    sleep(0.05)
+    assert handler.processed == []
+    assert queue_out.empty()
+
+    assert tracker.confirm_reopen_candidate("turn_1", 0, candidate_revision)
+    thread.join(timeout=1.0)
+
+    assert not thread.is_alive()
+    assert handler.processed == []
+    assert queue_out.get_nowait() == PIPELINE_END
+
+
+def test_stt_handler_drops_output_that_became_stale_during_processing():
+    tracker = SpeculativeTurnTracker()
+    tracker.observe("turn_1", 0)
+    queue_in = Queue()
+    queue_out = Queue()
+    handler = _handler(tracker, queue_in, queue_out, mark_stale_during_process=True)
+
+    queue_in.put(_vad_audio(revision=0))
+    queue_in.put(PIPELINE_END)
+
+    handler.run()
+
+    assert handler.processed == [("turn_1", 0)]
+    assert queue_out.get_nowait() == PIPELINE_END
+    try:
+        queue_out.get_nowait()
+    except Empty:
+        pass
+    else:
+        raise AssertionError("stale transcription output was emitted")

--- a/tests/test_stt_stale_filter.py
+++ b/tests/test_stt_stale_filter.py
@@ -17,9 +17,11 @@ class RecordingSTTHandler(BaseSTTHandler):
         self,
         speculative_turns: SpeculativeTurnTracker | None = None,
         mark_stale_during_process: bool = False,
+        final_revision_settle_s: float = 0.0,
     ) -> None:
         self.speculative_turns = speculative_turns
         self.mark_stale_during_process = mark_stale_during_process
+        self.final_revision_settle_s = final_revision_settle_s
         self.processed: list[tuple[str | None, int | None]] = []
 
     def process(self, vad_audio: VADAudio) -> Iterator[Transcription]:
@@ -33,8 +35,8 @@ class RecordingSTTHandler(BaseSTTHandler):
         )
 
 
-def _vad_audio(turn_id: str = "turn_1", revision: int = 0) -> VADAudio:
-    return VADAudio(audio=np.zeros(512, dtype=np.float32), turn_id=turn_id, turn_revision=revision)
+def _vad_audio(turn_id: str = "turn_1", revision: int = 0, mode: str | None = None) -> VADAudio:
+    return VADAudio(audio=np.zeros(512, dtype=np.float32), mode=mode, turn_id=turn_id, turn_revision=revision)
 
 
 def _handler(
@@ -43,6 +45,7 @@ def _handler(
     queue_out: Queue,
     *,
     mark_stale_during_process: bool = False,
+    final_revision_settle_s: float = 0.0,
 ) -> RecordingSTTHandler:
     return RecordingSTTHandler(
         Event(),
@@ -51,6 +54,7 @@ def _handler(
         setup_kwargs={
             "speculative_turns": tracker,
             "mark_stale_during_process": mark_stale_during_process,
+            "final_revision_settle_s": final_revision_settle_s,
         },
     )
 
@@ -71,6 +75,27 @@ def test_stt_handler_drops_stale_queued_audio_without_processing():
     assert queue_out.get_nowait() == PIPELINE_END
 
 
+def test_stt_handler_bulk_drops_stale_queued_audio():
+    tracker = SpeculativeTurnTracker()
+    tracker.observe("turn_1", 1)
+    queue_in = Queue()
+    queue_out = Queue()
+    handler = _handler(tracker, queue_in, queue_out)
+
+    for _ in range(5):
+        queue_in.put(_vad_audio(revision=0))
+    queue_in.put(_vad_audio(revision=1))
+    queue_in.put(PIPELINE_END)
+
+    handler.run()
+
+    assert handler.processed == [("turn_1", 1)]
+    output = queue_out.get_nowait()
+    assert isinstance(output, Transcription)
+    assert output.turn_revision == 1
+    assert queue_out.get_nowait() == PIPELINE_END
+
+
 def test_stt_handler_waits_for_pending_reopen_before_processing():
     tracker = SpeculativeTurnTracker()
     tracker.observe("turn_1", 0)
@@ -88,6 +113,28 @@ def test_stt_handler_waits_for_pending_reopen_before_processing():
     assert handler.processed == []
     assert queue_out.empty()
 
+    assert tracker.confirm_reopen_candidate("turn_1", 0, candidate_revision)
+    thread.join(timeout=1.0)
+
+    assert not thread.is_alive()
+    assert handler.processed == []
+    assert queue_out.get_nowait() == PIPELINE_END
+
+
+def test_stt_handler_waits_for_final_revision_stability_window():
+    tracker = SpeculativeTurnTracker()
+    tracker.observe("turn_1", 0)
+    queue_in = Queue()
+    queue_out = Queue()
+    handler = _handler(tracker, queue_in, queue_out, final_revision_settle_s=0.2)
+
+    queue_in.put(_vad_audio(revision=0, mode="final"))
+    queue_in.put(PIPELINE_END)
+    thread = Thread(target=handler.run)
+    thread.start()
+
+    sleep(0.05)
+    candidate_revision = tracker.begin_reopen_candidate("turn_1", 0)
     assert tracker.confirm_reopen_candidate("turn_1", 0, candidate_revision)
     thread.join(timeout=1.0)
 

--- a/tests/test_stt_stale_filter.py
+++ b/tests/test_stt_stale_filter.py
@@ -212,3 +212,50 @@ def test_stt_handler_bulk_drops_queued_progressives_after_final_emit():
     assert isinstance(remaining, VADAudio)
     assert remaining.turn_id == "turn_2"
     assert queue_in.empty()
+
+
+def test_stt_handler_drops_progressive_when_final_for_same_revision_is_queued():
+    tracker = SpeculativeTurnTracker()
+    tracker.observe("turn_1", 0)
+    queue_in = Queue()
+    queue_out = Queue()
+    handler = _handler(tracker, queue_in, queue_out)
+
+    queue_in.put(_vad_audio(revision=0, mode="final"))
+
+    assert not handler.should_process_input(_vad_audio(revision=0, mode="progressive"))
+
+
+def test_stt_handler_keeps_progressive_when_final_for_different_turn_is_queued():
+    tracker = SpeculativeTurnTracker()
+    tracker.observe("turn_1", 0)
+    queue_in = Queue()
+    queue_out = Queue()
+    handler = _handler(tracker, queue_in, queue_out)
+
+    queue_in.put(_vad_audio(turn_id="turn_2", revision=0, mode="final"))
+
+    assert handler.should_process_input(_vad_audio(revision=0, mode="progressive"))
+
+
+def test_stt_handler_bulk_drops_progressives_queued_before_matching_final():
+    tracker = SpeculativeTurnTracker()
+    tracker.observe("turn_1", 0)
+    queue_in = Queue()
+    queue_out = Queue()
+    handler = _handler(tracker, queue_in, queue_out)
+
+    queue_in.put(_vad_audio(revision=0, mode="progressive"))
+    queue_in.put(_vad_audio(revision=0, mode="final"))
+    queue_in.put(_vad_audio(turn_id="turn_2", revision=0, mode="progressive"))
+
+    assert handler._drop_stale_queued_inputs() == 1
+    first = queue_in.get_nowait()
+    second = queue_in.get_nowait()
+
+    assert isinstance(first, VADAudio)
+    assert first.mode == "final"
+    assert first.turn_id == "turn_1"
+    assert isinstance(second, VADAudio)
+    assert second.turn_id == "turn_2"
+    assert queue_in.empty()

--- a/tests/test_stt_stale_filter.py
+++ b/tests/test_stt_stale_filter.py
@@ -3,11 +3,11 @@ from __future__ import annotations
 from queue import Empty, Queue
 from threading import Event, Thread
 from time import sleep
-from typing import Iterator
+from typing import Iterator, Literal
 
 import numpy as np
 
-from speech_to_speech.pipeline.messages import PIPELINE_END, Transcription, VADAudio
+from speech_to_speech.pipeline.messages import PIPELINE_END, PartialTranscription, Transcription, VADAudio
 from speech_to_speech.pipeline.speculative_turns import SpeculativeTurnTracker
 from speech_to_speech.STT.base_stt_handler import BaseSTTHandler
 
@@ -27,6 +27,7 @@ class RecordingSTTHandler(BaseSTTHandler):
     def process(self, vad_audio: VADAudio) -> Iterator[Transcription]:
         self.processed.append((vad_audio.turn_id, vad_audio.turn_revision))
         if self.mark_stale_during_process and vad_audio.turn_id is not None and vad_audio.turn_revision is not None:
+            assert self.speculative_turns is not None
             self.speculative_turns.observe(vad_audio.turn_id, vad_audio.turn_revision + 1)
         yield Transcription(
             text="hello",
@@ -35,7 +36,11 @@ class RecordingSTTHandler(BaseSTTHandler):
         )
 
 
-def _vad_audio(turn_id: str = "turn_1", revision: int = 0, mode: str | None = None) -> VADAudio:
+def _vad_audio(
+    turn_id: str = "turn_1",
+    revision: int = 0,
+    mode: Literal["progressive", "final"] | None = None,
+) -> VADAudio:
     return VADAudio(audio=np.zeros(512, dtype=np.float32), mode=mode, turn_id=turn_id, turn_revision=revision)
 
 
@@ -163,3 +168,47 @@ def test_stt_handler_drops_output_that_became_stale_during_processing():
         pass
     else:
         raise AssertionError("stale transcription output was emitted")
+
+
+def test_stt_handler_drops_progressive_input_after_final_emit():
+    tracker = SpeculativeTurnTracker()
+    tracker.observe("turn_1", 0)
+    queue_in = Queue()
+    queue_out = Queue()
+    handler = _handler(tracker, queue_in, queue_out)
+
+    handler.before_emit_output(Transcription(text="done", turn_id="turn_1", turn_revision=0))
+
+    assert not handler.should_process_input(_vad_audio(revision=0, mode="progressive"))
+
+
+def test_stt_handler_drops_partial_output_after_final_emit():
+    tracker = SpeculativeTurnTracker()
+    tracker.observe("turn_1", 0)
+    queue_in = Queue()
+    queue_out = Queue()
+    handler = _handler(tracker, queue_in, queue_out)
+
+    handler.before_emit_output(Transcription(text="done", turn_id="turn_1", turn_revision=0))
+
+    assert not handler.should_emit_output(PartialTranscription(text="partial", turn_id="turn_1", turn_revision=0))
+
+
+def test_stt_handler_bulk_drops_queued_progressives_after_final_emit():
+    tracker = SpeculativeTurnTracker()
+    tracker.observe("turn_1", 0)
+    queue_in = Queue()
+    queue_out = Queue()
+    handler = _handler(tracker, queue_in, queue_out)
+
+    handler.before_emit_output(Transcription(text="done", turn_id="turn_1", turn_revision=0))
+    for _ in range(3):
+        queue_in.put(_vad_audio(revision=0, mode="progressive"))
+    queue_in.put(_vad_audio(turn_id="turn_2", revision=0, mode="progressive"))
+
+    assert not handler.should_process_input(_vad_audio(revision=0, mode="progressive"))
+    remaining = queue_in.get_nowait()
+
+    assert isinstance(remaining, VADAudio)
+    assert remaining.turn_id == "turn_2"
+    assert queue_in.empty()

--- a/tests/test_transcription_notifier.py
+++ b/tests/test_transcription_notifier.py
@@ -23,7 +23,7 @@ def test_empty_final_transcription_still_emits_completion_after_partial():
     notifier = _notifier(text_output_queue=text_output_queue)
 
     assert list(notifier.process(PartialTranscription(text="Yeah."))) == []
-    assert list(notifier.process(Transcription(text="", language_code="en"))) == []
+    assert list(notifier.process(Transcription(text="", language_code="en", speech_stopped_at_s=123.0))) == []
 
     partial = text_output_queue.get_nowait()
     completed = text_output_queue.get_nowait()
@@ -33,6 +33,7 @@ def test_empty_final_transcription_still_emits_completion_after_partial():
     assert isinstance(completed, TranscriptionCompletedEvent)
     assert completed.transcript == ""
     assert completed.language_code == "en"
+    assert completed.speech_stopped_at_s == 123.0
     assert text_output_queue.empty()
 
 
@@ -50,12 +51,13 @@ def test_non_empty_final_transcription_still_triggers_legacy_generation():
     should_listen = Event()
     notifier = _notifier(runtime_config=runtime_config, should_listen=should_listen)
 
-    result = list(notifier.process(Transcription(text="hello", language_code="en")))
+    result = list(notifier.process(Transcription(text="hello", language_code="en", speech_stopped_at_s=123.0)))
 
     assert len(result) == 1
     assert isinstance(result[0], GenerateResponseRequest)
     assert result[0].runtime_config is runtime_config
     assert result[0].language_code == "en"
+    assert result[0].speech_stopped_at_s == 123.0
     assert not should_listen.is_set()
 
 

--- a/tests/test_vad_iterator.py
+++ b/tests/test_vad_iterator.py
@@ -168,3 +168,29 @@ def test_brief_silence_is_preserved_when_speech_resumes() -> None:
     assert torch.equal(spoken_utterance[2], pause_chunks[1])
     assert torch.equal(spoken_utterance[3], resumed_chunk)
     assert all(torch.equal(chunk, ending_silence) for chunk in spoken_utterance[4:])
+
+
+def test_voiced_samples_exclude_pre_speech_padding_and_trailing_silence() -> None:
+    model = _FakeVADModel([0.1, 0.9, 0.1, 0.1, 0.1, 0.1, 0.1])
+    iterator = VADIterator(
+        model=model,
+        threshold=0.5,
+        sampling_rate=16000,
+        min_silence_duration_ms=100,
+        speech_pad_ms=512,
+    )
+
+    pre_speech_chunk = torch.ones(512)
+    speech_chunk = torch.ones(512) * 2
+    silence_chunk = torch.zeros(512)
+
+    assert iterator(pre_speech_chunk) is None
+    assert iterator(speech_chunk) is None
+    assert iterator.voiced_samples == 512
+
+    spoken_utterance = _finish_utterance(iterator, silence_chunk)
+
+    assert spoken_utterance is not None
+    assert iterator.last_utterance_voiced_samples == 512
+    assert iterator.voiced_samples == 0
+    assert len(spoken_utterance) > 2

--- a/tests/test_vad_iterator.py
+++ b/tests/test_vad_iterator.py
@@ -170,8 +170,8 @@ def test_brief_silence_is_preserved_when_speech_resumes() -> None:
     assert all(torch.equal(chunk, ending_silence) for chunk in spoken_utterance[4:])
 
 
-def test_voiced_samples_exclude_pre_speech_padding_and_trailing_silence() -> None:
-    model = _FakeVADModel([0.1, 0.9, 0.1, 0.1, 0.1, 0.1, 0.1])
+def test_active_speech_samples_include_hysteresis_band_and_exclude_trailing_silence() -> None:
+    model = _FakeVADModel([0.1, 0.9, 0.4, 0.1, 0.1, 0.1, 0.1, 0.1])
     iterator = VADIterator(
         model=model,
         threshold=0.5,
@@ -182,15 +182,17 @@ def test_voiced_samples_exclude_pre_speech_padding_and_trailing_silence() -> Non
 
     pre_speech_chunk = torch.ones(512)
     speech_chunk = torch.ones(512) * 2
+    maintained_speech_chunk = torch.ones(512) * 3
     silence_chunk = torch.zeros(512)
 
     assert iterator(pre_speech_chunk) is None
     assert iterator(speech_chunk) is None
-    assert iterator.voiced_samples == 512
+    assert iterator(maintained_speech_chunk) is None
+    assert iterator.active_speech_samples == 1024
 
     spoken_utterance = _finish_utterance(iterator, silence_chunk)
 
     assert spoken_utterance is not None
-    assert iterator.last_utterance_voiced_samples == 512
-    assert iterator.voiced_samples == 0
+    assert iterator.last_utterance_active_speech_samples == 1024
+    assert iterator.active_speech_samples == 0
     assert len(spoken_utterance) > 2


### PR DESCRIPTION
## Summary

Adds a raw-audio-first speculative turn path for realtime mode. VAD now soft-ends turns, keeps listening, and can reopen a recent turn by emitting a newer revision that contains the combined raw audio. Downstream stages carry turn/revision metadata so stale STT, LLM, and TTS work can be ignored instead of leaking into the active response.

## Details

- Adds a shared `SpeculativeTurnTracker` for latest/committed turn revisions.
- Threads `turn_id` and `turn_revision` through VAD audio, STT transcriptions, pipeline events, LLM requests/chunks, and TTS inputs.
- Replaces the previous speculative user transcript in realtime chat when a newer raw-audio revision lands.
- Stages assistant/tool chat writes in LLM handlers and only commits them if the revision is still current.
- Drops stale LLM/TTS output before it reaches clients or audio synthesis.
- Adds `--speculative_reopen_ms` to configure the realtime reopen window.

## Validation

- `uv run ruff check src/speech_to_speech tests/openai_realtime/test_realtime_service.py`
- `uv run pytest`

`uv run pytest` passed with 357 tests.
