### PR TITLE
Upgrade MLX LM for macOS release

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "speech-to-speech"
-version = "0.2.7"
+version = "0.2.8"
 description = "Low-latency speech-to-speech pipeline"
 readme = "README.md"
 requires-python = ">=3.10"
@@ -42,7 +42,7 @@ dependencies = [
     "torch>=2.4.0; platform_system != 'Darwin'",
     "torchaudio==2.11.0; platform_system == 'Darwin'",
     "torchaudio>=2.4.0; platform_system != 'Darwin'",
-    "transformers==5.6.2; platform_system == 'Darwin'",
+    "transformers==5.9.0; platform_system == 'Darwin'",
     "transformers>=4.57.0; platform_system != 'Darwin'",
     "uvicorn>=0.30.0",
     "websockets>=12.0",
@@ -50,10 +50,10 @@ dependencies = [
     "faster-qwen3-tts>=0.2.6; platform_system != 'Darwin'",
     "lingua-language-detector>=2.0.2",
     "miniaudio==1.61; platform_system == 'Darwin'",
-    "mlx==0.31.1; platform_system == 'Darwin'",
-    "mlx-audio==0.4.2; platform_system == 'Darwin'",
-    "mlx-lm==0.31.1; platform_system == 'Darwin'",
-    "mlx-metal==0.31.1; platform_system == 'Darwin'",
+    "mlx==0.31.2; platform_system == 'Darwin'",
+    "mlx-audio==0.4.3; platform_system == 'Darwin'",
+    "mlx-lm==0.31.3; platform_system == 'Darwin'",
+    "mlx-metal==0.31.2; platform_system == 'Darwin'",
     "misaki>=0.9.4; platform_system == 'Darwin'",
     "espeakng-loader>=0.2.4; platform_system == 'Darwin'",
     "spacy>=3.8.4; platform_system == 'Darwin'",
@@ -77,7 +77,7 @@ language-detection = [
     "lingua-language-detector>=2.0.2",
 ]
 mlx-lm = [
-    "mlx-lm==0.31.1; platform_system == 'Darwin'",
+    "mlx-lm==0.31.3; platform_system == 'Darwin'",
     "mlx-vlm==0.4.1; platform_system == 'Darwin'",
 ]
 paraformer = [

--- a/tests/install_smoke.py
+++ b/tests/install_smoke.py
@@ -119,12 +119,12 @@ def _validate_realtime_websocket_support() -> None:
 def _validate_darwin_dependency_pins() -> None:
     expected_versions = {
         "miniaudio": "1.61",
-        "mlx": "0.31.1",
-        "mlx-audio": "0.4.2",
-        "mlx-lm": "0.31.1",
-        "mlx-metal": "0.31.1",
+        "mlx": "0.31.2",
+        "mlx-audio": "0.4.3",
+        "mlx-lm": "0.31.3",
+        "mlx-metal": "0.31.2",
         "sounddevice": "0.5.3",
-        "transformers": "5.6.2",
+        "transformers": "5.9.0",
     }
     mismatches = []
     for package_name, expected_version in expected_versions.items():


### PR DESCRIPTION
## Summary
- bump the package version to `0.2.8`
- update the pinned macOS MLX stack for `mlx-lm` Gemma 4 support:
  - `mlx-lm==0.31.3`
  - `mlx==0.31.2`
  - `mlx-metal==0.31.2`
  - `mlx-audio==0.4.3`
  - `transformers==5.9.0`
- update the macOS install smoke expectations to match the new pins

## Why
`mlx-lm==0.31.1` does not support models with `model_type = gemma4`, which makes local Apple Silicon runs fail for models such as `mlx-community/gemma-4-e4b-it-OptiQ-4bit`.

`mlx-audio==0.4.2` pins `mlx-lm==0.31.1`, so it also needs to move to `0.4.3` for the dependency set to resolve with `mlx-lm==0.31.3`.

## Validation
- `uv run pytest tests/test_cli_defaults.py tests/openai_realtime/test_realtime_service.py`
- `uv build`
- `uvx twine check --strict dist/*`
- `uv run ruff check pyproject.toml tests/install_smoke.py`
- `uv run python tests/install_smoke.py`
- inspected wheel metadata for the `0.2.8` version and Darwin MLX pins
