### PR TITLE
Pin nltk to patched release

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "speech-to-speech"
-version = "0.2.4"
+version = "0.2.5"
 description = "Low-latency speech-to-speech pipeline"
 readme = "README.md"
 requires-python = ">=3.10"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -27,7 +27,7 @@ classifiers = [
 dependencies = [
     "fastapi>=0.115.0",
     "httpx>=0.28.0",
-    "nltk==3.9.1",
+    "nltk==3.9.4",
     "numpy>=1.26.0,<2.4.4; platform_system == 'Darwin'",
     "numpy>=1.26.0; platform_system != 'Darwin'",
     "openai==2.28.0",

--- a/src/speech_to_speech/__init__.py
+++ b/src/speech_to_speech/__init__.py
@@ -1,3 +1,3 @@
 """speech-to-speech: low-latency speech-to-speech pipeline."""
 
-__version__ = "0.2.4"
+__version__ = "0.2.5"


### PR DESCRIPTION
## Summary

- Pin `nltk` from `3.9.1` to `3.9.4`.
- Bump package version from `0.2.4` to `0.2.5` for a patch security release.
- Move the direct runtime dependency out of the vulnerable ranges reported by Dependabot.

## Dependabot Alerts Addressed

- #12: `nltk <= 3.9.2` critical Zip Slip / code injection, patched in `3.9.3`.
- #17: `nltk < 3.9.3` arbitrary file read, patched in `3.9.3`.
- #14 and #15: `nltk <= 3.9.3` WordNet app issues, patched in `3.9.4`.
- #13 and #16 list no explicit patched version in Dependabot metadata, but their vulnerable ranges end at `3.9.3` and `3.9.2` respectively, so `3.9.4` is outside those ranges.

## Release Plan

After this merges, tag and publish `v0.2.5` so PyPI users get the patched `nltk` constraint.

## Validation

- `uv run ruff check tests/install_smoke.py`
- `uv run python tests/install_smoke.py`
- Confirmed resolver installs `nltk==3.9.4` with `uv run python -c "import importlib.metadata as md; print(md.version('nltk'))"`
