### PR TITLE
Add torchaudio default dependency

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "speech-to-speech"
-version = "0.2.0"
+version = "0.2.1"
 description = "Low-latency speech-to-speech pipeline"
 readme = "README.md"
 requires-python = ">=3.10"
@@ -37,6 +37,8 @@ dependencies = [
     "soundfile>=0.13.0; platform_system == 'Darwin'",
     "torch==2.11.0; platform_system == 'Darwin'",
     "torch>=2.4.0; platform_system != 'Darwin'",
+    "torchaudio==2.11.0; platform_system == 'Darwin'",
+    "torchaudio>=2.4.0; platform_system != 'Darwin'",
     "transformers>=4.57.0",
     "uvicorn>=0.30.0",
     "nano-parakeet>=0.2.0; platform_system != 'Darwin'",

--- a/src/speech_to_speech/__init__.py
+++ b/src/speech_to_speech/__init__.py
@@ -1,3 +1,3 @@
 """speech-to-speech: low-latency speech-to-speech pipeline."""
 
-__version__ = "0.2.0"
+__version__ = "0.2.1"

--- a/tests/install_smoke.py
+++ b/tests/install_smoke.py
@@ -100,7 +100,7 @@ def _validate_pipeline_startup_primitives() -> None:
 
 
 def main() -> None:
-    required_modules = ["fastapi", "openai", "scipy", "sounddevice", "torch", "transformers", "uvicorn"]
+    required_modules = ["fastapi", "openai", "scipy", "sounddevice", "torch", "torchaudio", "transformers", "uvicorn"]
     if sys.platform == "darwin":
         required_modules.extend(["mlx_audio", "misaki", "soundfile", "spacy"])
     else:


### PR DESCRIPTION
## Summary
- add `torchaudio` to the default install because Silero VAD imports it through `torch.hub`
- bump the package version to `0.2.1` for the PyPI hotfix
- extend the installed-wheel smoke test so CI verifies `torchaudio` is present

## Validation
- `uv run ruff check src/ tests/install_smoke.py tests/test_cli_defaults.py tests/test_vad_iterator.py`
- `uv run ruff format --check src/ tests/install_smoke.py tests/test_cli_defaults.py tests/test_vad_iterator.py`
- `uv run pytest tests/test_cli_defaults.py tests/test_vad_iterator.py -q`
- `uv run mypy src/`
- `uv build --out-dir /tmp/s2s-0.2.1-dist`
- `uvx twine check --strict /tmp/s2s-0.2.1-dist/*`
- `uvx check-wheel-contents /tmp/s2s-0.2.1-dist/speech_to_speech-0.2.1-py3-none-any.whl`
- clean wheel install into `/tmp/s2s-0.2.1-smoke`; `python tests/install_smoke.py` passed

Note: `uv pip check` in the local aarch64 smoke venv reports an unrelated platform metadata incompatibility for an NVIDIA CUDA wheel, but the installed package smoke itself passes and CI will run the standard pip check on GitHub's ubuntu runner.
