### PR TITLE
Emit assistant transcript for fresh response when discard guard is stuck

### DIFF
--- a/src/speech_to_speech/LLM/lm_output_processor.py
+++ b/src/speech_to_speech/LLM/lm_output_processor.py
@@ -125,6 +125,7 @@ class LMOutputProcessor(BaseHandler[LLMOut, TTSIn]):
                 text=lm_output.text,
                 turn_id=lm_output.turn_id,
                 turn_revision=lm_output.turn_revision,
+                cancel_generation=lm_output.cancel_generation,
             )
             if lm_output.tools:
                 event.tools = lm_output.tools

--- a/src/speech_to_speech/api/openai_realtime/websocket_router.py
+++ b/src/speech_to_speech/api/openai_realtime/websocket_router.py
@@ -139,7 +139,7 @@ async def _drain_pending_response_events(
                 drained_usage += 1
             elif drain_assistant_events and isinstance(item, AssistantTextEvent):
                 drained_assistant += 1
-                if unit.cancel_scope.discarding:
+                if _generation_is_discardable(unit, item.cancel_generation):
                     continue
                 events = unit.service.dispatch_pipeline_event(session_id, item)
                 if ws is not None and events:
@@ -202,13 +202,26 @@ def _is_pipeline_end(item: Any) -> bool:
     return isinstance(payload, bytes) and payload == PIPELINE_END
 
 
-def _should_discard_audio(unit: PipelineUnit, item: Any) -> bool:
-    generation = _audio_generation(item)
+def _generation_is_discardable(unit: PipelineUnit, generation: int | None) -> bool:
+    """Whether output tagged with *generation* should be dropped.
+
+    A generation is discardable if it has been superseded (``is_stale``) or if the
+    cancel scope is in its post-cancel discard window and this is not the current
+    live generation. Shared by audio and assistant-text so the two paths stay in
+    lockstep: dropping text whenever ``discarding`` is set (without this generation
+    check) silently swallows the transcript of a fresh response when ``discarding``
+    lingers — e.g. a superseded speculative turn whose TTS never emitted an
+    AUDIO_RESPONSE_DONE sentinel, so response_done() never cleared the flag.
+    """
     if generation is not None and unit.cancel_scope.is_stale(generation):
         return True
     if unit.cancel_scope.discarding and generation != unit.cancel_scope.generation:
         return True
     return False
+
+
+def _should_discard_audio(unit: PipelineUnit, item: Any) -> bool:
+    return _generation_is_discardable(unit, _audio_generation(item))
 
 
 async def _release_unit_after_drain(unit: PipelineUnit, session: Any, session_id: str) -> None:
@@ -462,7 +475,9 @@ def create_app(pool: list[PipelineUnit], stop_event: ThreadingEvent) -> FastAPI:
                         was_in_response = st.in_response
                         was_response_pending = st.response_pending
 
-                    if unit.cancel_scope.discarding and isinstance(text_msg, AssistantTextEvent):
+                    if isinstance(text_msg, AssistantTextEvent) and _generation_is_discardable(
+                        unit, text_msg.cancel_generation
+                    ):
                         pass
                     elif ws is not None and isinstance(text_msg, PipelineEvent) and session_id:
                         events = unit.service.dispatch_pipeline_event(session_id, text_msg)

--- a/src/speech_to_speech/pipeline/events.py
+++ b/src/speech_to_speech/pipeline/events.py
@@ -72,6 +72,10 @@ class AssistantTextEvent(PipelineEvent):
     tools: list[ResponseFunctionToolCall] = Field(default_factory=list)
     turn_id: str | None = None
     turn_revision: int | None = None
+    # Response generation that produced this text, mirroring AudioOutput. Lets the
+    # send loop discard stale assistant text by the same generation-aware rule as
+    # audio, instead of blanket-dropping while cancel_scope.discarding is set.
+    cancel_generation: int | None = None
 
 
 class TokenUsageEvent(PipelineEvent):

--- a/tests/openai_realtime/test_websocket_router.py
+++ b/tests/openai_realtime/test_websocket_router.py
@@ -460,6 +460,43 @@ class TestSendLoop:
                 assert delta["type"] == "response.output_audio.delta"
                 assert len(base64.b64decode(delta["delta"])) == len(_pcm_bytes(512))
 
+    def test_current_generation_text_survives_stuck_discarding(self, setup):
+        """Regression: a fresh response's transcript must survive a stuck discard guard.
+
+        A superseded speculative turn can leave ``cancel_scope.discarding`` stuck True
+        (its TTS dropped the stale ``EndOfResponse`` without emitting AUDIO_RESPONSE_DONE,
+        so ``response_done()`` never cleared the flag). The next response's audio is tagged
+        with the current generation and streams fine, but the assistant text used to be
+        blanket-dropped while discarding — leaving audio + ``response.done`` with no
+        ``response.output_audio_transcript.done``. The text is now discarded by the same
+        generation-aware rule as audio, so a current-generation transcript is kept.
+        """
+        app, _, _, output_queue, text_output_queue, _, _, _, cancel_scope = setup
+        with TestClient(app) as client:
+            with client.websocket_connect("/v1/realtime") as ws:
+                ws.receive_json()  # session.created
+                cancel_scope.cancel()  # discarding=True, generation bumped; sentinel never arrived
+                current_generation = cancel_scope.generation
+                assert cancel_scope.discarding
+
+                text_output_queue.put(
+                    AssistantTextEvent(text="hello there", cancel_generation=current_generation)
+                )
+                output_queue.put(AudioOutput(audio=_pcm_bytes(256), cancel_generation=current_generation))
+                output_queue.put(AudioOutput(audio=AUDIO_RESPONSE_DONE, cancel_generation=current_generation))
+
+                types: list[str] = []
+                transcript = None
+                for _ in range(8):
+                    msg = ws.receive_json()
+                    types.append(msg["type"])
+                    if msg["type"] == "response.output_audio_transcript.done":
+                        transcript = msg["transcript"]
+                    if msg["type"] == "response.done":
+                        break
+                assert "response.output_audio_transcript.done" in types
+                assert transcript == "hello there"
+
     def test_stale_tagged_response_done_does_not_finish_current_response(self, setup):
         app, service, _, output_queue, _, _, _, _, cancel_scope = setup
         with TestClient(app) as client:

--- a/tests/openai_realtime/test_websocket_router.py
+++ b/tests/openai_realtime/test_websocket_router.py
@@ -479,9 +479,7 @@ class TestSendLoop:
                 current_generation = cancel_scope.generation
                 assert cancel_scope.discarding
 
-                text_output_queue.put(
-                    AssistantTextEvent(text="hello there", cancel_generation=current_generation)
-                )
+                text_output_queue.put(AssistantTextEvent(text="hello there", cancel_generation=current_generation))
                 output_queue.put(AudioOutput(audio=_pcm_bytes(256), cancel_generation=current_generation))
                 output_queue.put(AudioOutput(audio=AUDIO_RESPONSE_DONE, cancel_generation=current_generation))
 


### PR DESCRIPTION
## Problem

When speculative decoding fires, the response streams audio and `response.done` but **never sends `response.output_audio_transcript.done`**. From a live session log, the speculatively-decoded response emitted `response.created` → `output_audio.delta` → `output_audio.done` → `response.done`, with the transcript event missing entirely.

## Root cause

An asymmetry between how audio and assistant-text are discarded, combined with a `cancel_scope.discarding` flag that can get stuck `True`:

1. **`discarding` sticks `True`.** It's set by `cancel_scope.cancel()` (barge-in/reopen) and cleared only by `response_done()` — which fires when an `AUDIO_RESPONSE_DONE` sentinel reaches the send loop — or by a client `new_response()`. Server-VAD speculative responses never call `new_response()`, and when a speculative generation is superseded, every TTS handler drops its stale `EndOfResponse` **without emitting `AUDIO_RESPONSE_DONE`**. So that generation's sentinel never arrives and `discarding` stays `True`.

2. **Audio discard was generation-aware; text discard was not.** `_should_discard_audio` only drops audio whose generation is *not the current one*, so the next response's audio (current generation) streamed and completed fine. But the assistant-text drops in the send loop and in `_drain_pending_response_events` were a blanket `if discarding: drop` — so the *current, live* response's transcript was silently swallowed.

## Fix

Make assistant-text discard use the same generation-aware rule as audio:

- Add `cancel_generation` to `AssistantTextEvent` (mirroring `AudioOutput`).
- Populate it from `LLMResponseChunk.cancel_generation`, which the LLM already sets — it was just being dropped when building the event.
- Extract the shared `_generation_is_discardable(unit, generation)` helper, reuse it in `_should_discard_audio`, and use it at both assistant-text discard sites.

A current-generation transcript now survives even when `discarding` lingers. The `None`-generation path is exactly backward-compatible with the old blanket behavior.

## Tests

- Added `test_current_generation_text_survives_stuck_discarding` reproducing the exact scenario.
- Full suite green: 236 passed.

## Follow-up (out of scope)

`cancel_scope.discarding` can still get stuck `True` at its source (a superseded speculative generation never emits a sentinel to clear it). This change makes that harmless for transcripts; guaranteeing `response_done()` fires for every cancelled generation would be a deeper, separate fix.