### PR TITLE
Add WebSocket backend to default install

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "speech-to-speech"
-version = "0.2.3"
+version = "0.2.4"
 description = "Low-latency speech-to-speech pipeline"
 readme = "README.md"
 requires-python = ">=3.10"
@@ -45,6 +45,7 @@ dependencies = [
     "transformers==5.6.2; platform_system == 'Darwin'",
     "transformers>=4.57.0; platform_system != 'Darwin'",
     "uvicorn>=0.30.0",
+    "websockets>=12.0",
     "nano-parakeet>=0.2.0; platform_system != 'Darwin'",
     "faster-qwen3-tts>=0.2.6; platform_system != 'Darwin'",
     "miniaudio==1.61; platform_system == 'Darwin'",

--- a/src/speech_to_speech/__init__.py
+++ b/src/speech_to_speech/__init__.py
@@ -1,3 +1,3 @@
 """speech-to-speech: low-latency speech-to-speech pipeline."""
 
-__version__ = "0.2.3"
+__version__ = "0.2.4"

--- a/tests/install_smoke.py
+++ b/tests/install_smoke.py
@@ -112,6 +112,10 @@ def _validate_default_handler_imports() -> None:
         importlib.import_module(module_name)
 
 
+def _validate_realtime_websocket_support() -> None:
+    importlib.import_module("uvicorn.protocols.websockets.websockets_impl")
+
+
 def _validate_darwin_dependency_pins() -> None:
     expected_versions = {
         "miniaudio": "1.61",
@@ -148,6 +152,7 @@ def main() -> None:
         "torchaudio",
         "transformers",
         "uvicorn",
+        "websockets",
     ]
     if sys.platform == "darwin":
         required_modules.extend(["miniaudio", "mlx", "mlx_audio", "mlx_lm", "misaki", "soundfile", "spacy"])
@@ -162,6 +167,7 @@ def main() -> None:
     _validate_empty_qwen_ref_audio_arg()
     _validate_pipeline_startup_primitives()
     _validate_default_handler_imports()
+    _validate_realtime_websocket_support()
     print("speech-to-speech installed package smoke test passed")
 
 


### PR DESCRIPTION
## Summary

- Adds `websockets>=12.0` to the base install so default `--mode realtime` has a Uvicorn WebSocket protocol backend.
- Bumps the package version to `0.2.4` for the hotfix release.
- Extends the installed-package smoke test to verify both the `websockets` module and Uvicorn WebSocket implementation import successfully.

## Root Cause

The default CLI mode is `realtime`, which serves `/v1/realtime` through FastAPI/Uvicorn. The published base install included plain `uvicorn` but only exposed `websockets` behind the optional `websocket` extra, so Uvicorn could start but rejected upgrade requests with `No supported WebSocket library detected`.

## Validation

- `uv lock`
- `uv run ruff check tests/install_smoke.py`
- `uv run python tests/install_smoke.py`
- `uv build`
- `uvx twine check --strict dist/*` equivalent against a temp dist directory
