### PR TITLE
Fix Paraformer progressive transcription events

### DIFF
--- a/src/speech_to_speech/STT/paraformer_handler.py
+++ b/src/speech_to_speech/STT/paraformer_handler.py
@@ -9,7 +9,7 @@ from funasr import AutoModel
 from rich.console import Console
 
 from speech_to_speech.pipeline.handler_types import STTIn, STTOut
-from speech_to_speech.pipeline.messages import Transcription
+from speech_to_speech.pipeline.messages import PartialTranscription, Transcription
 from speech_to_speech.STT.base_stt_handler import BaseSTTHandler
 
 logging.basicConfig(
@@ -58,9 +58,16 @@ class ParaformerSTTHandler(BaseSTTHandler):
         logger.debug("finished paraformer inference")
         console.print(f"[yellow]USER: {pred_text}")
 
-        yield Transcription(
-            text=pred_text,
-            turn_id=vad_audio.turn_id,
-            turn_revision=vad_audio.turn_revision,
-            speech_stopped_at_s=vad_audio.created_at_s,
-        )
+        if vad_audio.mode == "progressive":
+            yield PartialTranscription(
+                text=pred_text,
+                turn_id=vad_audio.turn_id,
+                turn_revision=vad_audio.turn_revision,
+            )
+        else:
+            yield Transcription(
+                text=pred_text,
+                turn_id=vad_audio.turn_id,
+                turn_revision=vad_audio.turn_revision,
+                speech_stopped_at_s=vad_audio.created_at_s,
+            )

--- a/src/speech_to_speech/STT/paraformer_handler.py
+++ b/src/speech_to_speech/STT/paraformer_handler.py
@@ -5,7 +5,6 @@ from typing import Any, Iterator
 
 import numpy as np
 import torch
-from funasr import AutoModel
 from rich.console import Console
 
 from speech_to_speech.pipeline.handler_types import STTIn, STTOut
@@ -37,6 +36,13 @@ class ParaformerSTTHandler(BaseSTTHandler):
         if len(model_name.split("/")) > 1:
             model_name = model_name.split("/")[-1]
         self.device = device
+        try:
+            from funasr import AutoModel
+        except ModuleNotFoundError as exc:
+            raise ModuleNotFoundError(
+                "Paraformer STT requires the optional 'paraformer' extra. "
+                "Install it with `pip install speech-to-speech[paraformer]`."
+            ) from exc
         self.model = AutoModel(model=model_name, device=device)
         self.warmup()
 

--- a/tests/test_paraformer_transcription_events.py
+++ b/tests/test_paraformer_transcription_events.py
@@ -1,0 +1,62 @@
+import numpy as np
+
+from speech_to_speech.pipeline.messages import PartialTranscription, Transcription, VADAudio
+from speech_to_speech.STT import paraformer_handler
+from speech_to_speech.STT.paraformer_handler import ParaformerSTTHandler
+
+
+class _FakeParaformerModel:
+    def generate(self, audio):
+        return [{"text": " 今 天 天 气 不 错 "}]
+
+
+def _handler():
+    handler = object.__new__(ParaformerSTTHandler)
+    handler.model = _FakeParaformerModel()
+    return handler
+
+
+def test_progressive_paraformer_transcription_is_partial(monkeypatch):
+    monkeypatch.setattr(paraformer_handler.console, "print", lambda *args, **kwargs: None)
+    monkeypatch.setattr(paraformer_handler.torch.mps, "empty_cache", lambda: None)
+
+    result = list(
+        _handler().process(
+            VADAudio(
+                audio=np.zeros(16000, dtype=np.float32),
+                mode="progressive",
+                turn_id="turn_1",
+                turn_revision=2,
+            )
+        )
+    )
+
+    assert len(result) == 1
+    assert isinstance(result[0], PartialTranscription)
+    assert result[0].text == "今天天气不错"
+    assert result[0].turn_id == "turn_1"
+    assert result[0].turn_revision == 2
+
+
+def test_final_paraformer_transcription_is_final(monkeypatch):
+    monkeypatch.setattr(paraformer_handler.console, "print", lambda *args, **kwargs: None)
+    monkeypatch.setattr(paraformer_handler.torch.mps, "empty_cache", lambda: None)
+
+    result = list(
+        _handler().process(
+            VADAudio(
+                audio=np.zeros(16000, dtype=np.float32),
+                mode="final",
+                turn_id="turn_1",
+                turn_revision=2,
+                created_at_s=123.0,
+            )
+        )
+    )
+
+    assert len(result) == 1
+    assert isinstance(result[0], Transcription)
+    assert result[0].text == "今天天气不错"
+    assert result[0].turn_id == "turn_1"
+    assert result[0].turn_revision == 2
+    assert result[0].speech_stopped_at_s == 123.0


### PR DESCRIPTION
## Summary

Hi, and thank you for maintaining `speech-to-speech`.

This PR fixes Paraformer realtime/live transcription so progressive VAD chunks are emitted as `PartialTranscription` messages instead of final `Transcription` messages.

With the current behavior, a progressive Paraformer update can be treated as a completed user turn by downstream components. In a Chinese realtime setup this causes repeated LLM turns such as partial prefixes being sent as independent user messages before the final transcript arrives.

## Changes

- Return `PartialTranscription` when `VADAudio.mode == "progressive"`.
- Keep returning `Transcription` for final or legacy/non-progressive inputs.
- Preserve turn metadata on both partial and final outputs.
- Add focused Paraformer tests using a fake model, so the test does not require loading FunASR weights.

## Validation

Ran locally:

```bash
PYTHONPATH=src python3 -m pytest \
  tests/test_paraformer_transcription_events.py \
  tests/test_transcription_notifier.py -q
```

Result:

```text
7 passed, 2 warnings
```

The warnings were unrelated local environment warnings (`asyncio_mode` config without `pytest-asyncio`, and a `pydub` `audioop` deprecation warning).
