### PR TITLE
Install lingua by default

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -48,6 +48,7 @@ dependencies = [
     "websockets>=12.0",
     "nano-parakeet>=0.2.0; platform_system != 'Darwin'",
     "faster-qwen3-tts>=0.2.6; platform_system != 'Darwin'",
+    "lingua-language-detector>=2.0.2",
     "miniaudio==1.61; platform_system == 'Darwin'",
     "mlx==0.31.1; platform_system == 'Darwin'",
     "mlx-audio==0.4.2; platform_system == 'Darwin'",

--- a/tests/install_smoke.py
+++ b/tests/install_smoke.py
@@ -144,6 +144,7 @@ def _validate_darwin_dependency_pins() -> None:
 def main() -> None:
     required_modules = [
         "fastapi",
+        "lingua",
         "openai",
         "PIL",
         "scipy",


### PR DESCRIPTION
## Summary
- Add `lingua-language-detector` to the default package dependencies
- Require the `lingua` import in the installed-package smoke check

## Why
The default STT backend is Parakeet TDT, and its default auto-language path uses lingua-based text language detection. A plain `pip install speech-to-speech` could therefore emit `lingua-py not available` warnings and fall back to the previous language.

The existing `language-detection` extra is left in place so previous install commands continue to resolve, but default installs now include the dependency used by the default runtime path.

## Validation
- `uv run pytest tests/test_parakeet_language_detection.py`
- `uv run python tests/install_smoke.py`
- `uv build --out-dir /tmp/speech-to-speech-lingua-default-dist`
- `uvx twine check --strict /tmp/speech-to-speech-lingua-default-dist/*`
- Wheel metadata includes default `Requires-Dist: lingua-language-detector>=2.0.2`
- `uv run pytest --ignore tests/test_benchmark_llm_latency.py`
