### PR TITLE
fix CI

### DIFF
--- a/src/speech_to_speech/api/openai_realtime/service.py
+++ b/src/speech_to_speech/api/openai_realtime/service.py
@@ -2,7 +2,7 @@ import logging
 from collections.abc import Mapping
 from queue import Queue
 from threading import Event as ThreadingEvent
-from typing import Any, Callable, Literal, Optional, Union
+from typing import Any, Callable, Literal, Optional, TypeVar, Union
 
 from openai.types.realtime import (
     ConversationItemCreatedEvent,
@@ -94,6 +94,9 @@ ServerEvent = Union[
 RealtimeEvent = Union[ClientEvent, ServerEvent]
 
 
+_UsageMetricsT = TypeVar("_UsageMetricsT", bound="UsageMetrics")
+
+
 class UsageMetrics(BaseModel):
     """Per-response usage counters.
 
@@ -109,7 +112,7 @@ class UsageMetrics(BaseModel):
     tool_calls: int = 0
     turns: int = 0
 
-    def __iadd__(self, other: "UsageMetrics") -> "UsageMetrics":
+    def __iadd__(self: _UsageMetricsT, other: "UsageMetrics") -> _UsageMetricsT:
         for field in UsageMetrics.model_fields:
             setattr(self, field, getattr(self, field) + getattr(other, field))
         return self


### PR DESCRIPTION
## Summary
- Fix mypy failure on `main` caused by `UsageMetrics.__iadd__` widening `GlobalUsageMetrics` to its parent type
- `__iadd__` now uses a `TypeVar` bound to `UsageMetrics`, so `self._service.total_usage += st.response_usage` preserves the `GlobalUsageMetrics` type

## Test plan
- [x] `uv run mypy src/` — passes (81 source files)
- [x] `uv run ruff check src/ tests/` — passes
- [x] `uv run ruff format --check src/ tests/` — passes