### PR TITLE
Tighten tool-use prompting

### DIFF
--- a/src/speech_to_speech/LLM/tool_call/tool_prompt.py
+++ b/src/speech_to_speech/LLM/tool_call/tool_prompt.py
@@ -39,7 +39,6 @@ When you need to use a tool, output the function call between \
 
 {{ enter_code }}
 function_name(arg_name_1=value1, arg_name_2='string_value')
-another_function(arg_name_1='hello')
 {{ end_code }}
 
 RULES:
@@ -50,7 +49,7 @@ Do NOT write "Here is the call", "I will use", "Let me call", \
 in your response without any surrounding explanation.
 - Arguments MUST always be named: func(x=1, y=2). Positional arguments like func(1, 2) are NOT allowed.
 - String arguments must be quoted: func(name='hello').
-- Multiple tool calls can live in the same {{ enter_code }}…{{ end_code }} block.\
+- Only one tool call may appear in a response. Do not include more than one function call between the tags.\
 """,
     keep_trailing_newline=True,
 )

--- a/src/speech_to_speech/LLM/voice_prompt.py
+++ b/src/speech_to_speech/LLM/voice_prompt.py
@@ -39,6 +39,7 @@ Numbers, lists, and structures should be expressed as you would say them aloud.
 Speech is the default. Use a tool only when it is needed to satisfy the user's request, or when the current turn explicitly asks for a tool-only action such as idle behavior.
 Do not use tools for ordinary conversational behavior: acknowledgments, greetings, agreement, listening, thinking, curiosity, emotional color, or ending a turn. Speak instead.
 Do not call movement, dance, emotion, head movement, or stop_* tools unless the user explicitly asks for a physical action, the current turn explicitly asks for an idle action, or the tool is necessary to stop/cancel/pause an ongoing action.
+When the user explicitly asks for movement, dance, emotion, or head movement, you may call one matching tool, but include one brief spoken sentence in the same response unless the current turn explicitly requests silence or tool-only output.
 If a tool is required, call at most one tool in the response. Prefer a spoken response without tools when uncertain.
 Don't announce or describe the tool call — just use it naturally and keep talking.
 """

--- a/src/speech_to_speech/LLM/voice_prompt.py
+++ b/src/speech_to_speech/LLM/voice_prompt.py
@@ -36,8 +36,11 @@ Avoid markdown, bullet points, headers, asterisks, stars, or any formatting that
 Numbers, lists, and structures should be expressed as you would say them aloud.
 
 ## Tool Usage
-When a tool call is relevant to the user's request, include it alongside your spoken response. Don't announce or describe the tool call — just use it naturally and keep talking.
-Send always only one tool call per response.
+Speech is the default. Use a tool only when it is needed to satisfy the user's request, or when the current turn explicitly asks for a tool-only action such as idle behavior.
+Do not use tools for ordinary conversational behavior: acknowledgments, greetings, agreement, listening, thinking, curiosity, emotional color, or ending a turn. Speak instead.
+Do not call movement, dance, emotion, head movement, or stop_* tools unless the user explicitly asks for a physical action, the current turn explicitly asks for an idle action, or the tool is necessary to stop/cancel/pause an ongoing action.
+If a tool is required, call at most one tool in the response. Prefer a spoken response without tools when uncertain.
+Don't announce or describe the tool call — just use it naturally and keep talking.
 """
 
 # Skeleton for the assembled system message (placeholders filled in build_voice_system_prompt).

--- a/tests/test_voice_prompt.py
+++ b/tests/test_voice_prompt.py
@@ -1,0 +1,36 @@
+from speech_to_speech.LLM.tool_call.function_tool import FunctionTool
+from speech_to_speech.LLM.tool_call.tool_prompt import build_tool_system_prompt
+from speech_to_speech.LLM.voice_prompt import build_voice_system_prompt
+
+
+def test_voice_prompt_makes_speech_the_default():
+    prompt = build_voice_system_prompt("Be concise.")
+
+    assert "Speech is the default." in prompt
+    assert "Do not use tools for ordinary conversational behavior" in prompt
+    assert "acknowledgments, greetings, agreement, listening" in prompt
+    assert "call at most one tool" in prompt
+    assert "Prefer a spoken response without tools when uncertain." in prompt
+
+
+def test_voice_prompt_preserves_idle_action_escape_hatch():
+    prompt = build_voice_system_prompt("Be concise.")
+
+    assert "idle behavior" in prompt
+    assert "idle action" in prompt
+
+
+def test_local_tool_prompt_forbids_multiple_tool_calls():
+    prompt = build_tool_system_prompt(
+        [
+            FunctionTool(
+                type="function",
+                name="dance",
+                description="Dance once.",
+                parameters={"type": "object", "properties": {}},
+            )
+        ]
+    )
+
+    assert "Only one tool call may appear in a response." in prompt
+    assert "Multiple tool calls can live" not in prompt

--- a/tests/test_voice_prompt.py
+++ b/tests/test_voice_prompt.py
@@ -9,6 +9,7 @@ def test_voice_prompt_makes_speech_the_default():
     assert "Speech is the default." in prompt
     assert "Do not use tools for ordinary conversational behavior" in prompt
     assert "acknowledgments, greetings, agreement, listening" in prompt
+    assert "include one brief spoken sentence in the same response" in prompt
     assert "call at most one tool" in prompt
     assert "Prefer a spoken response without tools when uncertain." in prompt
 


### PR DESCRIPTION
## Summary

- Make speech the default in the voice prompt and narrow tool use to explicit or necessary actions.
- Discourage movement/emotion/stop tools for routine acknowledgments, greetings, listening, or turn-ending phrases.
- Update the local tool-call prompt to forbid multiple tool calls in a single response.
- Add focused prompt tests.

## Why

The model could treat expressive robot tools as conversational punctuation, producing tool-only responses for ordinary turns like acknowledgments or stopping phrases. The prompt now makes that behavior explicitly undesirable while keeping idle-action turns available.

## Validation

- `uv run pytest tests/test_voice_prompt.py tests/test_openai_api_language_model.py`
- `uv run pytest tests/tool_call tests/test_voice_prompt.py`
- `uv run ruff check src/speech_to_speech/LLM/voice_prompt.py src/speech_to_speech/LLM/tool_call/tool_prompt.py tests/test_voice_prompt.py`
- `uv run ruff format --check src/speech_to_speech/LLM/voice_prompt.py src/speech_to_speech/LLM/tool_call/tool_prompt.py tests/test_voice_prompt.py`