### PR TITLE
Add realtime session warmup greeting

### DIFF
--- a/README.md
+++ b/README.md
@@ -224,7 +224,7 @@ with client.beta.realtime.connect(model="model_name") as conn:
 | Event | Description |
 |---|---|
 | `input_audio_buffer.append` | Stream base64 PCM audio. Decoded, resampled to 16 kHz, and chunked for the VAD. |
-| `session.update` | Deep-merge session config (instructions, tools, voice, turn detection, audio format). |
+| `session.update` | Deep-merge session config (instructions, tools, voice, turn detection, audio format). Initial instructions trigger a one-time greeting/warmup response. |
 | `conversation.item.create` | Inject `input_text` or `function_call_output` into the LLM context without triggering generation. |
 | `response.create` | Trigger LLM generation. Supports per-response `instructions` and `tool_choice` overrides. |
 | `response.cancel` | Cancel the in-progress response and re-enable listening. |

--- a/src/speech_to_speech/LLM/language_model.py
+++ b/src/speech_to_speech/LLM/language_model.py
@@ -461,6 +461,8 @@ class BaseLanguageModelHandler(BaseHandler[LLMIn, LLMOut], ABC):
         tools = response.tools if response and response.tools else runtime_config.session.tools
         tool_choice = response.tool_choice if response and response.tool_choice else runtime_config.session.tool_choice
         self._apply_instructions(active_chat, instructions, tools, str(tool_choice) if tool_choice else None, ctx)
+        if request.ephemeral_user_prompt:
+            active_chat.add_item(make_user_message(request.ephemeral_user_prompt))
         language_code, lang_name = resolve_auto_language(language_code)
         if lang_name and self.enable_lang_prompt:
             active_chat.add_item(make_user_message(f"Please reply to my message in {lang_name}."))

--- a/src/speech_to_speech/LLM/responses_api_language_model.py
+++ b/src/speech_to_speech/LLM/responses_api_language_model.py
@@ -407,6 +407,8 @@ class ResponsesApiModelHandler(BaseHandler[LLMIn, LLMOut]):
             response.tool_choice if response and response.tool_choice else runtime_config.session.tool_choice
         )
         self._apply_config(active_chat, instructions)
+        if request.ephemeral_user_prompt:
+            active_chat.add_item(make_user_message(request.ephemeral_user_prompt))
         language_code, lang_name = resolve_auto_language(language_code)
         if lang_name and self.enable_lang_prompt:
             active_chat.add_item(make_user_message(f"Please reply to my message in {lang_name}."))

--- a/src/speech_to_speech/api/openai_realtime/README.md
+++ b/src/speech_to_speech/api/openai_realtime/README.md
@@ -47,7 +47,7 @@ flowchart LR
 3. **Transcription**: STT output passes through `TranscriptionNotifier`, which taps the transcript for `transcription.delta` / `transcription.completed` events before forwarding to the LLM.
 4. **Generation**: The LLM generates text (and optional tool calls). `LMOutputProcessor` splits the output: clean text goes to TTS, and `assistant_text` + tool call dicts go to the `text_output_queue`.
 5. **Outbound audio**: TTS writes PCM chunks to `send_audio_chunks_queue`. The router's async `_send_loop` drains both queues, encoding PCM as `response.output_audio.delta` events and translating internal messages into protocol events.
-6. **Session config**: `session.update` events deep-merge into `RuntimeConfig`, which is a shared Pydantic model read by VAD (turn detection thresholds), LLM (instructions, tools), and TTS (voice) at processing time.
+6. **Session config**: `session.update` events deep-merge into `RuntimeConfig`, which is a shared Pydantic model read by VAD (turn detection thresholds), LLM (instructions, tools), and TTS (voice) at processing time. The first update that supplies instructions also starts a one-time greeting/warmup response.
 
 ---
 
@@ -58,7 +58,7 @@ flowchart LR
 | Event | Description |
 |---|---|
 | `input_audio_buffer.append` | Stream base64 PCM audio. Decoded, resampled to 16 kHz, and chunked for the VAD. |
-| `session.update` | Deep-merge session config (instructions, tools, voice, turn detection, audio format). |
+| `session.update` | Deep-merge session config (instructions, tools, voice, turn detection, audio format). Initial instructions trigger a one-time greeting/warmup response. |
 | `conversation.item.create` | Inject `input_text` or `function_call_output` into the LLM context without triggering generation. |
 | `response.create` | Trigger LLM generation. Supports per-response `instructions` and `tool_choice` overrides. |
 | `response.cancel` | Cancel the in-progress response and re-enable listening. |

--- a/src/speech_to_speech/api/openai_realtime/handlers/response.py
+++ b/src/speech_to_speech/api/openai_realtime/handlers/response.py
@@ -128,7 +128,13 @@ class ResponseHandler(RealtimeBaseHandler):
 
     # ── Public handlers ───────────────────────────
 
-    def handle_response_create(self, conn_id: str, event: ResponseCreateEvent) -> ServerEvent | None:
+    def handle_response_create(
+        self,
+        conn_id: str,
+        event: ResponseCreateEvent,
+        *,
+        ephemeral_user_prompt: str | None = None,
+    ) -> ServerEvent | None:
         """Trigger a response.
 
         Returns a ``ResponseCreatedEvent`` on success, a ``RealtimeErrorEvent``
@@ -168,6 +174,7 @@ class ResponseHandler(RealtimeBaseHandler):
                 GenerateResponseRequest(
                     runtime_config=cfg,
                     response=event.response,
+                    ephemeral_user_prompt=ephemeral_user_prompt,
                     turn_id=st.speculative_user_turn_id,
                     turn_revision=st.speculative_user_turn_revision,
                     speech_stopped_at_s=st.speculative_user_speech_stopped_at_s,

--- a/src/speech_to_speech/api/openai_realtime/service.py
+++ b/src/speech_to_speech/api/openai_realtime/service.py
@@ -56,6 +56,11 @@ PIPELINE_SAMPLE_RATE = 16000
 CHUNK_SAMPLES = 512
 BYTES_PER_SAMPLE = 2
 CHUNK_SIZE_BYTES = CHUNK_SAMPLES * BYTES_PER_SAMPLE
+SESSION_WARMUP_PROMPT = (
+    "The local user has just joined this realtime voice session. "
+    "If your instructions ask you to introduce yourself, do that now. "
+    "Otherwise greet them briefly."
+)
 
 _ResponseStatus = Literal["completed", "cancelled", "failed", "incomplete", "in_progress"]
 _StatusReason = Literal["turn_detected", "client_cancelled", "max_output_tokens", "content_filter"]
@@ -168,6 +173,7 @@ class ConnState(BaseModel):
     speculative_user_item_id: Optional[str] = None
     speculative_input_item_id: Optional[str] = None
     speculative_audio_duration_s: float = 0.0
+    session_warmup_started: bool = False
 
 
 class RealtimeService:
@@ -268,6 +274,32 @@ class RealtimeService:
 
     def handle_session_update(self, conn_id: str, event: SessionUpdateEvent) -> Optional[RealtimeErrorEvent]:
         return self.session.handle_session_update(conn_id, event)
+
+    def maybe_start_session_warmup(self, conn_id: str, event: SessionUpdateEvent) -> ServerEvent | None:
+        """Start one prompt-aware greeting response after initial instructions arrive."""
+        st = self._state(conn_id)
+        session = event.session
+        fields_set = getattr(session, "model_fields_set", set()) if session is not None else set()
+        instructions = getattr(session, "instructions", None) if session is not None else None
+        if (
+            st.session_warmup_started
+            or st.in_response
+            or st.response_pending
+            or self.text_prompt_queue is None
+            or "instructions" not in fields_set
+            or not instructions
+            or st.last_item_id is not None
+        ):
+            return None
+
+        result = self.response.handle_response_create(
+            conn_id,
+            ResponseCreateEvent(type="response.create"),
+            ephemeral_user_prompt=SESSION_WARMUP_PROMPT,
+        )
+        if result is not None and result.type != "error":
+            st.session_warmup_started = True
+        return result
 
     def handle_audio_append(self, conn_id: str, event: InputAudioBufferAppendEvent) -> list[bytes]:
         return self.audio.handle_audio_append(conn_id, event)

--- a/src/speech_to_speech/api/openai_realtime/websocket_router.py
+++ b/src/speech_to_speech/api/openai_realtime/websocket_router.py
@@ -341,6 +341,12 @@ def create_app(pool: list[PipelineUnit], stop_event: ThreadingEvent) -> FastAPI:
                     err = unit.service.handle_session_update(session_id, event)
                     if err:
                         await _send_event(ws, err)
+                    else:
+                        result = unit.service.maybe_start_session_warmup(session_id, event)
+                        if result:
+                            if result.type != "error":
+                                unit.cancel_scope.new_response()
+                            await _send_event(ws, result)
 
                 elif isinstance(event, ConversationItemCreateEvent):
                     events = unit.service.handle_conversation_item_create(session_id, event)

--- a/src/speech_to_speech/pipeline/messages.py
+++ b/src/speech_to_speech/pipeline/messages.py
@@ -144,11 +144,16 @@ class GenerateResponseRequest(PipelineMessage):
     ``response`` carries per-response overrides from ``response.create``.
     Downstream handlers resolve each attribute by preferring the
     per-response value over the session default.
+
+    ``ephemeral_user_prompt`` is appended only to the per-request chat copy.
+    It lets the realtime layer trigger a join/greeting response without
+    storing a synthetic user message in conversation history.
     """
 
     tag: Literal["generate_response"] = "generate_response"
     runtime_config: RuntimeConfig
     response: RealtimeResponseCreateParams | None = None
+    ephemeral_user_prompt: str | None = None
     language_code: Optional[str] = None
     turn_id: str | None = None
     turn_revision: int | None = None

--- a/tests/openai_realtime/test_realtime_service.py
+++ b/tests/openai_realtime/test_realtime_service.py
@@ -34,6 +34,7 @@ from openai.types.realtime import (
 
 from speech_to_speech.api.openai_realtime.service import (
     CHUNK_SIZE_BYTES,
+    SESSION_WARMUP_PROMPT,
     RealtimeService,
 )
 from speech_to_speech.pipeline.events import (
@@ -256,6 +257,36 @@ class TestHandleSessionUpdate:
         service.handle_session_update(conn_id, self._make_update(instructions="Be concise"))
         assert runtime_config.session.instructions == "Be concise"
         assert runtime_config.session.audio.output.voice == "echo"  # preserved from first update
+
+    def test_session_update_with_instructions_starts_warmup_once(
+        self,
+        service,
+        conn_id,
+        runtime_config,
+        text_prompt_queue,
+    ):
+        evt = self._make_update(instructions="Introduce yourself as Rover.")
+
+        assert service.handle_session_update(conn_id, evt) is None
+        result = service.maybe_start_session_warmup(conn_id, evt)
+
+        assert isinstance(result, ResponseCreatedEvent)
+        req = text_prompt_queue.get(timeout=1)
+        assert isinstance(req, GenerateResponseRequest)
+        assert req.runtime_config is runtime_config
+        assert req.ephemeral_user_prompt == SESSION_WARMUP_PROMPT
+        assert service._state(conn_id).session_warmup_started is True
+
+        assert service.maybe_start_session_warmup(conn_id, evt) is None
+        assert text_prompt_queue.empty()
+
+    def test_session_update_without_instructions_does_not_warmup(self, service, conn_id, text_prompt_queue):
+        evt = self._make_update(audio={"output": {"voice": "shimmer"}})
+
+        assert service.handle_session_update(conn_id, evt) is None
+
+        assert service.maybe_start_session_warmup(conn_id, evt) is None
+        assert text_prompt_queue.empty()
 
 
 # ===================================================================

--- a/tests/openai_realtime/test_websocket_router.py
+++ b/tests/openai_realtime/test_websocket_router.py
@@ -18,12 +18,12 @@ from starlette.websockets import WebSocketState
 
 import speech_to_speech.api.openai_realtime.websocket_router as router_module
 from speech_to_speech.api.openai_realtime.pipeline_unit import PipelineUnit
-from speech_to_speech.api.openai_realtime.service import CHUNK_SIZE_BYTES, RealtimeService
+from speech_to_speech.api.openai_realtime.service import CHUNK_SIZE_BYTES, SESSION_WARMUP_PROMPT, RealtimeService
 from speech_to_speech.api.openai_realtime.websocket_router import create_app
 from speech_to_speech.pipeline.cancel_scope import CancelScope
 from speech_to_speech.pipeline.control import SESSION_END, PipelineControlMessage, is_control_message
 from speech_to_speech.pipeline.events import AssistantTextEvent, SpeechStartedEvent, TokenUsageEvent
-from speech_to_speech.pipeline.messages import AUDIO_RESPONSE_DONE, PIPELINE_END, AudioOutput
+from speech_to_speech.pipeline.messages import AUDIO_RESPONSE_DONE, PIPELINE_END, AudioOutput, GenerateResponseRequest
 
 # ---------------------------------------------------------------------------
 # Fixtures
@@ -193,6 +193,30 @@ class TestClientEventDispatch:
                 time.sleep(0.1)
                 cid = service.connection_ids[0]
                 assert service._state(cid).runtime_config.session.audio.output.voice == "coral"
+
+    def test_session_update_with_instructions_starts_initial_response(self, setup):
+        app, service, *_ = setup
+        with TestClient(app) as client:
+            with client.websocket_connect("/v1/realtime") as ws:
+                ws.receive_json()
+                ws.send_json(
+                    {
+                        "type": "session.update",
+                        "session": {
+                            "type": "realtime",
+                            "instructions": "Introduce yourself as Rover.",
+                        },
+                    }
+                )
+
+                msg = ws.receive_json()
+                assert msg["type"] == "response.created"
+                assert msg["response"]["status"] == "in_progress"
+
+                req = service.text_prompt_queue.get(timeout=1)
+                assert isinstance(req, GenerateResponseRequest)
+                assert req.ephemeral_user_prompt == SESSION_WARMUP_PROMPT
+                assert req.runtime_config.session.instructions == "Introduce yourself as Rover."
 
     def test_conversation_item_create_returns_events(self, setup):
         app, *_ = setup

--- a/tests/test_responses_api_language_model.py
+++ b/tests/test_responses_api_language_model.py
@@ -200,6 +200,33 @@ def test_no_disable_thinking_omits_extra_body():
     assert captured.get("extra_body") is None
 
 
+def test_ephemeral_user_prompt_is_sent_without_persisting_user_message():
+    handler = _make_handler(stream=False)
+    captured = {}
+    cfg = _make_runtime_config()
+
+    def fake_create(**kwargs):
+        captured.update(kwargs)
+        return _make_response(output=[])
+
+    handler.client = SimpleNamespace(responses=SimpleNamespace(create=fake_create))
+
+    outputs = list(
+        handler.process(
+            GenerateResponseRequest(
+                runtime_config=cfg,
+                ephemeral_user_prompt="The user just joined. Greet them briefly.",
+            )
+        )
+    )
+
+    assert isinstance(outputs[-1], EndOfResponse)
+    user_items = [item for item in captured["input"] if item.get("role") == "user"]
+    assert len(user_items) == 1
+    assert user_items[0]["content"][0]["text"] == "The user just joined. Greet them briefly."
+    assert cfg.chat.buffer == []
+
+
 def test_second_turn_flattens_assistant_history_for_responses():
     handler = _make_handler(stream=False)
     captured = {}


### PR DESCRIPTION
## Summary

Adds a one-time realtime session warmup response when the initial `session.update` supplies instructions.

The warmup uses the updated system prompt plus an ephemeral join prompt, so the assistant can greet or introduce itself without storing a synthetic user message in conversation history. This also exercises the configured LLM path before the user's first spoken turn, reducing first-response latency.

## Impact

- Initial realtime instructions can now produce a greeting/introduction immediately.
- The behavior applies to both local LLM and Responses API backends.
- Existing explicit `response.create` and audio/STT-triggered response flows remain unchanged.
- Docs now mention the one-time greeting/warmup behavior.

## Validation

- `.venv/bin/ruff check src/speech_to_speech/api/openai_realtime/service.py src/speech_to_speech/api/openai_realtime/websocket_router.py src/speech_to_speech/api/openai_realtime/handlers/response.py src/speech_to_speech/LLM/responses_api_language_model.py src/speech_to_speech/LLM/language_model.py src/speech_to_speech/pipeline/messages.py tests/openai_realtime/test_realtime_service.py tests/openai_realtime/test_websocket_router.py tests/test_responses_api_language_model.py`
- `.venv/bin/pytest tests/openai_realtime tests/test_responses_api_language_model.py tests/test_lm_output_processor.py tests/test_transcription_notifier.py`
- `.venv/bin/python -m compileall -q src/speech_to_speech/api/openai_realtime src/speech_to_speech/LLM src/speech_to_speech/pipeline/messages.py`
