### PR TITLE
[codex] Fix TTS benchmark input message

### DIFF
--- a/scripts/benchmark_tts.py
+++ b/scripts/benchmark_tts.py
@@ -19,6 +19,8 @@ from typing import Any, Dict, List, Optional
 
 import numpy as np
 
+from speech_to_speech.pipeline.messages import TTSInput
+
 logging.basicConfig(
     level=logging.INFO,
     format="%(asctime)s - %(name)s - %(levelname)s - %(message)s",
@@ -86,7 +88,13 @@ class BenchmarkResult:
         return stats
 
 
-def benchmark_handler(handler_name: str, text: str, iterations: int, handler_kwargs: Optional[Dict[str, Any]] = None) -> BenchmarkResult:
+def benchmark_handler(
+    handler_name: str,
+    text: str,
+    iterations: int,
+    handler_kwargs: Optional[Dict[str, Any]] = None,
+    language_code: Optional[str] = "en",
+) -> BenchmarkResult:
     logger.info(f"Benchmarking {handler_name}...")
     result = BenchmarkResult(handler_name)
 
@@ -169,7 +177,8 @@ def benchmark_handler(handler_name: str, text: str, iterations: int, handler_kwa
             first_output = True
             total_samples = 0
 
-            for chunk in handler.process(text):
+            tts_input = TTSInput(text=text, language_code=language_code)
+            for chunk in handler.process(tts_input):
                 if first_output:
                     time_to_first_chunk = time.perf_counter() - start_time
                     first_output = False
@@ -337,6 +346,12 @@ def main():
         help="Output JSON file for results (default: tts_benchmark_results.json)",
     )
     parser.add_argument(
+        "--language_code",
+        type=str,
+        default="en",
+        help="Language code to pass to TTS handlers (default: en)",
+    )
+    parser.add_argument(
         "--qwen3_mlx_quantizations",
         nargs="+",
         default=None,
@@ -365,6 +380,7 @@ def main():
             args.text,
             args.iterations,
             handler_kwargs=handler_kwargs,
+            language_code=args.language_code,
         )
         result.handler_name = result_name
         results.append(result)


### PR DESCRIPTION
## Summary

- Pass `TTSInput` messages to TTS handlers in `scripts/benchmark_tts.py` instead of raw strings.
- Add a `--language_code` benchmark option, defaulting to `en`, so handlers receive the language metadata they expect.

## Why

The benchmark script was calling `handler.process(text)`, but current TTS handlers consume pipeline message objects and access fields such as `runtime_config`, `language_code`, and `text`. This caused Kokoro and Pocket TTS benchmarks to fail before generating metrics.

Fixes #302.

## Validation

- `uv run ruff check scripts/benchmark_tts.py`

I did not run the real TTS benchmark because it depends on local model/backend setup.