### PR TITLE
Harden PyPI publish workflow

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -12,16 +12,21 @@ permissions:
 jobs:
   build:
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
     steps:
-      - uses: actions/checkout@v4
-      - uses: astral-sh/setup-uv@v5
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
+        with:
+          persist-credentials: false
+      - uses: astral-sh/setup-uv@d4b2f3b6ecc6e67c4457f6d3e41ec42d3d0fcb86 # v5.4.2
         with:
           version: "latest"
+          enable-cache: false
       - name: Build distributions
         run: uv build
       - name: Check package metadata
         run: uvx twine check --strict dist/*
-      - uses: actions/upload-artifact@v4
+      - uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4.6.2
         with:
           name: dist
           path: dist/*
@@ -33,10 +38,11 @@ jobs:
       name: pypi
       url: https://pypi.org/project/speech-to-speech/
     permissions:
+      contents: read
       id-token: write
     steps:
-      - uses: actions/download-artifact@v4
+      - uses: actions/download-artifact@d3f86a106a0bac45b974a628896c90dbdf5c8093 # v4.3.0
         with:
           name: dist
           path: dist
-      - uses: pypa/gh-action-pypi-publish@release/v1
+      - uses: pypa/gh-action-pypi-publish@cef221092ed1bacb1cc03d23a2d87d1d172e277b # release/v1


### PR DESCRIPTION
## Summary
- pin publish workflow actions to exact commits
- disable release-build caching in `setup-uv`
- prevent checkout credentials from persisting in the release build workspace
- make publish job permissions explicit while keeping OIDC publishing enabled

## Validation
- `uvx zizmor .github/workflows/publish.yml`
- `uv run python -c "import yaml; yaml.safe_load(open('.github/workflows/publish.yml')); print('yaml ok')"`
- `git diff --check`
