### PR TITLE
Add OpenAI Responses latency controls

### DIFF
--- a/src/speech_to_speech/LLM/README.md
+++ b/src/speech_to_speech/LLM/README.md
@@ -71,6 +71,23 @@ Common options:
 - `--open_api_chat_size`
 - `--open_api_init_chat_prompt`
 - `--open_api_user_role`
+- `--open_api_reasoning_effort`
+- `--open_api_service_tier`
+- `--open_api_max_output_tokens`
+
+Low-latency OpenAI Responses API example:
+
+```bash
+python s2s_pipeline.py \
+  --mode realtime \
+  --llm open_api \
+  --open_api_model_name gpt-5.4 \
+  --open_api_stream true \
+  --open_api_stream_batch_sentences 1 \
+  --open_api_reasoning_effort none \
+  --open_api_service_tier priority \
+  --open_api_max_output_tokens 64
+```
 
 ## LLM Behavior
 

--- a/src/speech_to_speech/LLM/lm_output_processor.py
+++ b/src/speech_to_speech/LLM/lm_output_processor.py
@@ -52,6 +52,10 @@ class LMOutputProcessor(BaseHandler[LLMOut, TTSIn]):
                     TokenUsageEvent(
                         input_tokens=lm_output.input_tokens or 0,
                         output_tokens=lm_output.output_tokens or 0,
+                        cached_tokens=lm_output.cached_tokens,
+                        reasoning_tokens=lm_output.reasoning_tokens,
+                        total_tokens=lm_output.total_tokens,
+                        service_tier=lm_output.service_tier,
                     )
                 )
             return

--- a/src/speech_to_speech/LLM/openai_api_language_model.py
+++ b/src/speech_to_speech/LLM/openai_api_language_model.py
@@ -57,6 +57,9 @@ class OpenApiModelHandler(BaseHandler[LLMIn, LLMOut]):
         user_role: str = "user",
         cancel_scope: CancelScope | None = None,
         disable_thinking: bool = True,
+        service_tier: Optional[str] = None,
+        reasoning_effort: Optional[str] = None,
+        max_output_tokens: Optional[int] = None,
         request_timeout_s: float = 20.0,
         stream_batch_sentences: int = 3,
         enable_lang_prompt: bool = False,
@@ -68,6 +71,14 @@ class OpenApiModelHandler(BaseHandler[LLMIn, LLMOut]):
         self.stream_batch_sentences = max(1, stream_batch_sentences)
         self.enable_lang_prompt = enable_lang_prompt
         self.gen_kwargs = dict(gen_kwargs)
+        self.service_tier = service_tier
+        self.reasoning_effort = reasoning_effort
+        self.max_output_tokens = max_output_tokens
+        self._request_kwargs = self._build_response_request_kwargs(
+            service_tier=service_tier,
+            reasoning_effort=reasoning_effort,
+            max_output_tokens=max_output_tokens,
+        )
         self.request_timeout_s = float(request_timeout_s)
         self.request_timeout = httpx.Timeout(
             self.request_timeout_s,
@@ -83,6 +94,22 @@ class OpenApiModelHandler(BaseHandler[LLMIn, LLMOut]):
         )
         self.warmup()
 
+    @staticmethod
+    def _build_response_request_kwargs(
+        *,
+        service_tier: Optional[str],
+        reasoning_effort: Optional[str],
+        max_output_tokens: Optional[int],
+    ) -> dict[str, Any]:
+        request_kwargs: dict[str, Any] = {}
+        if service_tier is not None:
+            request_kwargs["service_tier"] = service_tier
+        if reasoning_effort is not None:
+            request_kwargs["reasoning"] = {"effort": reasoning_effort}
+        if max_output_tokens is not None:
+            request_kwargs["max_output_tokens"] = max_output_tokens
+        return request_kwargs
+
     def warmup(self) -> None:
         logger.info(f"Warming up {self.__class__.__name__}")
         start = time.time()
@@ -97,9 +124,53 @@ class OpenApiModelHandler(BaseHandler[LLMIn, LLMOut]):
                 {"type": "message", "role": "user", "content": [{"type": "input_text", "text": "Hello"}]},
             ],
             timeout=self.request_timeout,
+            **self._request_kwargs,
         )
         end = time.time()
         logger.info(f"{self.__class__.__name__}:  warmed up! time: {(end - start):.3f} s")
+
+    @staticmethod
+    def _get_optional_value(value: Any, key: str) -> Any:
+        if value is None:
+            return None
+        if isinstance(value, dict):
+            return value.get(key)
+        return getattr(value, key, None)
+
+    @classmethod
+    def _get_nested_optional_value(cls, value: Any, *keys: str) -> Any:
+        for key in keys:
+            value = cls._get_optional_value(value, key)
+            if value is None:
+                return None
+        return value
+
+    @classmethod
+    def _extract_response_usage(cls, response: Any) -> dict[str, Any] | None:
+        usage = cls._get_optional_value(response, "usage")
+        service_tier = cls._get_optional_value(response, "service_tier")
+        if usage is None and service_tier is None:
+            return None
+        return {
+            "input_tokens": cls._get_optional_value(usage, "input_tokens") or 0,
+            "cached_tokens": cls._get_nested_optional_value(usage, "input_tokens_details", "cached_tokens"),
+            "output_tokens": cls._get_optional_value(usage, "output_tokens") or 0,
+            "reasoning_tokens": cls._get_nested_optional_value(usage, "output_tokens_details", "reasoning_tokens"),
+            "total_tokens": cls._get_optional_value(usage, "total_tokens"),
+            "service_tier": service_tier,
+        }
+
+    @staticmethod
+    def _log_response_usage(usage: dict[str, Any]) -> None:
+        logger.info(
+            "OpenAI usage: input=%s, cached=%s, output=%s, reasoning=%s, total=%s, service_tier=%s",
+            usage["input_tokens"],
+            usage["cached_tokens"],
+            usage["output_tokens"],
+            usage["reasoning_tokens"],
+            usage["total_tokens"],
+            usage["service_tier"],
+        )
 
     def _apply_config(
         self,
@@ -155,6 +226,7 @@ class OpenApiModelHandler(BaseHandler[LLMIn, LLMOut]):
         clean_text = ""
         input_tokens = 0
         output_tokens = 0
+        usage_stats: dict[str, Any] | None = None
         try:
             api_response = self.client.responses.create(
                 model=self.model_name,
@@ -162,6 +234,7 @@ class OpenApiModelHandler(BaseHandler[LLMIn, LLMOut]):
                 stream=self.stream,
                 extra_body=self._extra_body,
                 timeout=self.request_timeout,
+                **self._request_kwargs,
                 **optional_kwargs,
             )
             if isinstance(api_response, Stream):
@@ -219,10 +292,10 @@ class OpenApiModelHandler(BaseHandler[LLMIn, LLMOut]):
                                 )
                             )
                     elif isinstance(raw_event, ResponseCompletedEvent):
-                        usage = getattr(raw_event.response, "usage", None)
-                        if usage:
-                            input_tokens = usage.input_tokens or 0
-                            output_tokens = usage.output_tokens or 0
+                        usage_stats = self._extract_response_usage(raw_event.response)
+                        if usage_stats:
+                            input_tokens = usage_stats["input_tokens"]
+                            output_tokens = usage_stats["output_tokens"]
                 if not cancelled:
                     if printable_text.strip():
                         sentence_batch.append(printable_text.strip())
@@ -241,10 +314,10 @@ class OpenApiModelHandler(BaseHandler[LLMIn, LLMOut]):
                 if gen is not None and self.cancel_scope is not None and self.cancel_scope.is_stale(gen):
                     logger.info("LLM generation cancelled (interruption)")
                 else:
-                    usage = api_response.usage
-                    if usage:
-                        input_tokens = usage.input_tokens or 0
-                        output_tokens = usage.output_tokens or 0
+                    usage_stats = self._extract_response_usage(api_response)
+                    if usage_stats:
+                        input_tokens = usage_stats["input_tokens"]
+                        output_tokens = usage_stats["output_tokens"]
                     for message in api_response.output:
                         if isinstance(message, ResponseFunctionToolCall):
                             item = original_chat.add_item(
@@ -305,8 +378,16 @@ class OpenApiModelHandler(BaseHandler[LLMIn, LLMOut]):
                     pass
 
         original_chat.strip_images()
-        if input_tokens or output_tokens:
-            yield TokenUsage(input_tokens=input_tokens, output_tokens=output_tokens)
+        if usage_stats is not None:
+            self._log_response_usage(usage_stats)
+            yield TokenUsage(
+                input_tokens=input_tokens,
+                output_tokens=output_tokens,
+                cached_tokens=usage_stats["cached_tokens"],
+                reasoning_tokens=usage_stats["reasoning_tokens"],
+                total_tokens=usage_stats["total_tokens"],
+                service_tier=usage_stats["service_tier"],
+            )
         yield EndOfResponse()
 
     def on_session_end(self) -> None:

--- a/src/speech_to_speech/arguments_classes/open_api_language_model_arguments.py
+++ b/src/speech_to_speech/arguments_classes/open_api_language_model_arguments.py
@@ -53,6 +53,23 @@ class OpenApiLanguageModelHandlerArguments:
             "For Together Qwen3.5 models this sends chat_template_kwargs.enable_thinking=false."
         },
     )
+    open_api_service_tier: Optional[str] = field(
+        default=None,
+        metadata={
+            "help": "Optional Responses API service_tier value, for example 'priority'. Default is None."
+        },
+    )
+    open_api_reasoning_effort: Optional[str] = field(
+        default=None,
+        metadata={
+            "help": "Optional Responses API reasoning effort. GPT-5.4 documented values include: "
+            "'none', 'low', 'medium', 'high', 'xhigh'. Default is None."
+        },
+    )
+    open_api_max_output_tokens: Optional[int] = field(
+        default=None,
+        metadata={"help": "Optional Responses API max_output_tokens limit. Default is None."},
+    )
     open_api_stream_batch_sentences: int = field(
         default=3,
         metadata={

--- a/src/speech_to_speech/pipeline/events.py
+++ b/src/speech_to_speech/pipeline/events.py
@@ -65,3 +65,7 @@ class TokenUsageEvent(PipelineEvent):
     type: Literal["token_usage"] = "token_usage"
     input_tokens: int = 0
     output_tokens: int = 0
+    cached_tokens: Optional[int] = None
+    reasoning_tokens: Optional[int] = None
+    total_tokens: Optional[int] = None
+    service_tier: Optional[str] = None

--- a/src/speech_to_speech/pipeline/messages.py
+++ b/src/speech_to_speech/pipeline/messages.py
@@ -81,6 +81,10 @@ class TokenUsage(PipelineMessage):
     tag: Literal["token_usage"] = "token_usage"
     input_tokens: int
     output_tokens: int
+    cached_tokens: Optional[int] = None
+    reasoning_tokens: Optional[int] = None
+    total_tokens: Optional[int] = None
+    service_tier: Optional[str] = None
 
 
 class EndOfResponse(PipelineMessage):

--- a/tests/test_openai_api_language_model.py
+++ b/tests/test_openai_api_language_model.py
@@ -5,6 +5,7 @@ import httpx
 from openai import Stream
 from openai.types.responses import (
     Response,
+    ResponseCompletedEvent,
     ResponseOutputItemDoneEvent,
     ResponseOutputMessage,
     ResponseTextDeltaEvent,
@@ -15,7 +16,7 @@ from speech_to_speech.api.openai_realtime.runtime_config import RuntimeConfig
 from speech_to_speech.LLM.chat import Chat, make_user_message
 from speech_to_speech.LLM.openai_api_language_model import OpenApiModelHandler
 from speech_to_speech.pipeline.cancel_scope import CancelScope
-from speech_to_speech.pipeline.messages import EndOfResponse, GenerateResponseRequest, LLMResponseChunk
+from speech_to_speech.pipeline.messages import EndOfResponse, GenerateResponseRequest, LLMResponseChunk, TokenUsage
 
 
 def _make_text_delta_event(text):
@@ -48,10 +49,11 @@ def _make_stream(events):
     return stream
 
 
-def _make_response(output, usage=None):
+def _make_response(output, usage=None, service_tier=None):
     resp = MagicMock(spec=Response)
     resp.usage = usage
     resp.output = output
+    resp.service_tier = service_tier
     return resp
 
 
@@ -70,12 +72,28 @@ def _make_request(text="Hi", chat_size=2):
     return GenerateResponseRequest(runtime_config=cfg)
 
 
-def _make_handler(*, disable_thinking=False, stream=True, cancel_scope=None):
+def _make_handler(
+    *,
+    disable_thinking=False,
+    stream=True,
+    cancel_scope=None,
+    service_tier=None,
+    reasoning_effort=None,
+    max_output_tokens=None,
+):
     handler = object.__new__(OpenApiModelHandler)
     handler.model_name = "test-model"
     handler.stream = stream
     handler.stream_batch_sentences = 1
     handler.gen_kwargs = {}
+    handler.service_tier = service_tier
+    handler.reasoning_effort = reasoning_effort
+    handler.max_output_tokens = max_output_tokens
+    handler._request_kwargs = OpenApiModelHandler._build_response_request_kwargs(
+        service_tier=service_tier,
+        reasoning_effort=reasoning_effort,
+        max_output_tokens=max_output_tokens,
+    )
     handler.request_timeout_s = 20.0
     handler.request_timeout = 20.0
     handler.disable_thinking = disable_thinking
@@ -85,6 +103,18 @@ def _make_handler(*, disable_thinking=False, stream=True, cancel_scope=None):
     handler.tools = None
     handler.tools_choice = None
     return handler
+
+
+def _capture_create_kwargs(handler):
+    captured = {}
+
+    def fake_create(**kwargs):
+        captured.update(kwargs)
+        return _make_response(output=[])
+
+    handler.client = SimpleNamespace(responses=SimpleNamespace(create=fake_create))
+    list(handler.process(_make_request("Hi")))
+    return captured
 
 
 def test_process_streams_text_from_response_events():
@@ -184,6 +214,87 @@ def test_no_disable_thinking_omits_extra_body():
     list(handler.process(_make_request("Hi")))
 
     assert captured.get("extra_body") is None
+
+
+def test_service_tier_is_passed_when_set():
+    handler = _make_handler(stream=False, service_tier="priority")
+
+    captured = _capture_create_kwargs(handler)
+
+    assert captured["service_tier"] == "priority"
+
+
+def test_reasoning_effort_is_passed_when_set_to_none_string():
+    handler = _make_handler(stream=False, reasoning_effort="none")
+
+    captured = _capture_create_kwargs(handler)
+
+    assert captured["reasoning"] == {"effort": "none"}
+
+
+def test_max_output_tokens_is_passed_when_set():
+    handler = _make_handler(stream=False, max_output_tokens=64)
+
+    captured = _capture_create_kwargs(handler)
+
+    assert captured["max_output_tokens"] == 64
+
+
+def test_optional_openai_response_fields_are_omitted_by_default():
+    handler = _make_handler(stream=False)
+
+    captured = _capture_create_kwargs(handler)
+
+    assert "service_tier" not in captured
+    assert "reasoning" not in captured
+    assert "max_output_tokens" not in captured
+
+
+def test_nonstream_usage_tracks_cached_reasoning_total_and_service_tier():
+    handler = _make_handler(stream=False)
+    usage = SimpleNamespace(
+        input_tokens=12,
+        input_tokens_details=SimpleNamespace(cached_tokens=4),
+        output_tokens=6,
+        output_tokens_details=SimpleNamespace(reasoning_tokens=2),
+        total_tokens=18,
+    )
+    response = _make_response(output=[], usage=usage, service_tier="priority")
+    handler.client = SimpleNamespace(responses=SimpleNamespace(create=lambda **kwargs: response))
+
+    outputs = list(handler.process(_make_request("Hi")))
+
+    token_usage = next(output for output in outputs if isinstance(output, TokenUsage))
+    assert token_usage.input_tokens == 12
+    assert token_usage.cached_tokens == 4
+    assert token_usage.output_tokens == 6
+    assert token_usage.reasoning_tokens == 2
+    assert token_usage.total_tokens == 18
+    assert token_usage.service_tier == "priority"
+
+
+def test_stream_usage_tracks_cached_reasoning_total_and_service_tier():
+    handler = _make_handler(stream=True)
+    usage = SimpleNamespace(
+        input_tokens=12,
+        input_tokens_details=SimpleNamespace(cached_tokens=4),
+        output_tokens=6,
+        output_tokens_details=SimpleNamespace(reasoning_tokens=2),
+        total_tokens=18,
+    )
+    completed = MagicMock(spec=ResponseCompletedEvent)
+    completed.response = SimpleNamespace(usage=usage, service_tier="priority")
+    handler.client = SimpleNamespace(responses=SimpleNamespace(create=lambda **kwargs: _make_stream([completed])))
+
+    outputs = list(handler.process(_make_request("Hi")))
+
+    token_usage = next(output for output in outputs if isinstance(output, TokenUsage))
+    assert token_usage.input_tokens == 12
+    assert token_usage.cached_tokens == 4
+    assert token_usage.output_tokens == 6
+    assert token_usage.reasoning_tokens == 2
+    assert token_usage.total_tokens == 18
+    assert token_usage.service_tier == "priority"
 
 
 def test_second_turn_flattens_assistant_history_for_responses():


### PR DESCRIPTION
## Summary
- Add OpenAI-compatible backend args for Responses API `service_tier`, `reasoning.effort`, and `max_output_tokens`.
- Thread the optional request kwargs through warmup and generation while preserving existing streaming, tools, tool choice, and `disable_thinking` behavior.
- Extend usage extraction/logging for cached tokens, reasoning tokens, total tokens, and response service tier, with optional fields on token usage messages/events.
- Add focused OpenAI API handler tests and document a low-latency GPT-5.4 example.

## Validation
- `python3 -m py_compile src/speech_to_speech/arguments_classes/open_api_language_model_arguments.py src/speech_to_speech/pipeline/messages.py src/speech_to_speech/pipeline/events.py src/speech_to_speech/LLM/lm_output_processor.py src/speech_to_speech/LLM/openai_api_language_model.py tests/test_openai_api_language_model.py`
- `.venv/bin/python -m py_compile src/speech_to_speech/arguments_classes/open_api_language_model_arguments.py src/speech_to_speech/pipeline/messages.py src/speech_to_speech/pipeline/events.py src/speech_to_speech/LLM/lm_output_processor.py src/speech_to_speech/LLM/openai_api_language_model.py tests/test_openai_api_language_model.py`

`pytest` could not be run in this environment: it is not installed on PATH or in `.venv`, and `uv run pytest -q tests/test_openai_api_language_model.py` fails while building `fugashi==1.3.0` because MeCab is missing.
