### PR TITLE
Bump version to 0.2.7

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "speech-to-speech"
-version = "0.2.6"
+version = "0.2.7"
 description = "Low-latency speech-to-speech pipeline"
 readme = "README.md"
 requires-python = ">=3.10"


### PR DESCRIPTION
## Summary
- bump the package version from `0.2.6` to `0.2.7`

## Why
Prepares the next PyPI release after the Python 3.10 import fix was merged.

## Validation
- `uv build`
- `uvx twine check --strict dist/*`
