### PR TITLE
Fix tool-only realtime response completion

### DIFF
--- a/src/speech_to_speech/api/openai_realtime/websocket_router.py
+++ b/src/speech_to_speech/api/openai_realtime/websocket_router.py
@@ -113,31 +113,50 @@ def _flush_queue(q: Queue[QItem], *, preserve: Callable[[QItem], bool] | None = 
             q.not_empty.notify(len(preserved))
 
 
-def _drain_pending_token_usage(unit: PipelineUnit, session_id: str | None) -> None:
+async def _drain_pending_response_events(
+    ws: WebSocket | None,
+    unit: PipelineUnit,
+    session_id: str | None,
+) -> None:
     if session_id is None:
         return
 
     preserved: list[Any] = []
-    drained = 0
-    while True:
-        try:
-            item = unit.text_output_queue.get_nowait()
-        except Empty:
-            break
-        if isinstance(item, TokenUsageEvent):
-            unit.service.dispatch_pipeline_event(session_id, item)
-            drained += 1
-        else:
-            preserved.append(item)
+    drained_assistant = 0
+    drained_usage = 0
+    try:
+        while True:
+            try:
+                item = unit.text_output_queue.get_nowait()
+            except Empty:
+                break
+            if isinstance(item, TokenUsageEvent):
+                unit.service.dispatch_pipeline_event(session_id, item)
+                drained_usage += 1
+            elif isinstance(item, AssistantTextEvent):
+                drained_assistant += 1
+                if unit.cancel_scope.discarding:
+                    continue
+                events = unit.service.dispatch_pipeline_event(session_id, item)
+                if ws is not None and events:
+                    await _send_events(ws, events)
+            else:
+                preserved.append(item)
+                break
+    finally:
+        if preserved:
+            with unit.text_output_queue.mutex:
+                for item in reversed(preserved):
+                    unit.text_output_queue.queue.appendleft(item)
+                unit.text_output_queue.not_empty.notify(len(preserved))
 
-    if preserved:
-        with unit.text_output_queue.mutex:
-            for item in reversed(preserved):
-                unit.text_output_queue.queue.appendleft(item)
-            unit.text_output_queue.not_empty.notify(len(preserved))
-
-    if drained:
-        logger.debug("Pipeline %d: drained %d token usage event(s) before response completion", unit.index, drained)
+    if drained_assistant or drained_usage:
+        logger.debug(
+            "Pipeline %d: drained %d assistant event(s) and %d token usage event(s) before response completion",
+            unit.index,
+            drained_assistant,
+            drained_usage,
+        )
 
 
 def _clean_unit(unit: PipelineUnit, preserve: Callable[[Any], bool] | None = None) -> None:
@@ -478,6 +497,7 @@ def create_app(pool: list[PipelineUnit], stop_event: ThreadingEvent) -> FastAPI:
                         audio_chunk = unit.output_queue.get_nowait()
 
                     if _is_pipeline_end(audio_chunk):
+                        await _drain_pending_response_events(ws, unit, session_id)
                         if ws is not None and session_id:
                             await _send_events(ws, unit.service.finish_audio_response(session_id))
                         break
@@ -491,7 +511,7 @@ def create_app(pool: list[PipelineUnit], stop_event: ThreadingEvent) -> FastAPI:
                             unit.should_listen.set()
                             logger.info(f"Pipeline {unit.index}: stale response complete, listening re-enabled")
                             continue
-                        _drain_pending_token_usage(unit, session_id)
+                        await _drain_pending_response_events(ws, unit, session_id)
                         if ws is not None and session_id:
                             await _send_events(ws, unit.service.finish_audio_response(session_id))
                         if session_id:

--- a/src/speech_to_speech/api/openai_realtime/websocket_router.py
+++ b/src/speech_to_speech/api/openai_realtime/websocket_router.py
@@ -124,16 +124,20 @@ async def _drain_pending_response_events(
     preserved: list[Any] = []
     drained_assistant = 0
     drained_usage = 0
+    drain_assistant_events = True
     try:
         while True:
             try:
                 item = unit.text_output_queue.get_nowait()
             except Empty:
                 break
+            # Usage is accounting-only, so keep the old whole-queue drain behavior.
+            # Assistant events are client-visible response output and stop at the
+            # first non-response boundary to preserve normal text-event ordering.
             if isinstance(item, TokenUsageEvent):
                 unit.service.dispatch_pipeline_event(session_id, item)
                 drained_usage += 1
-            elif isinstance(item, AssistantTextEvent):
+            elif drain_assistant_events and isinstance(item, AssistantTextEvent):
                 drained_assistant += 1
                 if unit.cancel_scope.discarding:
                     continue
@@ -142,7 +146,7 @@ async def _drain_pending_response_events(
                     await _send_events(ws, events)
             else:
                 preserved.append(item)
-                break
+                drain_assistant_events = False
     finally:
         if preserved:
             with unit.text_output_queue.mutex:

--- a/tests/openai_realtime/test_websocket_router.py
+++ b/tests/openai_realtime/test_websocket_router.py
@@ -6,6 +6,7 @@ PipelineUnit pool (size 1, matching the single-session semantics of the
 old tests) so there is no cross-test state.
 """
 
+import asyncio
 import base64
 import time
 from queue import Empty, Queue
@@ -13,6 +14,7 @@ from threading import Event as ThreadingEvent
 
 import pytest
 from starlette.testclient import TestClient
+from starlette.websockets import WebSocketState
 
 import speech_to_speech.api.openai_realtime.websocket_router as router_module
 from speech_to_speech.api.openai_realtime.pipeline_unit import PipelineUnit
@@ -109,6 +111,16 @@ def _simulate_session_end_drain(input_queue: Queue, output_queue: Queue, timeout
 
 def _pcm_bytes(n_samples: int) -> bytes:
     return b"\x00" * (n_samples * 2)
+
+
+class _FakeWebSocket:
+    application_state = WebSocketState.CONNECTED
+
+    def __init__(self):
+        self.sent: list[dict] = []
+
+    async def send_json(self, payload: dict) -> None:
+        self.sent.append(payload)
 
 
 # ===================================================================
@@ -492,6 +504,95 @@ class TestSendLoop:
                 assert service.total_usage.output_tokens == 5
                 assert service._state(conn_id).response_usage.input_tokens == 0
                 assert service._state(conn_id).response_usage.output_tokens == 0
+
+    def test_response_completion_drain_sends_pending_tool_before_done(self, setup):
+        _, service, input_queue, output_queue, text_output_queue, should_listen, _, response_playing, cancel_scope = (
+            setup
+        )
+        unit = PipelineUnit(
+            index=0,
+            service=service,
+            cancel_scope=cancel_scope,
+            should_listen=should_listen,
+            response_playing=response_playing,
+            input_queue=input_queue,
+            output_queue=output_queue,
+            text_output_queue=text_output_queue,
+            text_prompt_queue=Queue(),
+            handlers=[],
+        )
+        conn_id = service.register()
+        response_id, _ = service.response._ensure_response(conn_id)
+        text_output_queue.put(
+            AssistantTextEvent(
+                text="",
+                tools=[
+                    {
+                        "type": "function_call",
+                        "call_id": "c1",
+                        "name": "play_emotion",
+                        "arguments": '{"emotion":"loving"}',
+                    }
+                ],
+            )
+        )
+        text_output_queue.put(TokenUsageEvent(input_tokens=10, output_tokens=5))
+        ws = _FakeWebSocket()
+
+        asyncio.run(router_module._drain_pending_response_events(ws, unit, conn_id))
+        done_events = service.finish_audio_response(conn_id)
+
+        assert [payload["type"] for payload in ws.sent] == ["response.function_call_arguments.done"]
+        assert [event.type for event in done_events] == ["response.output_audio.done", "response.done"]
+        assert ws.sent[0]["response_id"] == response_id
+        assert done_events[1].response.id == response_id
+        assert done_events[1].response.usage.input_tokens == 10
+        assert done_events[1].response.usage.output_tokens == 5
+        assert text_output_queue.empty()
+
+    def test_response_completion_drain_stops_at_non_response_boundary(self, setup):
+        _, service, input_queue, output_queue, text_output_queue, should_listen, _, response_playing, cancel_scope = (
+            setup
+        )
+        unit = PipelineUnit(
+            index=0,
+            service=service,
+            cancel_scope=cancel_scope,
+            should_listen=should_listen,
+            response_playing=response_playing,
+            input_queue=input_queue,
+            output_queue=output_queue,
+            text_output_queue=text_output_queue,
+            text_prompt_queue=Queue(),
+            handlers=[],
+        )
+        conn_id = service.register()
+        response_id, _ = service.response._ensure_response(conn_id)
+        text_output_queue.put(
+            AssistantTextEvent(
+                text="",
+                tools=[{"type": "function_call", "call_id": "c1", "name": "play_emotion", "arguments": "{}"}],
+            )
+        )
+        text_output_queue.put(SpeechStartedEvent())
+        text_output_queue.put(TokenUsageEvent(input_tokens=10, output_tokens=5))
+        ws = _FakeWebSocket()
+
+        asyncio.run(router_module._drain_pending_response_events(ws, unit, conn_id))
+        done_events = service.finish_audio_response(conn_id)
+
+        assert [payload["type"] for payload in ws.sent] == ["response.function_call_arguments.done"]
+        assert ws.sent[0]["response_id"] == response_id
+        assert done_events[1].response.usage.input_tokens == 0
+        assert done_events[1].response.usage.output_tokens == 0
+
+        boundary = text_output_queue.get_nowait()
+        usage = text_output_queue.get_nowait()
+        assert isinstance(boundary, SpeechStartedEvent)
+        assert isinstance(usage, TokenUsageEvent)
+        assert usage.input_tokens == 10
+        assert usage.output_tokens == 5
+        assert text_output_queue.empty()
 
     def test_speech_started_does_not_cancel_when_interrupt_disabled(self, setup):
         """With interrupt_response=False, speech during playback should NOT cancel or flush."""

--- a/tests/openai_realtime/test_websocket_router.py
+++ b/tests/openai_realtime/test_websocket_router.py
@@ -550,7 +550,7 @@ class TestSendLoop:
         assert done_events[1].response.usage.output_tokens == 5
         assert text_output_queue.empty()
 
-    def test_response_completion_drain_stops_at_non_response_boundary(self, setup):
+    def test_response_completion_drain_preserves_usage_across_non_response_boundary(self, setup):
         _, service, input_queue, output_queue, text_output_queue, should_listen, _, response_playing, cancel_scope = (
             setup
         )
@@ -576,6 +576,7 @@ class TestSendLoop:
         )
         text_output_queue.put(SpeechStartedEvent())
         text_output_queue.put(TokenUsageEvent(input_tokens=10, output_tokens=5))
+        text_output_queue.put(AssistantTextEvent(text="queued after boundary"))
         ws = _FakeWebSocket()
 
         asyncio.run(router_module._drain_pending_response_events(ws, unit, conn_id))
@@ -583,15 +584,14 @@ class TestSendLoop:
 
         assert [payload["type"] for payload in ws.sent] == ["response.function_call_arguments.done"]
         assert ws.sent[0]["response_id"] == response_id
-        assert done_events[1].response.usage.input_tokens == 0
-        assert done_events[1].response.usage.output_tokens == 0
+        assert done_events[1].response.usage.input_tokens == 10
+        assert done_events[1].response.usage.output_tokens == 5
 
         boundary = text_output_queue.get_nowait()
-        usage = text_output_queue.get_nowait()
+        queued_assistant = text_output_queue.get_nowait()
         assert isinstance(boundary, SpeechStartedEvent)
-        assert isinstance(usage, TokenUsageEvent)
-        assert usage.input_tokens == 10
-        assert usage.output_tokens == 5
+        assert isinstance(queued_assistant, AssistantTextEvent)
+        assert queued_assistant.text == "queued after boundary"
         assert text_output_queue.empty()
 
     def test_speech_started_does_not_cancel_when_interrupt_disabled(self, setup):


### PR DESCRIPTION
## Summary

Fixes #304.

This changes the OpenAI-compatible realtime websocket send loop so pending response-scoped side-channel events are dispatched before `response.done` is emitted. In particular, tool-only LLM responses now send queued `response.function_call_arguments.done` events before the response is closed, instead of leaving the tool event behind or emitting it after completion under a new response id.

## Root Cause

`LMOutputProcessor` sends assistant text/tool metadata through `text_output_queue`, while response completion is driven by the TTS/audio output queue. The completion path only drained token usage events before calling `finish_audio_response()`, preserving pending `AssistantTextEvent`s. For tool-only responses, that could allow `response.done` to reach the client before the function-call event.

## Changes

- Replace the token-only completion drain with a response-event drain that dispatches pending `AssistantTextEvent`s and `TokenUsageEvent`s before `response.done`.
- Apply the same response-event drain on the `PIPELINE_END` completion path before calling `finish_audio_response()`.
- Stop dispatching assistant/tool events at the first non-response text event and put that boundary item back on the queue, leaving subsequent visible events for the regular send-loop path.
- Continue scanning for `TokenUsageEvent`s across that boundary so usage attribution stays with the response being closed, matching the old token-only drain semantics.
- Restore preserved boundary events in a `finally` so an interrupted drain does not silently drop them.
- Add regression coverage asserting a pending tool call is emitted before response completion with the same response id and usage included.
- Add coverage for boundary semantics: assistant events behind a non-response text event stay queued, while token usage behind that boundary is still folded into the closing response.

## Behavior Note

Token usage is accounting-only, so the completion drain preserves the previous behavior of collecting pending `TokenUsageEvent`s wherever they sit in the text queue. Client-visible assistant/tool events are different: they are drained only until the first non-response text event, so speech/transcription boundaries still preserve normal text-event ordering.

## Validation

```text
uv run ruff check src/ tests/
All checks passed!

uv run ruff format --check src/ tests/
111 files already formatted

PYTHONPATH=src pytest tests/openai_realtime/test_websocket_router.py -q
32 passed, 1 warning
```