### PR TITLE
[codex] Prepare 0.2.9 dependency rollback release

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "speech-to-speech"
-version = "0.2.8"
+version = "0.2.9"
 description = "Low-latency speech-to-speech pipeline"
 readme = "README.md"
 requires-python = ">=3.10"
@@ -42,7 +42,7 @@ dependencies = [
     "torch>=2.4.0; platform_system != 'Darwin'",
     "torchaudio==2.11.0; platform_system == 'Darwin'",
     "torchaudio>=2.4.0; platform_system != 'Darwin'",
-    "transformers==5.9.0; platform_system == 'Darwin'",
+    "transformers==5.6.2; platform_system == 'Darwin'",
     "transformers>=4.57.0; platform_system != 'Darwin'",
     "uvicorn>=0.30.0",
     "websockets>=12.0",
@@ -50,10 +50,10 @@ dependencies = [
     "faster-qwen3-tts>=0.2.6; platform_system != 'Darwin'",
     "lingua-language-detector>=2.0.2",
     "miniaudio==1.61; platform_system == 'Darwin'",
-    "mlx==0.31.2; platform_system == 'Darwin'",
-    "mlx-audio==0.4.3; platform_system == 'Darwin'",
-    "mlx-lm==0.31.3; platform_system == 'Darwin'",
-    "mlx-metal==0.31.2; platform_system == 'Darwin'",
+    "mlx==0.31.1; platform_system == 'Darwin'",
+    "mlx-audio==0.4.2; platform_system == 'Darwin'",
+    "mlx-lm==0.31.1; platform_system == 'Darwin'",
+    "mlx-metal==0.31.1; platform_system == 'Darwin'",
     "misaki>=0.9.4; platform_system == 'Darwin'",
     "espeakng-loader>=0.2.4; platform_system == 'Darwin'",
     "spacy>=3.8.4; platform_system == 'Darwin'",
@@ -77,7 +77,7 @@ language-detection = [
     "lingua-language-detector>=2.0.2",
 ]
 mlx-lm = [
-    "mlx-lm==0.31.3; platform_system == 'Darwin'",
+    "mlx-lm==0.31.1; platform_system == 'Darwin'",
     "mlx-vlm==0.4.1; platform_system == 'Darwin'",
 ]
 paraformer = [

--- a/src/speech_to_speech/__init__.py
+++ b/src/speech_to_speech/__init__.py
@@ -1,3 +1,3 @@
 """speech-to-speech: low-latency speech-to-speech pipeline."""
 
-__version__ = "0.2.6"
+__version__ = "0.2.9"

--- a/tests/install_smoke.py
+++ b/tests/install_smoke.py
@@ -119,12 +119,12 @@ def _validate_realtime_websocket_support() -> None:
 def _validate_darwin_dependency_pins() -> None:
     expected_versions = {
         "miniaudio": "1.61",
-        "mlx": "0.31.2",
-        "mlx-audio": "0.4.3",
-        "mlx-lm": "0.31.3",
-        "mlx-metal": "0.31.2",
+        "mlx": "0.31.1",
+        "mlx-audio": "0.4.2",
+        "mlx-lm": "0.31.1",
+        "mlx-metal": "0.31.1",
         "sounddevice": "0.5.3",
-        "transformers": "5.9.0",
+        "transformers": "5.6.2",
     }
     mismatches = []
     for package_name, expected_version in expected_versions.items():


### PR DESCRIPTION
## Summary

This prepares the replacement `0.2.9` PyPI release after `4aa7d181d5600b4c1ec104afe37701a41339a711` caused regressions.

## Changes

- Bump package metadata from `0.2.8` to `0.2.9`.
- Restore the pre-`4aa7d18` macOS dependency pins for `transformers`, `mlx`, `mlx-audio`, `mlx-lm`, and `mlx-metal`.
- Update the install smoke test expectations to match the restored macOS pins.
- Align `speech_to_speech.__version__` with the new release version.

## Impact

The next PyPI release can use version `0.2.9` while undoing the dependency upgrades from the broken `0.2.8` release.

## Validation

- `uv build`
- `uvx twine check --strict dist/*`
- `PYTHONPATH=src python -m pytest tests/test_cli_defaults.py`
- Confirmed PyPI latest is currently `0.2.8` and `0.2.9` is not published yet.
