### PR TITLE
Add chat-completions LLM backend (OpenAI /v1/chat/completions)

### DIFF
--- a/README.md
+++ b/README.md
@@ -256,8 +256,9 @@ The LLM is the most compute-intensive and highest-latency component in the pipel
 - **Local inference** — `transformers` (CUDA / CPU) and `mlx-lm` (Apple Silicon) run the model entirely on your machine with no external dependency.
 - **Self-hosted servers** — `--llm_backend responses-api` can point at a local [vLLM](https://github.com/vllm-project/vllm) or [llama.cpp](https://github.com/ggerganov/llama.cpp) server, giving you control over quantization, batching, and hardware while keeping traffic on-premise.
 - **Provider APIs** — the same `responses-api` backend works with OpenAI, [HuggingFace Inference Providers](https://huggingface.co/inference-providers), [OpenRouter](https://openrouter.ai), and any other provider that implements the OpenAI Responses API.
+- **Chat Completions** — `--llm_backend chat-completions` targets the OpenAI-compatible `/v1/chat/completions` endpoint instead of `/v1/responses`. Use it for providers/servers where Responses cannot reliably disable reasoning, or whose Responses streaming tool-call path is unreliable (see [#312](https://github.com/huggingface/speech-to-speech/issues/312)).
 
-Select a backend with `--llm_backend` (`responses-api` by default) and pair it with `--model_name`. Backend-specific options (`--responses_api_base_url`, `--responses_api_api_key`, `--responses_api_stream`, etc.) are only needed for the `responses-api` backend.
+Select a backend with `--llm_backend` (`responses-api` by default) and pair it with `--model_name`. Backend-specific options (`--responses_api_base_url`, `--responses_api_api_key`, `--responses_api_stream`, etc.) are shared by the `responses-api` and `chat-completions` backends.
 
 > The examples below pair Parakeet TDT (local STT) and Qwen3-TTS (local TTS) with different LLM backends.
 
@@ -314,6 +315,44 @@ speech-to-speech \
     --responses_api_api_key "$HF_TOKEN" \
     --responses_api_stream \
     --enable_live_transcription
+```
+
+#### Chat Completions backend (`--llm_backend chat-completions`)
+
+Identical configuration to `responses-api` (it reuses the same `--responses_api_*`
+connection flags), but talks to `/v1/chat/completions` instead of `/v1/responses`.
+Prefer it when:
+
+- the provider ignores `chat_template_kwargs.enable_thinking` on the Responses path and
+  needs a `reasoning_effort` knob to suppress reasoning, or
+- the server's Responses **streaming tool-call** path is unreliable (e.g. some vLLM
+  builds), while its Chat Completions tool-call streaming is solid.
+
+Add `--responses_api_reasoning_effort none` (chat-completions only) to disable reasoning
+on providers where the chat-template flag has no effect:
+
+```bash
+# vLLM (local) serving a Qwen model with tool calling
+speech-to-speech \
+    --mode realtime \
+    --stt parakeet-tdt \
+    --llm_backend chat-completions \
+    --tts qwen3 \
+    --model_name "Qwen/Qwen3-4B-Instruct-2507" \
+    --responses_api_base_url "http://localhost:8000/v1" \
+    --responses_api_stream
+
+# GLM via the HF router — disable reasoning for low voice latency
+speech-to-speech \
+    --mode realtime \
+    --stt parakeet-tdt \
+    --llm_backend chat-completions \
+    --tts qwen3 \
+    --model_name "zai-org/GLM-4.7:cerebras" \
+    --responses_api_base_url "https://router.huggingface.co/v1" \
+    --responses_api_api_key "$HF_TOKEN" \
+    --responses_api_reasoning_effort none \
+    --responses_api_stream
 ```
 
 #### Fully local (Apple Silicon)

--- a/src/speech_to_speech/LLM/chat_completions_language_model.py
+++ b/src/speech_to_speech/LLM/chat_completions_language_model.py
@@ -1,0 +1,559 @@
+from __future__ import annotations
+
+import json
+import logging
+import time
+from collections.abc import Iterator
+from typing import Any, Optional
+
+import httpx
+from nltk import sent_tokenize
+from openai import OpenAI, Stream
+from openai.types.chat import ChatCompletionChunk
+from openai.types.realtime.conversation_item import (
+    RealtimeConversationItemAssistantMessage,
+    RealtimeConversationItemFunctionCall,
+)
+from openai.types.realtime.realtime_conversation_item_assistant_message import (
+    Content as AssistantContent,
+)
+from openai.types.responses import ResponseFunctionToolCall
+
+from speech_to_speech.baseHandler import BaseHandler
+from speech_to_speech.LLM.chat import Chat, SupportedItem, make_system_message, make_user_message
+from speech_to_speech.LLM.compaction_prompt import CompactGenerateFn, build_compactor
+from speech_to_speech.LLM.utils import remove_unspeechable, resolve_auto_language
+from speech_to_speech.LLM.voice_prompt import build_voice_system_prompt
+from speech_to_speech.pipeline.cancel_scope import CancelScope
+from speech_to_speech.pipeline.handler_types import LLMIn, LLMOut
+from speech_to_speech.pipeline.messages import (
+    EndOfResponse,
+    LLMResponseChunk,
+    TokenUsage,
+)
+from speech_to_speech.pipeline.speculative_turns import SpeculativeTurnTracker
+from speech_to_speech.utils.utils import _generate_id
+
+logger = logging.getLogger(__name__)
+
+
+def _to_chat_tools(req_tools: Any) -> list[dict[str, Any]] | None:
+    """Convert Responses-API function tools to Chat-Completions tool format.
+
+    Responses tools are flat ``{type:"function", name, description, parameters}``;
+    Chat Completions nests them under a ``function`` key. Items already in the
+    nested form (or non-function tools) are passed through untouched.
+    """
+    if not req_tools:
+        return None
+    chat_tools: list[dict[str, Any]] = []
+    for t in req_tools:
+        d = t if isinstance(t, dict) else t.model_dump(exclude_none=True)
+        if d.get("type") == "function" and "function" not in d:
+            fn = {k: d[k] for k in ("name", "description", "parameters") if k in d}
+            chat_tools.append({"type": "function", "function": fn})
+        else:
+            chat_tools.append(d)
+    return chat_tools
+
+
+def _to_chat_tool_choice(tool_choice: Any) -> Any:
+    """Convert a Responses-API tool_choice to Chat-Completions form.
+
+    The string forms ("auto"/"required"/"none") are identical across both APIs;
+    only the forced-function object differs (flat ``name`` vs nested ``function``).
+    """
+    if isinstance(tool_choice, dict) and tool_choice.get("type") == "function" and "name" in tool_choice:
+        return {"type": "function", "function": {"name": tool_choice["name"]}}
+    if tool_choice is not None and not isinstance(tool_choice, (str, dict)):
+        d = tool_choice.model_dump(exclude_none=True)
+        if d.get("type") == "function" and "name" in d:
+            return {"type": "function", "function": {"name": d["name"]}}
+        return d
+    return tool_choice
+
+
+class ChatCompletionsApiModelHandler(BaseHandler[LLMIn, LLMOut]):
+    """LLM handler that talks to an OpenAI-compatible ``/v1/chat/completions`` server.
+
+    Functionally mirrors :class:`ResponsesApiModelHandler` but uses the mature
+    Chat Completions streaming tool-call protocol (``choices[].delta.tool_calls``)
+    instead of ``/v1/responses``. This is the robust path for vLLM + Qwen tool
+    calling. The conversation is serialised with :meth:`Chat.to_transformers_chat`,
+    which already emits OpenAI chat messages including ``tool_calls``/``tool`` roles.
+    """
+
+    def setup(
+        self,
+        model_name: str = "gpt-5.4-mini",
+        device: str = "cuda",
+        gen_kwargs: dict[str, Any] = {},
+        base_url: Optional[str] = None,
+        api_key: Optional[str] = None,
+        stream: bool = True,
+        user_role: str = "user",
+        cancel_scope: CancelScope | None = None,
+        speculative_turns: SpeculativeTurnTracker | None = None,
+        disable_thinking: bool = True,
+        reasoning_effort: Optional[str] = None,
+        request_timeout_s: float = 20.0,
+        stream_batch_sentences: int = 3,
+        enable_lang_prompt: bool = False,
+        compact_history: bool = False,
+        **_kwargs: Any,
+    ) -> None:
+        self.cancel_scope = cancel_scope
+        self.speculative_turns = speculative_turns
+        self.model_name = model_name
+        self.stream = stream
+        self.stream_batch_sentences = max(1, stream_batch_sentences)
+        self.enable_lang_prompt = enable_lang_prompt
+        self.gen_kwargs = dict(gen_kwargs)
+        self.request_timeout_s = float(request_timeout_s)
+        self.request_timeout = httpx.Timeout(
+            self.request_timeout_s,
+            connect=min(10.0, self.request_timeout_s),
+        )
+
+        self.user_role = user_role
+        self.client = OpenAI(api_key=api_key, base_url=base_url)
+        self._extra_body = self._build_extra_body(base_url, disable_thinking, reasoning_effort)
+        self.compactor = build_compactor(self._build_compaction_generate_fn()) if compact_history else None
+        self.warmup()
+
+    @staticmethod
+    def _build_extra_body(
+        base_url: Optional[str],
+        disable_thinking: bool,
+        reasoning_effort: Optional[str],
+    ) -> Optional[dict[str, Any]]:
+        """Build the provider-specific ``extra_body`` used to disable reasoning.
+
+        Providers differ in how reasoning is turned off: vLLM/Qwen honour
+        ``chat_template_kwargs.enable_thinking=false``, while others (e.g. GLM via
+        the HF router) ignore that and require ``reasoning_effort='none'``. An
+        explicit ``reasoning_effort`` therefore takes precedence; otherwise we fall
+        back to the chat-template flag. None of this applies to the official
+        OpenAI server, which rejects unknown extra_body keys.
+        """
+        if base_url is None or base_url == "https://api.openai.com/v1":
+            return None
+        if reasoning_effort is not None:
+            return {"reasoning_effort": reasoning_effort}
+        if disable_thinking:
+            return {"chat_template_kwargs": {"enable_thinking": False}}
+        return None
+
+    def _turn_is_latest(self, turn_id: str | None, turn_revision: int | None) -> bool:
+        return self.speculative_turns is None or self.speculative_turns.is_latest(turn_id, turn_revision)
+
+    def _generation_is_stale(self, gen: int | None) -> bool:
+        return gen is not None and self.cancel_scope is not None and self.cancel_scope.is_stale(gen)
+
+    def _turn_output_allowed(self, turn_id: str | None, turn_revision: int | None) -> bool:
+        if self.speculative_turns is None:
+            return True
+        return self.speculative_turns.is_latest_after_reopen_grace(turn_id, turn_revision)
+
+    def warmup(self) -> None:
+        logger.info(f"Warming up {self.__class__.__name__}")
+        start = time.time()
+        self.client.chat.completions.create(
+            model=self.model_name,
+            messages=[
+                {"role": "system", "content": "You are a helpful assistant"},
+                {"role": "user", "content": "Hello"},
+            ],
+            extra_body=self._extra_body,
+            timeout=self.request_timeout,
+        )
+        end = time.time()
+        logger.info(f"{self.__class__.__name__}:  warmed up! time: {(end - start):.3f} s")
+
+    def _build_compaction_generate_fn(self) -> CompactGenerateFn:
+        """Return a generate fn that calls Chat Completions for compaction."""
+        client = self.client
+        model_name = self.model_name
+        timeout = self.request_timeout
+        extra_body = self._extra_body
+
+        def generate(system: str, user: str) -> str:
+            response = client.chat.completions.create(
+                model=model_name,
+                messages=[
+                    {"role": "system", "content": system},
+                    {"role": "user", "content": user},
+                ],
+                extra_body=extra_body,
+                timeout=timeout,
+            )
+            return response.choices[0].message.content or ""
+
+        return generate
+
+    def _apply_config(
+        self,
+        chat: Chat,
+        instructions: Optional[str],
+    ) -> None:
+        if instructions:
+            full_instructions = build_voice_system_prompt(instructions)
+            chat.add_item(make_system_message(full_instructions))
+
+    @staticmethod
+    def _chat_messages(chat: Chat) -> list[dict[str, Any]]:
+        """Serialise the chat for the Chat Completions API.
+
+        ``Chat.to_transformers_chat`` targets HuggingFace ``apply_chat_template``,
+        which expects tool-call ``arguments`` as a parsed object. The OpenAI Chat
+        Completions HTTP API instead requires ``arguments`` to be a JSON *string*,
+        so re-encode any object back to a string here.
+        """
+        messages = chat.to_transformers_chat()
+        for message in messages:
+            for tool_call in message.get("tool_calls") or []:
+                fn = tool_call.get("function")
+                if fn is not None and not isinstance(fn.get("arguments"), str):
+                    fn["arguments"] = json.dumps(fn.get("arguments") or {}, ensure_ascii=False)
+        return messages
+
+    def _generate(
+        self,
+        active_chat: Chat,
+        original_chat: Chat,
+        language_code: Optional[str],
+        gen: int | None,
+        runtime_config: Any,
+        response: Any,
+        optional_kwargs: dict[str, Any],
+        turn_id: str | None,
+        turn_revision: int | None,
+        speech_stopped_at_s: float | None,
+    ) -> Iterator[LLMOut]:
+        api_response: Stream[ChatCompletionChunk] | Any = None
+        tools: list[ResponseFunctionToolCall] = []
+        pending_chat_items: list[SupportedItem] = []
+        clean_text = ""
+        input_tokens = 0
+        output_tokens = 0
+
+        # Accumulate streamed tool-call deltas, keyed by their stream index.
+        tool_accum: dict[int, dict[str, str]] = {}
+
+        def _flush_batch(sentence_batch: list[str]) -> Iterator[LLMOut]:
+            if not sentence_batch:
+                return
+            if not self._turn_output_allowed(turn_id, turn_revision):
+                return
+            yield LLMResponseChunk(
+                text=" ".join(sentence_batch),
+                language_code=language_code,
+                runtime_config=runtime_config,
+                response=response,
+                turn_id=turn_id,
+                turn_revision=turn_revision,
+                speech_stopped_at_s=speech_stopped_at_s,
+                cancel_generation=gen,
+            )
+
+        try:
+            create_kwargs: dict[str, Any] = dict(optional_kwargs)
+            if self.stream:
+                create_kwargs["stream_options"] = {"include_usage": True}
+            api_response = self.client.chat.completions.create(
+                model=self.model_name,
+                messages=self._chat_messages(active_chat),
+                stream=self.stream,
+                extra_body=self._extra_body,
+                timeout=self.request_timeout,
+                **create_kwargs,
+            )
+
+            if isinstance(api_response, Stream):
+                cancelled = False
+                printable_text = ""
+                sentence_batch: list[str] = []
+                for chunk in api_response:
+                    if (
+                        gen is not None and self.cancel_scope is not None and self.cancel_scope.is_stale(gen)
+                    ) or not self._turn_is_latest(turn_id, turn_revision):
+                        logger.info("LLM generation cancelled (interruption)")
+                        cancelled = True
+                        break
+
+                    # Usage-only trailing chunk (choices == []) when include_usage is set.
+                    if chunk.usage is not None:
+                        input_tokens = chunk.usage.prompt_tokens or 0
+                        output_tokens = chunk.usage.completion_tokens or 0
+                    if not chunk.choices:
+                        continue
+
+                    delta = chunk.choices[0].delta
+
+                    if delta.content:
+                        new_text = remove_unspeechable(delta.content)
+                        clean_text += new_text
+                        printable_text += new_text
+                        sentences = sent_tokenize(printable_text)
+                        if len(sentences) > 1:
+                            for s in sentences[:-1]:
+                                sentence_batch.append(s)
+                                if len(sentence_batch) >= self.stream_batch_sentences:
+                                    if not self._turn_output_allowed(turn_id, turn_revision):
+                                        logger.info("LLM generation cancelled (stale speculative turn)")
+                                        cancelled = True
+                                        break
+                                    yield from _flush_batch(sentence_batch)
+                                    sentence_batch = []
+                            if cancelled:
+                                break
+                            printable_text = sentences[-1]
+
+                    if delta.tool_calls:
+                        for tc in delta.tool_calls:
+                            entry = tool_accum.setdefault(tc.index, {"name": "", "args": "", "id": ""})
+                            if tc.id:
+                                entry["id"] = tc.id
+                            if tc.function is not None:
+                                if tc.function.name:
+                                    entry["name"] = tc.function.name
+                                if tc.function.arguments:
+                                    entry["args"] += tc.function.arguments
+
+                if not cancelled:
+                    # Flush any trailing text before emitting tool calls.
+                    if printable_text.strip():
+                        sentence_batch.append(printable_text.strip())
+                    if sentence_batch:
+                        if self._generation_is_stale(gen):
+                            logger.info("LLM generation cancelled (interruption)")
+                        else:
+                            logger.debug(f"Clean text: {clean_text}")
+                            yield from _flush_batch(sentence_batch)
+                    if clean_text.strip():
+                        pending_chat_items.append(
+                            RealtimeConversationItemAssistantMessage(
+                                type="message",
+                                role="assistant",
+                                content=[AssistantContent(type="output_text", text=clean_text)],
+                            )
+                        )
+                    yield from self._emit_tool_calls(
+                        tool_accum,
+                        tools,
+                        pending_chat_items,
+                        language_code,
+                        gen,
+                        runtime_config,
+                        response,
+                        turn_id,
+                        turn_revision,
+                        speech_stopped_at_s,
+                    )
+                    if tools:
+                        logger.info(f"Tools: {tools}")
+            else:
+                if (
+                    gen is not None and self.cancel_scope is not None and self.cancel_scope.is_stale(gen)
+                ) or not self._turn_is_latest(turn_id, turn_revision):
+                    logger.info("LLM generation cancelled (interruption)")
+                else:
+                    usage = api_response.usage
+                    if usage:
+                        input_tokens = usage.prompt_tokens or 0
+                        output_tokens = usage.completion_tokens or 0
+                    message = api_response.choices[0].message
+                    message_text = remove_unspeechable(message.content or "")
+                    clean_text += message_text
+                    if message_text.strip():
+                        pending_chat_items.append(
+                            RealtimeConversationItemAssistantMessage(
+                                type="message",
+                                role="assistant",
+                                content=[AssistantContent(type="output_text", text=message.content or "")],
+                            )
+                        )
+                        if not self._generation_is_stale(gen) and self._turn_output_allowed(turn_id, turn_revision):
+                            yield LLMResponseChunk(
+                                text=message_text.strip(),
+                                language_code=language_code,
+                                runtime_config=runtime_config,
+                                response=response,
+                                turn_id=turn_id,
+                                turn_revision=turn_revision,
+                                speech_stopped_at_s=speech_stopped_at_s,
+                                cancel_generation=gen,
+                            )
+                    for tc in message.tool_calls or []:
+                        tool_accum[len(tool_accum)] = {
+                            "name": tc.function.name or "",
+                            "args": tc.function.arguments or "",
+                            "id": tc.id or "",
+                        }
+                    yield from self._emit_tool_calls(
+                        tool_accum,
+                        tools,
+                        pending_chat_items,
+                        language_code,
+                        gen,
+                        runtime_config,
+                        response,
+                        turn_id,
+                        turn_revision,
+                        speech_stopped_at_s,
+                    )
+                    logger.debug(f"Clean text: {clean_text}")
+                    if tools:
+                        logger.info(f"Tools: {tools}")
+        except httpx.ReadTimeout:
+            logger.warning(
+                "OpenAI API read timed out after %.1fs; ending the current response",
+                self.request_timeout_s,
+            )
+            if not self._generation_is_stale(gen) and self._turn_output_allowed(turn_id, turn_revision):
+                yield LLMResponseChunk(
+                    text="Wow I'm a bit slow today, could you repeat that?",
+                    runtime_config=runtime_config,
+                    response=response,
+                    turn_id=turn_id,
+                    turn_revision=turn_revision,
+                    speech_stopped_at_s=speech_stopped_at_s,
+                    cancel_generation=gen,
+                )
+        finally:
+            if api_response is not None and hasattr(api_response, "close"):
+                try:
+                    api_response.close()
+                except Exception:
+                    pass
+
+        if not self._generation_is_stale(gen) and self._turn_output_allowed(turn_id, turn_revision):
+            for item in pending_chat_items:
+                original_chat.add_item(item)
+            original_chat.strip_images()
+            original_chat.trim_if_needed(self.compactor)
+            if input_tokens or output_tokens:
+                yield TokenUsage(
+                    input_tokens=input_tokens,
+                    output_tokens=output_tokens,
+                    turn_id=turn_id,
+                    turn_revision=turn_revision,
+                )
+        yield EndOfResponse(turn_id=turn_id, turn_revision=turn_revision, cancel_generation=gen)
+
+    def _emit_tool_calls(
+        self,
+        tool_accum: dict[int, dict[str, str]],
+        tools: list[ResponseFunctionToolCall],
+        pending_chat_items: list[SupportedItem],
+        language_code: Optional[str],
+        gen: int | None,
+        runtime_config: Any,
+        response: Any,
+        turn_id: str | None,
+        turn_revision: int | None,
+        speech_stopped_at_s: float | None,
+    ) -> Iterator[LLMOut]:
+        """Turn accumulated tool-call deltas into ResponseFunctionToolCall events.
+
+        IDs are regenerated (mirroring the Responses handler) so the rest of the
+        pipeline pairs each call_id with its function_call_output consistently.
+        """
+        for index in sorted(tool_accum):
+            entry = tool_accum[index]
+            if not entry["name"]:
+                continue
+            call_id = _generate_id("call")
+            fc_id = _generate_id("fc")
+            item = ResponseFunctionToolCall(
+                type="function_call",
+                name=entry["name"],
+                arguments=entry["args"] or "{}",
+                call_id=call_id,
+                id=fc_id,
+                status="completed",
+            )
+            tools.append(item)
+            pending_chat_items.append(
+                RealtimeConversationItemFunctionCall(
+                    type="function_call",
+                    name=item.name,
+                    arguments=item.arguments,
+                    call_id=item.call_id,
+                    id=item.id,
+                    status=item.status,
+                )
+            )
+            if self._generation_is_stale(gen) or not self._turn_output_allowed(turn_id, turn_revision):
+                logger.info("LLM generation cancelled (stale speculative turn)")
+                continue
+            yield LLMResponseChunk(
+                text="",
+                language_code=language_code,
+                tools=[item],
+                runtime_config=runtime_config,
+                response=response,
+                turn_id=turn_id,
+                turn_revision=turn_revision,
+                speech_stopped_at_s=speech_stopped_at_s,
+                cancel_generation=gen,
+            )
+
+    def process(self, request: LLMIn) -> Iterator[LLMOut]:
+        """Process a language model request and yield LLMResponseChunks."""
+        runtime_config = request.runtime_config
+        response = request.response
+        turn_id = request.turn_id
+        turn_revision = request.turn_revision
+        speech_stopped_at_s = request.speech_stopped_at_s
+        if not self._turn_is_latest(turn_id, turn_revision):
+            logger.info("Skipping stale LLM request for turn=%s rev=%s", turn_id, turn_revision)
+            yield EndOfResponse(turn_id=turn_id, turn_revision=turn_revision)
+            return
+
+        original_chat = runtime_config.chat
+        active_chat = original_chat.copy()
+        language_code = request.language_code
+        instructions = (
+            response.instructions if response and response.instructions else runtime_config.session.instructions
+        ) or ""
+        req_tools = response.tools if response and response.tools else runtime_config.session.tools
+        req_tool_choice = (
+            response.tool_choice if response and response.tool_choice else runtime_config.session.tool_choice
+        )
+        self._apply_config(active_chat, instructions)
+        language_code, lang_name = resolve_auto_language(language_code)
+        if lang_name and self.enable_lang_prompt:
+            active_chat.add_item(make_user_message(f"Please reply to my message in {lang_name}."))
+
+        optional_kwargs: dict[str, Any] = {}
+        chat_tools = _to_chat_tools(req_tools)
+        if chat_tools is not None:
+            optional_kwargs["tools"] = chat_tools
+            if req_tool_choice is not None:
+                optional_kwargs["tool_choice"] = _to_chat_tool_choice(req_tool_choice)
+
+        gen = self.cancel_scope.generation if self.cancel_scope else None
+
+        yield from self._generate(
+            active_chat,
+            original_chat,
+            language_code,
+            gen,
+            runtime_config,
+            response,
+            optional_kwargs,
+            turn_id,
+            turn_revision,
+            speech_stopped_at_s,
+        )
+
+    def on_session_end(self) -> None:
+        logger.debug("Chat Completions API language model session state reset")
+
+    @property
+    def timing_log_level(self) -> int:
+        return logging.INFO
+
+    def should_log_timing(self, output: LLMOut) -> bool:
+        return isinstance(output, LLMResponseChunk) and self.last_time > self.min_time_to_debug

--- a/src/speech_to_speech/arguments_classes/chat_completions_language_model_arguments.py
+++ b/src/speech_to_speech/arguments_classes/chat_completions_language_model_arguments.py
@@ -1,0 +1,28 @@
+from dataclasses import dataclass, field
+from typing import Optional
+
+from speech_to_speech.arguments_classes.responses_api_language_model_arguments import (
+    ResponsesApiLanguageModelHandlerArguments,
+)
+
+
+@dataclass
+class ChatCompletionsLanguageModelHandlerArguments(ResponsesApiLanguageModelHandlerArguments):
+    """Arguments for the ``chat-completions`` LLM backend.
+
+    Inherits the OpenAI-compatible connection fields from the Responses-API
+    arguments (``responses_api_base_url`` / ``responses_api_api_key`` /
+    ``responses_api_stream`` / ``responses_api_disable_thinking``) so the same
+    CLI flags and launcher env vars drive both backends, and adds the
+    Chat-Completions-only ``reasoning_effort`` knob.
+    """
+
+    responses_api_reasoning_effort: Optional[str] = field(
+        default=None,
+        metadata={
+            "help": "Provider-specific reasoning level sent as extra_body={'reasoning_effort': <value>} on the "
+            "Chat Completions request. Use to disable reasoning on providers where "
+            "chat_template_kwargs.enable_thinking is ignored (e.g. 'none' / 'low'). When unset, falls back to "
+            "the disable_thinking behaviour (chat_template_kwargs.enable_thinking=false). Default is None."
+        },
+    )

--- a/src/speech_to_speech/arguments_classes/module_arguments.py
+++ b/src/speech_to_speech/arguments_classes/module_arguments.py
@@ -28,10 +28,11 @@ class ModuleArguments:
             "help": "The STT to use. Either 'whisper', 'whisper-mlx', 'mlx-audio-whisper', 'faster-whisper', 'parakeet-tdt', or 'paraformer'. Default is 'parakeet-tdt'."
         },
     )
-    llm_backend: Optional[Literal["transformers", "mlx-lm", "responses-api"]] = field(
+    llm_backend: Optional[Literal["transformers", "mlx-lm", "responses-api", "chat-completions"]] = field(
         default="responses-api",
         metadata={
-            "help": "The LLM backend to use. Either 'transformers', 'mlx-lm', or 'responses-api'. Default is 'responses-api'."
+            "help": "The LLM backend to use. Either 'transformers', 'mlx-lm', 'responses-api', or "
+            "'chat-completions' (OpenAI-compatible /v1/chat/completions). Default is 'responses-api'."
         },
     )
     tts: Optional[Literal["melo", "chatTTS", "facebookMMS", "pocket", "kokoro", "qwen3"]] = field(

--- a/src/speech_to_speech/s2s_pipeline.py
+++ b/src/speech_to_speech/s2s_pipeline.py
@@ -38,6 +38,9 @@ from speech_to_speech.arguments_classes.parakeet_tdt_arguments import (
 )
 from speech_to_speech.arguments_classes.pocket_tts_arguments import PocketTTSHandlerArguments
 from speech_to_speech.arguments_classes.qwen3_tts_arguments import Qwen3TTSHandlerArguments
+from speech_to_speech.arguments_classes.chat_completions_language_model_arguments import (
+    ChatCompletionsLanguageModelHandlerArguments,
+)
 from speech_to_speech.arguments_classes.responses_api_language_model_arguments import (
     ResponsesApiLanguageModelHandlerArguments,
 )
@@ -124,20 +127,25 @@ def rename_args(args: Any, prefix: str) -> None:
 
 
 def parse_arguments() -> ParsedArguments:
-    # Pre-parse to determine which LM backend is selected, so only one of the two
+    # Pre-parse to determine which LM backend is selected, so only one of the
     # mutually exclusive LM argument classes is registered with HfArgumentParser
     # (avoids duplicate field names from the shared LanguageModelBaseArguments base).
+    # chat-completions reuses the responses-api connection fields via subclassing.
+    _backend_lm_class = {
+        "responses-api": ResponsesApiLanguageModelHandlerArguments,
+        "chat-completions": ChatCompletionsLanguageModelHandlerArguments,
+    }
     _is_json = len(sys.argv) == 2 and sys.argv[1].endswith(".json")
     if _is_json:
         with open(sys.argv[1]) as _f:
-            _use_responses_api = json.load(_f).get("llm_backend") == "responses-api"
+            _backend = json.load(_f).get("llm_backend")
     else:
         _pre = argparse.ArgumentParser(add_help=False)
         _pre.add_argument("--llm_backend", default="responses-api")
-        _use_responses_api = _pre.parse_known_args()[0].llm_backend == "responses-api"
+        _backend = _pre.parse_known_args()[0].llm_backend
 
-    _lm_class = ResponsesApiLanguageModelHandlerArguments if _use_responses_api else LanguageModelHandlerArguments
-    logger.debug("LLM backend pre-parse: use_responses_api=%s, registering %s", _use_responses_api, _lm_class.__name__)
+    _lm_class = _backend_lm_class.get(_backend, LanguageModelHandlerArguments)
+    logger.debug("LLM backend pre-parse: backend=%s, registering %s", _backend, _lm_class.__name__)
 
     parser = HfArgumentParser(
         (  # type: ignore[arg-type]
@@ -181,8 +189,11 @@ def parse_arguments() -> ParsedArguments:
         mlx_audio_whisper_stt_handler_kwargs=by_type[MLXAudioWhisperSTTHandlerArguments],
         parakeet_tdt_stt_handler_kwargs=by_type[ParakeetTDTSTTHandlerArguments],
         language_model_handler_kwargs=by_type.get(LanguageModelHandlerArguments, LanguageModelHandlerArguments()),
+        # The OpenAI-compatible slot holds whichever class was registered:
+        # ChatCompletions... (a subclass) for chat-completions, else ResponsesApi....
         responses_api_language_model_handler_kwargs=by_type.get(
-            ResponsesApiLanguageModelHandlerArguments, ResponsesApiLanguageModelHandlerArguments()
+            ChatCompletionsLanguageModelHandlerArguments,
+            by_type.get(ResponsesApiLanguageModelHandlerArguments, ResponsesApiLanguageModelHandlerArguments()),
         ),
         chat_tts_handler_kwargs=by_type[ChatTTSHandlerArguments],
         facebook_mms_tts_handler_kwargs=by_type[FacebookMMSTTSHandlerArguments],
@@ -503,7 +514,7 @@ def _build_realtime_pipeline_unit(
         vars(kw)["cancel_scope"] = cancel_scope
         vars(kw)["speculative_turns"] = speculative_turns
 
-    if module_kwargs.llm_backend == "responses-api":
+    if module_kwargs.llm_backend in ("responses-api", "chat-completions"):
         chat_size = vars(responses_api_kw).get("chat_size", 10)
     else:
         chat_size = vars(lm_kw).get("chat_size", 10)
@@ -689,7 +700,7 @@ def build_pipeline(
         vad_handler_kwargs.enable_realtime_transcription = True
         vad_handler_kwargs.realtime_processing_pause = module_kwargs.live_transcription_update_interval
 
-    if module_kwargs.llm_backend == "responses-api":
+    if module_kwargs.llm_backend in ("responses-api", "chat-completions"):
         _lm_vars = vars(responses_api_language_model_handler_kwargs)
     else:
         _lm_vars = vars(language_model_handler_kwargs)
@@ -854,6 +865,18 @@ def get_llm_handler(
             setup_kwargs=vars(responses_api_language_model_handler_kwargs),
         )
 
+    if module_kwargs.llm_backend == "chat-completions":
+        from speech_to_speech.LLM.chat_completions_language_model import ChatCompletionsApiModelHandler
+
+        # Reuses the responses-api argument class (identical fields: model_name,
+        # base_url, api_key, stream, disable_thinking, ...).
+        return ChatCompletionsApiModelHandler(
+            stop_event,
+            queue_in=text_prompt_queue,
+            queue_out=lm_response_queue,
+            setup_kwargs=vars(responses_api_language_model_handler_kwargs),
+        )
+
     if module_kwargs.llm_backend in ("transformers", "mlx-lm"):
         lm_kwargs = vars(language_model_handler_kwargs)
         is_vlm = lm_kwargs.pop("is_vlm", False)
@@ -878,7 +901,7 @@ def get_llm_handler(
             setup_kwargs=lm_kwargs,
         )
 
-    raise ValueError("The LLM should be either transformers, mlx-lm or responses-api")
+    raise ValueError("The LLM should be either transformers, mlx-lm, responses-api or chat-completions")
 
 
 def get_tts_handler(

--- a/tests/test_chat_completions_backend.py
+++ b/tests/test_chat_completions_backend.py
@@ -1,0 +1,292 @@
+"""Unit tests for the chat-completions LLM backend.
+
+These run without a GPU or a live server: the OpenAI client is faked at the
+module level, so the streaming/non-streaming parse logic and the format
+converters are exercised purely in-process.
+
+Run with pytest, or standalone:  python tests/test_chat_completions_backend.py
+"""
+
+from __future__ import annotations
+
+import json
+import queue
+import threading
+from types import SimpleNamespace
+
+import speech_to_speech.LLM.chat_completions_language_model as ccm
+from speech_to_speech.LLM.chat_completions_language_model import (
+    ChatCompletionsApiModelHandler,
+    _to_chat_tools,
+    _to_chat_tool_choice,
+)
+from speech_to_speech.LLM.chat import Chat, make_user_message
+from speech_to_speech.api.openai_realtime.runtime_config import RuntimeConfig
+from speech_to_speech.pipeline.messages import (
+    GenerateResponseRequest,
+    LLMResponseChunk,
+    TokenUsage,
+)
+from openai.types.realtime.realtime_session_create_request import RealtimeSessionCreateRequest
+from openai.types.realtime.conversation_item import (
+    RealtimeConversationItemFunctionCall,
+    RealtimeConversationItemFunctionCallOutput,
+)
+from openai.types.responses import ResponseFunctionToolCall
+
+
+# ── Fakes ────────────────────────────────────────────────────────────────────
+
+
+class _FakeStream:
+    """Iterable stand-in for openai.Stream; yields preset chunks."""
+
+    def __init__(self, chunks):
+        self._chunks = chunks
+
+    def __iter__(self):
+        return iter(self._chunks)
+
+    def close(self):
+        pass
+
+
+# Make the handler's ``isinstance(resp, Stream)`` check recognise our fake as a
+# stream. Non-streaming fakes stay plain SimpleNamespace, so they still take the
+# non-stream branch.
+ccm.Stream = _FakeStream
+
+
+class _FakeCompletions:
+    def __init__(self):
+        self.next_result = SimpleNamespace(
+            choices=[SimpleNamespace(message=SimpleNamespace(content="ok", tool_calls=[]))],
+            usage=SimpleNamespace(prompt_tokens=1, completion_tokens=1),
+        )
+        self.last_kwargs = None
+
+    def create(self, **kwargs):
+        self.last_kwargs = kwargs
+        return self.next_result
+
+
+class _FakeChat:
+    def __init__(self):
+        self.completions = _FakeCompletions()
+
+
+class _FakeClient:
+    def __init__(self, *a, **k):
+        self.chat = _FakeChat()
+
+
+def _make_handler(stream=True):
+    """Build a handler whose warmup hits the fake client (no network)."""
+    orig_openai = ccm.OpenAI
+    ccm.OpenAI = _FakeClient
+    try:
+        h = ChatCompletionsApiModelHandler(
+            threading.Event(),
+            queue.Queue(),
+            queue.Queue(),
+            setup_kwargs=dict(
+                model_name="test-model",
+                base_url="http://fake/v1",
+                api_key="k",
+                stream=stream,
+                disable_thinking=True,
+                compact_history=False,
+            ),
+        )
+    finally:
+        ccm.OpenAI = orig_openai
+    return h
+
+
+def _chunk(content=None, tool_calls=None, usage=None):
+    choices = []
+    if content is not None or tool_calls is not None:
+        choices = [SimpleNamespace(delta=SimpleNamespace(content=content, tool_calls=tool_calls), finish_reason=None)]
+    return SimpleNamespace(choices=choices, usage=usage)
+
+
+def _tc_delta(index, id=None, name=None, arguments=None):
+    return SimpleNamespace(index=index, id=id, function=SimpleNamespace(name=name, arguments=arguments))
+
+
+def _drive(handler, *, tools=None, tool_choice=None, user="Hallo", chat=None):
+    chat = chat or Chat(10)
+    chat.add_item(make_user_message(user))
+    session = RealtimeSessionCreateRequest(type="realtime", instructions="Du bist ein Roboter.")
+    if tools is not None:
+        session.tools = tools
+    if tool_choice is not None:
+        session.tool_choice = tool_choice
+    rc = RuntimeConfig(chat=chat, session=session)
+    req = GenerateResponseRequest(
+        runtime_config=rc, response=None, language_code="de", turn_id="t", turn_revision=0
+    )
+    text, tools_out, usage = "", [], None
+    for out in handler.process(req):
+        if isinstance(out, LLMResponseChunk):
+            text += out.text
+            tools_out += list(out.tools)
+        elif isinstance(out, TokenUsage):
+            usage = (out.input_tokens, out.output_tokens)
+    return text, tools_out, usage, chat
+
+
+# ── Converter tests ──────────────────────────────────────────────────────────
+
+
+def test_to_chat_tools_flat_to_nested():
+    out = _to_chat_tools([{"type": "function", "name": "f", "description": "d", "parameters": {"type": "object"}}])
+    assert out == [{"type": "function", "function": {"name": "f", "description": "d", "parameters": {"type": "object"}}}]
+
+
+def test_to_chat_tools_passthrough_and_none():
+    nested = [{"type": "function", "function": {"name": "f"}}]
+    assert _to_chat_tools(nested) == nested
+    assert _to_chat_tools(None) is None
+    assert _to_chat_tools([]) is None
+
+
+def test_to_chat_tool_choice():
+    assert _to_chat_tool_choice("auto") == "auto"
+    assert _to_chat_tool_choice("required") == "required"
+    assert _to_chat_tool_choice({"type": "function", "name": "f"}) == {"type": "function", "function": {"name": "f"}}
+
+
+def test_build_extra_body_variants():
+    f = ChatCompletionsApiModelHandler._build_extra_body
+    assert f("http://x/v1", True, None) == {"chat_template_kwargs": {"enable_thinking": False}}
+    assert f("http://x/v1", True, "none") == {"reasoning_effort": "none"}  # explicit effort wins
+    assert f("https://api.openai.com/v1", True, "none") is None  # official OpenAI: no extra_body
+    assert f("http://x/v1", False, None) is None
+    assert f(None, True, None) is None
+
+
+def test_chat_messages_encodes_tool_arguments_as_string():
+    """to_transformers_chat emits arguments as a dict; the chat API needs a string."""
+    chat = Chat(10)
+    chat.add_item(make_user_message("Kopf links"))
+    chat.add_item(
+        RealtimeConversationItemFunctionCall(
+            type="function_call", name="move_head", arguments='{"direction": "left"}', call_id="call_1", id="fc_1"
+        )
+    )
+    chat.add_item(
+        RealtimeConversationItemFunctionCallOutput(type="function_call_output", call_id="call_1", output="ok")
+    )
+    messages = ChatCompletionsApiModelHandler._chat_messages(chat)
+    tool_call_msgs = [m for m in messages if m.get("tool_calls")]
+    assert tool_call_msgs, "expected an assistant message carrying tool_calls"
+    args = tool_call_msgs[0]["tool_calls"][0]["function"]["arguments"]
+    assert isinstance(args, str), f"arguments must be a JSON string, got {type(args)}"
+    assert json.loads(args) == {"direction": "left"}
+
+
+# ── Streaming / non-streaming parse tests ─────────────────────────────────────
+
+
+def test_streaming_text_and_usage():
+    h = _make_handler(stream=True)
+    h.client.chat.completions.create = lambda **k: _FakeStream(
+        [
+            _chunk(content="Hallo. "),
+            _chunk(content="Wie geht es dir?"),
+            _chunk(usage=SimpleNamespace(prompt_tokens=12, completion_tokens=5)),
+        ]
+    )
+    text, tools, usage, chat = _drive(h)
+    assert "Hallo" in text and "Wie geht es dir" in text
+    assert usage == (12, 5)
+    assert tools == []
+    # assistant text was stored back into the conversation history
+    assert any(getattr(i, "role", None) == "assistant" for i in chat.buffer)
+
+
+def test_streaming_tool_call_accumulates_arguments():
+    h = _make_handler(stream=True)
+    # Arguments arrive split across deltas, as real servers stream them.
+    h.client.chat.completions.create = lambda **k: _FakeStream(
+        [
+            _chunk(tool_calls=[_tc_delta(0, id="srv_1", name="move_head", arguments='{"direction"')]),
+            _chunk(tool_calls=[_tc_delta(0, arguments=': "left"}')]),
+            _chunk(usage=SimpleNamespace(prompt_tokens=20, completion_tokens=8)),
+        ]
+    )
+    text, tools, usage, chat = _drive(
+        h,
+        tools=[{"type": "function", "name": "move_head", "parameters": {"type": "object"}}],
+        tool_choice="required",
+    )
+    assert len(tools) == 1
+    tc = tools[0]
+    assert isinstance(tc, ResponseFunctionToolCall)
+    assert tc.name == "move_head"
+    assert json.loads(tc.arguments) == {"direction": "left"}  # reassembled from two deltas
+    assert usage == (20, 8)
+    # the function_call was stored in history with a freshly minted call_id
+    assert chat._pending_tool_calls, "tool call should be recorded in chat history"
+
+
+def test_non_streaming_tool_call():
+    h = _make_handler(stream=False)
+    h.client.chat.completions.create = lambda **k: SimpleNamespace(
+        choices=[
+            SimpleNamespace(
+                message=SimpleNamespace(
+                    content="",
+                    tool_calls=[
+                        SimpleNamespace(
+                            id="srv_9",
+                            function=SimpleNamespace(name="move_head", arguments='{"direction": "right"}'),
+                        )
+                    ],
+                )
+            )
+        ],
+        usage=SimpleNamespace(prompt_tokens=7, completion_tokens=3),
+    )
+    text, tools, usage, chat = _drive(
+        h,
+        tools=[{"type": "function", "name": "move_head", "parameters": {"type": "object"}}],
+        tool_choice="required",
+    )
+    assert len(tools) == 1 and tools[0].name == "move_head"
+    assert json.loads(tools[0].arguments) == {"direction": "right"}
+    assert usage == (7, 3)
+
+
+def test_tools_converted_to_chat_format_on_request():
+    """The request sent to the server must carry Chat-Completions-shaped tools."""
+    h = _make_handler(stream=True)
+    captured = {}
+
+    def fake_create(**kwargs):
+        captured.update(kwargs)
+        return _FakeStream([_chunk(content="ok.")])
+
+    h.client.chat.completions.create = fake_create
+    _drive(h, tools=[{"type": "function", "name": "f", "parameters": {"type": "object"}}], tool_choice="auto")
+    assert captured["tools"] == [{"type": "function", "function": {"name": "f", "parameters": {"type": "object"}}}]
+    assert captured["tool_choice"] == "auto"
+    assert captured["stream"] is True
+    assert captured["stream_options"] == {"include_usage": True}
+
+
+# ── Standalone runner (no pytest required) ────────────────────────────────────
+
+if __name__ == "__main__":
+    tests = [v for k, v in sorted(globals().items()) if k.startswith("test_") and callable(v)]
+    failed = 0
+    for t in tests:
+        try:
+            t()
+            print(f"PASS  {t.__name__}")
+        except Exception as e:  # noqa: BLE001
+            failed += 1
+            print(f"FAIL  {t.__name__}: {type(e).__name__}: {e}")
+    print(f"\n{len(tests) - failed}/{len(tests)} passed")
+    raise SystemExit(1 if failed else 0)


### PR DESCRIPTION
## Summary

Adds a fourth `--llm_backend` value, `chat-completions`, that drives the
OpenAI-compatible `/v1/chat/completions` endpoint instead of `/v1/responses`.
It mirrors the existing `responses-api` handler (streaming, tool calls, token
usage, history, compaction, cancellation) but uses the Chat Completions
streaming protocol (`choices[].delta.tool_calls`).

Closes #312.

## Motivation

Two independent problems with the Responses path on some OpenAI-compatible
servers, both fixed by using Chat Completions:

1. **Reasoning cannot be disabled (the #312 case).** For some providers (e.g.
   `zai-org/GLM-4.7:cerebras` via the HF router) neither `reasoning.effort` nor
   `chat_template_kwargs.enable_thinking=false` reliably suppresses reasoning on
   `/v1/responses`, so speakable text is delayed or never produced within the
   output-token budget. Chat Completions with `extra_body={"reasoning_effort":
   "none"}` returns visible text immediately.

2. **Responses streaming tool calls are unreliable on some vLLM builds.** With
   auto tool choice + streaming, vLLM's `responses_stream_generator` can raise a
   pydantic `ValidationError` building `ResponseCreatedEvent` (the internal
   `json_schema` tool-calling format fails `response.text.format` validation),
   killing the stream; replayed tool-call arguments can also arrive duplicated
   and fail `json.loads`. The Chat Completions streaming tool-call path is
   unaffected.

## What changed

- `LLM/chat_completions_language_model.py` — new `ChatCompletionsApiModelHandler`.
  Serialises the conversation with `Chat.to_transformers_chat()` and re-encodes
  tool-call `arguments` from object back to a JSON string (the Chat Completions
  API requires a string, whereas `apply_chat_template` wants an object).
- `arguments_classes/chat_completions_language_model_arguments.py` — new
  `ChatCompletionsLanguageModelHandlerArguments`, subclassing the responses-api
  arguments (shared connection flags) and adding `responses_api_reasoning_effort`.
- `arguments_classes/module_arguments.py` — `chat-completions` added to the
  `llm_backend` literal.
- `s2s_pipeline.py` — backend→argument-class selection, handler factory branch,
  shared chat-size / runtime-config wiring.
- `README.md` — documents the new backend and `reasoning_effort`.
- `tests/test_chat_completions_backend.py` — mock-based unit tests (no GPU/server).

### `reasoning_effort` precedence

`extra_body` is built as: explicit `reasoning_effort` → `{"reasoning_effort": …}`;
else `disable_thinking` → `{"chat_template_kwargs": {"enable_thinking": false}}`;
else none. Never sent to the official OpenAI server (`api.openai.com`).

## Testing

- Unit tests (`tests/test_chat_completions_backend.py`, 9 tests) cover the tool/
  tool_choice converters, `arguments` string re-encoding, `extra_body` precedence,
  and the streaming + non-streaming parse via a faked client. They need no
  network (`pytest tests/test_chat_completions_backend.py`).
- Verified live against a local vLLM (`Qwen3` model, `--tool-call-parser
  qwen3_coder`): plain text, forced tool call with arguments reassembled from
  streamed deltas, and multi-turn replay of stored tool calls — no 400s/crashes,
  in both streaming and non-streaming modes.

## Design note: shared vs. dedicated arguments

`ChatCompletionsLanguageModelHandlerArguments` subclasses the responses-api
arguments, so both OpenAI-compatible backends share the `--responses_api_*` flags
and a single pipeline slot. This keeps the change small and avoids threading a new
argument set through the pipeline builders. The alternative — a fully independent
`--chat_completions_*` argument set with its own slot — is a reasonable design if
stronger separation between the two backends is preferred.
