### PR TITLE
Add audio-input LLM STT bypass

### DIFF
--- a/src/speech_to_speech/LLM/audio_input_notifier.py
+++ b/src/speech_to_speech/LLM/audio_input_notifier.py
@@ -1,0 +1,60 @@
+from __future__ import annotations
+
+import logging
+from collections.abc import Iterator
+from threading import Event
+
+from speech_to_speech.api.openai_realtime.runtime_config import RuntimeConfig
+from speech_to_speech.baseHandler import BaseHandler
+from speech_to_speech.pipeline.handler_types import LLMIn
+from speech_to_speech.pipeline.messages import GenerateResponseRequest, VADAudio
+from speech_to_speech.pipeline.speculative_turns import SpeculativeTurnTracker
+
+logger = logging.getLogger(__name__)
+
+
+class AudioInputNotifier(BaseHandler[VADAudio, LLMIn]):
+    """Bridge final VAD audio directly into the LLM stage."""
+
+    def setup(
+        self,
+        runtime_config: RuntimeConfig | None = None,
+        should_listen: Event | None = None,
+        sample_rate: int = 16000,
+        speculative_turns: SpeculativeTurnTracker | None = None,
+    ) -> None:
+        self.runtime_config = runtime_config
+        self.should_listen = should_listen
+        self.sample_rate = sample_rate
+        self.speculative_turns = speculative_turns
+
+    def should_process_input(self, item: VADAudio) -> bool:
+        if item.mode == "progressive":
+            return False
+        if self.speculative_turns is None or item.turn_id is None or item.turn_revision is None:
+            return True
+        return self.speculative_turns.is_latest_after_pending_reopen(item.turn_id, item.turn_revision)
+
+    def process(self, vad_audio: VADAudio) -> Iterator[LLMIn]:
+        runtime_config = vad_audio.runtime_config or self.runtime_config
+        if runtime_config is None:
+            logger.error("AudioInputNotifier received audio without RuntimeConfig; dropping LLM request")
+            if self.should_listen is not None:
+                self.should_listen.set()
+            return
+
+        audio_duration_s = len(vad_audio.audio) / self.sample_rate if self.sample_rate else 0.0
+        logger.info(
+            "Audio input completed: %.3fs turn=%s rev=%s",
+            audio_duration_s,
+            vad_audio.turn_id,
+            vad_audio.turn_revision,
+        )
+        yield GenerateResponseRequest(
+            runtime_config=runtime_config,
+            audio=vad_audio.audio,
+            audio_sample_rate=self.sample_rate,
+            turn_id=vad_audio.turn_id,
+            turn_revision=vad_audio.turn_revision,
+            speech_stopped_at_s=vad_audio.created_at_s,
+        )

--- a/src/speech_to_speech/LLM/chat.py
+++ b/src/speech_to_speech/LLM/chat.py
@@ -191,11 +191,13 @@ class Chat:
                 item.content = [
                     p
                     for p in item.content
-                    if (p.type == "input_text" and p.text) or (p.type == "input_image" and p.image_url)
+                    if (p.type == "input_text" and p.text)
+                    or (p.type == "input_image" and p.image_url)
+                    or (p.type == "input_audio" and p.audio)
                 ]
                 if not item.content:
                     raise ChatItemError(
-                        "Message has no supported content. Supported modalities: input_text, input_image."
+                        "Message has no supported content. Supported modalities: input_text, input_image, input_audio."
                     )
                 self.buffer.append(item)
                 self._user_turn_count += 1
@@ -425,6 +427,44 @@ class Chat:
                     )
             return [m.model_dump() for m in messages]
 
+    def to_chat_completions_chat(self) -> list[dict[str, Any]]:
+        """Serialize the chat for OpenAI-compatible Chat Completions."""
+        with self._lock:
+            messages: list[dict[str, Any]] = []
+            if self.init_chat_message:
+                text = " ".join(p.text for p in self.init_chat_message.content if p.text)
+                if text:
+                    messages.append({"role": "system", "content": text})
+            for item in self.buffer:
+                if isinstance(item, RealtimeConversationItemUserMessage):
+                    content: list[dict[str, Any]] = []
+                    for user_part in item.content:
+                        if user_part.type == "input_text" and user_part.text is not None:
+                            content.append({"type": "text", "text": user_part.text})
+                        elif user_part.type == "input_image" and user_part.image_url is not None:
+                            content.append({"type": "image_url", "image_url": {"url": user_part.image_url}})
+                        elif user_part.type == "input_audio" and user_part.audio is not None:
+                            content.append(
+                                {
+                                    "type": "input_audio",
+                                    "input_audio": {
+                                        "data": user_part.audio,
+                                        "format": "wav",
+                                    },
+                                }
+                            )
+                    if content:
+                        messages.append({"role": "user", "content": content})
+                elif isinstance(item, RealtimeConversationItemAssistantMessage):
+                    text = " ".join(p.text for p in item.content if p.text)
+                    if text:
+                        messages.append({"role": "assistant", "content": text})
+                elif isinstance(item, RealtimeConversationItemFunctionCall):
+                    logger.debug("Skipping function_call in chat completions serialization")
+                elif isinstance(item, RealtimeConversationItemFunctionCallOutput):
+                    logger.debug("Skipping function_call_output in chat completions serialization")
+            return messages
+
     def copy(self) -> Chat:
         """Return a shallow snapshot safe for concurrent read access."""
         with self._lock:
@@ -467,6 +507,13 @@ class Chat:
                 if isinstance(item, RealtimeConversationItemUserMessage):
                     item.content = [p for p in item.content if p.type != "input_image"]
 
+    def strip_audio(self) -> None:
+        """Remove all audio content parts from user messages in the buffer."""
+        with self._lock:
+            for item in self.buffer:
+                if isinstance(item, RealtimeConversationItemUserMessage):
+                    item.content = [p for p in item.content if p.type != "input_audio"]
+
     # ── Compaction internals ──────────────────────────────────
 
     def _snapshot_for_compaction(
@@ -497,14 +544,18 @@ class Chat:
         items_to_compact = self.buffer[:end_idx]
         marker_ids = {entry.id for entry in items_to_compact if entry.id is not None}
         snapshot = self._to_responses_api_chat_locked(items=items_to_compact)
-        # Strip image parts so the summarizer doesn't have to handle them.
+        # Strip media parts so the summarizer doesn't have to handle them.
         for raw in snapshot:
             if not isinstance(raw, dict) or raw.get("role") != "user":
                 continue
             msg: dict[str, Any] = raw  # type: ignore[assignment]
             content = msg.get("content")
             if isinstance(content, list):
-                msg["content"] = [c for c in content if not (isinstance(c, dict) and c.get("type") == "input_image")]
+                msg["content"] = [
+                    c
+                    for c in content
+                    if not (isinstance(c, dict) and c.get("type") in {"input_image", "input_audio"})
+                ]
         return snapshot, marker_ids, n_turns
 
     def _maybe_trigger_compaction(self, compactor: CompactFn) -> None:
@@ -671,6 +722,14 @@ def make_user_message(text: str) -> RealtimeConversationItemUserMessage:
         type="message",
         role="user",
         content=[UserContent(type="input_text", text=text)],
+    )
+
+
+def make_user_audio_message(audio_b64: str) -> RealtimeConversationItemUserMessage:
+    return RealtimeConversationItemUserMessage(
+        type="message",
+        role="user",
+        content=[UserContent(type="input_audio", audio=audio_b64)],
     )
 
 

--- a/src/speech_to_speech/LLM/responses_api_language_model.py
+++ b/src/speech_to_speech/LLM/responses_api_language_model.py
@@ -1,11 +1,15 @@
 from __future__ import annotations
 
+import base64
+import io
 import logging
 import time
+import wave
 from collections.abc import Iterator
 from typing import Any, Optional
 
 import httpx
+import numpy as np
 from nltk import sent_tokenize
 from openai import OpenAI, Stream
 from openai.types.realtime.conversation_item import (
@@ -26,7 +30,14 @@ from openai.types.responses import (
 )
 
 from speech_to_speech.baseHandler import BaseHandler
-from speech_to_speech.LLM.chat import Chat, SupportedItem, make_system_message, make_user_message
+from speech_to_speech.LLM.chat import (
+    Chat,
+    SupportedItem,
+    make_assistant_message,
+    make_system_message,
+    make_user_audio_message,
+    make_user_message,
+)
 from speech_to_speech.LLM.compaction_prompt import CompactGenerateFn, build_compactor
 from speech_to_speech.LLM.utils import remove_unspeechable, resolve_auto_language
 from speech_to_speech.LLM.voice_prompt import build_voice_system_prompt
@@ -64,6 +75,8 @@ class ResponsesApiModelHandler(BaseHandler[LLMIn, LLMOut]):
         stream_batch_sentences: int = 3,
         enable_lang_prompt: bool = False,
         compact_history: bool = False,
+        audio_max_tokens: int = 256,
+        audio_temperature: float = 0.0,
         **_kwargs: Any,
     ) -> None:
         self.cancel_scope = cancel_scope
@@ -73,6 +86,8 @@ class ResponsesApiModelHandler(BaseHandler[LLMIn, LLMOut]):
         self.stream_batch_sentences = max(1, stream_batch_sentences)
         self.enable_lang_prompt = enable_lang_prompt
         self.gen_kwargs = dict(gen_kwargs)
+        self.audio_max_tokens = audio_max_tokens
+        self.audio_temperature = audio_temperature
         self.request_timeout_s = float(request_timeout_s)
         self.request_timeout = httpx.Timeout(
             self.request_timeout_s,
@@ -80,6 +95,8 @@ class ResponsesApiModelHandler(BaseHandler[LLMIn, LLMOut]):
         )
 
         self.user_role = user_role
+        if api_key is None and base_url is not None and base_url != "https://api.openai.com/v1":
+            api_key = "none"
         self.client = OpenAI(api_key=api_key, base_url=base_url)
         self._extra_body = (
             {"chat_template_kwargs": {"enable_thinking": False}}
@@ -155,6 +172,192 @@ class ResponsesApiModelHandler(BaseHandler[LLMIn, LLMOut]):
         if instructions:
             full_instructions = build_voice_system_prompt(instructions)
             chat.add_item(make_system_message(full_instructions))
+
+    def _audio_to_wav_base64(self, audio: np.ndarray, sample_rate: int) -> str:
+        audio_array = np.asarray(audio)
+        if audio_array.ndim > 1:
+            audio_array = np.mean(audio_array, axis=1)
+        if np.issubdtype(audio_array.dtype, np.floating):
+            pcm = (np.clip(audio_array, -1.0, 1.0) * 32767.0).astype("<i2")
+        else:
+            pcm = np.clip(audio_array, -32768, 32767).astype("<i2")
+
+        with io.BytesIO() as wav_io:
+            with wave.open(wav_io, "wb") as wav_file:
+                wav_file.setnchannels(1)
+                wav_file.setsampwidth(2)
+                wav_file.setframerate(sample_rate)
+                wav_file.writeframes(pcm.tobytes())
+            return base64.b64encode(wav_io.getvalue()).decode("ascii")
+
+    def _chat_usage_tokens(self, usage: Any) -> tuple[int, int]:
+        if usage is None:
+            return 0, 0
+        input_tokens = getattr(usage, "prompt_tokens", None)
+        if input_tokens is None:
+            input_tokens = getattr(usage, "input_tokens", 0)
+        output_tokens = getattr(usage, "completion_tokens", None)
+        if output_tokens is None:
+            output_tokens = getattr(usage, "output_tokens", 0)
+        return int(input_tokens or 0), int(output_tokens or 0)
+
+    def _audio_chat_kwargs(self, response: Any, optional_kwargs: dict[str, Any]) -> dict[str, Any]:
+        kwargs = dict(optional_kwargs)
+        max_tokens = getattr(response, "max_output_tokens", None) if response is not None else None
+        kwargs.setdefault("max_tokens", max_tokens or self.audio_max_tokens)
+        kwargs.setdefault("temperature", self.audio_temperature)
+        return kwargs
+
+    def _generate_audio_chat_completions(
+        self,
+        active_chat: Chat,
+        original_chat: Chat,
+        request_audio: np.ndarray,
+        audio_sample_rate: int,
+        language_code: Optional[str],
+        gen: int | None,
+        runtime_config: Any,
+        response: Any,
+        optional_kwargs: dict[str, Any],
+        turn_id: str | None,
+        turn_revision: int | None,
+        speech_stopped_at_s: float | None,
+    ) -> Iterator[LLMOut]:
+        audio_message = make_user_audio_message(self._audio_to_wav_base64(request_audio, audio_sample_rate))
+        active_chat.add_item(audio_message)
+
+        api_response: Any = None
+        clean_text = ""
+        input_tokens = 0
+        output_tokens = 0
+        cancelled = False
+        try:
+            api_response = self.client.chat.completions.create(
+                model=self.model_name,
+                messages=active_chat.to_chat_completions_chat(),
+                stream=self.stream,
+                extra_body=self._extra_body,
+                timeout=self.request_timeout,
+                **self._audio_chat_kwargs(response, optional_kwargs),
+            )
+            if isinstance(api_response, Stream):
+                printable_text = ""
+                sentence_batch: list[str] = []
+                for raw_event in api_response:
+                    if self._generation_is_stale(gen) or not self._turn_is_latest(turn_id, turn_revision):
+                        logger.info("Audio LLM generation cancelled (interruption)")
+                        cancelled = True
+                        break
+                    usage = getattr(raw_event, "usage", None)
+                    if usage:
+                        input_tokens, output_tokens = self._chat_usage_tokens(usage)
+                    if not getattr(raw_event, "choices", None):
+                        continue
+                    delta = raw_event.choices[0].delta
+                    new_text = remove_unspeechable(getattr(delta, "content", None) or "")
+                    if not new_text:
+                        continue
+                    clean_text += new_text
+                    printable_text += new_text
+                    sentences = sent_tokenize(printable_text)
+                    if len(sentences) > 1:
+                        for sentence in sentences[:-1]:
+                            sentence_batch.append(sentence)
+                            if len(sentence_batch) >= self.stream_batch_sentences:
+                                if not self._turn_output_allowed(turn_id, turn_revision):
+                                    logger.info("Audio LLM generation cancelled (stale speculative turn)")
+                                    cancelled = True
+                                    break
+                                yield LLMResponseChunk(
+                                    text=" ".join(sentence_batch),
+                                    language_code=language_code,
+                                    runtime_config=runtime_config,
+                                    response=response,
+                                    turn_id=turn_id,
+                                    turn_revision=turn_revision,
+                                    speech_stopped_at_s=speech_stopped_at_s,
+                                    cancel_generation=gen,
+                                )
+                                sentence_batch = []
+                        if cancelled:
+                            break
+                        printable_text = sentences[-1]
+                if not cancelled:
+                    if printable_text.strip():
+                        sentence_batch.append(printable_text.strip())
+                    remaining = " ".join(sentence_batch)
+                    if remaining and not self._generation_is_stale(gen) and self._turn_output_allowed(
+                        turn_id,
+                        turn_revision,
+                    ):
+                        yield LLMResponseChunk(
+                            text=remaining,
+                            language_code=language_code,
+                            runtime_config=runtime_config,
+                            response=response,
+                            turn_id=turn_id,
+                            turn_revision=turn_revision,
+                            speech_stopped_at_s=speech_stopped_at_s,
+                            cancel_generation=gen,
+                        )
+            else:
+                usage = getattr(api_response, "usage", None)
+                input_tokens, output_tokens = self._chat_usage_tokens(usage)
+                if self._generation_is_stale(gen) or not self._turn_is_latest(turn_id, turn_revision):
+                    logger.info("Audio LLM generation cancelled (interruption)")
+                    cancelled = True
+                elif getattr(api_response, "choices", None):
+                    content = api_response.choices[0].message.content or ""
+                    clean_text = remove_unspeechable(content).strip()
+                    if clean_text and self._turn_output_allowed(turn_id, turn_revision):
+                        yield LLMResponseChunk(
+                            text=clean_text,
+                            language_code=language_code,
+                            runtime_config=runtime_config,
+                            response=response,
+                            turn_id=turn_id,
+                            turn_revision=turn_revision,
+                            speech_stopped_at_s=speech_stopped_at_s,
+                            cancel_generation=gen,
+                        )
+        except httpx.ReadTimeout:
+            logger.warning(
+                "OpenAI-compatible audio chat read timed out after %.1fs; ending the current response",
+                self.request_timeout_s,
+            )
+            cancelled = True
+            if not self._generation_is_stale(gen) and self._turn_output_allowed(turn_id, turn_revision):
+                yield LLMResponseChunk(
+                    text="Wow I'm a bit slow today, could you repeat that?",
+                    runtime_config=runtime_config,
+                    response=response,
+                    turn_id=turn_id,
+                    turn_revision=turn_revision,
+                    speech_stopped_at_s=speech_stopped_at_s,
+                    cancel_generation=gen,
+                )
+        finally:
+            if api_response is not None and hasattr(api_response, "close"):
+                try:
+                    api_response.close()
+                except Exception:
+                    pass
+
+        if not cancelled and not self._generation_is_stale(gen) and self._turn_output_allowed(turn_id, turn_revision):
+            original_chat.add_item(audio_message)
+            if clean_text.strip():
+                original_chat.add_item(make_assistant_message(clean_text.strip()))
+            original_chat.strip_audio()
+            original_chat.strip_images()
+            original_chat.trim_if_needed(self.compactor)
+            if input_tokens or output_tokens:
+                yield TokenUsage(
+                    input_tokens=input_tokens,
+                    output_tokens=output_tokens,
+                    turn_id=turn_id,
+                    turn_revision=turn_revision,
+                )
+        yield EndOfResponse(turn_id=turn_id, turn_revision=turn_revision, cancel_generation=gen)
 
     def _generate(
         self,
@@ -366,6 +569,7 @@ class ResponsesApiModelHandler(BaseHandler[LLMIn, LLMOut]):
             for item in pending_chat_items:
                 original_chat.add_item(item)
             original_chat.strip_images()
+            original_chat.strip_audio()
             original_chat.trim_if_needed(self.compactor)
             if input_tokens or output_tokens:
                 yield TokenUsage(
@@ -423,6 +627,23 @@ class ResponsesApiModelHandler(BaseHandler[LLMIn, LLMOut]):
         # option is to run this API call in a child process and terminate() on session
         # end (IPC and lifecycle cost).
         gen = self.cancel_scope.generation if self.cancel_scope else None
+
+        if request.audio is not None:
+            yield from self._generate_audio_chat_completions(
+                active_chat,
+                original_chat,
+                request.audio,
+                request.audio_sample_rate,
+                language_code,
+                gen,
+                runtime_config,
+                response,
+                optional_kwargs,
+                turn_id,
+                turn_revision,
+                speech_stopped_at_s,
+            )
+            return
 
         yield from self._generate(
             active_chat,

--- a/src/speech_to_speech/VAD/vad_handler.py
+++ b/src/speech_to_speech/VAD/vad_handler.py
@@ -405,12 +405,16 @@ class VADHandler(BaseHandler[VADIn, VADOut]):
         if self._uses_realtime_turn_handling():
             # Realtime mode keeps turns reopenable; live transcription additionally
             # emits progressive audio chunks while speaking.
-            yield from self._process_realtime(vad_output)
+            yield from self._process_realtime(vad_output, runtime_config)
         else:
             # Original mode: yield only when speech ends
-            yield from self._process_normal(vad_output)
+            yield from self._process_normal(vad_output, runtime_config)
 
-    def _process_realtime(self, vad_output: list[torch.Tensor] | None) -> Iterator[VADOut]:
+    def _process_realtime(
+        self,
+        vad_output: list[torch.Tensor] | None,
+        runtime_config: RuntimeConfig | None = None,
+    ) -> Iterator[VADOut]:
         """Process with real-time progressive audio release."""
         # Check if we're currently in a speech segment.
         if self.enable_realtime_transcription and hasattr(self.iterator, "buffer") and len(self.iterator.buffer) > 0:
@@ -435,6 +439,7 @@ class VADHandler(BaseHandler[VADIn, VADOut]):
                     turn_id, turn_revision = self._current_turn_metadata()
                     yield VADAudio(
                         audio=self._combined_turn_audio(array),
+                        runtime_config=runtime_config,
                         mode="progressive",
                         turn_id=turn_id,
                         turn_revision=turn_revision,
@@ -532,7 +537,13 @@ class VADHandler(BaseHandler[VADIn, VADOut]):
                     )
                 else:
                     self.should_listen.clear()
-                yield VADAudio(audio=output_array, mode="final", turn_id=turn_id, turn_revision=turn_revision)
+                yield VADAudio(
+                    audio=output_array,
+                    runtime_config=runtime_config,
+                    mode="final",
+                    turn_id=turn_id,
+                    turn_revision=turn_revision,
+                )
                 self.last_process_time = 0.0
                 self._speech_started_emitted = False
 
@@ -549,7 +560,11 @@ class VADHandler(BaseHandler[VADIn, VADOut]):
             multiplier = 6.0
         return min(base_pause * multiplier, 2.0)
 
-    def _process_normal(self, vad_output: list[torch.Tensor] | None) -> Iterator[VADOut]:
+    def _process_normal(
+        self,
+        vad_output: list[torch.Tensor] | None,
+        runtime_config: RuntimeConfig | None = None,
+    ) -> Iterator[VADOut]:
         """Original processing: yield only when speech ends."""
         if vad_output is not None:
             if len(vad_output) == 0:
@@ -589,7 +604,7 @@ class VADHandler(BaseHandler[VADIn, VADOut]):
                     self.text_output_queue.put(SpeechStoppedEvent(duration_s=duration_ms / 1000.0, audio_end_ms=end_ms))
                 if self.audio_enhancement:
                     array = self._apply_audio_enhancement(array)
-                yield VADAudio(audio=array)
+                yield VADAudio(audio=array, runtime_config=runtime_config)
                 self._speech_started_emitted = False
 
     def _apply_audio_enhancement(self, array: np.ndarray) -> np.ndarray:

--- a/src/speech_to_speech/arguments_classes/module_arguments.py
+++ b/src/speech_to_speech/arguments_classes/module_arguments.py
@@ -21,11 +21,21 @@ class ModuleArguments:
         },
     )
     stt: Optional[
-        Literal["whisper", "whisper-mlx", "mlx-audio-whisper", "faster-whisper", "parakeet-tdt", "paraformer"]
+        Literal[
+            "none",
+            "whisper",
+            "whisper-mlx",
+            "mlx-audio-whisper",
+            "faster-whisper",
+            "parakeet-tdt",
+            "paraformer",
+        ]
     ] = field(
         default="parakeet-tdt",
         metadata={
-            "help": "The STT to use. Either 'whisper', 'whisper-mlx', 'mlx-audio-whisper', 'faster-whisper', 'parakeet-tdt', or 'paraformer'. Default is 'parakeet-tdt'."
+            "help": "The STT to use. Use 'none' to send VAD audio directly to an audio-input LLM. "
+            "Otherwise choose 'whisper', 'whisper-mlx', 'mlx-audio-whisper', 'faster-whisper', "
+            "'parakeet-tdt', or 'paraformer'. Default is 'parakeet-tdt'."
         },
     )
     llm_backend: Optional[Literal["transformers", "mlx-lm", "responses-api"]] = field(

--- a/src/speech_to_speech/arguments_classes/responses_api_language_model_arguments.py
+++ b/src/speech_to_speech/arguments_classes/responses_api_language_model_arguments.py
@@ -32,3 +32,11 @@ class ResponsesApiLanguageModelHandlerArguments(LanguageModelBaseArguments):
             "For Together Qwen3.5 models this sends chat_template_kwargs.enable_thinking=false."
         },
     )
+    responses_api_audio_max_tokens: int = field(
+        default=256,
+        metadata={"help": "Maximum chat completion tokens for audio-input LLM requests. Default is 256."},
+    )
+    responses_api_audio_temperature: float = field(
+        default=0.0,
+        metadata={"help": "Chat completion temperature for audio-input LLM requests. Default is 0.0."},
+    )

--- a/src/speech_to_speech/pipeline/messages.py
+++ b/src/speech_to_speech/pipeline/messages.py
@@ -41,6 +41,7 @@ class VADAudio(PipelineMessage):
 
     tag: Literal["vad_audio"] = "vad_audio"
     audio: np.ndarray
+    runtime_config: RuntimeConfig | None = None
     mode: Literal["progressive", "final"] | None = None
     turn_id: str | None = None
     turn_revision: int | None = None
@@ -149,6 +150,8 @@ class GenerateResponseRequest(PipelineMessage):
     tag: Literal["generate_response"] = "generate_response"
     runtime_config: RuntimeConfig
     response: RealtimeResponseCreateParams | None = None
+    audio: np.ndarray | None = None
+    audio_sample_rate: int = 16000
     language_code: Optional[str] = None
     turn_id: str | None = None
     turn_revision: int | None = None

--- a/src/speech_to_speech/s2s_pipeline.py
+++ b/src/speech_to_speech/s2s_pipeline.py
@@ -270,6 +270,8 @@ def prepare_module_args(module_kwargs: ModuleArguments, *handler_kwargs: Any) ->
     optimal_mac_settings(module_kwargs.local_mac_optimal_settings, module_kwargs, *handler_kwargs)
     if module_kwargs.tts is None:
         module_kwargs.tts = "qwen3"
+    if module_kwargs.stt == "none" and module_kwargs.llm_backend != "responses-api":
+        raise ValueError("--stt none requires --llm_backend responses-api for audio-input LLM requests.")
     if platform == "darwin":
         check_mac_settings(module_kwargs)
     overwrite_device_argument(module_kwargs.device, *handler_kwargs)
@@ -366,7 +368,7 @@ def _build_pipeline_handlers(
     qwen3_tts_handler_kwargs: Qwen3TTSHandlerArguments,
     speculative_turns: SpeculativeTurnTracker | None = None,
 ) -> list[Any]:
-    """Build the shared handler chain: VAD → STT → TranscriptionNotifier → LM → LMOutputProcessor → TTS.
+    """Build the shared handler chain: VAD → STT/AudioInput → LM → LMOutputProcessor → TTS.
 
     Callers own the queues, events, and any per-mode mutations to handler kwargs (cancel_scope,
     text_output_queue, live transcription flags). `transcription_notifier_setup` differs by mode:
@@ -382,25 +384,44 @@ def _build_pipeline_handlers(
         setup_kwargs=vars(vad_handler_kwargs),
     )
 
-    transcription_notifier = TranscriptionNotifier(
-        stop_event,
-        queue_in=stt_output_queue,
-        queue_out=text_prompt_queue,  # type: ignore[arg-type]
-        setup_kwargs=transcription_notifier_setup,
-    )
+    speech_input_handlers: list[Any]
+    if module_kwargs.stt == "none":
+        from speech_to_speech.LLM.audio_input_notifier import AudioInputNotifier
 
-    stt = get_stt_handler(
-        module_kwargs,
-        stop_event,
-        spoken_prompt_queue,
-        stt_output_queue,
-        speculative_turns,
-        whisper_stt_handler_kwargs,
-        faster_whisper_stt_handler_kwargs,
-        paraformer_stt_handler_kwargs,
-        mlx_audio_whisper_stt_handler_kwargs,
-        parakeet_tdt_stt_handler_kwargs,
-    )
+        speech_input_handlers = [
+            AudioInputNotifier(
+                stop_event,
+                queue_in=spoken_prompt_queue,
+                queue_out=text_prompt_queue,
+                setup_kwargs={
+                    "runtime_config": transcription_notifier_setup.get("runtime_config"),
+                    "should_listen": should_listen,
+                    "sample_rate": vad_handler_kwargs.sample_rate,
+                    "speculative_turns": speculative_turns,
+                },
+            )
+        ]
+    else:
+        transcription_notifier = TranscriptionNotifier(
+            stop_event,
+            queue_in=stt_output_queue,
+            queue_out=text_prompt_queue,  # type: ignore[arg-type]
+            setup_kwargs=transcription_notifier_setup,
+        )
+
+        stt = get_stt_handler(
+            module_kwargs,
+            stop_event,
+            spoken_prompt_queue,
+            stt_output_queue,
+            speculative_turns,
+            whisper_stt_handler_kwargs,
+            faster_whisper_stt_handler_kwargs,
+            paraformer_stt_handler_kwargs,
+            mlx_audio_whisper_stt_handler_kwargs,
+            parakeet_tdt_stt_handler_kwargs,
+        )
+        speech_input_handlers = [stt, transcription_notifier]
 
     lm = get_llm_handler(
         module_kwargs,
@@ -431,7 +452,7 @@ def _build_pipeline_handlers(
         qwen3_tts_handler_kwargs,
     )
 
-    return [vad, stt, transcription_notifier, lm, lm_processor, tts]
+    return [vad, *speech_input_handlers, lm, lm_processor, tts]
 
 
 def _build_realtime_pipeline_unit(
@@ -832,7 +853,7 @@ def get_stt_handler(
         )
     else:
         raise ValueError(
-            "The STT should be either whisper, whisper-mlx, mlx-audio-whisper, faster-whisper, parakeet-tdt, or paraformer."
+            "The STT should be either none, whisper, whisper-mlx, mlx-audio-whisper, faster-whisper, parakeet-tdt, or paraformer."
         )
 
 

--- a/tests/test_audio_input_notifier.py
+++ b/tests/test_audio_input_notifier.py
@@ -1,0 +1,62 @@
+from threading import Event
+
+import numpy as np
+
+from speech_to_speech.LLM.audio_input_notifier import AudioInputNotifier
+from speech_to_speech.api.openai_realtime.runtime_config import RuntimeConfig
+from speech_to_speech.pipeline.messages import GenerateResponseRequest, VADAudio
+
+
+def _notifier(runtime_config: RuntimeConfig | None = None) -> AudioInputNotifier:
+    notifier = object.__new__(AudioInputNotifier)
+    notifier.setup(
+        runtime_config=runtime_config,
+        should_listen=Event(),
+        sample_rate=16000,
+        speculative_turns=None,
+    )
+    return notifier
+
+
+def test_audio_input_notifier_ignores_progressive_audio():
+    notifier = _notifier(RuntimeConfig())
+    audio = np.zeros(1600, dtype=np.float32)
+
+    assert not notifier.should_process_input(VADAudio(audio=audio, mode="progressive"))
+
+
+def test_audio_input_notifier_forwards_final_audio_to_llm_request():
+    runtime_config = RuntimeConfig()
+    notifier = _notifier(runtime_config)
+    audio = np.zeros(1600, dtype=np.float32)
+
+    outputs = list(
+        notifier.process(
+            VADAudio(
+                audio=audio,
+                mode="final",
+                turn_id="turn_1",
+                turn_revision=2,
+            )
+        )
+    )
+
+    assert len(outputs) == 1
+    request = outputs[0]
+    assert isinstance(request, GenerateResponseRequest)
+    assert request.runtime_config is runtime_config
+    assert np.array_equal(request.audio, audio)
+    assert request.audio_sample_rate == 16000
+    assert request.turn_id == "turn_1"
+    assert request.turn_revision == 2
+
+
+def test_audio_input_notifier_prefers_runtime_config_from_vad_audio():
+    setup_config = RuntimeConfig()
+    item_config = RuntimeConfig()
+    notifier = _notifier(setup_config)
+    audio = np.zeros(1600, dtype=np.float32)
+
+    request = next(notifier.process(VADAudio(audio=audio, runtime_config=item_config, mode="final")))
+
+    assert request.runtime_config is item_config

--- a/tests/test_chat.py
+++ b/tests/test_chat.py
@@ -34,6 +34,7 @@ from speech_to_speech.LLM.chat import (
     CompactionResult,
     make_assistant_message,
     make_system_message,
+    make_user_audio_message,
     make_user_message,
 )
 
@@ -138,6 +139,15 @@ class TestFactoryHelpers:
         assert len(msg.content) == 1
         assert msg.content[0].type == "input_text"
         assert msg.content[0].text == "hello"
+
+    def test_make_user_audio_message(self):
+        msg = make_user_audio_message("abc123")
+        assert isinstance(msg, RealtimeConversationItemUserMessage)
+        assert msg.role == "user"
+        assert msg.type == "message"
+        assert len(msg.content) == 1
+        assert msg.content[0].type == "input_audio"
+        assert msg.content[0].audio == "abc123"
 
     def test_make_assistant_message(self):
         msg = make_assistant_message("world")
@@ -366,6 +376,14 @@ class TestAddItem:
         chat.add_item(msg)
         assert len(chat.buffer[0].content) == 1
         assert chat.buffer[0].content[0].type == "input_text"
+
+    def test_user_message_keeps_audio_content_with_base64_audio(self):
+        chat = Chat(size=5)
+        msg = make_user_audio_message("abc123")
+        chat.add_item(msg)
+        assert len(chat.buffer[0].content) == 1
+        assert chat.buffer[0].content[0].type == "input_audio"
+        assert chat.buffer[0].content[0].audio == "abc123"
 
     def test_user_message_keeps_image_content(self):
         chat = Chat(size=5)
@@ -741,7 +759,47 @@ class TestToTransformersChat:
 
 
 # ===================================================================
-# 9. TestCopyAndReset
+# 9. TestToChatCompletionsChat
+# ===================================================================
+
+
+class TestToChatCompletionsChat:
+    def test_audio_message_serializes_to_llama_cpp_shape(self):
+        chat = Chat(size=5)
+        chat.init_chat(_system("Be concise."))
+        chat.add_item(make_user_audio_message("abc123"))
+        chat.add_item(_assistant("Yes."))
+
+        result = chat.to_chat_completions_chat()
+
+        assert result == [
+            {"role": "system", "content": "Be concise."},
+            {
+                "role": "user",
+                "content": [
+                    {
+                        "type": "input_audio",
+                        "input_audio": {
+                            "data": "abc123",
+                            "format": "wav",
+                        },
+                    }
+                ],
+            },
+            {"role": "assistant", "content": "Yes."},
+        ]
+
+    def test_strip_audio_removes_audio_from_future_serialization(self):
+        chat = Chat(size=5)
+        chat.add_item(make_user_audio_message("abc123"))
+        chat.strip_audio()
+
+        assert chat.to_chat_completions_chat() == []
+        assert chat._user_turn_count == 1
+
+
+# ===================================================================
+# 10. TestCopyAndReset
 # ===================================================================
 
 

--- a/tests/test_cli_defaults.py
+++ b/tests/test_cli_defaults.py
@@ -119,6 +119,28 @@ def test_parse_arguments_transformers_backend():
     assert args.responses_api_language_model_handler_kwargs.model_name == "gpt-5.4-mini"
 
 
+def test_parse_arguments_stt_none_uses_responses_api_audio_path():
+    original_argv = sys.argv[:]
+    try:
+        sys.argv = [
+            "speech-to-speech",
+            "--stt",
+            "none",
+            "--responses_api_base_url",
+            "http://127.0.0.1:8080/v1",
+            "--model_name",
+            "ggml-org/gemma-4-12B-it-GGUF",
+        ]
+        args = parse_arguments()
+    finally:
+        sys.argv = original_argv
+
+    assert args.module_kwargs.stt == "none"
+    assert args.module_kwargs.llm_backend == "responses-api"
+    assert args.responses_api_language_model_handler_kwargs.responses_api_base_url == "http://127.0.0.1:8080/v1"
+    assert args.responses_api_language_model_handler_kwargs.model_name == "ggml-org/gemma-4-12B-it-GGUF"
+
+
 def test_parse_arguments_all_fields_populated():
     original_argv = sys.argv[:]
     try:

--- a/tests/test_responses_api_language_model.py
+++ b/tests/test_responses_api_language_model.py
@@ -3,6 +3,7 @@ from types import SimpleNamespace
 from unittest.mock import MagicMock
 
 import httpx
+import numpy as np
 from openai import Stream
 from openai.types.responses import (
     Response,
@@ -12,6 +13,7 @@ from openai.types.responses import (
 )
 from openai.types.responses.response_output_text import ResponseOutputText
 
+import speech_to_speech.LLM.responses_api_language_model as responses_api_language_model
 from speech_to_speech.api.openai_realtime.runtime_config import RuntimeConfig
 from speech_to_speech.LLM.chat import Chat, make_user_message
 from speech_to_speech.LLM.responses_api_language_model import ResponsesApiModelHandler
@@ -88,6 +90,8 @@ def _make_handler(*, disable_thinking=False, stream=True, cancel_scope=None):
     handler.tools_choice = None
     handler.enable_lang_prompt = False
     handler.compactor = None
+    handler.audio_max_tokens = 80
+    handler.audio_temperature = 0.0
     return handler
 
 
@@ -138,6 +142,26 @@ def test_responses_api_timing_logs_only_text_chunks():
     assert handler.should_log_timing(LLMResponseChunk(text="Hello."))
     assert not handler.should_log_timing(TokenUsage(input_tokens=1, output_tokens=1))
     assert not handler.should_log_timing(EndOfResponse())
+
+
+def test_setup_uses_dummy_api_key_for_custom_base_url(monkeypatch):
+    captured = {}
+
+    class FakeOpenAI:
+        def __init__(self, *, api_key, base_url):
+            captured["api_key"] = api_key
+            captured["base_url"] = base_url
+
+    monkeypatch.setattr(responses_api_language_model, "OpenAI", FakeOpenAI)
+    monkeypatch.setattr(ResponsesApiModelHandler, "warmup", lambda self: None)
+
+    handler = object.__new__(ResponsesApiModelHandler)
+    handler.setup(base_url="http://127.0.0.1:8080/v1", api_key=None, compact_history=False)
+
+    assert captured == {
+        "api_key": "none",
+        "base_url": "http://127.0.0.1:8080/v1",
+    }
 
 
 def test_process_read_timeout_ends_response_cleanly():
@@ -243,3 +267,40 @@ def test_second_turn_flattens_assistant_history_for_responses():
     assert len(ai["content"]) == 1
     assert ai["content"][0]["type"] == "output_text"
     assert ai["content"][0]["text"] == "Hello."
+
+
+def test_audio_request_uses_chat_completions_input_audio_payload():
+    handler = _make_handler(stream=False)
+    captured = {}
+
+    def fake_create(**kwargs):
+        captured.update(kwargs)
+        return SimpleNamespace(
+            choices=[SimpleNamespace(message=SimpleNamespace(content="Yes, I heard you."))],
+            usage=SimpleNamespace(prompt_tokens=12, completion_tokens=5),
+        )
+
+    handler.client = SimpleNamespace(
+        chat=SimpleNamespace(completions=SimpleNamespace(create=fake_create)),
+    )
+
+    request = _make_request("unused")
+    request.audio = np.zeros(1600, dtype=np.float32)
+    request.audio_sample_rate = 16000
+    outputs = list(handler.process(request))
+
+    assert isinstance(outputs[0], LLMResponseChunk)
+    assert outputs[0].text == "Yes, I heard you."
+    assert isinstance(outputs[1], TokenUsage)
+    assert outputs[1].input_tokens == 12
+    assert outputs[1].output_tokens == 5
+    assert isinstance(outputs[2], EndOfResponse)
+
+    assert captured["model"] == "test-model"
+    assert captured["stream"] is False
+    assert captured["max_tokens"] == 80
+    user_messages = [m for m in captured["messages"] if m["role"] == "user"]
+    assert user_messages[-1]["content"][0]["type"] == "input_audio"
+    audio_part = user_messages[-1]["content"][0]["input_audio"]
+    assert audio_part["format"] == "wav"
+    assert audio_part["data"]


### PR DESCRIPTION
## Summary

Adds an STT bypass mode for audio-input LLMs over the existing OpenAI-compatible responses-api configuration. `--stt none` routes final VAD audio directly to the LLM stage, and audio requests use `/v1/chat/completions` with llama.cpp-compatible `input_audio` content parts while ordinary text requests continue using `client.responses.create`.

## Validation

Superseded by a replacement PR from a branch on the upstream repository.