### PR TITLE
feat: add Astraflow provider support

### DIFF
--- a/README.md
+++ b/README.md
@@ -270,6 +270,8 @@ Select a backend with `--llm_backend` (`responses-api` by default) and pair it w
 | OpenAI | *(omit, uses OpenAI default)* | `$OPENAI_API_KEY` |
 | HF Inference Providers | `https://router.huggingface.co/v1` | `$HF_TOKEN` |
 | OpenRouter | `https://openrouter.ai/api/v1` | `$OPENROUTER_API_KEY` |
+| Astraflow (global) | `https://api-us-ca.umodelverse.ai/v1` | `$ASTRAFLOW_API_KEY` |
+| Astraflow (China) | `https://api.modelverse.cn/v1` | `$ASTRAFLOW_CN_API_KEY` |
 | vLLM (local) | `http://localhost:8000/v1` | *(omit or any string)* |
 | llama.cpp (local) | `http://localhost:8080/v1` | *(omit or any string)* |
 
@@ -312,6 +314,38 @@ speech-to-speech \
     --model_name "openai/gpt-oss-20b:groq" \
     --responses_api_base_url "https://router.huggingface.co/v1" \
     --responses_api_api_key "$HF_TOKEN" \
+    --responses_api_stream \
+    --enable_live_transcription
+```
+
+```bash
+# Astraflow (global) — OpenAI-compatible platform supporting 200+ models
+# Sign up at https://astraflow.ucloud-global.com
+speech-to-speech \
+    --mode local \
+    --stt parakeet-tdt \
+    --llm_backend responses-api \
+    --tts qwen3 \
+    --qwen3_tts_mlx_quantization 6bit \
+    --model_name "<model-name>" \
+    --responses_api_base_url "https://api-us-ca.umodelverse.ai/v1" \
+    --responses_api_api_key "$ASTRAFLOW_API_KEY" \
+    --responses_api_stream \
+    --enable_live_transcription
+```
+
+```bash
+# Astraflow (China) — OpenAI-compatible platform supporting 200+ models
+# Sign up at https://astraflow.ucloud.cn
+speech-to-speech \
+    --mode local \
+    --stt parakeet-tdt \
+    --llm_backend responses-api \
+    --tts qwen3 \
+    --qwen3_tts_mlx_quantization 6bit \
+    --model_name "<model-name>" \
+    --responses_api_base_url "https://api.modelverse.cn/v1" \
+    --responses_api_api_key "$ASTRAFLOW_CN_API_KEY" \
     --responses_api_stream \
     --enable_live_transcription
 ```


### PR DESCRIPTION
## Summary

Adds [Astraflow](https://astraflow.ucloud-global.com) by UCloud as a supported OpenAI-compatible LLM backend.

Astraflow is an OpenAI-compatible AI model aggregation platform supporting 200+ models. Because it is fully OpenAI-compatible, no new code or SDK is required — integration is simply a matter of setting `--responses_api_base_url` and `--responses_api_api_key` when using the existing `--llm_backend responses-api` path.

## Changes

- **`README.md`**: Added Astraflow (global and China endpoints) to the OpenAI-compatible backends table and added two corresponding usage examples.

## Usage

**Global endpoint** (sign up at https://astraflow.ucloud-global.com):
```bash
export ASTRAFLOW_API_KEY=your_api_key

speech-to-speech \
    --mode local \
    --stt parakeet-tdt \
    --llm_backend responses-api \
    --tts qwen3 \
    --qwen3_tts_mlx_quantization 6bit \
    --model_name "<model-name>" \
    --responses_api_base_url "https://api-us-ca.umodelverse.ai/v1" \
    --responses_api_api_key "$ASTRAFLOW_API_KEY" \
    --responses_api_stream \
    --enable_live_transcription
```

**China endpoint** (sign up at https://astraflow.ucloud.cn):
```bash
export ASTRAFLOW_CN_API_KEY=your_api_key

speech-to-speech \
    --mode local \
    --stt parakeet-tdt \
    --llm_backend responses-api \
    --tts qwen3 \
    --qwen3_tts_mlx_quantization 6bit \
    --model_name "<model-name>" \
    --responses_api_base_url "https://api.modelverse.cn/v1" \
    --responses_api_api_key "$ASTRAFLOW_CN_API_KEY" \
    --responses_api_stream \
    --enable_live_transcription
```

No new dependencies, no new files, no new argument classes — just documentation of an already-supported integration pattern.