### PR TITLE
Normalize Qwen3-TTS language aliases

### DIFF
--- a/src/speech_to_speech/TTS/qwen3_tts_handler.py
+++ b/src/speech_to_speech/TTS/qwen3_tts_handler.py
@@ -51,6 +51,28 @@ ESTIMATED_QWEN3_CHARS_PER_SECOND = 14.0
 QWEN3_TOKEN_SAFETY_MARGIN = 1.35
 QWEN3_BASE_PROMPT_SECONDS = 1.0
 QWEN3_PUNCTUATION_PAUSE_SECONDS = 0.5
+QWEN3_LANGUAGE_ALIASES = {
+    "zh": "chinese",
+    "zh-cn": "chinese",
+    "zh-hans": "chinese",
+    "zh-hant": "chinese",
+    "cmn": "chinese",
+    "en": "english",
+    "en-us": "english",
+    "en-gb": "english",
+    "ja": "japanese",
+    "jp": "japanese",
+    "ko": "korean",
+    "kr": "korean",
+    "de": "german",
+    "fr": "french",
+    "ru": "russian",
+    "pt": "portuguese",
+    "pt-br": "portuguese",
+    "pt-pt": "portuguese",
+    "es": "spanish",
+    "it": "italian",
+}
 
 
 class Qwen3TTSHandler(BaseHandler[TTSIn, TTSOut]):
@@ -96,7 +118,7 @@ class Qwen3TTSHandler(BaseHandler[TTSIn, TTSOut]):
         self.requested_device = device
         self.ref_audio = ref_audio
         self.ref_text = ref_text
-        self.language = language
+        self.language = self._normalize_language(language)
         self.speaker = speaker
         self.instruct = instruct
         self.xvec_only = xvec_only
@@ -266,6 +288,14 @@ class Qwen3TTSHandler(BaseHandler[TTSIn, TTSOut]):
         if self.backend == "mlx":
             return DEFAULT_MLX_STREAMING_CHUNK_SIZE
         return DEFAULT_FASTER_STREAMING_CHUNK_SIZE
+
+    def _normalize_language(self, language: str | None) -> str:
+        if language is None:
+            return "auto"
+        normalized = str(language).strip().replace("_", "-").lower()
+        if not normalized:
+            return "auto"
+        return QWEN3_LANGUAGE_ALIASES.get(normalized, normalized)
 
     def _infer_model_type_from_name(self) -> str:
         name = (self.model_name or "").lower()

--- a/tests/test_qwen3_tts_handler_backend.py
+++ b/tests/test_qwen3_tts_handler_backend.py
@@ -152,6 +152,37 @@ def test_setup_defaults_to_custom_voice_profile_off_darwin(monkeypatch):
     assert handler.non_streaming_mode is True
 
 
+@pytest.mark.parametrize(
+    ("language", "expected"),
+    [
+        ("zh", "chinese"),
+        ("zh-CN", "chinese"),
+        ("zh_Hans", "chinese"),
+        ("Chinese", "chinese"),
+        ("en-US", "english"),
+        ("English", "english"),
+        ("Auto", "auto"),
+        ("", "auto"),
+    ],
+)
+def test_setup_normalizes_qwen3_language_aliases(monkeypatch, language, expected):
+    def _setup_mlx(self, *args, **kwargs):
+        raise AssertionError("Non-Darwin setup should not use the mlx backend")
+
+    def _setup_faster(self, model_name, dtype, attn_implementation):
+        return None
+
+    monkeypatch.setattr(qwen3_tts_module, "platform", "linux")
+    monkeypatch.setattr(Qwen3TTSHandler, "_setup_mlx", _setup_mlx)
+    monkeypatch.setattr(Qwen3TTSHandler, "_setup_faster", _setup_faster)
+    monkeypatch.setattr(Qwen3TTSHandler, "warmup", lambda self: None)
+
+    handler = object.__new__(Qwen3TTSHandler)
+    handler.setup(Event(), language=language)
+
+    assert handler.language == expected
+
+
 def test_setup_preserves_explicit_chunk_size_on_darwin(monkeypatch):
     def _setup_mlx(self, model_name):
         return None


### PR DESCRIPTION
## Summary

Hi, and thank you for the great work on `speech-to-speech`.

This PR adds a small language-normalization layer to the Qwen3-TTS handler. It accepts common language-code aliases such as `zh`, `zh-CN`, `en-US`, and `ja`, and maps them to the language names expected by the Qwen3-TTS backend, such as `chinese`, `english`, and `japanese`.

## Motivation

Qwen3-TTS validates requested languages against the model-supported language names. In practice, users often configure STT/LLM/TTS pipelines with BCP-47 or ISO-style language codes, e.g. `zh` for Chinese. Passing that directly to Qwen3-TTS can fail at synthesis time with an unsupported-language error, even though the intended target language is supported.

Normalizing these aliases in the handler makes the CLI more forgiving without changing the public option name or bypassing backend validation for genuinely unsupported values.

## Changes

- Add `QWEN3_LANGUAGE_ALIASES` for common aliases across the Qwen3-TTS supported languages.
- Normalize `language` during `Qwen3TTSHandler.setup()`.
- Treat `None` and empty strings as `auto`.
- Add tests for Chinese, English, and `auto` aliases.

## Validation

Ran locally:

```bash
PYTHONPATH=src python3 -m pytest tests/test_qwen3_tts_handler_backend.py -q
```

Result:

```text
43 passed, 1 warning
```

The warning was an unrelated local environment warning about `asyncio_mode` without `pytest-asyncio` installed.
