### PR TITLE
Emit empty final transcription events

### DIFF
--- a/src/speech_to_speech/STT/transcription_notifier.py
+++ b/src/speech_to_speech/STT/transcription_notifier.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 import logging
 from queue import Queue
+from threading import Event
 from typing import Iterator, Union
 
 from speech_to_speech.api.openai_realtime.runtime_config import RuntimeConfig
@@ -32,9 +33,11 @@ class TranscriptionNotifier(BaseHandler[STTOut, Union[STTOut, LLMIn]]):
         self,
         text_output_queue: Queue[TextEventItem] | None = None,
         runtime_config: RuntimeConfig | None = None,
+        should_listen: Event | None = None,
     ) -> None:
         self.text_output_queue = text_output_queue
         self.runtime_config = runtime_config
+        self.should_listen = should_listen
 
     def process(self, transcription: STTOut) -> Iterator[Union[STTOut, LLMIn]]:
         if isinstance(transcription, PartialTranscription):
@@ -50,11 +53,23 @@ class TranscriptionNotifier(BaseHandler[STTOut, Union[STTOut, LLMIn]]):
             text = transcription
             language_code = None
 
-        if self.text_output_queue and text:
-            self.text_output_queue.put(TranscriptionCompletedEvent(transcript=str(text), language_code=language_code))
-            logger.debug("Transcription completed: %s", str(text)[:80])
+        transcript = str(text)
+        # Always close the client-visible transcription item. Empty final STT
+        # results should not trigger the LLM, but clients may already have
+        # received partial deltas and still need a completed event.
+        if self.text_output_queue is not None:
+            self.text_output_queue.put(TranscriptionCompletedEvent(transcript=transcript, language_code=language_code))
 
-        if self.runtime_config is not None and text:
+        if not transcript:
+            logger.debug("Transcription completed with empty transcript")
+            if self.should_listen is not None:
+                self.should_listen.set()
+                logger.debug("Empty transcription completed; listening re-enabled")
+            return
+
+        logger.debug("Transcription completed: %s", transcript[:80])
+
+        if self.runtime_config is not None:
             self.runtime_config.chat.add_item(make_user_message(str(text)))
             yield GenerateResponseRequest(
                 runtime_config=self.runtime_config,

--- a/src/speech_to_speech/s2s_pipeline.py
+++ b/src/speech_to_speech/s2s_pipeline.py
@@ -404,6 +404,7 @@ def build_pipeline(
 
     transcription_notifier_kwargs: dict[str, Any] = {
         "text_output_queue": text_output_queue,
+        "should_listen": should_listen,
     }
     if module_kwargs.mode != "realtime":
         if module_kwargs.llm == "open_api":

--- a/tests/openai_realtime/test_realtime_service.py
+++ b/tests/openai_realtime/test_realtime_service.py
@@ -798,6 +798,31 @@ class TestDispatchPipelineEvent:
         assert evt.usage.seconds == 3.2
         assert evt.usage.type == "duration"
 
+    def test_empty_transcription_completed_emits_event_without_response(
+        self,
+        service,
+        conn_id,
+        runtime_config,
+        text_prompt_queue,
+    ):
+        service.dispatch_pipeline_event(conn_id, SpeechStartedEvent())
+        service.dispatch_pipeline_event(
+            conn_id,
+            SpeechStoppedEvent(duration_s=1.1),
+        )
+        events = service.dispatch_pipeline_event(
+            conn_id,
+            TranscriptionCompletedEvent(transcript="", language_code="en"),
+        )
+
+        assert len(events) == 1
+        evt = events[0]
+        assert isinstance(evt, ConversationItemInputAudioTranscriptionCompletedEvent)
+        assert evt.transcript == ""
+        assert evt.usage.seconds == 1.1
+        assert text_prompt_queue.empty()
+        assert runtime_config.chat.buffer == []
+
     # -- unknown --
 
     def test_unknown_type_returns_empty(self, service, conn_id):

--- a/tests/test_transcription_notifier.py
+++ b/tests/test_transcription_notifier.py
@@ -1,0 +1,67 @@
+from queue import Queue
+from threading import Event
+
+from speech_to_speech.api.openai_realtime.runtime_config import RuntimeConfig
+from speech_to_speech.pipeline.events import PartialTranscriptionEvent, TranscriptionCompletedEvent
+from speech_to_speech.pipeline.messages import GenerateResponseRequest, PartialTranscription, Transcription
+from speech_to_speech.STT.transcription_notifier import TranscriptionNotifier
+
+
+def _notifier(
+    text_output_queue: Queue | None = None,
+    runtime_config: RuntimeConfig | None = None,
+    should_listen: Event | None = None,
+) -> TranscriptionNotifier:
+    notifier = object.__new__(TranscriptionNotifier)
+    notifier.setup(text_output_queue=text_output_queue, runtime_config=runtime_config, should_listen=should_listen)
+    return notifier
+
+
+def test_empty_final_transcription_still_emits_completion_after_partial():
+    text_output_queue = Queue()
+    notifier = _notifier(text_output_queue=text_output_queue)
+
+    assert list(notifier.process(PartialTranscription(text="Yeah."))) == []
+    assert list(notifier.process(Transcription(text="", language_code="en"))) == []
+
+    partial = text_output_queue.get_nowait()
+    completed = text_output_queue.get_nowait()
+
+    assert isinstance(partial, PartialTranscriptionEvent)
+    assert partial.delta == "Yeah."
+    assert isinstance(completed, TranscriptionCompletedEvent)
+    assert completed.transcript == ""
+    assert completed.language_code == "en"
+    assert text_output_queue.empty()
+
+
+def test_empty_final_transcription_does_not_trigger_legacy_generation():
+    runtime_config = RuntimeConfig()
+    should_listen = Event()
+    notifier = _notifier(runtime_config=runtime_config, should_listen=should_listen)
+
+    assert list(notifier.process(Transcription(text="", language_code="en"))) == []
+    assert should_listen.is_set()
+
+
+def test_non_empty_final_transcription_still_triggers_legacy_generation():
+    runtime_config = RuntimeConfig()
+    should_listen = Event()
+    notifier = _notifier(runtime_config=runtime_config, should_listen=should_listen)
+
+    result = list(notifier.process(Transcription(text="hello", language_code="en")))
+
+    assert len(result) == 1
+    assert isinstance(result[0], GenerateResponseRequest)
+    assert result[0].runtime_config is runtime_config
+    assert result[0].language_code == "en"
+    assert not should_listen.is_set()
+
+
+def test_empty_final_transcription_reenables_listening_without_runtime_config():
+    should_listen = Event()
+    notifier = _notifier(should_listen=should_listen)
+
+    assert list(notifier.process(Transcription(text="", language_code="en"))) == []
+
+    assert should_listen.is_set()


### PR DESCRIPTION
## Summary

Fixes empty final STT results so they no longer leave clients or the pipeline waiting forever.

`TranscriptionNotifier` now always emits a final `TranscriptionCompletedEvent` for final STT output, including `transcript=""`. When the final transcript is empty, it re-enables `should_listen` directly because no LLM/TTS response will be queued to re-enable listening later.

This is handled in the shared notifier path, so it applies to local, socket, websocket, and realtime modes.

## Root Cause

VAD clears `should_listen` when it detects the end of a speech segment. For normal non-empty STT results, the transcript is sent to the LLM, TTS eventually emits `AUDIO_RESPONSE_DONE`, and the output side re-enables listening.

For empty final STT results, `TranscriptionNotifier` used to drop the completion event because it was gated on truthy text. That meant:

- realtime/websocket clients could receive partial transcription deltas without a matching completion event
- no LLM request was queued
- no response completion happened
- `should_listen` could remain cleared

## Fix

- Emit `TranscriptionCompletedEvent` for every final `Transcription`, even when the transcript is empty.
- Pass `should_listen` into `TranscriptionNotifier` from the shared pipeline builder.
- In the empty-transcript path, set `should_listen` and return before chat insertion or LLM generation.
- Keep empty transcripts out of chat and avoid enqueueing `GenerateResponseRequest` for them.

## Validation

- `uv run ruff check src/ tests/`
- `./.venv/bin/python -m pytest tests/test_transcription_notifier.py`
- `./.venv/bin/python -m pytest tests/openai_realtime/test_realtime_service.py -k 'transcription_completed or partial_transcription'`
- GitHub CI passing: `ruff`, `pytest`, `mypy`
