### PR TITLE
Fix Python 3.10 typing import

### DIFF
--- a/src/speech_to_speech/api/openai_realtime/service.py
+++ b/src/speech_to_speech/api/openai_realtime/service.py
@@ -2,7 +2,7 @@ import logging
 from collections.abc import Mapping
 from queue import Queue
 from threading import Event as ThreadingEvent
-from typing import Any, Callable, Literal, Optional, Self, Union
+from typing import Any, Callable, Literal, Optional, Union
 
 from openai.types.realtime import (
     ConversationItemCreatedEvent,
@@ -109,7 +109,7 @@ class UsageMetrics(BaseModel):
     tool_calls: int = 0
     turns: int = 0
 
-    def __iadd__(self, other: "UsageMetrics") -> Self:
+    def __iadd__(self, other: "UsageMetrics") -> "UsageMetrics":
         for field in UsageMetrics.model_fields:
             setattr(self, field, getattr(self, field) + getattr(other, field))
         return self


### PR DESCRIPTION
## Summary
- replace the Python 3.11-only `typing.Self` import with a Python 3.10-compatible quoted return annotation

## Root Cause
The package advertises Python 3.10 support, but `typing.Self` is only available in Python 3.11+. Installing and running the CLI under Python 3.10 can crash when importing the OpenAI realtime service.

## Validation
- `python3.10 -m compileall -q src tests scripts benchmark_llm_latency.py benchmark_llm_buffering.py`
- `uv run --python 3.10 pytest tests/openai_realtime/test_realtime_service.py tests/test_cli_defaults.py tests/test_vad_iterator.py`
- `uv run --python 3.10 python tests/install_smoke.py`
- `uv run --python 3.10 ruff check src/speech_to_speech/api/openai_realtime/service.py`