### PR TITLE
Support text-only and out-of-band (conversation=none) responses

### DIFF
--- a/src/speech_to_speech/LLM/chat.py
+++ b/src/speech_to_speech/LLM/chat.py
@@ -6,6 +6,7 @@ import threading
 from collections.abc import Callable
 from typing import Any, Literal, Union
 
+from openai.types.realtime import ConversationItem
 from openai.types.realtime.conversation_item import (
     RealtimeConversationItemAssistantMessage,
     RealtimeConversationItemFunctionCall,
@@ -18,6 +19,7 @@ from openai.types.realtime.realtime_conversation_item_assistant_message import (
 )
 from openai.types.realtime.realtime_conversation_item_system_message import Content as SystemContent
 from openai.types.realtime.realtime_conversation_item_user_message import Content as UserContent
+from openai.types.realtime.realtime_response_create_params import RealtimeResponseCreateParams
 from openai.types.responses.response_input_image_param import ResponseInputImageParam
 from openai.types.responses.response_input_message_content_list_param import (
     ResponseInputMessageContentListParam,
@@ -688,3 +690,54 @@ def make_system_message(text: str) -> RealtimeConversationItemSystemMessage:
         role="system",
         content=[SystemContent(type="input_text", text=text)],
     )
+
+
+def add_supported_item(chat: Chat, item: ConversationItem) -> None:
+    """Narrow a protocol ``ConversationItem`` to a :data:`SupportedItem` and add it to *chat*.
+
+    Raises :class:`ChatItemError` on validation failure or unsupported type. Shared
+    by the conversation handler (in-band item injection) and the language-model
+    handlers (seeding an out-of-band response's throwaway chat from ``response.input``).
+    """
+    # call_id on function_call items must be client-supplied: it is referenced later by
+    # function_call_output items, so we cannot silently generate one here.
+    if isinstance(item, RealtimeConversationItemFunctionCall) and (
+        item.call_id is None or not item.call_id.startswith("call_")
+    ):
+        raise ChatItemError("function_call item is missing a call_id. The call_id should start with 'call_'.")
+
+    if isinstance(
+        item,
+        (
+            RealtimeConversationItemSystemMessage,
+            RealtimeConversationItemUserMessage,
+            RealtimeConversationItemAssistantMessage,
+            RealtimeConversationItemFunctionCall,
+            RealtimeConversationItemFunctionCallOutput,
+        ),
+    ):
+        chat.add_item(item)
+        return
+
+    raise ChatItemError(f"Unsupported item type: {getattr(item, 'type', None)}")
+
+
+def build_active_chat(original_chat: Chat, response: RealtimeResponseCreateParams | None) -> Chat:
+    """Build the chat an *out-of-band* response generates against (caller ensures out-of-band).
+
+    Mirrors the OpenAI realtime semantics for ``input``:
+
+    - ``input is None`` -> a read-only **copy of the default conversation** (the
+      out-of-band response reads history but never commits back).
+    - ``input == []`` -> a **fresh, empty chat** (context cleared; only the
+      system prompt, added later by the handler, will be present).
+    - ``input == [...]`` -> a **fresh chat seeded** with those items.
+
+    Raises :class:`ChatItemError` if an ``input`` item fails validation.
+    """
+    if response is not None and response.input is not None:
+        fresh = Chat(original_chat.size)
+        for item in response.input:
+            add_supported_item(fresh, item)
+        return fresh
+    return original_chat.copy()

--- a/src/speech_to_speech/LLM/language_model.py
+++ b/src/speech_to_speech/LLM/language_model.py
@@ -521,55 +521,68 @@ class BaseLanguageModelHandler(BaseHandler[LLMIn, LLMOut], ABC):
         gen = self.cancel_scope.generation if self.cancel_scope else None
         ctx.cancel_generation = gen
 
-        yield from self._generate(active_chat, language_code, gen, ctx, runtime_config, response)
+        try:
+            yield from self._generate(active_chat, language_code, gen, ctx, runtime_config, response)
 
-        if ctx.stopped:
-            return
+            if ctx.stopped:
+                return
 
-        turn_output_allowed = not ctx.cancelled and self._turn_output_allowed(ctx.turn_id, ctx.turn_revision)
-        # Out-of-band responses still emit output, but never write back to the default
-        # conversation (their context was a throwaway chat).
-        commit_allowed = turn_output_allowed and not out_of_band
-        if commit_allowed:
-            original_chat.add_item(make_assistant_message(ctx.generated_text))
-        if commit_allowed and ctx.tools:
-            for t in ctx.tools:
-                original_chat.add_item(
-                    RealtimeConversationItemFunctionCall(
-                        type="function_call",
-                        id=t.id,
-                        call_id=t.call_id,
-                        name=t.name,
-                        arguments=t.arguments,
-                        status=t.status,
+            turn_output_allowed = not ctx.cancelled and self._turn_output_allowed(ctx.turn_id, ctx.turn_revision)
+            # Out-of-band responses still emit output, but never write back to the default
+            # conversation (their context was a throwaway chat).
+            commit_allowed = turn_output_allowed and not out_of_band
+            if commit_allowed:
+                original_chat.add_item(make_assistant_message(ctx.generated_text))
+            if commit_allowed and ctx.tools:
+                for t in ctx.tools:
+                    original_chat.add_item(
+                        RealtimeConversationItemFunctionCall(
+                            type="function_call",
+                            id=t.id,
+                            call_id=t.call_id,
+                            name=t.name,
+                            arguments=t.arguments,
+                            status=t.status,
+                        )
                     )
+            if commit_allowed:
+                original_chat.strip_images()
+                original_chat.trim_if_needed(self.compactor)
+            logger.debug("Clean text: %s", ctx.generated_text)
+            logger.info(f"Tools: {ctx.tools}")
+
+            if turn_output_allowed and ctx.printable_text.strip():
+                yield LLMResponseChunk(
+                    text=ctx.printable_text.strip(),
+                    language_code=language_code,
+                    runtime_config=runtime_config,
+                    response=response,
+                    turn_id=ctx.turn_id,
+                    turn_revision=ctx.turn_revision,
+                    speech_stopped_at_s=ctx.speech_stopped_at_s,
+                    cancel_generation=ctx.cancel_generation,
                 )
-        if commit_allowed:
-            original_chat.strip_images()
-            original_chat.trim_if_needed(self.compactor)
-        logger.debug("Clean text: %s", ctx.generated_text)
-        logger.info(f"Tools: {ctx.tools}")
 
-        if turn_output_allowed and ctx.printable_text.strip():
-            yield LLMResponseChunk(
-                text=ctx.printable_text.strip(),
-                language_code=language_code,
-                runtime_config=runtime_config,
-                response=response,
+            output_tokens = len(self.tokenizer.encode(ctx.raw_generated_text)) if ctx.raw_generated_text else 0
+            if turn_output_allowed and (ctx.input_tokens or output_tokens):
+                yield TokenUsage(
+                    input_tokens=ctx.input_tokens,
+                    output_tokens=output_tokens,
+                    turn_id=ctx.turn_id,
+                    turn_revision=ctx.turn_revision,
+                )
+        except Exception as exc:
+            # Any generation failure must still terminate the response. Without this
+            # the exception would escape process() and no EndOfResponse would be
+            # emitted, leaving st.in_response stuck and locking every later response.
+            logger.exception("LLM generation failed; ending the current response")
+            yield EndOfResponse(
                 turn_id=ctx.turn_id,
                 turn_revision=ctx.turn_revision,
-                speech_stopped_at_s=ctx.speech_stopped_at_s,
                 cancel_generation=ctx.cancel_generation,
+                error=f"Language model generation failed: {exc}",
             )
-
-        output_tokens = len(self.tokenizer.encode(ctx.raw_generated_text)) if ctx.raw_generated_text else 0
-        if turn_output_allowed and (ctx.input_tokens or output_tokens):
-            yield TokenUsage(
-                input_tokens=ctx.input_tokens,
-                output_tokens=output_tokens,
-                turn_id=ctx.turn_id,
-                turn_revision=ctx.turn_revision,
-            )
+            return
         yield EndOfResponse(
             turn_id=ctx.turn_id,
             turn_revision=ctx.turn_revision,

--- a/src/speech_to_speech/LLM/language_model.py
+++ b/src/speech_to_speech/LLM/language_model.py
@@ -31,7 +31,14 @@ from transformers import (
 
 from speech_to_speech.api.openai_realtime.runtime_config import RuntimeConfig
 from speech_to_speech.baseHandler import BaseHandler
-from speech_to_speech.LLM.chat import Chat, make_assistant_message, make_system_message, make_user_message
+from speech_to_speech.LLM.chat import (
+    Chat,
+    ChatItemError,
+    build_active_chat,
+    make_assistant_message,
+    make_system_message,
+    make_user_message,
+)
 from speech_to_speech.LLM.compaction_prompt import CompactGenerateFn, build_compactor
 from speech_to_speech.LLM.text_prompt import build_text_system_prompt
 from speech_to_speech.LLM.tool_call.function_call import extract_function_calls_from_text
@@ -48,7 +55,7 @@ from speech_to_speech.pipeline.messages import (
     TokenUsage,
 )
 from speech_to_speech.pipeline.speculative_turns import SpeculativeTurnTracker
-from speech_to_speech.utils.utils import response_wants_audio
+from speech_to_speech.utils.utils import is_out_of_band, response_wants_audio
 
 try:
     import mlx.core as mx
@@ -483,7 +490,16 @@ class BaseLanguageModelHandler(BaseHandler[LLMIn, LLMOut], ABC):
         runtime_config = request.runtime_config
         response = request.response
         original_chat = runtime_config.chat
-        active_chat = original_chat.copy()
+        out_of_band = is_out_of_band(response)
+        if out_of_band:
+            try:
+                active_chat = build_active_chat(original_chat, response)
+            except ChatItemError as exc:
+                logger.info("Out-of-band response rejected: %s", exc)
+                yield EndOfResponse(turn_id=ctx.turn_id, turn_revision=ctx.turn_revision, error=str(exc))
+                return
+        else:
+            active_chat = original_chat.copy()
         language_code = request.language_code
         instructions = (
             response.instructions if response and response.instructions else runtime_config.session.instructions
@@ -511,9 +527,12 @@ class BaseLanguageModelHandler(BaseHandler[LLMIn, LLMOut], ABC):
             return
 
         turn_output_allowed = not ctx.cancelled and self._turn_output_allowed(ctx.turn_id, ctx.turn_revision)
-        if turn_output_allowed:
+        # Out-of-band responses still emit output, but never write back to the default
+        # conversation (their context was a throwaway chat).
+        commit_allowed = turn_output_allowed and not out_of_band
+        if commit_allowed:
             original_chat.add_item(make_assistant_message(ctx.generated_text))
-        if turn_output_allowed and ctx.tools:
+        if commit_allowed and ctx.tools:
             for t in ctx.tools:
                 original_chat.add_item(
                     RealtimeConversationItemFunctionCall(
@@ -525,7 +544,7 @@ class BaseLanguageModelHandler(BaseHandler[LLMIn, LLMOut], ABC):
                         status=t.status,
                     )
                 )
-        if turn_output_allowed:
+        if commit_allowed:
             original_chat.strip_images()
             original_chat.trim_if_needed(self.compactor)
         logger.debug("Clean text: %s", ctx.generated_text)

--- a/src/speech_to_speech/LLM/language_model.py
+++ b/src/speech_to_speech/LLM/language_model.py
@@ -33,6 +33,7 @@ from speech_to_speech.api.openai_realtime.runtime_config import RuntimeConfig
 from speech_to_speech.baseHandler import BaseHandler
 from speech_to_speech.LLM.chat import Chat, make_assistant_message, make_system_message, make_user_message
 from speech_to_speech.LLM.compaction_prompt import CompactGenerateFn, build_compactor
+from speech_to_speech.LLM.text_prompt import build_text_system_prompt
 from speech_to_speech.LLM.tool_call.function_call import extract_function_calls_from_text
 from speech_to_speech.LLM.tool_call.function_tool import FunctionTool
 from speech_to_speech.LLM.tool_call.tool_prompt import END_CODE, ENTER_CODE, build_block_regex, build_tool_system_prompt
@@ -47,6 +48,7 @@ from speech_to_speech.pipeline.messages import (
     TokenUsage,
 )
 from speech_to_speech.pipeline.speculative_turns import SpeculativeTurnTracker
+from speech_to_speech.utils.utils import response_wants_audio
 
 try:
     import mlx.core as mx
@@ -248,6 +250,7 @@ class BaseLanguageModelHandler(BaseHandler[LLMIn, LLMOut], ABC):
         raw_tools: list[Any] | None,
         tool_choice: Optional[str],
         ctx: StreamContext | None = None,
+        wants_audio: bool = True,
     ) -> None:
         if not instructions:
             return
@@ -256,14 +259,16 @@ class BaseLanguageModelHandler(BaseHandler[LLMIn, LLMOut], ABC):
 
         function_tools = [FunctionTool(**t.model_dump()) for t in raw_tools if t.type == "function"]
 
+        build_system_prompt = build_voice_system_prompt if wants_audio else build_text_system_prompt
+
         if function_tools and tool_choice != "none":
-            tool_section = build_tool_system_prompt(function_tools)
-            full_instructions = build_voice_system_prompt(instructions, tool_section=tool_section)
+            tool_section = build_tool_system_prompt(function_tools, text_only=not wants_audio)
+            full_instructions = build_system_prompt(instructions, tool_section=tool_section)
             block_regex = build_block_regex()
             enter_code = ENTER_CODE
             end_code = END_CODE
         else:
-            full_instructions = build_voice_system_prompt(instructions)
+            full_instructions = build_system_prompt(instructions)
             block_regex = None
             enter_code = None
             end_code = None
@@ -485,7 +490,14 @@ class BaseLanguageModelHandler(BaseHandler[LLMIn, LLMOut], ABC):
         )
         tools = response.tools if response and response.tools else runtime_config.session.tools
         tool_choice = response.tool_choice if response and response.tool_choice else runtime_config.session.tool_choice
-        self._apply_instructions(active_chat, instructions, tools, str(tool_choice) if tool_choice else None, ctx)
+        self._apply_instructions(
+            active_chat,
+            instructions,
+            tools,
+            str(tool_choice) if tool_choice else None,
+            ctx,
+            response_wants_audio(response),
+        )
         language_code, lang_name = resolve_auto_language(language_code)
         if lang_name and self.enable_lang_prompt:
             active_chat.add_item(make_user_message(f"Please reply to my message in {lang_name}."))

--- a/src/speech_to_speech/LLM/language_model.py
+++ b/src/speech_to_speech/LLM/language_model.py
@@ -368,6 +368,25 @@ class BaseLanguageModelHandler(BaseHandler[LLMIn, LLMOut], ABC):
                 printable_text = code_and_after
             return chunks, tools, printable_text
 
+        if printable_text and not response_wants_audio(response) and ctx.enter_code is None:
+            # Text-only with no tool block: stream the raw text immediately. No TTS
+            # means no need to split into sentences, and sent_tokenize would collapse
+            # newlines / markdown. Streaming (vs buffering to the end) keeps the
+            # response interruptible by a new speech turn.
+            chunks.append(
+                LLMResponseChunk(
+                    text=printable_text,
+                    language_code=language_code,
+                    runtime_config=runtime_config,
+                    response=response,
+                    turn_id=ctx.turn_id,
+                    turn_revision=ctx.turn_revision,
+                    speech_stopped_at_s=ctx.speech_stopped_at_s,
+                    cancel_generation=ctx.cancel_generation,
+                )
+            )
+            return chunks, tools, ""
+
         if printable_text:
             sentences = sent_tokenize(printable_text)
             if len(sentences) > 1:
@@ -417,6 +436,9 @@ class BaseLanguageModelHandler(BaseHandler[LLMIn, LLMOut], ABC):
         response: RealtimeResponseCreateParams | None = None,
     ) -> Iterator[LLMResponseChunk]:
         """Consume *token_iter*, accumulate text in *ctx*, yield sentence chunks."""
+        # Text-only output keeps every character; only audio strips TTS-unfriendly
+        # symbols via remove_unspeechable.
+        wants_audio = response_wants_audio(response)
         while True:
             try:
                 token = next(token_iter)
@@ -432,7 +454,7 @@ class BaseLanguageModelHandler(BaseHandler[LLMIn, LLMOut], ABC):
 
             raw_text: str = token.text if hasattr(token, "text") else token
             ctx.raw_generated_text += raw_text
-            clean = remove_unspeechable(raw_text)
+            clean = raw_text if not wants_audio else remove_unspeechable(raw_text)
             ctx.generated_text += clean
             ctx.printable_text += clean
             chunks, ctx.tools, ctx.printable_text = self._process_printable_text(

--- a/src/speech_to_speech/LLM/lm_output_processor.py
+++ b/src/speech_to_speech/LLM/lm_output_processor.py
@@ -13,7 +13,7 @@ from collections.abc import Iterator
 from queue import Queue
 
 from speech_to_speech.baseHandler import BaseHandler
-from speech_to_speech.pipeline.events import AssistantTextEvent, TokenUsageEvent
+from speech_to_speech.pipeline.events import AssistantTextEvent, ResponseFailedEvent, TokenUsageEvent
 from speech_to_speech.pipeline.handler_types import LLMOut, TTSIn
 from speech_to_speech.pipeline.messages import EndOfResponse, LLMResponseChunk, TokenUsage, TTSInput
 from speech_to_speech.pipeline.queue_types import TextEventItem
@@ -89,6 +89,17 @@ class LMOutputProcessor(BaseHandler[LLMOut, TTSIn]):
                     lm_output.turn_revision,
                 )
                 return
+            # A failed generation (e.g. invalid out-of-band input) closes the response as
+            # "failed" via the text side-channel, then falls through to emit the normal
+            # EndOfResponse so the audio path still re-enables listening / releases the slot.
+            if lm_output.error and self.text_output_queue is not None:
+                self.text_output_queue.put(
+                    ResponseFailedEvent(
+                        message=lm_output.error,
+                        turn_id=lm_output.turn_id,
+                        turn_revision=lm_output.turn_revision,
+                    )
+                )
             yield EndOfResponse(
                 turn_id=lm_output.turn_id,
                 turn_revision=lm_output.turn_revision,

--- a/src/speech_to_speech/LLM/lm_output_processor.py
+++ b/src/speech_to_speech/LLM/lm_output_processor.py
@@ -18,6 +18,7 @@ from speech_to_speech.pipeline.handler_types import LLMOut, TTSIn
 from speech_to_speech.pipeline.messages import EndOfResponse, LLMResponseChunk, TokenUsage, TTSInput
 from speech_to_speech.pipeline.queue_types import TextEventItem
 from speech_to_speech.pipeline.speculative_turns import SpeculativeTurnTracker
+from speech_to_speech.utils.utils import response_wants_audio
 
 logger = logging.getLogger(__name__)
 
@@ -121,7 +122,7 @@ class LMOutputProcessor(BaseHandler[LLMOut, TTSIn]):
                 logger.debug(f"Sending to clients: text='{lm_output.text}' (no tools)")
             self.text_output_queue.put(event)
 
-        if lm_output.text:
+        if lm_output.text and response_wants_audio(lm_output.response):
             logger.debug(f"Forwarding to TTS: '{lm_output.text}'")
             yield TTSInput(
                 text=lm_output.text,

--- a/src/speech_to_speech/LLM/responses_api_language_model.py
+++ b/src/speech_to_speech/LLM/responses_api_language_model.py
@@ -28,6 +28,7 @@ from openai.types.responses import (
 from speech_to_speech.baseHandler import BaseHandler
 from speech_to_speech.LLM.chat import Chat, SupportedItem, make_system_message, make_user_message
 from speech_to_speech.LLM.compaction_prompt import CompactGenerateFn, build_compactor
+from speech_to_speech.LLM.text_prompt import build_text_system_prompt
 from speech_to_speech.LLM.utils import remove_unspeechable, resolve_auto_language
 from speech_to_speech.LLM.voice_prompt import build_voice_system_prompt
 from speech_to_speech.pipeline.cancel_scope import CancelScope
@@ -38,7 +39,7 @@ from speech_to_speech.pipeline.messages import (
     TokenUsage,
 )
 from speech_to_speech.pipeline.speculative_turns import SpeculativeTurnTracker
-from speech_to_speech.utils.utils import _generate_id
+from speech_to_speech.utils.utils import _generate_id, response_wants_audio
 
 logger = logging.getLogger(__name__)
 
@@ -151,9 +152,11 @@ class ResponsesApiModelHandler(BaseHandler[LLMIn, LLMOut]):
         self,
         chat: Chat,
         instructions: Optional[str],
+        wants_audio: bool = True,
     ) -> None:
         if instructions:
-            full_instructions = build_voice_system_prompt(instructions)
+            builder = build_voice_system_prompt if wants_audio else build_text_system_prompt
+            full_instructions = builder(instructions)
             chat.add_item(make_system_message(full_instructions))
 
     def _generate(
@@ -456,7 +459,7 @@ class ResponsesApiModelHandler(BaseHandler[LLMIn, LLMOut]):
         req_tool_choice = (
             response.tool_choice if response and response.tool_choice else runtime_config.session.tool_choice
         )
-        self._apply_config(active_chat, instructions)
+        self._apply_config(active_chat, instructions, response_wants_audio(response))
         language_code, lang_name = resolve_auto_language(language_code)
         if lang_name and self.enable_lang_prompt:
             active_chat.add_item(make_user_message(f"Please reply to my message in {lang_name}."))

--- a/src/speech_to_speech/LLM/responses_api_language_model.py
+++ b/src/speech_to_speech/LLM/responses_api_language_model.py
@@ -185,11 +185,15 @@ class ResponsesApiModelHandler(BaseHandler[LLMIn, LLMOut]):
         clean_text = ""
         input_tokens = 0
         output_tokens = 0
+        # Text-only responses have no TTS to feed, so streaming buys no latency:
+        # force a single non-streamed call (the Response branch yields one full-text
+        # chunk). Audio responses keep streaming for low-latency synthesis.
+        use_stream = self.stream and response_wants_audio(response)
         try:
             api_response = self.client.responses.create(
                 model=self.model_name,
                 input=active_chat.to_responses_api_chat(),
-                stream=self.stream,
+                stream=use_stream,
                 extra_body=self._extra_body,
                 timeout=self.request_timeout,
                 **optional_kwargs,

--- a/src/speech_to_speech/LLM/responses_api_language_model.py
+++ b/src/speech_to_speech/LLM/responses_api_language_model.py
@@ -185,19 +185,27 @@ class ResponsesApiModelHandler(BaseHandler[LLMIn, LLMOut]):
         clean_text = ""
         input_tokens = 0
         output_tokens = 0
+        error_message: str | None = None
         # Text-only responses have no TTS to feed, so streaming buys no latency:
         # force a single non-streamed call (the Response branch yields one full-text
         # chunk). Audio responses keep streaming for low-latency synthesis.
         use_stream = self.stream and response_wants_audio(response)
+        api_input = active_chat.to_responses_api_chat()
+        if not api_input:
+            # Nothing to send: empty `instructions` and no `input` (in the response,
+            # the default conversation, or the out-of-band context). The provider
+            # would reject this; fail with a clear message instead of an opaque error.
+            error_message = "Cannot generate a response: no instructions and no input were provided."
         try:
-            api_response = self.client.responses.create(
-                model=self.model_name,
-                input=active_chat.to_responses_api_chat(),
-                stream=use_stream,
-                extra_body=self._extra_body,
-                timeout=self.request_timeout,
-                **optional_kwargs,
-            )
+            if error_message is None:
+                api_response = self.client.responses.create(
+                    model=self.model_name,
+                    input=api_input,
+                    stream=use_stream,
+                    extra_body=self._extra_body,
+                    timeout=self.request_timeout,
+                    **optional_kwargs,
+                )
             if isinstance(api_response, Stream):
                 cancelled = False
                 printable_text = ""
@@ -419,6 +427,14 @@ class ResponsesApiModelHandler(BaseHandler[LLMIn, LLMOut]):
                     speech_stopped_at_s=speech_stopped_at_s,
                     cancel_generation=gen,
                 )
+        except Exception as exc:
+            # Any other generation failure must still terminate the response: record
+            # the error and fall through to the EndOfResponse below. Without this the
+            # exception would escape process() and no EndOfResponse would be emitted,
+            # leaving st.in_response stuck and locking every subsequent response.
+            logger.exception("LLM generation failed; ending the current response")
+            if error_message is None:
+                error_message = f"Language model generation failed: {exc}"
         finally:
             if api_response is not None and hasattr(api_response, "close"):
                 try:
@@ -426,7 +442,11 @@ class ResponsesApiModelHandler(BaseHandler[LLMIn, LLMOut]):
                 except Exception:
                     pass
 
-        if not self._generation_is_stale(gen) and self._turn_output_allowed(turn_id, turn_revision):
+        if (
+            error_message is None
+            and not self._generation_is_stale(gen)
+            and self._turn_output_allowed(turn_id, turn_revision)
+        ):
             # Out-of-band responses emit output and usage but never write back to the
             # default conversation (their context was a throwaway chat).
             if not is_out_of_band(response):
@@ -441,7 +461,7 @@ class ResponsesApiModelHandler(BaseHandler[LLMIn, LLMOut]):
                     turn_id=turn_id,
                     turn_revision=turn_revision,
                 )
-        yield EndOfResponse(turn_id=turn_id, turn_revision=turn_revision, cancel_generation=gen)
+        yield EndOfResponse(turn_id=turn_id, turn_revision=turn_revision, cancel_generation=gen, error=error_message)
 
     def process(self, request: LLMIn) -> Iterator[LLMOut]:
         """

--- a/src/speech_to_speech/LLM/responses_api_language_model.py
+++ b/src/speech_to_speech/LLM/responses_api_language_model.py
@@ -26,7 +26,14 @@ from openai.types.responses import (
 )
 
 from speech_to_speech.baseHandler import BaseHandler
-from speech_to_speech.LLM.chat import Chat, SupportedItem, make_system_message, make_user_message
+from speech_to_speech.LLM.chat import (
+    Chat,
+    ChatItemError,
+    SupportedItem,
+    build_active_chat,
+    make_system_message,
+    make_user_message,
+)
 from speech_to_speech.LLM.compaction_prompt import CompactGenerateFn, build_compactor
 from speech_to_speech.LLM.text_prompt import build_text_system_prompt
 from speech_to_speech.LLM.utils import remove_unspeechable, resolve_auto_language
@@ -39,7 +46,7 @@ from speech_to_speech.pipeline.messages import (
     TokenUsage,
 )
 from speech_to_speech.pipeline.speculative_turns import SpeculativeTurnTracker
-from speech_to_speech.utils.utils import _generate_id, response_wants_audio
+from speech_to_speech.utils.utils import _generate_id, is_out_of_band, response_wants_audio
 
 logger = logging.getLogger(__name__)
 
@@ -416,10 +423,13 @@ class ResponsesApiModelHandler(BaseHandler[LLMIn, LLMOut]):
                     pass
 
         if not self._generation_is_stale(gen) and self._turn_output_allowed(turn_id, turn_revision):
-            for item in pending_chat_items:
-                original_chat.add_item(item)
-            original_chat.strip_images()
-            original_chat.trim_if_needed(self.compactor)
+            # Out-of-band responses emit output and usage but never write back to the
+            # default conversation (their context was a throwaway chat).
+            if not is_out_of_band(response):
+                for item in pending_chat_items:
+                    original_chat.add_item(item)
+                original_chat.strip_images()
+                original_chat.trim_if_needed(self.compactor)
             if input_tokens or output_tokens:
                 yield TokenUsage(
                     input_tokens=input_tokens,
@@ -450,7 +460,16 @@ class ResponsesApiModelHandler(BaseHandler[LLMIn, LLMOut]):
             return
 
         original_chat = runtime_config.chat
-        active_chat = original_chat.copy()
+        out_of_band = is_out_of_band(response)
+        if out_of_band:
+            try:
+                active_chat = build_active_chat(original_chat, response)
+            except ChatItemError as exc:
+                logger.info("Out-of-band response rejected: %s", exc)
+                yield EndOfResponse(turn_id=turn_id, turn_revision=turn_revision, error=str(exc))
+                return
+        else:
+            active_chat = original_chat.copy()
         language_code = request.language_code
         instructions = (
             response.instructions if response and response.instructions else runtime_config.session.instructions

--- a/src/speech_to_speech/LLM/responses_api_language_model.py
+++ b/src/speech_to_speech/LLM/responses_api_language_model.py
@@ -186,10 +186,7 @@ class ResponsesApiModelHandler(BaseHandler[LLMIn, LLMOut]):
         input_tokens = 0
         output_tokens = 0
         error_message: str | None = None
-        # Text-only responses have no TTS to feed, so streaming buys no latency:
-        # force a single non-streamed call (the Response branch yields one full-text
-        # chunk). Audio responses keep streaming for low-latency synthesis.
-        use_stream = self.stream and response_wants_audio(response)
+        wants_audio = response_wants_audio(response)
         api_input = active_chat.to_responses_api_chat()
         if not api_input:
             # Nothing to send: empty `instructions` and no `input` (in the response,
@@ -201,7 +198,7 @@ class ResponsesApiModelHandler(BaseHandler[LLMIn, LLMOut]):
                 api_response = self.client.responses.create(
                     model=self.model_name,
                     input=api_input,
-                    stream=use_stream,
+                    stream=self.stream,
                     extra_body=self._extra_body,
                     timeout=self.request_timeout,
                     **optional_kwargs,
@@ -218,6 +215,29 @@ class ResponsesApiModelHandler(BaseHandler[LLMIn, LLMOut]):
                         cancelled = True
                         break
                     if isinstance(raw_event, ResponseTextDeltaEvent):
+                        if not wants_audio:
+                            # Text-only: forward the delta verbatim. Keep every
+                            # character (no remove_unspeechable, which strips
+                            # TTS-unfriendly symbols) and don't sentence-split
+                            # (sent_tokenize would collapse newlines / markdown).
+                            delta = raw_event.delta
+                            clean_text += delta
+                            if delta:
+                                if not self._turn_output_allowed(turn_id, turn_revision):
+                                    logger.info("LLM generation cancelled (stale speculative turn)")
+                                    cancelled = True
+                                    break
+                                yield LLMResponseChunk(
+                                    text=delta,
+                                    language_code=language_code,
+                                    runtime_config=runtime_config,
+                                    response=response,
+                                    turn_id=turn_id,
+                                    turn_revision=turn_revision,
+                                    speech_stopped_at_s=speech_stopped_at_s,
+                                    cancel_generation=gen,
+                                )
+                            continue
                         new_text = remove_unspeechable(raw_event.delta)
                         clean_text += new_text
                         printable_text += new_text
@@ -387,19 +407,22 @@ class ResponsesApiModelHandler(BaseHandler[LLMIn, LLMOut]):
                                     type="message", role="assistant", content=content
                                 )
                             )
+                            # Text-only keeps every character verbatim; audio strips
+                            # TTS-unfriendly symbols via remove_unspeechable.
                             message_text = ""
                             for chunk in message.content:
                                 if chunk.type == "output_text":
-                                    message_text += remove_unspeechable(chunk.text)
+                                    message_text += chunk.text if not wants_audio else remove_unspeechable(chunk.text)
                             clean_text += message_text
-                            if message_text.strip():
+                            chunk_text = message_text if not wants_audio else message_text.strip()
+                            if chunk_text:
                                 if self._generation_is_stale(gen):
                                     logger.info("LLM generation cancelled (interruption)")
                                 elif not self._turn_output_allowed(turn_id, turn_revision):
                                     logger.info("LLM generation cancelled (stale speculative turn)")
                                 else:
                                     yield LLMResponseChunk(
-                                        text=message_text.strip(),
+                                        text=chunk_text,
                                         language_code=language_code,
                                         runtime_config=runtime_config,
                                         response=response,

--- a/src/speech_to_speech/LLM/text_prompt.py
+++ b/src/speech_to_speech/LLM/text_prompt.py
@@ -2,7 +2,7 @@
 
 TEXT_SYSTEM_PROMPT_LEAD = """\
 You are in a text conversation. The user reads your written replies.
-The session prompt defines persona, facts, goals, and tool descriptions. These channel rules only control written output and tool-use behavior.
+The session prompt defines who you are and what to do. These channel rules only control written output and tool-use behavior.
 """
 
 TEXT_SYSTEM_PROMPT_TAIL = """\

--- a/src/speech_to_speech/LLM/text_prompt.py
+++ b/src/speech_to_speech/LLM/text_prompt.py
@@ -1,0 +1,45 @@
+"""Text-channel system prompt: lead + session prompt + tail (strongest constraints last)."""
+
+TEXT_SYSTEM_PROMPT_LEAD = """\
+You are in a text conversation. The user reads your written replies.
+The session prompt defines persona, facts, goals, and tool descriptions. These channel rules only control written output and tool-use behavior.
+"""
+
+TEXT_SYSTEM_PROMPT_TAIL = """\
+## Text Rules
+- Write clearly and directly. Match length to the request: concise for simple questions, fuller when the task genuinely needs it.
+- Use markdown when it helps (lists, code blocks, tables, emphasis); don't over-format simple answers.
+- This is a written channel: no spoken-style filler and no action/emote text like *laughs*.
+- Use tools when they help fulfill the request. No preamble sentence is required before a tool call.
+- For slow or external tools, just call the tool and use the result; you don't need to announce it.
+- If unsure whether a tool is needed, just answer directly.
+"""
+
+# Skeleton for the assembled system message (placeholders filled in build_text_system_prompt).
+_TEXT_SYSTEM_PROMPT_FULL = """\
+{lead}
+
+Session Prompt:
+{session_prompt}{optional_tools}
+
+{tail}
+"""
+
+
+def build_text_system_prompt(session_prompt: str, *, tool_section: str = "") -> str:
+    """Context → session prompt → optional tool block → strongest text rules last."""
+    tools = tool_section.strip()
+    optional_tools = f"\n\n{tools}" if tools else ""
+    return _TEXT_SYSTEM_PROMPT_FULL.format(
+        lead=TEXT_SYSTEM_PROMPT_LEAD.rstrip(),
+        session_prompt=session_prompt.strip(),
+        optional_tools=optional_tools,
+        tail=TEXT_SYSTEM_PROMPT_TAIL.rstrip(),
+    )
+
+
+# Full text instructions without a separate session block (legacy / rare direct use).
+TEXT_SYSTEM_PROMPT = "{lead}\n\n{tail}".format(
+    lead=TEXT_SYSTEM_PROMPT_LEAD.rstrip(),
+    tail=TEXT_SYSTEM_PROMPT_TAIL.rstrip(),
+)

--- a/src/speech_to_speech/LLM/text_prompt.py
+++ b/src/speech_to_speech/LLM/text_prompt.py
@@ -2,7 +2,6 @@
 
 TEXT_SYSTEM_PROMPT_LEAD = """\
 You are in a text conversation. The user reads your written replies.
-The session prompt defines who you are and what to do. These channel rules only control written output and tool-use behavior.
 """
 
 TEXT_SYSTEM_PROMPT_TAIL = """\

--- a/src/speech_to_speech/LLM/text_prompt.py
+++ b/src/speech_to_speech/LLM/text_prompt.py
@@ -1,7 +1,7 @@
 """Text-channel system prompt: lead + session prompt + tail (strongest constraints last)."""
 
 TEXT_SYSTEM_PROMPT_LEAD = """\
-You are in a text conversation. The user reads your written replies.
+You are a helpful assistant.
 """
 
 TEXT_SYSTEM_PROMPT_TAIL = """\

--- a/src/speech_to_speech/LLM/text_prompt.py
+++ b/src/speech_to_speech/LLM/text_prompt.py
@@ -1,7 +1,7 @@
 """Text-channel system prompt: lead + session prompt + tail (strongest constraints last)."""
 
 TEXT_SYSTEM_PROMPT_LEAD = """\
-You are a helpful assistant.
+You are a helpful assistant in a text conversation.
 """
 
 TEXT_SYSTEM_PROMPT_TAIL = """\

--- a/src/speech_to_speech/LLM/tool_call/tool_prompt.py
+++ b/src/speech_to_speech/LLM/tool_call/tool_prompt.py
@@ -47,6 +47,28 @@ Rules:
     keep_trailing_newline=True,
 )
 
+# Text-channel variant: same call format and structural rules, without the
+# voice-specific "speak first" prose.
+TEXT_TOOL_PROMPT_TEMPLATE = Template(
+    """\
+Available tools:
+
+{% for tool in tools %}
+{{ tool.to_code_prompt() }}
+
+{% endfor %}
+To call a tool, put exactly one named-argument function call inside {{ enter_code }}...{{ end_code }}:
+{{ enter_code }}function_name(required_arg='value'){{ end_code }}
+
+Rules:
+- Call a tool directly when it helps fulfill the request; no preamble sentence is required.
+- Do not mention tags, functions, or tools in your prose, and do not claim tool results before a tool result is available.
+- Use named arguments only; quote strings. Omit optional args instead of placeholder values like "random", "none", "", or null.
+- Only one tool call may appear in a response.\
+""",
+    keep_trailing_newline=True,
+)
+
 
 # ---------------------------------------------------------------------------
 # Public helpers
@@ -57,16 +79,20 @@ def build_tool_system_prompt(
     tools: list[FunctionTool],
     enter_code: str = ENTER_CODE,
     end_code: str = END_CODE,
+    *,
+    text_only: bool = False,
 ) -> str:
     """Render the tool-calling system-prompt section.
 
     Returns an empty string when *tools* is empty so it can be
-    unconditionally appended to a base system prompt.
+    unconditionally appended to a base system prompt.  When *text_only* is set,
+    the written-channel variant is used (no voice "speak first" prose).
     """
     if not tools:
         return ""
 
-    return TOOL_PROMPT_TEMPLATE.render(
+    template = TEXT_TOOL_PROMPT_TEMPLATE if text_only else TOOL_PROMPT_TEMPLATE
+    return template.render(
         tools=tools,
         enter_code=enter_code,
         end_code=end_code,

--- a/src/speech_to_speech/api/openai_realtime/README.md
+++ b/src/speech_to_speech/api/openai_realtime/README.md
@@ -162,7 +162,7 @@ sequenceDiagram
 3. **Cancel + queue flush**: if `response_playing` is set, the send loop calls `cancel_scope.cancel()` (increments generation, enables discard), drains both `output_queue` (preserving `__RESPONSE_DONE__` sentinels) and `text_output_queue`, then clears `response_playing`.
 4. **LLM/TTS cancellation**: handlers capture `gen = cancel_scope.generation` at the start of each response and check `cancel_scope.is_stale(gen)` on every streaming token, aborting early when stale.
 5. **Discard guard**: while `cancel_scope.discarding` is True, the send loop silently drops stale audio chunks and assistant text. The guard clears when `__RESPONSE_DONE__` arrives (via `cancel_scope.response_done()`).
-6. **Client-initiated cancel**: `response.cancel` calls `cancel_scope.cancel()` (only if a response was active), triggers `finish_audio_response(status="cancelled", reason="client_cancelled")`, and re-enables `should_listen`.
+6. **Client-initiated cancel**: `response.cancel` calls `cancel_scope.cancel()` (only if a response was active), triggers `finish_response(status="cancelled", reason="client_cancelled")`, and re-enables `should_listen`.
 7. **Spurious cancel safety**: if no response is active, `cancel_scope.cancel()` is not called, preventing the discard guard from being set without a `__RESPONSE_DONE__` to clear it.
 
 ---

--- a/src/speech_to_speech/api/openai_realtime/handlers/audio.py
+++ b/src/speech_to_speech/api/openai_realtime/handlers/audio.py
@@ -99,7 +99,7 @@ class AudioHandler(RealtimeBaseHandler):
         events: list[ServerEvent] = []
         st = self._state(conn_id)
         if st.in_response and event.interrupt_response and st.runtime_config.interrupt_response_enabled:
-            events.extend(response.finish_audio_response(conn_id, status="cancelled", reason="turn_detected"))
+            events.extend(response.finish_response(conn_id, status="cancelled", reason="turn_detected"))
         is_reopen = bool(event.reopened and event.turn_id is not None and event.turn_id == st.speculative_turn_id)
         preserve_active_response = st.in_response
         if is_reopen:

--- a/src/speech_to_speech/api/openai_realtime/handlers/conversation.py
+++ b/src/speech_to_speech/api/openai_realtime/handlers/conversation.py
@@ -10,19 +10,12 @@ from openai.types.realtime import (
     ConversationItemInputAudioTranscriptionCompletedEvent,
     ConversationItemInputAudioTranscriptionDeltaEvent,
 )
-from openai.types.realtime.conversation_item import (
-    RealtimeConversationItemAssistantMessage,
-    RealtimeConversationItemFunctionCall,
-    RealtimeConversationItemFunctionCallOutput,
-    RealtimeConversationItemSystemMessage,
-    RealtimeConversationItemUserMessage,
-)
 from openai.types.realtime.conversation_item_input_audio_transcription_completed_event import (
     UsageTranscriptTextUsageDuration,
 )
 
 from speech_to_speech.api.openai_realtime.handlers.base import RealtimeBaseHandler
-from speech_to_speech.LLM.chat import ChatItemError
+from speech_to_speech.LLM.chat import ChatItemError, add_supported_item
 from speech_to_speech.pipeline.events import PartialTranscriptionEvent, TranscriptionCompletedEvent
 
 if TYPE_CHECKING:
@@ -72,29 +65,7 @@ class ConversationHandler(RealtimeBaseHandler):
 
         Raises :class:`ChatItemError` on validation failure or unsupported type.
         """
-        chat = self._state(conn_id).runtime_config.chat
-
-        # call_id on function_call items must be client-supplied: it is referenced later by
-        # function_call_output items, so we cannot silently generate one here.
-        if isinstance(item, RealtimeConversationItemFunctionCall) and (
-            item.call_id is None or not item.call_id.startswith("call_")
-        ):
-            raise ChatItemError("function_call item is missing a call_id. The call_id should start with 'call_'.")
-
-        if isinstance(
-            item,
-            (
-                RealtimeConversationItemSystemMessage,
-                RealtimeConversationItemUserMessage,
-                RealtimeConversationItemAssistantMessage,
-                RealtimeConversationItemFunctionCall,
-                RealtimeConversationItemFunctionCallOutput,
-            ),
-        ):
-            chat.add_item(item)
-            return
-
-        raise ChatItemError(f"Unsupported item type: {getattr(item, 'type', None)}")
+        add_supported_item(self._state(conn_id).runtime_config.chat, item)
 
     # ── Pipeline event handlers ────────────────────
 

--- a/src/speech_to_speech/api/openai_realtime/handlers/response.py
+++ b/src/speech_to_speech/api/openai_realtime/handlers/response.py
@@ -22,7 +22,7 @@ from speech_to_speech.api.openai_realtime.handlers.base import RealtimeBaseHandl
 from speech_to_speech.LLM.chat import ChatItemError
 from speech_to_speech.pipeline.events import AssistantTextEvent
 from speech_to_speech.pipeline.messages import GenerateResponseRequest
-from speech_to_speech.utils.utils import _generate_id, response_wants_audio
+from speech_to_speech.utils.utils import _generate_id, is_out_of_band, response_wants_audio
 
 if TYPE_CHECKING:
     from speech_to_speech.api.openai_realtime.service import ServerEvent, _ResponseStatus, _StatusReason
@@ -113,13 +113,16 @@ class ResponseHandler(RealtimeBaseHandler):
             audio_output = audio_cfg.output if audio_cfg is not None else None
             voice = str(audio_output.voice) if audio_output is not None and audio_output.voice else None
 
+        # Out-of-band responses are not threaded into any conversation: report a null id.
+        conversation_id = None if is_out_of_band(rp) else st.conversation_id
+
         return RealtimeResponse(
             id=st.current_response_id,
             object="realtime.response",
             status=status,
             status_details=status_details,
             audio=Audio(output=AudioOutput(voice=str(voice) if voice else None)),  # type: ignore[arg-type]
-            conversation_id=st.conversation_id,
+            conversation_id=conversation_id,
             metadata=metadata,
             usage=RealtimeResponseUsage(
                 input_tokens=st.response_usage.input_tokens,
@@ -149,7 +152,12 @@ class ResponseHandler(RealtimeBaseHandler):
                 _type="conversation_already_has_active_response",
             )
 
-        if event.response and event.response.input:
+        out_of_band = is_out_of_band(event.response)
+
+        # In-band: response.input items are added to the default conversation here so
+        # they appear in history. Out-of-band: leave the default conversation untouched —
+        # the input rides along on the request and seeds a throwaway chat in the LM.
+        if not out_of_band and event.response and event.response.input:
             for input_item in event.response.input:
                 try:
                     self._service.conversation._append_item(conn_id, input_item)
@@ -166,13 +174,16 @@ class ResponseHandler(RealtimeBaseHandler):
         cfg = st.runtime_config
         queue = self._queue(conn_id)
         if queue:
+            # Out-of-band responses carry no turn identity: a null turn_id makes every
+            # speculative-turn staleness gate treat them as always-latest, so a new user
+            # turn mid-generation can never silently drop their output.
             queue.put(
                 GenerateResponseRequest(
                     runtime_config=cfg,
                     response=event.response,
-                    turn_id=st.speculative_user_turn_id,
-                    turn_revision=st.speculative_user_turn_revision,
-                    speech_stopped_at_s=st.speculative_user_speech_stopped_at_s,
+                    turn_id=None if out_of_band else st.speculative_user_turn_id,
+                    turn_revision=None if out_of_band else st.speculative_user_turn_revision,
+                    speech_stopped_at_s=None if out_of_band else st.speculative_user_speech_stopped_at_s,
                 )
             )
         logger.debug("response.create received, LLM generation triggered")

--- a/src/speech_to_speech/api/openai_realtime/handlers/response.py
+++ b/src/speech_to_speech/api/openai_realtime/handlers/response.py
@@ -241,7 +241,7 @@ class ResponseHandler(RealtimeBaseHandler):
                         item_id=item_id,
                         output_index=0,
                         response_id=resp_id,
-                        text=" ".join(st.pending_output_text_parts),
+                        text="".join(st.pending_output_text_parts),
                     )
                 )
             events.append(

--- a/src/speech_to_speech/api/openai_realtime/handlers/response.py
+++ b/src/speech_to_speech/api/openai_realtime/handlers/response.py
@@ -70,6 +70,7 @@ class ResponseHandler(RealtimeBaseHandler):
         st.in_response = False
         st.response_pending = False
         st.current_response_params = None
+        st.pending_output_text_parts = []
 
     def _start_item(self, conn_id: str) -> str:
         """Generate a new item ID, reset content index, and store it."""
@@ -195,20 +196,27 @@ class ResponseHandler(RealtimeBaseHandler):
 
     def handle_response_cancel(self, conn_id: str) -> list[ServerEvent]:
         """Cancel the in-progress response and re-enable listening."""
-        events = self.finish_audio_response(conn_id, status="cancelled", reason="client_cancelled")
+        events = self.finish_response(conn_id, status="cancelled", reason="client_cancelled")
         should_listen = self._should_listen(conn_id)
         if should_listen:
             should_listen.set()
         logger.info("Response cancelled, listening re-enabled")
         return events
 
-    def finish_audio_response(
+    def finish_response(
         self,
         conn_id: str,
         status: _ResponseStatus = "completed",
         reason: _StatusReason | None = None,
     ) -> list[ServerEvent]:
-        """Close the current response (audio done + response done)."""
+        """Close the current response (audio/text done + response done).
+
+        Audio responses emit ``response.output_audio.done`` for any terminal
+        status. Text-only responses emit a single ``response.output_text.done``
+        carrying the full streamed text, but only on ``status="completed"`` —
+        a cancelled or failed text response sends no audio, so it just closes
+        with ``response.done``.
+        """
         st = self._state(conn_id)
         events: list[ServerEvent] = []
         if st.in_response:
@@ -222,6 +230,18 @@ class ResponseHandler(RealtimeBaseHandler):
                         item_id=item_id,
                         output_index=0,
                         response_id=resp_id,
+                    )
+                )
+            elif status == "completed" and st.pending_output_text_parts:
+                events.append(
+                    ResponseTextDoneEvent(
+                        type="response.output_text.done",
+                        event_id=self._next_event_id(),
+                        content_index=0,
+                        item_id=item_id,
+                        output_index=0,
+                        response_id=resp_id,
+                        text=" ".join(st.pending_output_text_parts),
                     )
                 )
             events.append(
@@ -280,6 +300,10 @@ class ResponseHandler(RealtimeBaseHandler):
                     )
                 )
             else:
+                # Stream the delta now; the matching response.output_text.done is
+                # emitted once at close in finish_response, carrying the per-chunk
+                # parts collected here, space-joined ("" when there were none).
+                st.pending_output_text_parts.append(event.text)
                 events.append(
                     ResponseTextDeltaEvent(
                         type="response.output_text.delta",
@@ -289,17 +313,6 @@ class ResponseHandler(RealtimeBaseHandler):
                         output_index=output_idx,
                         response_id=resp_id,
                         delta=event.text,
-                    )
-                )
-                events.append(
-                    ResponseTextDoneEvent(
-                        type="response.output_text.done",
-                        event_id=self._next_event_id(),
-                        content_index=0,
-                        item_id=item_id,
-                        output_index=output_idx,
-                        response_id=resp_id,
-                        text=event.text,
                     )
                 )
             output_idx += 1

--- a/src/speech_to_speech/api/openai_realtime/handlers/response.py
+++ b/src/speech_to_speech/api/openai_realtime/handlers/response.py
@@ -11,6 +11,8 @@ from openai.types.realtime import (
     ResponseCreateEvent,
     ResponseDoneEvent,
     ResponseFunctionCallArgumentsDoneEvent,
+    ResponseTextDeltaEvent,
+    ResponseTextDoneEvent,
 )
 from openai.types.realtime.realtime_response import Audio, AudioOutput
 from openai.types.realtime.realtime_response_status import RealtimeResponseStatus
@@ -20,7 +22,7 @@ from speech_to_speech.api.openai_realtime.handlers.base import RealtimeBaseHandl
 from speech_to_speech.LLM.chat import ChatItemError
 from speech_to_speech.pipeline.events import AssistantTextEvent
 from speech_to_speech.pipeline.messages import GenerateResponseRequest
-from speech_to_speech.utils.utils import _generate_id
+from speech_to_speech.utils.utils import _generate_id, response_wants_audio
 
 if TYPE_CHECKING:
     from speech_to_speech.api.openai_realtime.service import ServerEvent, _ResponseStatus, _StatusReason
@@ -200,16 +202,17 @@ class ResponseHandler(RealtimeBaseHandler):
         events: list[ServerEvent] = []
         if st.in_response:
             resp_id, item_id = self._ensure_response(conn_id)
-            events.append(
-                ResponseAudioDoneEvent(
-                    type="response.output_audio.done",
-                    event_id=self._next_event_id(),
-                    content_index=0,
-                    item_id=item_id,
-                    output_index=0,
-                    response_id=resp_id,
+            if response_wants_audio(st.current_response_params):
+                events.append(
+                    ResponseAudioDoneEvent(
+                        type="response.output_audio.done",
+                        event_id=self._next_event_id(),
+                        content_index=0,
+                        item_id=item_id,
+                        output_index=0,
+                        response_id=resp_id,
+                    )
                 )
-            )
             events.append(
                 ResponseDoneEvent(
                     type="response.done",
@@ -253,17 +256,41 @@ class ResponseHandler(RealtimeBaseHandler):
         st.last_item_id = item_id
         output_idx = 0
         if event.text:
-            events.append(
-                ResponseAudioTranscriptDoneEvent(
-                    type="response.output_audio_transcript.done",
-                    event_id=self._next_event_id(),
-                    content_index=0,
-                    item_id=item_id,
-                    output_index=output_idx,
-                    response_id=resp_id,
-                    transcript=event.text,
+            if response_wants_audio(st.current_response_params):
+                events.append(
+                    ResponseAudioTranscriptDoneEvent(
+                        type="response.output_audio_transcript.done",
+                        event_id=self._next_event_id(),
+                        content_index=0,
+                        item_id=item_id,
+                        output_index=output_idx,
+                        response_id=resp_id,
+                        transcript=event.text,
+                    )
                 )
-            )
+            else:
+                events.append(
+                    ResponseTextDeltaEvent(
+                        type="response.output_text.delta",
+                        event_id=self._next_event_id(),
+                        content_index=0,
+                        item_id=item_id,
+                        output_index=output_idx,
+                        response_id=resp_id,
+                        delta=event.text,
+                    )
+                )
+                events.append(
+                    ResponseTextDoneEvent(
+                        type="response.output_text.done",
+                        event_id=self._next_event_id(),
+                        content_index=0,
+                        item_id=item_id,
+                        output_index=output_idx,
+                        response_id=resp_id,
+                        text=event.text,
+                    )
+                )
             output_idx += 1
         if event.tools:
             st.response_usage.tool_calls += len(event.tools)

--- a/src/speech_to_speech/api/openai_realtime/service.py
+++ b/src/speech_to_speech/api/openai_realtime/service.py
@@ -42,6 +42,7 @@ from speech_to_speech.pipeline.events import (
     AssistantTextEvent,
     PartialTranscriptionEvent,
     PipelineEvent,
+    ResponseFailedEvent,
     SpeechStartedEvent,
     SpeechStoppedEvent,
     TokenUsageEvent,
@@ -207,6 +208,7 @@ class RealtimeService:
             TokenUsageEvent: self._on_token_usage,
             PartialTranscriptionEvent: self.conversation.on_partial_transcription,
             TranscriptionCompletedEvent: self._on_transcription_completed,
+            ResponseFailedEvent: self._on_response_failed,
         }
 
     # ── Connection lifecycle ─────────────────────
@@ -452,6 +454,16 @@ class RealtimeService:
             st.response_usage.output_tokens,
         )
         return []
+
+    def _on_response_failed(self, conn_id: str, event: ResponseFailedEvent) -> list[ServerEvent]:
+        """Close the in-progress response with ``status="failed"``.
+
+        Emitted when generation could not start (e.g. invalid out-of-band input).
+        Idempotent: ``finish_audio_response`` is a no-op once the response slot is
+        already closed, so a subsequent EndOfResponse-driven close does nothing.
+        """
+        logger.info("Response failed: %s", event.message)
+        return self.response.finish_audio_response(conn_id, status="failed")
 
     def get_usage(self) -> dict[str, Any]:
         """Return cumulative usage metrics across all completed responses."""

--- a/src/speech_to_speech/api/openai_realtime/service.py
+++ b/src/speech_to_speech/api/openai_realtime/service.py
@@ -457,14 +457,23 @@ class RealtimeService:
         return []
 
     def _on_response_failed(self, conn_id: str, event: ResponseFailedEvent) -> list[ServerEvent]:
-        """Close the in-progress response with ``status="failed"``.
+        """Surface the failure to the client and close the response as ``failed``.
 
-        Emitted when generation could not start (e.g. invalid out-of-band input).
-        Idempotent: ``finish_response`` is a no-op once the response slot is
-        already closed, so a subsequent EndOfResponse-driven close does nothing.
+        Emitted when generation failed (e.g. invalid out-of-band input, or the
+        provider rejecting an empty context). A top-level ``error`` event carries
+        the human-readable reason — ``response.done.status_details.error`` only
+        has code/type, no message — then ``finish_response`` closes the slot.
+
+        Idempotent: gated on an active response, and ``finish_response`` is itself
+        a no-op once the slot is closed, so a later EndOfResponse-driven close does
+        nothing.
         """
         logger.info("Response failed: %s", event.message)
-        return self.response.finish_response(conn_id, status="failed")
+        if not self._state(conn_id).in_response:
+            return []
+        events: list[ServerEvent] = [self.make_error(event.message, "response_failed")]
+        events.extend(self.response.finish_response(conn_id, status="failed"))
+        return events
 
     def get_usage(self) -> dict[str, Any]:
         """Return cumulative usage metrics across all completed responses."""

--- a/src/speech_to_speech/api/openai_realtime/service.py
+++ b/src/speech_to_speech/api/openai_realtime/service.py
@@ -164,6 +164,7 @@ class ConnState(BaseModel):
     input_audio_duration_s: float = 0.0
     last_item_id: Optional[str] = None
     current_response_params: RealtimeResponseCreateParams | None = None
+    pending_output_text_parts: list[str] = Field(default_factory=list)
     response_usage: UsageMetrics = Field(default_factory=UsageMetrics)
     speculative_turn_id: Optional[str] = None
     speculative_turn_revision: Optional[int] = None
@@ -290,13 +291,13 @@ class RealtimeService:
     def handle_response_cancel(self, conn_id: str) -> list[ServerEvent]:
         return self.response.handle_response_cancel(conn_id)
 
-    def finish_audio_response(
+    def finish_response(
         self,
         conn_id: str,
         status: _ResponseStatus = "completed",
         reason: _StatusReason | None = None,
     ) -> list[ServerEvent]:
-        return self.response.finish_audio_response(conn_id, status, reason)
+        return self.response.finish_response(conn_id, status, reason)
 
     def handle_conversation_item_create(self, conn_id: str, event: ConversationItemCreateEvent) -> list[ServerEvent]:
         return self.conversation.handle_conversation_item_create(conn_id, event)
@@ -459,11 +460,11 @@ class RealtimeService:
         """Close the in-progress response with ``status="failed"``.
 
         Emitted when generation could not start (e.g. invalid out-of-band input).
-        Idempotent: ``finish_audio_response`` is a no-op once the response slot is
+        Idempotent: ``finish_response`` is a no-op once the response slot is
         already closed, so a subsequent EndOfResponse-driven close does nothing.
         """
         logger.info("Response failed: %s", event.message)
-        return self.response.finish_audio_response(conn_id, status="failed")
+        return self.response.finish_response(conn_id, status="failed")
 
     def get_usage(self) -> dict[str, Any]:
         """Return cumulative usage metrics across all completed responses."""

--- a/src/speech_to_speech/api/openai_realtime/service.py
+++ b/src/speech_to_speech/api/openai_realtime/service.py
@@ -22,6 +22,8 @@ from openai.types.realtime import (
     ResponseCreateEvent,
     ResponseDoneEvent,
     ResponseFunctionCallArgumentsDoneEvent,
+    ResponseTextDeltaEvent,
+    ResponseTextDoneEvent,
     SessionCreatedEvent,
     SessionUpdateEvent,
 )
@@ -90,6 +92,8 @@ ServerEvent = Union[
     ResponseAudioDoneEvent,
     ResponseAudioTranscriptDoneEvent,
     ResponseFunctionCallArgumentsDoneEvent,
+    ResponseTextDeltaEvent,
+    ResponseTextDoneEvent,
 ]
 
 RealtimeEvent = Union[ClientEvent, ServerEvent]

--- a/src/speech_to_speech/api/openai_realtime/websocket_router.py
+++ b/src/speech_to_speech/api/openai_realtime/websocket_router.py
@@ -503,7 +503,7 @@ def create_app(pool: list[PipelineUnit], stop_event: ThreadingEvent) -> FastAPI:
                     if _is_pipeline_end(audio_chunk):
                         await _drain_pending_response_events(ws, unit, session_id)
                         if ws is not None and session_id:
-                            await _send_events(ws, unit.service.finish_audio_response(session_id))
+                            await _send_events(ws, unit.service.finish_response(session_id))
                         break
 
                     if _is_audio_done(audio_chunk):
@@ -517,7 +517,7 @@ def create_app(pool: list[PipelineUnit], stop_event: ThreadingEvent) -> FastAPI:
                             continue
                         await _drain_pending_response_events(ws, unit, session_id)
                         if ws is not None and session_id:
-                            await _send_events(ws, unit.service.finish_audio_response(session_id))
+                            await _send_events(ws, unit.service.finish_response(session_id))
                         if session_id:
                             unit.service._state(session_id).response_pending = False
                         unit.response_playing.clear()

--- a/src/speech_to_speech/pipeline/events.py
+++ b/src/speech_to_speech/pipeline/events.py
@@ -80,3 +80,16 @@ class TokenUsageEvent(PipelineEvent):
     output_tokens: int = 0
     turn_id: str | None = None
     turn_revision: int | None = None
+
+
+class ResponseFailedEvent(PipelineEvent):
+    """Signals that a response could not be generated (e.g. invalid out-of-band input).
+
+    Dispatched to the service so it can close the in-progress response with
+    ``status="failed"`` instead of the usual ``completed``.
+    """
+
+    type: Literal["response_failed"] = "response_failed"
+    message: str = ""
+    turn_id: str | None = None
+    turn_revision: int | None = None

--- a/src/speech_to_speech/pipeline/messages.py
+++ b/src/speech_to_speech/pipeline/messages.py
@@ -99,12 +99,19 @@ class TokenUsage(PipelineMessage):
 
 
 class EndOfResponse(PipelineMessage):
-    """Sentinel marking the end of a response."""
+    """Sentinel marking the end of a response.
+
+    ``error`` is set when generation could not start (e.g. an out-of-band
+    response whose ``input`` failed validation); the output processor turns it
+    into a ``response.done(status="failed")`` while still closing the response
+    normally for pipeline cleanup.
+    """
 
     tag: Literal["end_of_response"] = "end_of_response"
     turn_id: str | None = None
     turn_revision: int | None = None
     cancel_generation: int | None = None
+    error: str | None = None
 
 
 # ── LMOutputProcessor → TTS ──────────────────────────────────────────

--- a/src/speech_to_speech/utils/utils.py
+++ b/src/speech_to_speech/utils/utils.py
@@ -13,13 +13,14 @@ def response_wants_audio(response: RealtimeResponseCreateParams | None) -> bool:
     """Whether a response should produce audio (and audio events) vs. text only.
 
     Mirrors the OpenAI realtime semantics for ``output_modalities``: an absent
-    value (``None``) or an explicit ``"audio"`` entry means audio; an explicit
-    list without ``"audio"`` (e.g. ``["text"]``) means text only.
+    value (``None``) or an empty list, or an explicit ``"audio"`` entry means
+    audio; a non-empty list without ``"audio"`` (e.g. ``["text"]``) means text
+    only.
     """
     if response is None:
         return True
     mods = response.output_modalities
-    return mods is None or "audio" in mods
+    return not mods or "audio" in mods
 
 
 def next_power_of_2(x: int) -> int:

--- a/src/speech_to_speech/utils/utils.py
+++ b/src/speech_to_speech/utils/utils.py
@@ -1,6 +1,25 @@
+from __future__ import annotations
+
 import uuid
+from typing import TYPE_CHECKING
 
 import numpy as np
+
+if TYPE_CHECKING:
+    from openai.types.realtime.realtime_response_create_params import RealtimeResponseCreateParams
+
+
+def response_wants_audio(response: RealtimeResponseCreateParams | None) -> bool:
+    """Whether a response should produce audio (and audio events) vs. text only.
+
+    Mirrors the OpenAI realtime semantics for ``output_modalities``: an absent
+    value (``None``) or an explicit ``"audio"`` entry means audio; an explicit
+    list without ``"audio"`` (e.g. ``["text"]``) means text only.
+    """
+    if response is None:
+        return True
+    mods = response.output_modalities
+    return mods is None or "audio" in mods
 
 
 def next_power_of_2(x: int) -> int:

--- a/src/speech_to_speech/utils/utils.py
+++ b/src/speech_to_speech/utils/utils.py
@@ -23,6 +23,18 @@ def response_wants_audio(response: RealtimeResponseCreateParams | None) -> bool:
     return not mods or "audio" in mods
 
 
+def is_out_of_band(response: RealtimeResponseCreateParams | None) -> bool:
+    """Whether a response is *out-of-band* (``conversation="none"``).
+
+    Out-of-band responses are generated against a temporary context and are
+    never threaded into the default conversation: their ``input`` (if any)
+    seeds a throwaway chat, their assistant output is not committed back, and
+    their ``conversation_id`` is reported as ``null``. Any other ``conversation``
+    value (``"auto"``, ``None``, or an arbitrary id) is treated as in-band.
+    """
+    return response is not None and response.conversation == "none"
+
+
 def next_power_of_2(x: int) -> int:
     return 1 if x == 0 else 2 ** (x - 1).bit_length()
 

--- a/tests/openai_realtime/test_realtime_service.py
+++ b/tests/openai_realtime/test_realtime_service.py
@@ -915,18 +915,18 @@ class TestDispatchPipelineEvent:
         assert text_done[0].output_index == 0
         assert text_done[0].text == "Hello there"
 
-    def test_text_only_done_space_joins_streamed_parts(self, service, conn_id):
+    def test_text_only_done_concatenates_streamed_parts(self, service, conn_id):
         from openai.types.realtime.realtime_response_create_params import RealtimeResponseCreateParams
 
         service._state(conn_id).current_response_params = RealtimeResponseCreateParams(
             output_modalities=["text"],
         )
-        service.dispatch_pipeline_event(conn_id, AssistantTextEvent(text="Hello there."))
+        service.dispatch_pipeline_event(conn_id, AssistantTextEvent(text="Hello there. "))
         service.dispatch_pipeline_event(conn_id, AssistantTextEvent(text="How are you?"))
         done_events = service.finish_response(conn_id)
         text_done = [e for e in done_events if isinstance(e, ResponseTextDoneEvent)]
         assert len(text_done) == 1
-        # done.text space-joins the per-chunk parts collected during streaming.
+        # done.text concatenates the raw streamed parts verbatim (== sum of deltas).
         assert text_done[0].text == "Hello there. How are you?"
 
     def test_text_only_no_text_done_on_cancel(self, service, conn_id):

--- a/tests/openai_realtime/test_realtime_service.py
+++ b/tests/openai_realtime/test_realtime_service.py
@@ -531,6 +531,72 @@ class TestHandleResponseCreate:
         assert isinstance(result2, RealtimeErrorEvent)
         assert result2.error.type == "conversation_already_has_active_response"
 
+    @staticmethod
+    def _user_input(text):
+        return {"type": "message", "role": "user", "content": [{"type": "input_text", "text": text}]}
+
+    def test_response_create_out_of_band_does_not_append_input_to_default_chat(
+        self, service, conn_id, text_prompt_queue
+    ):
+        chat = service._state(conn_id).runtime_config.chat
+        assert len(chat.buffer) == 0
+        evt = ResponseCreateEvent(
+            type="response.create",
+            response={"conversation": "none", "input": [self._user_input("OOB question")]},
+        )
+        result = service.handle_response_create(conn_id, evt)
+        assert isinstance(result, ResponseCreatedEvent)
+        # Out-of-band: the default conversation is left untouched...
+        assert len(chat.buffer) == 0
+        # ...while the input still rides along on the queued request for the LM to use.
+        req = text_prompt_queue.get()
+        assert isinstance(req, GenerateResponseRequest)
+        assert req.response.input is not None and len(req.response.input) == 1
+
+    def test_response_create_in_band_appends_input_to_default_chat(self, service, conn_id, text_prompt_queue):
+        chat = service._state(conn_id).runtime_config.chat
+        evt = ResponseCreateEvent(type="response.create", response={"input": [self._user_input("in band")]})
+        result = service.handle_response_create(conn_id, evt)
+        assert isinstance(result, ResponseCreatedEvent)
+        assert len(chat.buffer) == 1  # in-band input is threaded into the conversation
+
+    def test_response_create_out_of_band_carries_null_turn(self, service, conn_id, text_prompt_queue):
+        service.dispatch_pipeline_event(
+            conn_id,
+            TranscriptionCompletedEvent(
+                transcript="hello",
+                language_code="en",
+                turn_id="turn_1",
+                turn_revision=2,
+                speech_stopped_at_s=123.0,
+            ),
+        )
+        text_prompt_queue.get()  # drain the STT-triggered request
+
+        result = service.handle_response_create(
+            conn_id, ResponseCreateEvent(type="response.create", response={"conversation": "none"})
+        )
+        assert isinstance(result, ResponseCreatedEvent)
+        req = text_prompt_queue.get()
+        # Null turn identity makes every speculative-staleness gate treat it as always-latest.
+        assert req.turn_id is None
+        assert req.turn_revision is None
+        assert req.speech_stopped_at_s is None
+
+    def test_response_create_out_of_band_reports_null_conversation_id(self, service, conn_id):
+        result = service.handle_response_create(
+            conn_id, ResponseCreateEvent(type="response.create", response={"conversation": "none"})
+        )
+        assert isinstance(result, ResponseCreatedEvent)
+        assert result.response.conversation_id is None
+        done = [e for e in service.finish_audio_response(conn_id) if isinstance(e, ResponseDoneEvent)]
+        assert done and done[0].response.conversation_id is None
+
+    def test_response_create_in_band_reports_conversation_id(self, service, conn_id):
+        result = service.handle_response_create(conn_id, ResponseCreateEvent(type="response.create"))
+        assert isinstance(result, ResponseCreatedEvent)
+        assert result.response.conversation_id == service._state(conn_id).conversation_id
+
 
 # ===================================================================
 # Response cancel

--- a/tests/openai_realtime/test_realtime_service.py
+++ b/tests/openai_realtime/test_realtime_service.py
@@ -589,7 +589,7 @@ class TestHandleResponseCreate:
         )
         assert isinstance(result, ResponseCreatedEvent)
         assert result.response.conversation_id is None
-        done = [e for e in service.finish_audio_response(conn_id) if isinstance(e, ResponseDoneEvent)]
+        done = [e for e in service.finish_response(conn_id) if isinstance(e, ResponseDoneEvent)]
         assert done and done[0].response.conversation_id is None
 
     def test_response_create_in_band_reports_conversation_id(self, service, conn_id):
@@ -666,7 +666,7 @@ class TestEncodeAudioChunk:
 class TestFinishAudioResponse:
     def test_finish_emits_audio_done_and_response_done(self, service, conn_id):
         service.response._ensure_response(conn_id)
-        events = service.finish_audio_response(conn_id)
+        events = service.finish_response(conn_id)
         assert len(events) == 2
         assert isinstance(events[0], ResponseAudioDoneEvent)
         assert events[0].content_index == 0
@@ -680,7 +680,7 @@ class TestFinishAudioResponse:
             output_modalities=["text"],
         )
         service.response._ensure_response(conn_id)
-        events = service.finish_audio_response(conn_id)
+        events = service.finish_response(conn_id)
         assert len(events) == 1
         assert isinstance(events[0], ResponseDoneEvent)
         assert events[0].response.status == "completed"
@@ -688,7 +688,7 @@ class TestFinishAudioResponse:
 
     def test_finish_with_cancel_status(self, service, conn_id):
         service.response._ensure_response(conn_id)
-        events = service.finish_audio_response(conn_id, status="cancelled", reason="turn_detected")
+        events = service.finish_response(conn_id, status="cancelled", reason="turn_detected")
         done = events[1]
         assert done.response.status == "cancelled"
         assert done.response.status_details.reason == "turn_detected"
@@ -700,7 +700,7 @@ class TestFinishAudioResponse:
             metadata={"k": "v"},
         )
         service.response._ensure_response(conn_id)
-        service.finish_audio_response(conn_id)
+        service.finish_response(conn_id)
         st = service._state(conn_id)
         assert st.in_response is False
         assert st.current_response_id is None
@@ -779,7 +779,7 @@ class TestDispatchPipelineEvent:
         assert isinstance(events[0], InputAudioBufferSpeechStartedEvent)
         assert service._state(conn_id).in_response is True
         assert service._state(conn_id).current_item_id == response_item_id
-        done_events = service.finish_audio_response(conn_id)
+        done_events = service.finish_response(conn_id)
         assert done_events[0].item_id == response_item_id
 
     def test_consecutive_speech_cycles_get_distinct_item_ids(self, service, conn_id):
@@ -897,16 +897,47 @@ class TestDispatchPipelineEvent:
             conn_id,
             AssistantTextEvent(text="Hello there"),
         )
-        assert len(events) == 2
+        # on_assistant_text streams only the delta now; the matching done is
+        # emitted once at close in finish_response.
+        assert len(events) == 1
         assert isinstance(events[0], ResponseTextDeltaEvent)
         assert events[0].content_index == 0
         assert events[0].output_index == 0
         assert events[0].delta == "Hello there"
-        assert isinstance(events[1], ResponseTextDoneEvent)
-        assert events[1].content_index == 0
-        assert events[1].output_index == 0
-        assert events[1].text == "Hello there"
+        assert not any(isinstance(e, ResponseTextDoneEvent) for e in events)
         assert not any(isinstance(e, ResponseAudioTranscriptDoneEvent) for e in events)
+
+        done_events = service.finish_response(conn_id)
+        text_done = [e for e in done_events if isinstance(e, ResponseTextDoneEvent)]
+        assert len(text_done) == 1
+        assert text_done[0].content_index == 0
+        assert text_done[0].output_index == 0
+        assert text_done[0].text == "Hello there"
+
+    def test_text_only_done_space_joins_streamed_parts(self, service, conn_id):
+        from openai.types.realtime.realtime_response_create_params import RealtimeResponseCreateParams
+
+        service._state(conn_id).current_response_params = RealtimeResponseCreateParams(
+            output_modalities=["text"],
+        )
+        service.dispatch_pipeline_event(conn_id, AssistantTextEvent(text="Hello there."))
+        service.dispatch_pipeline_event(conn_id, AssistantTextEvent(text="How are you?"))
+        done_events = service.finish_response(conn_id)
+        text_done = [e for e in done_events if isinstance(e, ResponseTextDoneEvent)]
+        assert len(text_done) == 1
+        # done.text space-joins the per-chunk parts collected during streaming.
+        assert text_done[0].text == "Hello there. How are you?"
+
+    def test_text_only_no_text_done_on_cancel(self, service, conn_id):
+        from openai.types.realtime.realtime_response_create_params import RealtimeResponseCreateParams
+
+        service._state(conn_id).current_response_params = RealtimeResponseCreateParams(
+            output_modalities=["text"],
+        )
+        service.dispatch_pipeline_event(conn_id, AssistantTextEvent(text="partial"))
+        done_events = service.finish_response(conn_id, status="cancelled", reason="client_cancelled")
+        assert not any(isinstance(e, ResponseTextDoneEvent) for e in done_events)
+        assert any(isinstance(e, ResponseDoneEvent) for e in done_events)
 
     def test_assistant_text_text_only_keeps_tool_events(self, service, conn_id):
         from openai.types.realtime.realtime_response_create_params import RealtimeResponseCreateParams
@@ -921,9 +952,10 @@ class TestDispatchPipelineEvent:
                 tools=[{"type": "function_call", "call_id": "c1", "name": "get_weather", "arguments": "{}"}],
             ),
         )
+        # No per-chunk done anymore: delta, then the tool event at output_index 1.
         assert isinstance(events[0], ResponseTextDeltaEvent)
-        assert isinstance(events[1], ResponseTextDoneEvent)
-        tool_event = events[2]
+        assert not any(isinstance(e, ResponseTextDoneEvent) for e in events)
+        tool_event = events[1]
         assert isinstance(tool_event, ResponseFunctionCallArgumentsDoneEvent)
         assert tool_event.output_index == 1
         assert tool_event.name == "get_weather"
@@ -1551,7 +1583,7 @@ class TestUsageMetricsTracking:
             conn_id,
             TokenUsageEvent(input_tokens=100, output_tokens=50),
         )
-        events = service.finish_audio_response(conn_id)
+        events = service.finish_response(conn_id)
         done_evt = events[1]
         assert isinstance(done_evt, ResponseDoneEvent)
         assert done_evt.response.usage.input_tokens == 100
@@ -1615,14 +1647,14 @@ class TestUsageMetricsTracking:
         assert service.total_usage.input_tokens == 0
         assert service.total_usage.output_tokens == 0
 
-    def test_finish_audio_response_resets_per_response_tokens(self, service, conn_id):
-        """After finish_audio_response, per-response counters are zero."""
+    def test_finish_response_resets_per_response_tokens(self, service, conn_id):
+        """After finish_response, per-response counters are zero."""
         service.response._ensure_response(conn_id)
         service.dispatch_pipeline_event(
             conn_id,
             TokenUsageEvent(input_tokens=50, output_tokens=25),
         )
-        service.finish_audio_response(conn_id)
+        service.finish_response(conn_id)
         usage = service._state(conn_id).response_usage
         assert usage.input_tokens == 0
         assert usage.output_tokens == 0
@@ -1669,23 +1701,23 @@ class TestUsageMetricsTracking:
 
     def test_responses_completed_increments(self, service, conn_id):
         service.response._ensure_response(conn_id)
-        service.finish_audio_response(conn_id)
+        service.finish_response(conn_id)
         assert service.total_usage.responses_completed == 1
         assert service.total_usage.responses_cancelled == 0
 
     def test_responses_cancelled_increments(self, service, conn_id):
         service.response._ensure_response(conn_id)
-        service.finish_audio_response(conn_id, status="cancelled", reason="turn_detected")
+        service.finish_response(conn_id, status="cancelled", reason="turn_detected")
         assert service.total_usage.responses_cancelled == 1
         assert service.total_usage.responses_completed == 0
 
     def test_multiple_responses_accumulate_status_counters(self, service, conn_id):
         service.response._ensure_response(conn_id)
-        service.finish_audio_response(conn_id)
+        service.finish_response(conn_id)
         service.response._ensure_response(conn_id)
-        service.finish_audio_response(conn_id, status="cancelled", reason="client_cancelled")
+        service.finish_response(conn_id, status="cancelled", reason="client_cancelled")
         service.response._ensure_response(conn_id)
-        service.finish_audio_response(conn_id)
+        service.finish_response(conn_id)
         assert service.total_usage.responses_completed == 2
         assert service.total_usage.responses_cancelled == 1
 
@@ -1713,7 +1745,7 @@ class TestUsageMetricsTracking:
                 tools=[{"type": "function_call", "call_id": "c1", "name": "f1", "arguments": "{}"}],
             ),
         )
-        service.finish_audio_response(conn_id)
+        service.finish_response(conn_id)
         assert service.total_usage.tool_calls == 1
         assert service._state(conn_id).response_usage.tool_calls == 0
 
@@ -1778,7 +1810,7 @@ class TestUsageMetricsTracking:
                 tools=[{"type": "function_call", "call_id": "c1", "name": "f1", "arguments": "{}"}],
             ),
         )
-        service.finish_audio_response(conn_id)
+        service.finish_response(conn_id)
         service.make_error("oops", "some_error")
         usage = service.get_usage()
         assert usage["input_tokens"] == 10

--- a/tests/openai_realtime/test_realtime_service.py
+++ b/tests/openai_realtime/test_realtime_service.py
@@ -41,6 +41,7 @@ from speech_to_speech.api.openai_realtime.service import (
 from speech_to_speech.pipeline.events import (
     AssistantTextEvent,
     PartialTranscriptionEvent,
+    ResponseFailedEvent,
     SpeechStartedEvent,
     SpeechStoppedEvent,
     TokenUsageEvent,
@@ -1411,6 +1412,34 @@ class TestDispatchPipelineEvent:
         assert len(user_items) == 1
         assert user_items[0].content[0].text == "hello and more"
         service.unregister(conn_id)
+
+    # -- response_failed --
+
+    def test_response_failed_emits_error_and_failed_done(self, service, conn_id):
+        service.response._ensure_response(conn_id)
+        events = service.dispatch_pipeline_event(
+            conn_id,
+            ResponseFailedEvent(message="input must not be empty"),
+        )
+        # A top-level error event carries the reason (response.done can't), then
+        # the response is closed as failed.
+        err = events[0]
+        assert isinstance(err, RealtimeErrorEvent)
+        assert err.error.message == "input must not be empty"
+        assert err.error.type == "response_failed"
+        done = [e for e in events if isinstance(e, ResponseDoneEvent)]
+        assert len(done) == 1
+        assert done[0].response.status == "failed"
+        # Slot released so the next response is not locked out.
+        assert service._state(conn_id).in_response is False
+
+    def test_response_failed_without_active_response_is_noop(self, service, conn_id):
+        # No active response (e.g. already closed): nothing to fail, emit nothing.
+        events = service.dispatch_pipeline_event(
+            conn_id,
+            ResponseFailedEvent(message="too late"),
+        )
+        assert events == []
 
     # -- unknown --
 

--- a/tests/openai_realtime/test_realtime_service.py
+++ b/tests/openai_realtime/test_realtime_service.py
@@ -28,6 +28,8 @@ from openai.types.realtime import (
     ResponseCreateEvent,
     ResponseDoneEvent,
     ResponseFunctionCallArgumentsDoneEvent,
+    ResponseTextDeltaEvent,
+    ResponseTextDoneEvent,
     SessionCreatedEvent,
     SessionUpdateEvent,
 )
@@ -605,6 +607,19 @@ class TestFinishAudioResponse:
         assert isinstance(events[1], ResponseDoneEvent)
         assert events[1].response.status == "completed"
 
+    def test_finish_text_only_skips_audio_done(self, service, conn_id):
+        from openai.types.realtime.realtime_response_create_params import RealtimeResponseCreateParams
+
+        service._state(conn_id).current_response_params = RealtimeResponseCreateParams(
+            output_modalities=["text"],
+        )
+        service.response._ensure_response(conn_id)
+        events = service.finish_audio_response(conn_id)
+        assert len(events) == 1
+        assert isinstance(events[0], ResponseDoneEvent)
+        assert events[0].response.status == "completed"
+        assert not any(isinstance(e, ResponseAudioDoneEvent) for e in events)
+
     def test_finish_with_cancel_status(self, service, conn_id):
         service.response._ensure_response(conn_id)
         events = service.finish_audio_response(conn_id, status="cancelled", reason="turn_detected")
@@ -805,6 +820,47 @@ class TestDispatchPipelineEvent:
         assert len(events) == 1
         assert isinstance(events[0], ResponseFunctionCallArgumentsDoneEvent)
         assert events[0].output_index == 0
+
+    def test_assistant_text_text_only_emits_text_events(self, service, conn_id):
+        from openai.types.realtime.realtime_response_create_params import RealtimeResponseCreateParams
+
+        service._state(conn_id).current_response_params = RealtimeResponseCreateParams(
+            output_modalities=["text"],
+        )
+        events = service.dispatch_pipeline_event(
+            conn_id,
+            AssistantTextEvent(text="Hello there"),
+        )
+        assert len(events) == 2
+        assert isinstance(events[0], ResponseTextDeltaEvent)
+        assert events[0].content_index == 0
+        assert events[0].output_index == 0
+        assert events[0].delta == "Hello there"
+        assert isinstance(events[1], ResponseTextDoneEvent)
+        assert events[1].content_index == 0
+        assert events[1].output_index == 0
+        assert events[1].text == "Hello there"
+        assert not any(isinstance(e, ResponseAudioTranscriptDoneEvent) for e in events)
+
+    def test_assistant_text_text_only_keeps_tool_events(self, service, conn_id):
+        from openai.types.realtime.realtime_response_create_params import RealtimeResponseCreateParams
+
+        service._state(conn_id).current_response_params = RealtimeResponseCreateParams(
+            output_modalities=["text"],
+        )
+        events = service.dispatch_pipeline_event(
+            conn_id,
+            AssistantTextEvent(
+                text="Let me check",
+                tools=[{"type": "function_call", "call_id": "c1", "name": "get_weather", "arguments": "{}"}],
+            ),
+        )
+        assert isinstance(events[0], ResponseTextDeltaEvent)
+        assert isinstance(events[1], ResponseTextDoneEvent)
+        tool_event = events[2]
+        assert isinstance(tool_event, ResponseFunctionCallArgumentsDoneEvent)
+        assert tool_event.output_index == 1
+        assert tool_event.name == "get_weather"
 
     def test_assistant_text_waits_for_pending_reopen_and_drops_confirmed_stale_turn(
         self,

--- a/tests/openai_realtime/test_websocket_router.py
+++ b/tests/openai_realtime/test_websocket_router.py
@@ -468,7 +468,7 @@ class TestSendLoop:
                 conn_id = list(service._conns.keys())[0]
                 stale_generation = cancel_scope.generation
                 service.response._ensure_response(conn_id)
-                service.finish_audio_response(conn_id, status="cancelled")
+                service.finish_response(conn_id, status="cancelled")
                 cancel_scope.cancel()
                 current_response_id, _ = service.response._ensure_response(conn_id)
 
@@ -540,7 +540,7 @@ class TestSendLoop:
         ws = _FakeWebSocket()
 
         asyncio.run(router_module._drain_pending_response_events(ws, unit, conn_id))
-        done_events = service.finish_audio_response(conn_id)
+        done_events = service.finish_response(conn_id)
 
         assert [payload["type"] for payload in ws.sent] == ["response.function_call_arguments.done"]
         assert [event.type for event in done_events] == ["response.output_audio.done", "response.done"]
@@ -580,7 +580,7 @@ class TestSendLoop:
         ws = _FakeWebSocket()
 
         asyncio.run(router_module._drain_pending_response_events(ws, unit, conn_id))
-        done_events = service.finish_audio_response(conn_id)
+        done_events = service.finish_response(conn_id)
 
         assert [payload["type"] for payload in ws.sent] == ["response.function_call_arguments.done"]
         assert ws.sent[0]["response_id"] == response_id

--- a/tests/test_chat.py
+++ b/tests/test_chat.py
@@ -27,11 +27,13 @@ from openai.types.realtime.realtime_conversation_item_system_message import (
 from openai.types.realtime.realtime_conversation_item_user_message import (
     Content as UserContent,
 )
+from openai.types.realtime.realtime_response_create_params import RealtimeResponseCreateParams
 
 from speech_to_speech.LLM.chat import (
     Chat,
     ChatItemError,
     CompactionResult,
+    build_active_chat,
     make_assistant_message,
     make_system_message,
     make_user_message,
@@ -1197,3 +1199,59 @@ class TestCompaction:
             if isinstance(msg, dict) and msg.get("role") == "user":
                 for c in msg.get("content", []):
                     assert c.get("type") != "input_image"
+
+
+# ===================================================================
+# build_active_chat (out-of-band response context)
+# ===================================================================
+
+
+class TestBuildActiveChat:
+    def _default(self) -> Chat:
+        chat = Chat(size=4)
+        chat.init_chat(make_system_message("default system"))
+        chat.add_item(_user("default question"))
+        return chat
+
+    def test_input_items_seed_fresh_chat(self):
+        original = self._default()
+        resp = RealtimeResponseCreateParams(conversation="none", input=[make_user_message("fresh question")])
+
+        active = build_active_chat(original, resp)
+
+        assert active is not original
+        texts = [p.text for item in active.buffer for p in item.content]
+        assert texts == ["fresh question"]
+        # The default conversation's history did not leak in.
+        assert active.init_chat_message is None
+
+    def test_empty_input_clears_context(self):
+        original = self._default()
+        resp = RealtimeResponseCreateParams(conversation="none", input=[])
+
+        active = build_active_chat(original, resp)
+
+        assert active.buffer == []
+
+    def test_absent_input_copies_default(self):
+        original = self._default()
+        resp = RealtimeResponseCreateParams(conversation="none", input=None)
+
+        active = build_active_chat(original, resp)
+
+        assert active is not original
+        texts = [p.text for item in active.buffer for p in item.content]
+        assert texts == ["default question"]
+        assert active.init_chat_message is original.init_chat_message
+
+    def test_invalid_input_item_raises(self):
+        original = self._default()
+        from openai.types.realtime.conversation_item import RealtimeConversationItemFunctionCallOutput
+
+        orphan = RealtimeConversationItemFunctionCallOutput(
+            type="function_call_output", call_id="call_missing", output="{}"
+        )
+        resp = RealtimeResponseCreateParams(conversation="none", input=[orphan])
+
+        with pytest.raises(ChatItemError):
+            build_active_chat(original, resp)

--- a/tests/test_lm_output_processor.py
+++ b/tests/test_lm_output_processor.py
@@ -1,8 +1,10 @@
 from queue import Queue
 from threading import Event, Thread
 
+from openai.types.realtime.realtime_response_create_params import RealtimeResponseCreateParams
+
 from speech_to_speech.LLM.lm_output_processor import LMOutputProcessor
-from speech_to_speech.pipeline.messages import EndOfResponse, LLMResponseChunk
+from speech_to_speech.pipeline.messages import EndOfResponse, LLMResponseChunk, TTSInput
 from speech_to_speech.pipeline.speculative_turns import SpeculativeTurnTracker
 
 
@@ -52,6 +54,49 @@ def test_cancel_generation_is_forwarded_to_tts():
 
     assert len(outputs) == 1
     assert outputs[0].cancel_generation == 7
+
+
+def test_text_only_chunk_is_not_forwarded_to_tts():
+    tracker = SpeculativeTurnTracker()
+    tracker.observe("turn_1", 0)
+    processor = _processor(tracker)
+
+    outputs = list(
+        processor.process(
+            LLMResponseChunk(
+                text="hello",
+                turn_id="turn_1",
+                turn_revision=0,
+                response=RealtimeResponseCreateParams(output_modalities=["text"]),
+            )
+        )
+    )
+
+    assert outputs == []
+    # The assistant text still reaches clients even when TTS is skipped.
+    event = processor.text_output_queue.get_nowait()
+    assert event.text == "hello"
+
+
+def test_audio_chunk_is_forwarded_to_tts():
+    tracker = SpeculativeTurnTracker()
+    tracker.observe("turn_1", 0)
+    processor = _processor(tracker)
+
+    outputs = list(
+        processor.process(
+            LLMResponseChunk(
+                text="hello",
+                turn_id="turn_1",
+                turn_revision=0,
+                response=RealtimeResponseCreateParams(output_modalities=["audio"]),
+            )
+        )
+    )
+
+    assert len(outputs) == 1
+    assert isinstance(outputs[0], TTSInput)
+    assert outputs[0].text == "hello"
 
 
 def test_pending_reopen_holds_assistant_chunk_until_cancelled():

--- a/tests/test_lm_output_processor.py
+++ b/tests/test_lm_output_processor.py
@@ -99,6 +99,26 @@ def test_audio_chunk_is_forwarded_to_tts():
     assert outputs[0].text == "hello"
 
 
+def test_empty_modalities_is_forwarded_to_tts():
+    tracker = SpeculativeTurnTracker()
+    tracker.observe("turn_1", 0)
+    processor = _processor(tracker)
+
+    outputs = list(
+        processor.process(
+            LLMResponseChunk(
+                text="hello",
+                turn_id="turn_1",
+                turn_revision=0,
+                response=RealtimeResponseCreateParams(output_modalities=[]),
+            )
+        )
+    )
+
+    assert len(outputs) == 1
+    assert isinstance(outputs[0], TTSInput)
+
+
 def test_pending_reopen_holds_assistant_chunk_until_cancelled():
     tracker = SpeculativeTurnTracker()
     tracker.observe("turn_1", 0)

--- a/tests/test_responses_api_language_model.py
+++ b/tests/test_responses_api_language_model.py
@@ -134,6 +134,56 @@ def test_process_streams_text_from_response_events():
     assert isinstance(outputs[2], EndOfResponse)
 
 
+def test_text_only_response_forces_non_streaming_call():
+    handler = _make_handler(stream=True)
+    captured = {}
+
+    def fake_create(**kwargs):
+        captured.update(kwargs)
+        return _make_response(
+            output=[
+                ResponseOutputMessage(
+                    id="msg_1",
+                    type="message",
+                    role="assistant",
+                    status="completed",
+                    content=[ResponseOutputText(type="output_text", text="Hello there.", annotations=[])],
+                )
+            ]
+        )
+
+    handler.client = SimpleNamespace(responses=SimpleNamespace(create=fake_create))
+
+    cfg = _make_runtime_config()
+    cfg.chat.add_item(make_user_message("Hi"))
+    req = GenerateResponseRequest(
+        runtime_config=cfg,
+        response=RealtimeResponseCreateParams(output_modalities=["text"]),
+    )
+
+    outputs = list(handler.process(req))
+
+    # Text-only forces stream=False even though the handler is configured to stream.
+    assert captured["stream"] is False
+    assert any(isinstance(o, LLMResponseChunk) and o.text == "Hello there." for o in outputs)
+
+
+def test_audio_response_keeps_streaming_call():
+    handler = _make_handler(stream=True)
+    captured = {}
+
+    def fake_create(**kwargs):
+        captured.update(kwargs)
+        return _make_stream([_make_text_delta_event("Hi."), _make_output_item_done_event(content="Hi.")])
+
+    handler.client = SimpleNamespace(responses=SimpleNamespace(create=fake_create))
+
+    # response=None defaults to audio, so streaming is preserved.
+    list(handler.process(_make_request("Hi")))
+
+    assert captured["stream"] is True
+
+
 def test_process_flushes_tool_lead_in_before_function_call_with_sentence_batching():
     handler = _make_handler()
     handler.stream_batch_sentences = 3

--- a/tests/test_responses_api_language_model.py
+++ b/tests/test_responses_api_language_model.py
@@ -333,6 +333,62 @@ def test_process_read_timeout_ends_response_cleanly():
     assert isinstance(outputs[1], EndOfResponse)
 
 
+def test_generation_error_emits_failed_end_of_response():
+    """A non-timeout failure (e.g. provider rejecting empty input) must still emit a
+    terminating EndOfResponse carrying the error, so the response is closed instead
+    of escaping process() and locking st.in_response forever."""
+    handler = _make_handler()
+
+    def boom(**kwargs):
+        raise RuntimeError("input must not be empty")
+
+    handler.client = SimpleNamespace(responses=SimpleNamespace(create=boom))
+
+    outputs = list(handler.process(_make_request("Hi")))
+
+    eors = [o for o in outputs if isinstance(o, EndOfResponse)]
+    assert len(eors) == 1
+    assert eors[0].error is not None
+    assert "input must not be empty" in eors[0].error
+    # No partial output committed; the only thing emitted is the failed EndOfResponse.
+    assert all(isinstance(o, EndOfResponse) for o in outputs)
+
+
+def test_empty_context_fails_with_clear_message_without_calling_provider():
+    """Out-of-band, text-only, empty `instructions`, input=[] -> empty context. We
+    fail fast with a clear, instructions-aware message and never call the provider
+    (which would reject the empty input), so the response terminates instead of
+    hanging."""
+    handler = _make_handler()
+    called = False
+
+    def fake_create(**kwargs):
+        nonlocal called
+        called = True
+        return _make_response(output=[])
+
+    handler.client = SimpleNamespace(responses=SimpleNamespace(create=fake_create))
+
+    cfg = _make_runtime_config(instructions="")  # empty instructions -> no system message
+    req = GenerateResponseRequest(
+        runtime_config=cfg,
+        response=RealtimeResponseCreateParams(
+            conversation="none",
+            output_modalities=["text"],
+            input=[],
+        ),
+    )
+
+    outputs = list(handler.process(req))
+
+    assert not called  # short-circuited before reaching the provider
+    eors = [o for o in outputs if isinstance(o, EndOfResponse)]
+    assert len(eors) == 1
+    assert eors[0].error is not None
+    assert "instructions" in eors[0].error
+    assert "input" in eors[0].error
+
+
 def test_disable_thinking_passes_extra_body():
     handler = _make_handler(disable_thinking=True)
     captured = {}

--- a/tests/test_responses_api_language_model.py
+++ b/tests/test_responses_api_language_model.py
@@ -134,21 +134,20 @@ def test_process_streams_text_from_response_events():
     assert isinstance(outputs[2], EndOfResponse)
 
 
-def test_text_only_response_forces_non_streaming_call():
+def test_text_only_streams_raw_deltas_without_sentence_trimming():
+    """Text-only streams (so a new speech turn can interrupt it) and forwards each
+    delta verbatim — no sent_tokenize (newlines / markdown survive) and no
+    remove_unspeechable (emoji / symbols survive)."""
     handler = _make_handler(stream=True)
     captured = {}
 
     def fake_create(**kwargs):
         captured.update(kwargs)
-        return _make_response(
-            output=[
-                ResponseOutputMessage(
-                    id="msg_1",
-                    type="message",
-                    role="assistant",
-                    status="completed",
-                    content=[ResponseOutputText(type="output_text", text="Hello there.", annotations=[])],
-                )
+        return _make_stream(
+            [
+                _make_text_delta_event("# Title 🎉\n"),
+                _make_text_delta_event("- one\n- two 😀\n"),
+                _make_output_item_done_event(content="# Title 🎉\n- one\n- two 😀\n"),
             ]
         )
 
@@ -163,12 +162,15 @@ def test_text_only_response_forces_non_streaming_call():
 
     outputs = list(handler.process(req))
 
-    # Text-only forces stream=False even though the handler is configured to stream.
-    assert captured["stream"] is False
-    assert any(isinstance(o, LLMResponseChunk) and o.text == "Hello there." for o in outputs)
+    # Still streamed, not a single buffered chunk.
+    assert captured["stream"] is True
+    texts = [o.text for o in outputs if isinstance(o, LLMResponseChunk)]
+    # Raw deltas: markdown layout AND emoji preserved (no trimming, no unspeechable filter).
+    assert texts == ["# Title 🎉\n", "- one\n- two 😀\n"]
+    assert "".join(texts) == "# Title 🎉\n- one\n- two 😀\n"
 
 
-def test_audio_response_keeps_streaming_call():
+def test_audio_response_sentence_batches_streaming_call():
     handler = _make_handler(stream=True)
     captured = {}
 

--- a/tests/test_responses_api_language_model.py
+++ b/tests/test_responses_api_language_model.py
@@ -4,6 +4,11 @@ from unittest.mock import MagicMock
 
 import httpx
 from openai import Stream
+from openai.types.realtime.conversation_item import (
+    RealtimeConversationItemAssistantMessage,
+    RealtimeConversationItemFunctionCallOutput,
+)
+from openai.types.realtime.realtime_response_create_params import RealtimeResponseCreateParams
 from openai.types.responses import (
     Response,
     ResponseFunctionToolCall,
@@ -361,3 +366,101 @@ def test_second_turn_flattens_assistant_history_for_responses():
     assert len(ai["content"]) == 1
     assert ai["content"][0]["type"] == "output_text"
     assert ai["content"][0]["text"] == "Hello."
+
+
+# ── Out-of-band (conversation="none") responses ──────────────────────────
+
+
+def _make_oob_request(input_items, *, conversation="none", chat_size=2, seed_default="Hi"):
+    cfg = _make_runtime_config(chat_size=chat_size)
+    if seed_default is not None:
+        cfg.chat.add_item(make_user_message(seed_default))
+    resp = RealtimeResponseCreateParams(conversation=conversation, input=input_items)
+    return GenerateResponseRequest(runtime_config=cfg, response=resp), cfg
+
+
+def _capture_create(handler, events):
+    captured = {}
+
+    def fake_create(**kwargs):
+        captured.update(kwargs)
+        return _make_stream(events)
+
+    handler.client = SimpleNamespace(responses=SimpleNamespace(create=fake_create))
+    return captured
+
+
+def test_out_of_band_emits_output_but_does_not_commit_to_default_conversation():
+    handler = _make_handler()
+    req, cfg = _make_oob_request([make_user_message("OOB question")])
+    events = [_make_text_delta_event("OOB answer."), _make_output_item_done_event(content="OOB answer.")]
+    _capture_create(handler, events)
+
+    outputs = list(handler.process(req))
+
+    # The response is still produced and streamed back to the client...
+    assert any(isinstance(o, LLMResponseChunk) and o.text == "OOB answer." for o in outputs)
+    # ...but the default conversation keeps only the seeded user turn — no assistant commit.
+    assert len(cfg.chat.buffer) == 1
+    assert not any(isinstance(i, RealtimeConversationItemAssistantMessage) for i in cfg.chat.buffer)
+
+
+def test_out_of_band_input_builds_fresh_context():
+    handler = _make_handler()
+    req, _cfg = _make_oob_request([make_user_message("OOB question")])
+    captured = _capture_create(handler, [_make_output_item_done_event(content="ok")])
+
+    list(handler.process(req))
+
+    serialized = str(captured["input"])
+    assert "OOB question" in serialized
+    assert "Hi" not in serialized  # default conversation history is excluded
+
+
+def test_out_of_band_empty_input_clears_context():
+    handler = _make_handler()
+    req, _cfg = _make_oob_request([])
+    captured = _capture_create(handler, [_make_output_item_done_event(content="ok")])
+
+    list(handler.process(req))
+
+    serialized = str(captured["input"])
+    assert "Hi" not in serialized  # default conversation not used
+    assert "helpful AI assistant" in serialized  # only the system prompt remains
+
+
+def test_out_of_band_absent_input_reads_default_conversation():
+    handler = _make_handler()
+    req, cfg = _make_oob_request(None)
+    captured = _capture_create(handler, [_make_output_item_done_event(content="ok")])
+
+    list(handler.process(req))
+
+    serialized = str(captured["input"])
+    assert "Hi" in serialized  # default conversation used as read-only context
+    # Still read-only: no assistant message committed back.
+    assert len(cfg.chat.buffer) == 1
+
+
+def test_out_of_band_invalid_input_emits_failed_end_of_response():
+    handler = _make_handler()
+    called = False
+
+    def fake_create(**kwargs):
+        nonlocal called
+        called = True
+        return _make_stream([])
+
+    handler.client = SimpleNamespace(responses=SimpleNamespace(create=fake_create))
+    # function_call_output referencing an unknown call_id fails validation.
+    orphan = RealtimeConversationItemFunctionCallOutput(
+        type="function_call_output", call_id="call_missing", output="{}"
+    )
+    req, _cfg = _make_oob_request([orphan])
+
+    outputs = list(handler.process(req))
+
+    assert not called  # generation never started
+    assert len(outputs) == 1
+    assert isinstance(outputs[0], EndOfResponse)
+    assert outputs[0].error is not None

--- a/tests/test_text_prompt.py
+++ b/tests/test_text_prompt.py
@@ -6,8 +6,8 @@ from speech_to_speech.LLM.tool_call.tool_prompt import build_tool_system_prompt
 def test_text_prompt_keeps_persona_in_session_prompt():
     prompt = build_text_system_prompt("Be helpful.")
 
-    assert "The session prompt defines who you are and what to do." in prompt
     assert "Be helpful." in prompt
+    assert "You are in a text conversation." in prompt
     assert "You are in a text conversation." in TEXT_SYSTEM_PROMPT
 
 

--- a/tests/test_text_prompt.py
+++ b/tests/test_text_prompt.py
@@ -7,8 +7,8 @@ def test_text_prompt_keeps_persona_in_session_prompt():
     prompt = build_text_system_prompt("Be helpful.")
 
     assert "Be helpful." in prompt
-    assert "You are a helpful assistant." in prompt
-    assert "You are a helpful assistant." in TEXT_SYSTEM_PROMPT
+    assert "You are a helpful assistant in a text conversation." in prompt
+    assert "You are a helpful assistant in a text conversation." in TEXT_SYSTEM_PROMPT
 
 
 def test_text_prompt_allows_markdown_and_drops_voice_rules():

--- a/tests/test_text_prompt.py
+++ b/tests/test_text_prompt.py
@@ -6,7 +6,7 @@ from speech_to_speech.LLM.tool_call.tool_prompt import build_tool_system_prompt
 def test_text_prompt_keeps_persona_in_session_prompt():
     prompt = build_text_system_prompt("Be helpful.")
 
-    assert "The session prompt defines persona" in prompt
+    assert "The session prompt defines who you are and what to do." in prompt
     assert "Be helpful." in prompt
     assert "You are in a text conversation." in TEXT_SYSTEM_PROMPT
 

--- a/tests/test_text_prompt.py
+++ b/tests/test_text_prompt.py
@@ -7,8 +7,8 @@ def test_text_prompt_keeps_persona_in_session_prompt():
     prompt = build_text_system_prompt("Be helpful.")
 
     assert "Be helpful." in prompt
-    assert "You are in a text conversation." in prompt
-    assert "You are in a text conversation." in TEXT_SYSTEM_PROMPT
+    assert "You are a helpful assistant." in prompt
+    assert "You are a helpful assistant." in TEXT_SYSTEM_PROMPT
 
 
 def test_text_prompt_allows_markdown_and_drops_voice_rules():

--- a/tests/test_text_prompt.py
+++ b/tests/test_text_prompt.py
@@ -1,0 +1,51 @@
+from speech_to_speech.LLM.text_prompt import TEXT_SYSTEM_PROMPT, build_text_system_prompt
+from speech_to_speech.LLM.tool_call.function_tool import FunctionTool
+from speech_to_speech.LLM.tool_call.tool_prompt import build_tool_system_prompt
+
+
+def test_text_prompt_keeps_persona_in_session_prompt():
+    prompt = build_text_system_prompt("Be helpful.")
+
+    assert "The session prompt defines persona" in prompt
+    assert "Be helpful." in prompt
+    assert "You are in a text conversation." in TEXT_SYSTEM_PROMPT
+
+
+def test_text_prompt_allows_markdown_and_drops_voice_rules():
+    prompt = build_text_system_prompt("Be helpful.")
+
+    assert "Use markdown when it helps" in prompt
+    assert "If unsure whether a tool is needed, just answer directly." in prompt
+    # No spoken-channel rules leak into the text prompt.
+    assert "Speech is the default." not in prompt
+    assert "Treat transcripts as noisy." not in prompt
+    assert "Before a tool call, use a brief natural utterance" not in prompt
+    assert "speak first" not in prompt
+
+
+def _dance_tool() -> FunctionTool:
+    return FunctionTool(
+        type="function",
+        name="dance",
+        description="Dance once.",
+        parameters={"type": "object", "properties": {}},
+    )
+
+
+def test_text_tool_prompt_drops_speak_first_but_keeps_structural_rules():
+    prompt = build_tool_system_prompt([_dance_tool()], text_only=True)
+
+    assert "no preamble sentence is required" in prompt
+    assert "Only one tool call may appear in a response." in prompt
+    assert "Omit optional args instead of placeholder values" in prompt
+    assert "do not claim tool results before a tool result is available" in prompt
+    # Voice choreography must not appear in the text variant.
+    assert "always speak first" not in prompt
+    assert "Sure, here's my best <emotion>." not in prompt
+    assert "fitting empathetic sentence" not in prompt
+
+
+def test_voice_tool_prompt_is_default():
+    prompt = build_tool_system_prompt([_dance_tool()])
+
+    assert "always speak first" in prompt


### PR DESCRIPTION
## What

Two related additions to `response.create` handling, both mirroring OpenAI realtime semantics.

### 1. Text-only responses via `output_modalities`

When the requested modalities are a non-empty list omitting `"audio"` (e.g. `["text"]`), the backend produces a **text-only** response: it skips TTS, emits `response.output_text.delta` / `response.output_text.done` instead of audio transcript + `response.output_audio.done`, and instructs the model with a written-channel system prompt.

- `output_modalities` absent (`None`), `[]`, or containing `"audio"` → audio (unchanged).
- a non-empty list without `"audio"` (e.g. `["text"]`) → text only.

### 2. Out-of-band responses via `conversation="none"`

When `conversation == "none"`, the response is generated against a **throwaway chat** and is never threaded into the default conversation.

- **Context** from `input`: `None` → read-only copy of the default conversation; `[]` → system prompt only (context cleared); `[...]` → system + those items.
- **Output is not committed** back to the default conversation.
- **`conversation_id` is reported as `null`** on `response.created` / `response.done`.
- Any non-`"none"` `conversation` value (`"auto"`, `None`, arbitrary id) keeps today's in-band behavior.

## How

### Text-only (event / TTS gating)
- `response_wants_audio(response)` helper in `utils/utils.py` — single source of truth.
- `LMOutputProcessor` gates the `TTSInput` yield on it; `EndOfResponse` still flows so the lifecycle closes and the mic re-enables as before.
- `ResponseHandler.on_assistant_text` emits text delta/done when audio isn't wanted; `finish_audio_response` skips `response.output_audio.done` while still emitting `response.done`.
- New `LLM/text_prompt.py` (mirrors `voice_prompt.py`); `build_tool_system_prompt` gains a `text_only` variant. Both LM backends pick voice vs text builders via `wants_audio`.

### Out-of-band
- `is_out_of_band(response)` helper in `utils/utils.py`.
- `LLM/chat.py`: extracted `add_supported_item` (the `ConversationItem` → `SupportedItem` narrow+validate, now shared with the conversation handler) and `build_active_chat` implementing the three-way `input` rule.
- `handlers/response.py`: `handle_response_create` skips the default-chat append for out-of-band and tags the request with `turn_id=None`; `_build_response` nulls `conversation_id`.
- Both LM backends build the ephemeral chat via `build_active_chat` and suppress the commit-back to the default conversation.
- **Staleness bypass for free:** every `SpeculativeTurnTracker` method returns the permissive result for a `None` turn_id, so out-of-band responses are never dropped by a concurrent user turn — no gating-code changes needed.
- **Invalid `input`** surfaces as `response.done(status="failed")` via a new `EndOfResponse.error` → `ResponseFailedEvent` → `_on_response_failed` path (idempotent via the `in_response` guard) instead of taking down the worker.

### Scope notes
- Out-of-band reuses the single-response slot: rejected while another response is active, and barge-in / `response.cancel` still cancels it. True concurrency is out of scope.
- `input` is honored as fresh context only for `conversation="none"`; the in-band `input` path is unchanged.

## Tests

- **Text-only:** `response_wants_audio` gating in `LMOutputProcessor`; `on_assistant_text` text events; `finish_audio_response` skips audio.done; text prompt / tool-prompt content.
- **Out-of-band:** context composition (`input` present / `[]` / absent), output not committed to the default conversation, `conversation_id` null, null-turn staleness bypass, in-band contrast, invalid input → failed response, and `build_active_chat` units.

ruff, ruff format, mypy, and pytest (527 passed) all green locally.