### PR TITLE
Limit OpenAI tool calls per response

### DIFF
--- a/src/speech_to_speech/LLM/openai_api_language_model.py
+++ b/src/speech_to_speech/LLM/openai_api_language_model.py
@@ -76,6 +76,7 @@ class OpenApiModelHandler(BaseHandler[LLMIn, LLMOut]):
 
         self.user_role = user_role
         self.client = OpenAI(api_key=api_key, base_url=base_url)
+        self._use_openai_tool_call_limits = base_url is None
         self._extra_body = (
             {"chat_template_kwargs": {"enable_thinking": False}}
             if disable_thinking and base_url is not None  # Only for other than OpenAI Official Server
@@ -141,6 +142,9 @@ class OpenApiModelHandler(BaseHandler[LLMIn, LLMOut]):
         optional_kwargs: dict[str, Any] = {}
         if req_tools is not None:
             optional_kwargs["tools"] = req_tools
+            if req_tool_choice != "none" and getattr(self, "_use_openai_tool_call_limits", True):
+                optional_kwargs["parallel_tool_calls"] = False
+                optional_kwargs["max_tool_calls"] = 1
         if req_tool_choice is not None:
             optional_kwargs["tool_choice"] = req_tool_choice
 

--- a/tests/test_openai_api_language_model.py
+++ b/tests/test_openai_api_language_model.py
@@ -186,6 +186,62 @@ def test_no_disable_thinking_omits_extra_body():
     assert captured.get("extra_body") is None
 
 
+def test_tools_disable_parallel_tool_calls_and_limit_count():
+    handler = _make_handler()
+    captured = {}
+    cfg = _make_runtime_config()
+    cfg.session.tools = [
+        {
+            "type": "function",
+            "name": "test_tool",
+            "description": "Test tool",
+            "parameters": {"type": "object", "properties": {}},
+        }
+    ]
+    cfg.session.tool_choice = "auto"
+    cfg.chat.add_item(make_user_message("Hi"))
+
+    def fake_create(**kwargs):
+        captured.update(kwargs)
+        return _make_stream([_make_text_delta_event("Ok")])
+
+    handler.client = SimpleNamespace(responses=SimpleNamespace(create=fake_create))
+
+    list(handler.process(GenerateResponseRequest(runtime_config=cfg)))
+
+    assert captured["tools"] == cfg.session.tools
+    assert captured["tool_choice"] == "auto"
+    assert captured["parallel_tool_calls"] is False
+    assert captured["max_tool_calls"] == 1
+
+
+def test_tool_call_limits_omitted_for_custom_base_url_compatibility():
+    handler = _make_handler()
+    handler._use_openai_tool_call_limits = False
+    captured = {}
+    cfg = _make_runtime_config()
+    cfg.session.tools = [
+        {
+            "type": "function",
+            "name": "test_tool",
+            "description": "Test tool",
+            "parameters": {"type": "object", "properties": {}},
+        }
+    ]
+    cfg.chat.add_item(make_user_message("Hi"))
+
+    def fake_create(**kwargs):
+        captured.update(kwargs)
+        return _make_stream([_make_text_delta_event("Ok")])
+
+    handler.client = SimpleNamespace(responses=SimpleNamespace(create=fake_create))
+
+    list(handler.process(GenerateResponseRequest(runtime_config=cfg)))
+
+    assert "parallel_tool_calls" not in captured
+    assert "max_tool_calls" not in captured
+
+
 def test_second_turn_flattens_assistant_history_for_responses():
     handler = _make_handler(stream=False)
     captured = {}


### PR DESCRIPTION
## Summary
- pass `parallel_tool_calls=False` and `max_tool_calls=1` for official OpenAI Responses API requests when tools are enabled
- keep those parameters off for custom OpenAI-compatible base URLs for compatibility
- add unit coverage for both paths

## Context
Recent realtime logs showed the model returning multiple tool calls in a single response (`play_emotion`, `stop_dance`, `stop_emotion`) even though the voice prompt asks for one tool call. This enforces that request at the API parameter level for the OpenAI path.

This does not replace the app-side fix for repeated follow-up `response.create` events after tool outputs; it only prevents one model response from producing multiple tool calls at once.

## Tests
- `uv run pytest tests/test_openai_api_language_model.py tests/openai_realtime/test_realtime_service.py`
- `uv run ruff check src/speech_to_speech/LLM/openai_api_language_model.py tests/test_openai_api_language_model.py`
