### PR TITLE
Fix Qwen3 voice override validation

### DIFF
--- a/src/speech_to_speech/TTS/qwen3_tts_handler.py
+++ b/src/speech_to_speech/TTS/qwen3_tts_handler.py
@@ -374,7 +374,19 @@ class Qwen3TTSHandler(BaseHandler[TTSIn, TTSOut]):
             return
 
         if model_type == "custom_voice":
-            self.speaker = session_voice
+            speaker = self._canonical_supported_speaker(session_voice)
+            if speaker is None:
+                supported = self._supported_speakers()
+                supported_text = ", ".join(sorted(supported, key=str.lower)) if supported else "unknown"
+                logger.warning(
+                    "Ignoring Qwen3-TTS session voice override %r because it is not a supported "
+                    "CustomVoice speaker. Supported speakers: %s",
+                    session_voice,
+                    supported_text,
+                )
+                return
+
+            self.speaker = speaker
             self.ref_audio = None
             return
 
@@ -414,14 +426,52 @@ class Qwen3TTSHandler(BaseHandler[TTSIn, TTSOut]):
         inner = getattr(getattr(self.model, "model", None), "model", None)
         return getattr(inner, "tts_model_type", None) or self._infer_model_type_from_name()
 
+    def _speaker_model_candidates(self) -> Iterator[Any]:
+        seen: set[int] = set()
+        candidates = (
+            self.model,
+            getattr(self.model, "model", None),
+            getattr(getattr(self.model, "model", None), "model", None),
+        )
+        for candidate in candidates:
+            if candidate is None:
+                continue
+            candidate_id = id(candidate)
+            if candidate_id in seen:
+                continue
+            seen.add(candidate_id)
+            yield candidate
+
+    def _supported_speakers(self) -> list[str] | None:
+        for candidate in self._speaker_model_candidates():
+            get_speakers = getattr(candidate, "get_supported_speakers", None)
+            if callable(get_speakers):
+                speakers = get_speakers()
+                if speakers is None:
+                    return None
+                return [str(speaker) for speaker in speakers if speaker]
+        return None
+
+    def _canonical_supported_speaker(self, speaker: str) -> str | None:
+        supported = self._supported_speakers()
+        if supported is None:
+            return speaker
+
+        lookup = {candidate.lower(): candidate for candidate in supported}
+        return lookup.get(speaker.lower())
+
     def _resolve_speaker(self) -> Optional[str]:
         if self.speaker:
-            return self.speaker
+            speaker = self._canonical_supported_speaker(self.speaker)
+            if speaker is not None:
+                return speaker
+            logger.warning(
+                "Configured Qwen3-TTS speaker %r is not supported by this model; falling back to the first "
+                "supported speaker.",
+                self.speaker,
+            )
 
-        for candidate in (
-            self.model,
-            getattr(getattr(self.model, "model", None), "model", None),
-        ):
+        for candidate in self._speaker_model_candidates():
             get_speakers = getattr(candidate, "get_supported_speakers", None)
             if callable(get_speakers):
                 speakers = list(get_speakers() or [])

--- a/src/speech_to_speech/TTS/qwen3_tts_handler.py
+++ b/src/speech_to_speech/TTS/qwen3_tts_handler.py
@@ -374,19 +374,22 @@ class Qwen3TTSHandler(BaseHandler[TTSIn, TTSOut]):
             return
 
         if model_type == "custom_voice":
-            speaker = self._canonical_supported_speaker(session_voice)
-            if speaker is None:
-                supported = self._supported_speakers()
-                supported_text = ", ".join(sorted(supported, key=str.lower)) if supported else "unknown"
-                logger.warning(
-                    "Ignoring Qwen3-TTS session voice override %r because it is not a supported "
-                    "CustomVoice speaker. Supported speakers: %s",
-                    session_voice,
-                    supported_text,
-                )
-                return
+            supported_speakers = self._supported_speakers()
+            if supported_speakers is not None:
+                speakers_by_lower = {speaker.lower(): speaker for speaker in supported_speakers}
+                speaker = speakers_by_lower.get(session_voice.lower())
+                if speaker is None:
+                    supported_text = ", ".join(sorted(supported_speakers, key=str.lower)) or "unknown"
+                    logger.warning(
+                        "Ignoring Qwen3-TTS session voice override %r because it is not a supported "
+                        "CustomVoice speaker. Supported speakers: %s",
+                        session_voice,
+                        supported_text,
+                    )
+                    return
+                session_voice = speaker
 
-            self.speaker = speaker
+            self.speaker = session_voice
             self.ref_audio = None
             return
 
@@ -426,24 +429,12 @@ class Qwen3TTSHandler(BaseHandler[TTSIn, TTSOut]):
         inner = getattr(getattr(self.model, "model", None), "model", None)
         return getattr(inner, "tts_model_type", None) or self._infer_model_type_from_name()
 
-    def _speaker_model_candidates(self) -> Iterator[Any]:
-        seen: set[int] = set()
-        candidates = (
+    def _supported_speakers(self) -> list[str] | None:
+        for candidate in (
             self.model,
             getattr(self.model, "model", None),
             getattr(getattr(self.model, "model", None), "model", None),
-        )
-        for candidate in candidates:
-            if candidate is None:
-                continue
-            candidate_id = id(candidate)
-            if candidate_id in seen:
-                continue
-            seen.add(candidate_id)
-            yield candidate
-
-    def _supported_speakers(self) -> list[str] | None:
-        for candidate in self._speaker_model_candidates():
+        ):
             get_speakers = getattr(candidate, "get_supported_speakers", None)
             if callable(get_speakers):
                 speakers = get_speakers()
@@ -452,26 +443,14 @@ class Qwen3TTSHandler(BaseHandler[TTSIn, TTSOut]):
                 return [str(speaker) for speaker in speakers if speaker]
         return None
 
-    def _canonical_supported_speaker(self, speaker: str) -> str | None:
-        supported = self._supported_speakers()
-        if supported is None:
-            return speaker
-
-        lookup = {candidate.lower(): candidate for candidate in supported}
-        return lookup.get(speaker.lower())
-
     def _resolve_speaker(self) -> Optional[str]:
         if self.speaker:
-            speaker = self._canonical_supported_speaker(self.speaker)
-            if speaker is not None:
-                return speaker
-            logger.warning(
-                "Configured Qwen3-TTS speaker %r is not supported by this model; falling back to the first "
-                "supported speaker.",
-                self.speaker,
-            )
+            return self.speaker
 
-        for candidate in self._speaker_model_candidates():
+        for candidate in (
+            self.model,
+            getattr(getattr(self.model, "model", None), "model", None),
+        ):
             get_speakers = getattr(candidate, "get_supported_speakers", None)
             if callable(get_speakers):
                 speakers = list(get_speakers() or [])

--- a/tests/test_qwen3_tts_handler_backend.py
+++ b/tests/test_qwen3_tts_handler_backend.py
@@ -269,6 +269,79 @@ def test_apply_session_voice_override_warns_for_non_file_for_base_model(caplog):
     assert "Ignoring Qwen3-TTS session voice override" in caplog.text
 
 
+def test_apply_session_voice_override_ignores_unsupported_custom_voice_speaker(caplog):
+    handler = object.__new__(Qwen3TTSHandler)
+    fake_cfg = SimpleNamespace(session=SimpleNamespace(audio=SimpleNamespace(output=SimpleNamespace(voice="cedar"))))
+    handler.ref_audio = None
+    handler.speaker = "Aiden"
+    handler.model = SimpleNamespace(model=SimpleNamespace(get_supported_speakers=lambda: ["aiden", "vivian"]))
+
+    with caplog.at_level("WARNING"):
+        handler._apply_session_voice_override("custom_voice", runtime_config=fake_cfg)
+
+    assert handler.ref_audio is None
+    assert handler.speaker == "Aiden"
+    assert "not a supported CustomVoice speaker" in caplog.text
+    assert "cedar" in caplog.text
+
+
+def test_apply_session_voice_override_accepts_supported_custom_voice_speaker():
+    handler = object.__new__(Qwen3TTSHandler)
+    fake_cfg = SimpleNamespace(session=SimpleNamespace(audio=SimpleNamespace(output=SimpleNamespace(voice="vivian"))))
+    handler.ref_audio = "TTS/ref_audio.wav"
+    handler.speaker = "Aiden"
+    handler.model = SimpleNamespace(model=SimpleNamespace(get_supported_speakers=lambda: ["aiden", "vivian"]))
+
+    handler._apply_session_voice_override("custom_voice", runtime_config=fake_cfg)
+
+    assert handler.ref_audio is None
+    assert handler.speaker == "vivian"
+
+
+def test_process_ignores_openai_voice_for_custom_voice_model(monkeypatch, caplog):
+    captured = {}
+    runtime_config = RuntimeConfig()
+    runtime_config.session.audio.output.voice = "cedar"
+
+    qwen_model = SimpleNamespace(
+        model=SimpleNamespace(tts_model_type="custom_voice"),
+        get_supported_speakers=lambda: ["aiden", "vivian"],
+    )
+    handler = object.__new__(Qwen3TTSHandler)
+    handler.should_listen = Event()
+    handler.cancel_scope = None
+    handler.ref_audio = None
+    handler.ref_text = "Reference text."
+    handler.speaker = "Aiden"
+    handler.instruct = None
+    handler.language = "English"
+    handler.xvec_only = False
+    handler.parity_mode = False
+    handler.non_streaming_mode = True
+    handler.streaming_chunk_size = 8
+    handler.max_new_tokens = 360
+    handler.blocksize = 512
+    handler.backend = "faster_qwen3_tts"
+    handler.queue_in = Queue()
+    handler.model = SimpleNamespace(
+        model=qwen_model,
+        generate_custom_voice_streaming=lambda **kwargs: (
+            captured.update(kwargs),
+            iter([(_audible_stream_chunk(), 16000, {})]),
+        )[1],
+    )
+
+    monkeypatch.setattr(qwen3_tts_module.console, "print", lambda *args, **kwargs: None)
+
+    with caplog.at_level("WARNING"):
+        outputs = list(handler.process(TTSInput(text="Hello there.", runtime_config=runtime_config)))
+
+    assert len(outputs) == 1
+    assert captured["speaker"] == "aiden"
+    assert handler.speaker == "Aiden"
+    assert "not a supported CustomVoice speaker" in caplog.text
+
+
 def test_process_only_reenables_listening_after_end_of_response(monkeypatch):
     handler = object.__new__(Qwen3TTSHandler)
     handler.should_listen = Event()

--- a/tests/test_qwen3_tts_handler_backend.py
+++ b/tests/test_qwen3_tts_handler_backend.py
@@ -287,7 +287,7 @@ def test_apply_session_voice_override_ignores_unsupported_custom_voice_speaker(c
 
 def test_apply_session_voice_override_accepts_supported_custom_voice_speaker():
     handler = object.__new__(Qwen3TTSHandler)
-    fake_cfg = SimpleNamespace(session=SimpleNamespace(audio=SimpleNamespace(output=SimpleNamespace(voice="vivian"))))
+    fake_cfg = SimpleNamespace(session=SimpleNamespace(audio=SimpleNamespace(output=SimpleNamespace(voice="Vivian"))))
     handler.ref_audio = "TTS/ref_audio.wav"
     handler.speaker = "Aiden"
     handler.model = SimpleNamespace(model=SimpleNamespace(get_supported_speakers=lambda: ["aiden", "vivian"]))
@@ -296,50 +296,6 @@ def test_apply_session_voice_override_accepts_supported_custom_voice_speaker():
 
     assert handler.ref_audio is None
     assert handler.speaker == "vivian"
-
-
-def test_process_ignores_openai_voice_for_custom_voice_model(monkeypatch, caplog):
-    captured = {}
-    runtime_config = RuntimeConfig()
-    runtime_config.session.audio.output.voice = "cedar"
-
-    qwen_model = SimpleNamespace(
-        model=SimpleNamespace(tts_model_type="custom_voice"),
-        get_supported_speakers=lambda: ["aiden", "vivian"],
-    )
-    handler = object.__new__(Qwen3TTSHandler)
-    handler.should_listen = Event()
-    handler.cancel_scope = None
-    handler.ref_audio = None
-    handler.ref_text = "Reference text."
-    handler.speaker = "Aiden"
-    handler.instruct = None
-    handler.language = "English"
-    handler.xvec_only = False
-    handler.parity_mode = False
-    handler.non_streaming_mode = True
-    handler.streaming_chunk_size = 8
-    handler.max_new_tokens = 360
-    handler.blocksize = 512
-    handler.backend = "faster_qwen3_tts"
-    handler.queue_in = Queue()
-    handler.model = SimpleNamespace(
-        model=qwen_model,
-        generate_custom_voice_streaming=lambda **kwargs: (
-            captured.update(kwargs),
-            iter([(_audible_stream_chunk(), 16000, {})]),
-        )[1],
-    )
-
-    monkeypatch.setattr(qwen3_tts_module.console, "print", lambda *args, **kwargs: None)
-
-    with caplog.at_level("WARNING"):
-        outputs = list(handler.process(TTSInput(text="Hello there.", runtime_config=runtime_config)))
-
-    assert len(outputs) == 1
-    assert captured["speaker"] == "aiden"
-    assert handler.speaker == "Aiden"
-    assert "not a supported CustomVoice speaker" in caplog.text
 
 
 def test_process_only_reenables_listening_after_end_of_response(monkeypatch):


### PR DESCRIPTION
## Summary

- Validate Realtime voice overrides against Qwen3 CustomVoice supported speakers before applying them.
- Ignore unsupported OpenAI voice names such as `cedar` so Qwen3 generation keeps using the configured speaker.
- Add regression tests for unsupported and supported CustomVoice overrides.

## Root Cause

The Qwen3 CustomVoice handler treated any Realtime `audio.output.voice` value as a Qwen speaker. OpenAI Realtime voice names like `cedar` are valid protocol values but are not valid Qwen3 speakers, so they reached `faster-qwen3-tts` and caused an unsupported speaker error.

## Validation

- `pytest tests/test_qwen3_tts_handler_backend.py`
- `ruff check src/speech_to_speech/TTS/qwen3_tts_handler.py tests/test_qwen3_tts_handler_backend.py`