### PR TITLE
Prepare 0.2.10 release

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,26 @@
+# Repository Instructions
+
+- Never include `codex` in branch names or pull request titles.
+- Keep release pull requests focused on version metadata and release documentation.
+- Do not commit local build artifacts such as `dist/`, `build/`, or generated wheel/sdist files.
+
+## Publishing to PyPI
+
+PyPI publishing is handled by GitHub Actions in `.github/workflows/publish.yml`. The workflow runs on pushed tags that match `v*`, builds the package with `uv build`, checks the artifacts with `twine check --strict`, and publishes through the configured `pypi` environment.
+
+To prepare a release:
+
+1. Confirm the intended version is not already published on PyPI.
+2. Bump `version` in `pyproject.toml`.
+3. Bump `__version__` in `src/speech_to_speech/__init__.py`.
+4. Open and merge a pull request with only the release preparation changes.
+
+To publish after the release PR is merged:
+
+1. Update `main` locally: `git checkout main && git pull origin main`.
+2. Create an annotated tag for the version: `git tag -a vX.Y.Z -m "Release vX.Y.Z"`.
+3. Push the tag: `git push origin vX.Y.Z`.
+4. Watch the `Publish` GitHub Actions workflow complete successfully.
+5. Verify the new version appears at `https://pypi.org/project/speech-to-speech/`.
+
+Only upload manually if the GitHub Actions workflow is unavailable and the maintainers have explicitly chosen that fallback.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "speech-to-speech"
-version = "0.2.9"
+version = "0.2.10"
 description = "Low-latency speech-to-speech pipeline"
 readme = "README.md"
 requires-python = ">=3.10"

--- a/src/speech_to_speech/__init__.py
+++ b/src/speech_to_speech/__init__.py
@@ -1,3 +1,3 @@
 """speech-to-speech: low-latency speech-to-speech pipeline."""
 
-__version__ = "0.2.9"
+__version__ = "0.2.10"


### PR DESCRIPTION
## Summary

- Bump the package version from `0.2.9` to `0.2.10` in `pyproject.toml` and `speech_to_speech.__version__`.
- Add `AGENTS.md` with repository instructions and the tag-based PyPI publishing flow.

## Validation

- Confirmed PyPI currently reports `speech-to-speech` version `0.2.9` as latest.
- Ran a lightweight version consistency check for `pyproject.toml` and `src/speech_to_speech/__init__.py`.
- Ran `git diff --cached --check` before committing.

## Publishing notes

After this PR is merged, publish by creating and pushing an annotated `v0.2.10` tag from updated `main`. The existing `Publish` workflow builds the artifacts, checks them with Twine, and publishes to PyPI.