### PR TITLE
Add pipeline latency and transcript info logs

### DIFF
--- a/src/speech_to_speech/LLM/responses_api_language_model.py
+++ b/src/speech_to_speech/LLM/responses_api_language_model.py
@@ -311,3 +311,10 @@ class ResponsesApiModelHandler(BaseHandler[LLMIn, LLMOut]):
 
     def on_session_end(self) -> None:
         logger.debug("OpenAI API language model session state reset")
+
+    @property
+    def timing_log_level(self) -> int:
+        return logging.INFO
+
+    def should_log_timing(self, output: LLMOut) -> bool:
+        return isinstance(output, LLMResponseChunk) and self.last_time > self.min_time_to_debug

--- a/src/speech_to_speech/STT/parakeet_tdt_handler.py
+++ b/src/speech_to_speech/STT/parakeet_tdt_handler.py
@@ -309,6 +309,13 @@ class ParakeetTDTSTTHandler(BaseHandler[STTIn, STTOut]):
 
         yield Transcription(text=pred_text, language_code=language_code)
 
+    @property
+    def timing_log_level(self) -> int:
+        return logging.INFO
+
+    def should_log_timing(self, output: STTOut) -> bool:
+        return isinstance(output, Transcription) and self.last_time > self.min_time_to_debug
+
     def _detect_language_from_text(self, text: str) -> Optional[str]:
         """
         Detect language from transcribed text using lingua-py.

--- a/src/speech_to_speech/STT/transcription_notifier.py
+++ b/src/speech_to_speech/STT/transcription_notifier.py
@@ -67,7 +67,10 @@ class TranscriptionNotifier(BaseHandler[STTOut, Union[STTOut, LLMIn]]):
                 logger.debug("Empty transcription completed; listening re-enabled")
             return
 
-        logger.debug("Transcription completed: %s", transcript[:80])
+        if language_code:
+            logger.info("Transcription completed (language=%s): %s", language_code, transcript)
+        else:
+            logger.info("Transcription completed: %s", transcript)
 
         if self.runtime_config is not None:
             self.runtime_config.chat.add_item(make_user_message(str(text)))

--- a/src/speech_to_speech/baseHandler.py
+++ b/src/speech_to_speech/baseHandler.py
@@ -81,8 +81,8 @@ class BaseHandler(Generic[InT, OutT]):
             try:
                 for output in self.process(cast(InT, item)):
                     self._times.append(perf_counter() - start_time)
-                    if self.last_time > self.min_time_to_debug:
-                        logger.debug(f"{self.__class__.__name__}: {self.last_time: .3f} s")
+                    if self.should_log_timing(output):
+                        logger.log(self.timing_log_level, "%s: %.3f s", self.__class__.__name__, self.last_time)
                     self.queue_out.put(output)
                     start_time = perf_counter()
             except Exception as e:
@@ -98,6 +98,13 @@ class BaseHandler(Generic[InT, OutT]):
     @property
     def min_time_to_debug(self) -> float:
         return 0.001
+
+    @property
+    def timing_log_level(self) -> int:
+        return logging.DEBUG
+
+    def should_log_timing(self, output: OutT) -> bool:
+        return self.last_time > self.min_time_to_debug
 
     def cleanup(self) -> None:
         pass

--- a/tests/test_parakeet_transcription_events.py
+++ b/tests/test_parakeet_transcription_events.py
@@ -1,3 +1,4 @@
+import logging
 from contextlib import contextmanager
 from types import SimpleNamespace
 
@@ -65,6 +66,15 @@ def test_process_yields_final_transcript(monkeypatch):
     assert isinstance(result[0], Transcription)
     assert result[0].text == "I am here."
     assert result[0].language_code == "en"
+
+
+def test_parakeet_timing_logs_only_final_transcriptions():
+    handler = object.__new__(ParakeetTDTSTTHandler)
+    handler._times = [0.01]
+
+    assert handler.timing_log_level == logging.INFO
+    assert handler.should_log_timing(Transcription(text="I am here.", language_code="en"))
+    assert not handler.should_log_timing(PartialTranscription(text="I am"))
 
 
 def test_final_transcription_resets_live_streaming_state(monkeypatch):

--- a/tests/test_responses_api_language_model.py
+++ b/tests/test_responses_api_language_model.py
@@ -1,3 +1,4 @@
+import logging
 from types import SimpleNamespace
 from unittest.mock import MagicMock
 
@@ -15,7 +16,7 @@ from speech_to_speech.api.openai_realtime.runtime_config import RuntimeConfig
 from speech_to_speech.LLM.chat import Chat, make_user_message
 from speech_to_speech.LLM.responses_api_language_model import ResponsesApiModelHandler
 from speech_to_speech.pipeline.cancel_scope import CancelScope
-from speech_to_speech.pipeline.messages import EndOfResponse, GenerateResponseRequest, LLMResponseChunk
+from speech_to_speech.pipeline.messages import EndOfResponse, GenerateResponseRequest, LLMResponseChunk, TokenUsage
 
 
 def _make_text_delta_event(text):
@@ -124,6 +125,16 @@ def test_process_handles_cancellation():
 
     assert len(outputs) == 1
     assert isinstance(outputs[0], EndOfResponse)
+
+
+def test_responses_api_timing_logs_only_text_chunks():
+    handler = object.__new__(ResponsesApiModelHandler)
+    handler._times = [0.01]
+
+    assert handler.timing_log_level == logging.INFO
+    assert handler.should_log_timing(LLMResponseChunk(text="Hello."))
+    assert not handler.should_log_timing(TokenUsage(input_tokens=1, output_tokens=1))
+    assert not handler.should_log_timing(EndOfResponse())
 
 
 def test_process_read_timeout_ends_response_cleanly():

--- a/tests/test_transcription_notifier.py
+++ b/tests/test_transcription_notifier.py
@@ -1,3 +1,4 @@
+import logging
 from queue import Queue
 from threading import Event
 
@@ -56,6 +57,16 @@ def test_non_empty_final_transcription_still_triggers_legacy_generation():
     assert result[0].runtime_config is runtime_config
     assert result[0].language_code == "en"
     assert not should_listen.is_set()
+
+
+def test_non_empty_final_transcription_logs_full_text_at_info(caplog):
+    notifier = _notifier()
+    transcript = "hello " * 30
+
+    with caplog.at_level(logging.INFO, logger="speech_to_speech.STT.transcription_notifier"):
+        assert list(notifier.process(Transcription(text=transcript, language_code="en"))) == []
+
+    assert "Transcription completed (language=en): " + transcript in caplog.text
 
 
 def test_empty_final_transcription_reenables_listening_without_runtime_config():


### PR DESCRIPTION
## Summary
- Promote selected handler latency timings to info logs without enabling full debug output.
- Log completed non-empty STT transcripts at info level with the full transcript and language when available.
- Keep progressive STT partials, token usage events, and response-end sentinels out of info timing logs.

## Validation
- uv run pytest tests/test_transcription_notifier.py tests/test_parakeet_transcription_events.py tests/test_responses_api_language_model.py tests/test_websocket_session_lifecycle.py
- uv run ruff check src/speech_to_speech/baseHandler.py src/speech_to_speech/STT/parakeet_tdt_handler.py src/speech_to_speech/LLM/responses_api_language_model.py src/speech_to_speech/STT/transcription_notifier.py tests/test_parakeet_transcription_events.py tests/test_responses_api_language_model.py tests/test_transcription_notifier.py
- git diff --check HEAD~1 HEAD
