### PR TITLE
Prepare PyPI release 0.2.6

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "speech-to-speech"
-version = "0.2.5"
+version = "0.2.6"
 description = "Low-latency speech-to-speech pipeline"
 readme = "README.md"
 requires-python = ">=3.10"

--- a/src/speech_to_speech/__init__.py
+++ b/src/speech_to_speech/__init__.py
@@ -1,3 +1,3 @@
 """speech-to-speech: low-latency speech-to-speech pipeline."""
 
-__version__ = "0.2.5"
+__version__ = "0.2.6"


### PR DESCRIPTION
## Summary
- Bump the package version from 0.2.5 to 0.2.6 in `pyproject.toml`
- Keep `speech_to_speech.__version__` in sync at 0.2.6

## Validation
- `uv run python - <<'PY' ...` version sync check
- `uv build --out-dir /tmp/speech-to-speech-dist-0.2.6`
- `uvx twine check --strict /tmp/speech-to-speech-dist-0.2.6/*`
- `uv run pytest --ignore tests/test_benchmark_llm_latency.py`
