### PR TITLE
Warm up Parakeet Lingua detection

### DIFF
--- a/src/speech_to_speech/STT/parakeet_tdt_handler.py
+++ b/src/speech_to_speech/STT/parakeet_tdt_handler.py
@@ -76,7 +76,14 @@ if LINGUA_AVAILABLE:
         for code in SUPPORTED_LANGUAGES
         if _LINGUA_CODE_MAP.get(code, code) in _lingua_iso_to_code
     ]
-    _lingua_detector = LanguageDetectorBuilder.from_languages(*_lingua_languages).build()
+
+    def _build_lingua_detector():
+        # Preloading can take multiple seconds on some hardware, including the
+        # deployed server. Pay that cost at startup instead of on the first user
+        # request, where it would look like slow STT.
+        return LanguageDetectorBuilder.from_languages(*_lingua_languages).with_preloaded_language_models().build()
+
+    _lingua_detector = _build_lingua_detector()
 
 
 class ParakeetTDTSTTHandler(BaseHandler[STTIn, STTOut]):

--- a/tests/test_parakeet_language_detection.py
+++ b/tests/test_parakeet_language_detection.py
@@ -4,6 +4,31 @@ from speech_to_speech.STT import parakeet_tdt_handler
 from speech_to_speech.STT.parakeet_tdt_handler import ParakeetTDTSTTHandler
 
 
+def test_build_lingua_detector_preloads_language_models(monkeypatch):
+    calls = []
+    detector = object()
+
+    class Builder:
+        def with_preloaded_language_models(self):
+            calls.append("preload")
+            return self
+
+        def build(self):
+            calls.append("build")
+            return detector
+
+    class BuilderFactory:
+        @staticmethod
+        def from_languages(*languages):
+            calls.append(("languages", languages))
+            return Builder()
+
+    monkeypatch.setattr(parakeet_tdt_handler, "LanguageDetectorBuilder", BuilderFactory)
+
+    assert parakeet_tdt_handler._build_lingua_detector() is detector
+    assert calls == [("languages", tuple(parakeet_tdt_handler._lingua_languages)), "preload", "build"]
+
+
 def test_detect_language_from_short_text_returns_none_without_querying_detector(monkeypatch):
     handler = object.__new__(ParakeetTDTSTTHandler)
 


### PR DESCRIPTION
## Summary

Builds the Lingua detector with `with_preloaded_language_models()` unconditionally, so all configured language models are loaded before the first user-facing Parakeet final transcription.

## Root Cause

Recent session logs showed a Parakeet final turn taking about 3.99s even though nano-parakeet transcribed in about 48ms. The debug timings isolated the delay to `detect_language_of`, which took about 3.92s on the first detected utterance.

By default Lingua lazy-loads language models on demand. This PR removes the lazy detector path for Parakeet by always using Lingua's preload mode when constructing the configured detector.

## Validation

- `python3 -m py_compile src/speech_to_speech/STT/parakeet_tdt_handler.py`
- `./.venv/bin/python -m pytest tests/test_parakeet_language_detection.py -k 'build_lingua_detector_preloads_language_models or short_text'`
- `./.venv/bin/python -m pytest tests/test_parakeet_transcription_events.py`
- `git diff --check`
