### PR TITLE
Pin macOS audio dependencies

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "speech-to-speech"
-version = "0.2.2"
+version = "0.2.3"
 description = "Low-latency speech-to-speech pipeline"
 readme = "README.md"
 requires-python = ">=3.10"
@@ -28,23 +28,30 @@ dependencies = [
     "fastapi>=0.115.0",
     "httpx>=0.28.0",
     "nltk==3.9.1",
-    "numpy>=1.26.0",
+    "numpy>=1.26.0,<2.4.4; platform_system == 'Darwin'",
+    "numpy>=1.26.0; platform_system != 'Darwin'",
     "openai==2.28.0",
     "pillow>=10.0.0",
     "pydantic>=2.0",
     "rich>=13.0",
     "scipy>=1.10.0",
-    "sounddevice>=0.5.0",
+    "sounddevice==0.5.3; platform_system == 'Darwin'",
+    "sounddevice>=0.5.0; platform_system != 'Darwin'",
     "soundfile>=0.13.0; platform_system == 'Darwin'",
     "torch==2.11.0; platform_system == 'Darwin'",
     "torch>=2.4.0; platform_system != 'Darwin'",
     "torchaudio==2.11.0; platform_system == 'Darwin'",
     "torchaudio>=2.4.0; platform_system != 'Darwin'",
-    "transformers>=4.57.0",
+    "transformers==5.6.2; platform_system == 'Darwin'",
+    "transformers>=4.57.0; platform_system != 'Darwin'",
     "uvicorn>=0.30.0",
     "nano-parakeet>=0.2.0; platform_system != 'Darwin'",
     "faster-qwen3-tts>=0.2.6; platform_system != 'Darwin'",
-    "mlx-audio>=0.4.0,<0.5.0; platform_system == 'Darwin'",
+    "miniaudio==1.61; platform_system == 'Darwin'",
+    "mlx==0.31.1; platform_system == 'Darwin'",
+    "mlx-audio==0.4.2; platform_system == 'Darwin'",
+    "mlx-lm==0.31.1; platform_system == 'Darwin'",
+    "mlx-metal==0.31.1; platform_system == 'Darwin'",
     "misaki>=0.9.4; platform_system == 'Darwin'",
     "espeakng-loader>=0.2.4; platform_system == 'Darwin'",
     "spacy>=3.8.4; platform_system == 'Darwin'",
@@ -68,7 +75,7 @@ language-detection = [
     "lingua-language-detector>=2.0.2",
 ]
 mlx-lm = [
-    "mlx-lm>=0.14.0; platform_system == 'Darwin'",
+    "mlx-lm==0.31.1; platform_system == 'Darwin'",
     "mlx-vlm==0.4.1; platform_system == 'Darwin'",
 ]
 paraformer = [

--- a/src/speech_to_speech/__init__.py
+++ b/src/speech_to_speech/__init__.py
@@ -1,3 +1,3 @@
 """speech-to-speech: low-latency speech-to-speech pipeline."""
 
-__version__ = "0.2.2"
+__version__ = "0.2.3"

--- a/tests/install_smoke.py
+++ b/tests/install_smoke.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 import importlib
+import importlib.metadata as metadata
 import importlib.util
 import os
 import subprocess
@@ -111,6 +112,31 @@ def _validate_default_handler_imports() -> None:
         importlib.import_module(module_name)
 
 
+def _validate_darwin_dependency_pins() -> None:
+    expected_versions = {
+        "miniaudio": "1.61",
+        "mlx": "0.31.1",
+        "mlx-audio": "0.4.2",
+        "mlx-lm": "0.31.1",
+        "mlx-metal": "0.31.1",
+        "sounddevice": "0.5.3",
+        "transformers": "5.6.2",
+    }
+    mismatches = []
+    for package_name, expected_version in expected_versions.items():
+        actual_version = metadata.version(package_name)
+        if actual_version != expected_version:
+            mismatches.append(f"{package_name}=={actual_version} (expected {expected_version})")
+
+    numpy_version = metadata.version("numpy")
+    numpy_version_parts = tuple(int(part) for part in numpy_version.split(".")[:3])
+    if numpy_version_parts >= (2, 4, 4):
+        mismatches.append(f"numpy=={numpy_version} (expected <2.4.4 on macOS)")
+
+    if mismatches:
+        raise RuntimeError("Unexpected macOS dependency versions: " + ", ".join(mismatches))
+
+
 def main() -> None:
     required_modules = [
         "fastapi",
@@ -124,11 +150,13 @@ def main() -> None:
         "uvicorn",
     ]
     if sys.platform == "darwin":
-        required_modules.extend(["mlx_audio", "misaki", "soundfile", "spacy"])
+        required_modules.extend(["miniaudio", "mlx", "mlx_audio", "mlx_lm", "misaki", "soundfile", "spacy"])
     else:
         required_modules.extend(["faster_qwen3_tts", "nano_parakeet"])
 
     _require_modules(required_modules)
+    if sys.platform == "darwin":
+        _validate_darwin_dependency_pins()
     _run_installed_cli_help()
     _validate_package_defaults()
     _validate_empty_qwen_ref_audio_arg()


### PR DESCRIPTION
## Summary

Pins the macOS default audio/MLX dependency stack to the versions that fixed the PyPI install audio corruption locally:

- `mlx-audio==0.4.2`
- `mlx==0.31.1`
- `mlx-lm==0.31.1`
- `mlx-metal==0.31.1`
- `sounddevice==0.5.3`
- `miniaudio==1.61`
- `transformers==5.6.2`
- `numpy<2.4.4` on Darwin

Also bumps the package version to `0.2.3` for the hotfix release.

## Root Cause

The published `0.2.2` install allowed the macOS resolver to pick newer audio/MLX package versions than the local source environment. That stack reproduced broken playback/static, and force-reinstalling the older known-good versions fixed it.

## Validation

- `uv lock`
- `uv run ruff check tests/install_smoke.py`
- `uv run python tests/install_smoke.py`

The install smoke test now verifies the macOS dependency pins so CI catches this resolver drift before release.
