### PR TITLE
Fix Parakeet progressive empty windows

### DIFF
--- a/src/speech_to_speech/STT/parakeet_tdt_handler.py
+++ b/src/speech_to_speech/STT/parakeet_tdt_handler.py
@@ -292,11 +292,12 @@ class ParakeetTDTSTTHandler(BaseHandler[STTIn, STTOut]):
             if language_code:
                 console.print(f"[dim]Language: {language_code}[/dim]")
 
-        yield Transcription(text=pred_text, language_code=language_code)
-
-        # Reset processing_final flag for next utterance
         if self.enable_live_transcription:
             self.processing_final = False
+            if self.streaming_handler is not None:
+                self.streaming_handler.reset()
+
+        yield Transcription(text=pred_text, language_code=language_code)
 
     def _detect_language_from_text(self, text: str) -> Optional[str]:
         """

--- a/src/speech_to_speech/STT/parakeet_tdt_handler.py
+++ b/src/speech_to_speech/STT/parakeet_tdt_handler.py
@@ -292,6 +292,9 @@ class ParakeetTDTSTTHandler(BaseHandler[STTIn, STTOut]):
             if language_code:
                 console.print(f"[dim]Language: {language_code}[/dim]")
 
+        # Reset per-utterance live transcription state only after final STT
+        # completes. The streaming handler carries fixed sentence timing within
+        # an utterance, and stale timing must not leak into the next turn.
         if self.enable_live_transcription:
             self.processing_final = False
             if self.streaming_handler is not None:

--- a/src/speech_to_speech/STT/smart_progressive_streaming.py
+++ b/src/speech_to_speech/STT/smart_progressive_streaming.py
@@ -97,14 +97,6 @@ class SmartProgressiveStreamingHandler:
         # Skip if not enough new audio
         current_length = len(audio)
         window_start_samples = int(self.fixed_end_time * self.sample_rate)
-        if window_start_samples > current_length and (self.fixed_end_time > 0 or self.fixed_sentences):
-            logger.debug(
-                "Resetting progressive stream state because fixed_end_time %.3fs exceeds current audio %.3fs",
-                self.fixed_end_time,
-                current_length / self.sample_rate,
-            )
-            self.reset()
-            window_start_samples = 0
 
         if current_length < self.sample_rate * 0.5:  # Need at least 500ms
             return PartialTranscription(
@@ -123,7 +115,12 @@ class SmartProgressiveStreamingHandler:
                 is_final=False,
             )
 
-        if window_start_samples == current_length:
+        if window_start_samples >= current_length:
+            logger.debug(
+                "Skipping progressive decode because fixed_end_time %.3fs covers current audio %.3fs",
+                self.fixed_end_time,
+                current_length / self.sample_rate,
+            )
             self.last_transcribed_length = current_length
             return PartialTranscription(
                 fixed_text=" ".join(self.fixed_sentences),

--- a/src/speech_to_speech/STT/smart_progressive_streaming.py
+++ b/src/speech_to_speech/STT/smart_progressive_streaming.py
@@ -93,7 +93,6 @@ class SmartProgressiveStreamingHandler:
         """
         # Skip if not enough new audio
         current_length = len(audio)
-
         if current_length < self.sample_rate * 0.5:  # Need at least 500ms
             return PartialTranscription(
                 fixed_text=" ".join(self.fixed_sentences),

--- a/src/speech_to_speech/STT/smart_progressive_streaming.py
+++ b/src/speech_to_speech/STT/smart_progressive_streaming.py
@@ -8,11 +8,14 @@ Provides frequent partial transcriptions (every 250ms) with:
 - Fixed sentences + active transcription
 """
 
+import logging
 from dataclasses import dataclass
 from types import SimpleNamespace
 from typing import Any, Generator
 
 import numpy as np
+
+logger = logging.getLogger(__name__)
 
 
 @dataclass
@@ -93,6 +96,16 @@ class SmartProgressiveStreamingHandler:
         """
         # Skip if not enough new audio
         current_length = len(audio)
+        window_start_samples = int(self.fixed_end_time * self.sample_rate)
+        if window_start_samples >= current_length and (self.fixed_end_time > 0 or self.fixed_sentences):
+            logger.debug(
+                "Resetting progressive stream state because fixed_end_time %.3fs exceeds current audio %.3fs",
+                self.fixed_end_time,
+                current_length / self.sample_rate,
+            )
+            self.reset()
+            window_start_samples = 0
+
         if current_length < self.sample_rate * 0.5:  # Need at least 500ms
             return PartialTranscription(
                 fixed_text=" ".join(self.fixed_sentences),
@@ -113,7 +126,6 @@ class SmartProgressiveStreamingHandler:
         self.last_transcribed_length = current_length
 
         # Extract window for transcription (from last fixed sentence to end)
-        window_start_samples = int(self.fixed_end_time * self.sample_rate)
         audio_window = audio[window_start_samples:]
 
         # Transcribe current window

--- a/src/speech_to_speech/STT/smart_progressive_streaming.py
+++ b/src/speech_to_speech/STT/smart_progressive_streaming.py
@@ -8,14 +8,11 @@ Provides frequent partial transcriptions (every 250ms) with:
 - Fixed sentences + active transcription
 """
 
-import logging
 from dataclasses import dataclass
 from types import SimpleNamespace
 from typing import Any, Generator
 
 import numpy as np
-
-logger = logging.getLogger(__name__)
 
 
 @dataclass
@@ -96,7 +93,6 @@ class SmartProgressiveStreamingHandler:
         """
         # Skip if not enough new audio
         current_length = len(audio)
-        window_start_samples = int(self.fixed_end_time * self.sample_rate)
 
         if current_length < self.sample_rate * 0.5:  # Need at least 500ms
             return PartialTranscription(
@@ -115,23 +111,10 @@ class SmartProgressiveStreamingHandler:
                 is_final=False,
             )
 
-        if window_start_samples >= current_length:
-            logger.debug(
-                "Skipping progressive decode because fixed_end_time %.3fs covers current audio %.3fs",
-                self.fixed_end_time,
-                current_length / self.sample_rate,
-            )
-            self.last_transcribed_length = current_length
-            return PartialTranscription(
-                fixed_text=" ".join(self.fixed_sentences),
-                active_text="",
-                timestamp=current_length / self.sample_rate,
-                is_final=False,
-            )
-
         self.last_transcribed_length = current_length
 
         # Extract window for transcription (from last fixed sentence to end)
+        window_start_samples = int(self.fixed_end_time * self.sample_rate)
         audio_window = audio[window_start_samples:]
 
         # Transcribe current window

--- a/src/speech_to_speech/STT/smart_progressive_streaming.py
+++ b/src/speech_to_speech/STT/smart_progressive_streaming.py
@@ -97,7 +97,7 @@ class SmartProgressiveStreamingHandler:
         # Skip if not enough new audio
         current_length = len(audio)
         window_start_samples = int(self.fixed_end_time * self.sample_rate)
-        if window_start_samples >= current_length and (self.fixed_end_time > 0 or self.fixed_sentences):
+        if window_start_samples > current_length and (self.fixed_end_time > 0 or self.fixed_sentences):
             logger.debug(
                 "Resetting progressive stream state because fixed_end_time %.3fs exceeds current audio %.3fs",
                 self.fixed_end_time,
@@ -116,6 +116,15 @@ class SmartProgressiveStreamingHandler:
 
         # Skip if no new audio since last transcription
         if current_length == self.last_transcribed_length:
+            return PartialTranscription(
+                fixed_text=" ".join(self.fixed_sentences),
+                active_text="",
+                timestamp=current_length / self.sample_rate,
+                is_final=False,
+            )
+
+        if window_start_samples == current_length:
+            self.last_transcribed_length = current_length
             return PartialTranscription(
                 fixed_text=" ".join(self.fixed_sentences),
                 active_text="",

--- a/tests/test_parakeet_transcription_events.py
+++ b/tests/test_parakeet_transcription_events.py
@@ -115,6 +115,28 @@ def test_progressive_stream_resets_stale_fixed_end_before_decoding():
     assert handler.fixed_end_time == 0.0
 
 
+def test_progressive_stream_keeps_fixed_text_at_exact_boundary():
+    class Model:
+        def __init__(self):
+            self.lengths = []
+
+        def transcribe(self, audio, timestamps=True):
+            self.lengths.append(len(audio))
+            return SimpleNamespace(text="active", timestamp={"segment": []})
+
+    model = Model()
+    handler = SmartProgressiveStreamingHandler(model)
+    handler.fixed_sentences = ["kept fixed"]
+    handler.fixed_end_time = 1.0
+
+    result = handler.transcribe_incremental(np.zeros(16000, dtype=np.float32))
+
+    assert model.lengths == []
+    assert result.fixed_text == "kept fixed"
+    assert result.active_text == ""
+    assert handler.fixed_end_time == 1.0
+
+
 def test_on_session_end_resets_streaming_state():
     handler = object.__new__(ParakeetTDTSTTHandler)
     handler.start_language = "en"

--- a/tests/test_parakeet_transcription_events.py
+++ b/tests/test_parakeet_transcription_events.py
@@ -6,6 +6,7 @@ import numpy as np
 from speech_to_speech.pipeline.messages import PartialTranscription, Transcription, VADAudio
 from speech_to_speech.STT import parakeet_tdt_handler
 from speech_to_speech.STT.parakeet_tdt_handler import ParakeetTDTSTTHandler
+from speech_to_speech.STT.smart_progressive_streaming import SmartProgressiveStreamingHandler
 
 
 def test_show_progressive_transcription_returns_combined_text(monkeypatch):
@@ -64,6 +65,54 @@ def test_process_yields_final_transcript(monkeypatch):
     assert isinstance(result[0], Transcription)
     assert result[0].text == "I am here."
     assert result[0].language_code == "en"
+
+
+def test_final_transcription_resets_live_streaming_state(monkeypatch):
+    handler = object.__new__(ParakeetTDTSTTHandler)
+    handler.enable_live_transcription = True
+    handler.backend = "nano_parakeet"
+    handler.last_language = "en"
+    handler.start_language = None
+    handler.processing_final = False
+    reset_calls = []
+    handler.streaming_handler = SimpleNamespace(reset=lambda: reset_calls.append(True))
+
+    @contextmanager
+    def fake_lock(*args, **kwargs):
+        yield True
+
+    handler._compute_lock_context = fake_lock
+    handler._process_nano_parakeet = lambda audio_input: ("I am here.", "en")
+    monkeypatch.setattr(parakeet_tdt_handler.console, "print", lambda *args, **kwargs: None)
+
+    result = list(handler.process(VADAudio(audio=np.zeros(16000, dtype=np.float32), mode="final")))
+
+    assert len(result) == 1
+    assert isinstance(result[0], Transcription)
+    assert handler.processing_final is False
+    assert reset_calls == [True]
+
+
+def test_progressive_stream_resets_stale_fixed_end_before_decoding():
+    class Model:
+        def __init__(self):
+            self.lengths = []
+
+        def transcribe(self, audio, timestamps=True):
+            self.lengths.append(len(audio))
+            return SimpleNamespace(text="fresh partial", timestamp={"segment": []})
+
+    model = Model()
+    handler = SmartProgressiveStreamingHandler(model)
+    handler.fixed_sentences = ["stale text"]
+    handler.fixed_end_time = 10.0
+
+    result = handler.transcribe_incremental(np.zeros(16000, dtype=np.float32))
+
+    assert model.lengths == [16000]
+    assert result.fixed_text == ""
+    assert result.active_text == "fresh partial"
+    assert handler.fixed_end_time == 0.0
 
 
 def test_on_session_end_resets_streaming_state():

--- a/tests/test_parakeet_transcription_events.py
+++ b/tests/test_parakeet_transcription_events.py
@@ -6,6 +6,7 @@ import numpy as np
 from speech_to_speech.pipeline.messages import PartialTranscription, Transcription, VADAudio
 from speech_to_speech.STT import parakeet_tdt_handler
 from speech_to_speech.STT.parakeet_tdt_handler import ParakeetTDTSTTHandler
+from speech_to_speech.STT.smart_progressive_streaming import SmartProgressiveStreamingHandler
 
 
 def test_show_progressive_transcription_returns_combined_text(monkeypatch):
@@ -90,6 +91,47 @@ def test_final_transcription_resets_live_streaming_state(monkeypatch):
     assert isinstance(result[0], Transcription)
     assert handler.processing_final is False
     assert reset_calls == [True]
+
+
+def test_final_transcription_prevents_stale_fixed_window_on_next_progressive(monkeypatch):
+    class Model:
+        def __init__(self):
+            self.progressive_window_lengths = []
+
+        def transcribe(self, audio, timestamps=True):
+            self.progressive_window_lengths.append(len(audio))
+            return SimpleNamespace(text="new partial", timestamp={"segment": []})
+
+    model = Model()
+    handler = object.__new__(ParakeetTDTSTTHandler)
+    handler.enable_live_transcription = True
+    handler.backend = "nano_parakeet"
+    handler.last_language = "en"
+    handler.start_language = None
+    handler.processing_final = False
+    handler.streaming_handler = SmartProgressiveStreamingHandler(model)
+    handler.streaming_handler.fixed_sentences = ["previous fixed sentence"]
+    handler.streaming_handler.fixed_end_time = 10.0
+    handler.streaming_handler.last_transcribed_length = 20 * 16000
+
+    @contextmanager
+    def fake_lock(*args, **kwargs):
+        yield True
+
+    handler._compute_lock_context = fake_lock
+    handler._process_nano_parakeet = lambda audio_input: ("previous final", "en")
+    monkeypatch.setattr(parakeet_tdt_handler.console, "print", lambda *args, **kwargs: None)
+
+    final_result = list(handler.process(VADAudio(audio=np.zeros(16000, dtype=np.float32), mode="final")))
+    progressive_audio = np.zeros(852 * 16, dtype=np.float32)
+    progressive_result = list(handler.process(VADAudio(audio=progressive_audio, mode="progressive")))
+
+    assert len(final_result) == 1
+    assert isinstance(final_result[0], Transcription)
+    assert model.progressive_window_lengths == [len(progressive_audio)]
+    assert len(progressive_result) == 1
+    assert isinstance(progressive_result[0], PartialTranscription)
+    assert progressive_result[0].text == "new partial"
 
 
 def test_on_session_end_resets_streaming_state():

--- a/tests/test_parakeet_transcription_events.py
+++ b/tests/test_parakeet_transcription_events.py
@@ -6,7 +6,6 @@ import numpy as np
 from speech_to_speech.pipeline.messages import PartialTranscription, Transcription, VADAudio
 from speech_to_speech.STT import parakeet_tdt_handler
 from speech_to_speech.STT.parakeet_tdt_handler import ParakeetTDTSTTHandler
-from speech_to_speech.STT.smart_progressive_streaming import SmartProgressiveStreamingHandler
 
 
 def test_show_progressive_transcription_returns_combined_text(monkeypatch):
@@ -91,50 +90,6 @@ def test_final_transcription_resets_live_streaming_state(monkeypatch):
     assert isinstance(result[0], Transcription)
     assert handler.processing_final is False
     assert reset_calls == [True]
-
-
-def test_progressive_stream_preserves_fixed_text_when_fixed_end_exceeds_audio():
-    class Model:
-        def __init__(self):
-            self.lengths = []
-
-        def transcribe(self, audio, timestamps=True):
-            self.lengths.append(len(audio))
-            return SimpleNamespace(text="fresh partial", timestamp={"segment": []})
-
-    model = Model()
-    handler = SmartProgressiveStreamingHandler(model)
-    handler.fixed_sentences = ["stale text"]
-    handler.fixed_end_time = 10.0
-
-    result = handler.transcribe_incremental(np.zeros(16000, dtype=np.float32))
-
-    assert model.lengths == []
-    assert result.fixed_text == "stale text"
-    assert result.active_text == ""
-    assert handler.fixed_end_time == 10.0
-
-
-def test_progressive_stream_keeps_fixed_text_at_exact_boundary():
-    class Model:
-        def __init__(self):
-            self.lengths = []
-
-        def transcribe(self, audio, timestamps=True):
-            self.lengths.append(len(audio))
-            return SimpleNamespace(text="active", timestamp={"segment": []})
-
-    model = Model()
-    handler = SmartProgressiveStreamingHandler(model)
-    handler.fixed_sentences = ["kept fixed"]
-    handler.fixed_end_time = 1.0
-
-    result = handler.transcribe_incremental(np.zeros(16000, dtype=np.float32))
-
-    assert model.lengths == []
-    assert result.fixed_text == "kept fixed"
-    assert result.active_text == ""
-    assert handler.fixed_end_time == 1.0
 
 
 def test_on_session_end_resets_streaming_state():

--- a/tests/test_parakeet_transcription_events.py
+++ b/tests/test_parakeet_transcription_events.py
@@ -93,7 +93,7 @@ def test_final_transcription_resets_live_streaming_state(monkeypatch):
     assert reset_calls == [True]
 
 
-def test_progressive_stream_resets_stale_fixed_end_before_decoding():
+def test_progressive_stream_preserves_fixed_text_when_fixed_end_exceeds_audio():
     class Model:
         def __init__(self):
             self.lengths = []
@@ -109,10 +109,10 @@ def test_progressive_stream_resets_stale_fixed_end_before_decoding():
 
     result = handler.transcribe_incremental(np.zeros(16000, dtype=np.float32))
 
-    assert model.lengths == [16000]
-    assert result.fixed_text == ""
-    assert result.active_text == "fresh partial"
-    assert handler.fixed_end_time == 0.0
+    assert model.lengths == []
+    assert result.fixed_text == "stale text"
+    assert result.active_text == ""
+    assert handler.fixed_end_time == 10.0
 
 
 def test_progressive_stream_keeps_fixed_text_at_exact_boundary():


### PR DESCRIPTION
## Summary
- Reset Parakeet live transcription streaming state after every final transcription.
- Add regression coverage for the final transcription reset path.
- Add a representative turn-to-turn regression test: a previous long live turn has fixed sentence timing, final STT completes, and the next short progressive chunk must decode from the start instead of being sliced to an empty window.

## Root Cause
The failure was not caused by VAD sending empty audio. The logs show VAD was silent for many seconds, then yielded real progressive audio for the next utterance (`532ms`, then `852ms`). The empty `[1, 1, 0]` tensor was created later in Parakeet progressive STT windowing.

`SmartProgressiveStreamingHandler` keeps per-utterance progressive state, including `fixed_sentences` and `fixed_end_time`. That state only becomes non-zero after a long enough live transcription window fixes completed sentences, so most short turns are unaffected. This is why the bug was intermittent rather than constant.

Before this change, the nano-parakeet final transcription path cleared `processing_final` but did not reset `streaming_handler`. After a previous long/progressive utterance, stale `fixed_end_time` could survive across the silence gap. On the next turn, the first progressive chunk might be only a few hundred milliseconds, so slicing from the stale fixed boundary could produce an empty window and trigger the model error.

This patch resets the progressive handler at the utterance boundary after final STT completes. It does not clear fixed sentences during an in-progress utterance.

## Validation
- `python3 -m py_compile src/speech_to_speech/STT/parakeet_tdt_handler.py src/speech_to_speech/STT/smart_progressive_streaming.py tests/test_parakeet_transcription_events.py`
- `git diff --check main...HEAD`
- `PYTHONPATH=src uv run --no-project --with pytest --with numpy --with rich --with openai==2.28.0 --with pydantic pytest -q tests/test_parakeet_transcription_events.py` (`6 passed, 1 warning`)
