### PR TITLE
Add chat-completions LLM backend (OpenAI /v1/chat/completions)

### DIFF
--- a/README.md
+++ b/README.md
@@ -256,8 +256,9 @@ The LLM is the most compute-intensive and highest-latency component in the pipel
 - **Local inference** — `transformers` (CUDA / CPU) and `mlx-lm` (Apple Silicon) run the model entirely on your machine with no external dependency.
 - **Self-hosted servers** — `--llm_backend responses-api` can point at a local [vLLM](https://github.com/vllm-project/vllm) or [llama.cpp](https://github.com/ggerganov/llama.cpp) server, giving you control over quantization, batching, and hardware while keeping traffic on-premise.
 - **Provider APIs** — the same `responses-api` backend works with OpenAI, [HuggingFace Inference Providers](https://huggingface.co/inference-providers), [OpenRouter](https://openrouter.ai), and any other provider that implements the OpenAI Responses API.
+- **Chat Completions** — `--llm_backend chat-completions` targets the OpenAI-compatible `/v1/chat/completions` endpoint instead of `/v1/responses`. Use it for providers/servers where Responses cannot reliably disable reasoning, or whose Responses streaming tool-call path is unreliable (see [#312](https://github.com/huggingface/speech-to-speech/issues/312)).
 
-Select a backend with `--llm_backend` (`responses-api` by default) and pair it with `--model_name`. Backend-specific options (`--responses_api_base_url`, `--responses_api_api_key`, `--responses_api_stream`, etc.) are only needed for the `responses-api` backend.
+Select a backend with `--llm_backend` (`responses-api` by default) and pair it with `--model_name`. Backend-specific options (`--responses_api_base_url`, `--responses_api_api_key`, `--responses_api_stream`, etc.) are shared by the `responses-api` and `chat-completions` backends.
 
 > The examples below pair Parakeet TDT (local STT) and Qwen3-TTS (local TTS) with different LLM backends.
 
@@ -314,6 +315,44 @@ speech-to-speech \
     --responses_api_api_key "$HF_TOKEN" \
     --responses_api_stream \
     --enable_live_transcription
+```
+
+#### Chat Completions backend (`--llm_backend chat-completions`)
+
+Identical configuration to `responses-api` (it reuses the same `--responses_api_*`
+connection flags), but talks to `/v1/chat/completions` instead of `/v1/responses`.
+Prefer it when:
+
+- the provider ignores `chat_template_kwargs.enable_thinking` on the Responses path and
+  needs a `reasoning_effort` knob to suppress reasoning, or
+- the server's Responses **streaming tool-call** path is unreliable (e.g. some vLLM
+  builds), while its Chat Completions tool-call streaming is solid.
+
+Add `--responses_api_reasoning_effort none` (chat-completions only) to disable reasoning
+on providers where the chat-template flag has no effect:
+
+```bash
+# vLLM (local) serving a Qwen model with tool calling
+speech-to-speech \
+    --mode realtime \
+    --stt parakeet-tdt \
+    --llm_backend chat-completions \
+    --tts qwen3 \
+    --model_name "Qwen/Qwen3-4B-Instruct-2507" \
+    --responses_api_base_url "http://localhost:8000/v1" \
+    --responses_api_stream
+
+# GLM via the HF router — disable reasoning for low voice latency
+speech-to-speech \
+    --mode realtime \
+    --stt parakeet-tdt \
+    --llm_backend chat-completions \
+    --tts qwen3 \
+    --model_name "zai-org/GLM-4.7:cerebras" \
+    --responses_api_base_url "https://router.huggingface.co/v1" \
+    --responses_api_api_key "$HF_TOKEN" \
+    --responses_api_reasoning_effort none \
+    --responses_api_stream
 ```
 
 #### Fully local (Apple Silicon)

--- a/src/speech_to_speech/LLM/base_openai_compatible_language_model.py
+++ b/src/speech_to_speech/LLM/base_openai_compatible_language_model.py
@@ -1,0 +1,550 @@
+from __future__ import annotations
+
+import logging
+from abc import ABC, abstractmethod
+from collections.abc import Iterator
+from dataclasses import dataclass, field
+from typing import Any, Optional
+
+import httpx
+from nltk import sent_tokenize
+from openai import OpenAI
+from openai.types.realtime.conversation_item import (
+    RealtimeConversationItemAssistantMessage,
+    RealtimeConversationItemFunctionCall,
+)
+from openai.types.realtime.realtime_conversation_item_assistant_message import (
+    Content as AssistantContent,
+)
+from openai.types.responses import ResponseFunctionToolCall
+
+from speech_to_speech.baseHandler import BaseHandler
+from speech_to_speech.LLM.chat import (
+    Chat,
+    ChatItemError,
+    SupportedItem,
+    build_active_chat,
+    make_system_message,
+    make_user_message,
+)
+from speech_to_speech.LLM.compaction_prompt import CompactGenerateFn, build_compactor
+from speech_to_speech.LLM.text_prompt import build_text_system_prompt
+from speech_to_speech.LLM.utils import remove_unspeechable, resolve_auto_language
+from speech_to_speech.LLM.voice_prompt import build_voice_system_prompt
+from speech_to_speech.pipeline.cancel_scope import CancelScope
+from speech_to_speech.pipeline.handler_types import LLMIn, LLMOut
+from speech_to_speech.pipeline.messages import (
+    EndOfResponse,
+    LLMResponseChunk,
+    TokenUsage,
+)
+from speech_to_speech.pipeline.speculative_turns import SpeculativeTurnTracker
+from speech_to_speech.utils.utils import is_out_of_band, response_wants_audio
+
+logger = logging.getLogger(__name__)
+
+
+# ── Normalised provider events ────────────────────────────────────────────────
+# Each backend's stream/response is mapped to this small vocabulary so the shared
+# speech-pipeline logic (sentence batching, cancellation, history, token usage)
+# lives in one place. Subclasses differ only in how they produce these events.
+
+
+@dataclass
+class TextDelta:
+    """Incremental assistant text. Always RAW (unfiltered); the base applies
+    ``remove_unspeechable`` for the audio path."""
+
+    text: str
+
+
+@dataclass
+class AssistantMessage:
+    """A complete assistant turn to write back to history."""
+
+    content: list[AssistantContent]
+
+
+@dataclass
+class ToolCall:
+    """A complete function tool call (``call_id`` / ``id`` already regenerated)."""
+
+    item: ResponseFunctionToolCall
+
+
+@dataclass
+class Usage:
+    """Token accounting for the turn."""
+
+    input_tokens: int
+    output_tokens: int
+
+
+ProviderEvent = TextDelta | AssistantMessage | ToolCall | Usage
+
+
+@dataclass
+class _Turn:
+    """Per-request context threaded through generation (immutable for the turn)."""
+
+    language_code: Optional[str]
+    gen: int | None
+    runtime_config: Any
+    response: Any
+    turn_id: str | None
+    turn_revision: int | None
+    speech_stopped_at_s: float | None
+    wants_audio: bool
+
+
+@dataclass
+class _GenState:
+    """Mutable accumulators collected while consuming a turn's events."""
+
+    tools: list[ResponseFunctionToolCall] = field(default_factory=list)
+    pending: list[SupportedItem] = field(default_factory=list)
+    clean_text: str = ""  # filtered text, kept only for the debug log
+    input_tokens: int = 0
+    output_tokens: int = 0
+
+
+class BaseOpenAICompatibleHandler(BaseHandler[LLMIn, LLMOut], ABC):
+    """Shared lifecycle for OpenAI-compatible LLM backends (Responses & Chat
+    Completions).
+
+    Subclasses implement four hooks — :meth:`warmup`,
+    :meth:`_build_compaction_generate_fn`, :meth:`_serialize`, :meth:`_request`,
+    :meth:`_iter_events` and :meth:`_build_optional_kwargs` — and inherit the
+    request/response orchestration: speculative-turn gating, cancellation,
+    sentence batching, text-only vs audio handling, history write-back, token
+    usage, out-of-band handling and error termination.
+    """
+
+    # ── setup ─────────────────────────────────────────────────────────────────
+
+    def setup(
+        self,
+        model_name: str = "gpt-5.4-mini",
+        device: str = "cuda",
+        gen_kwargs: dict[str, Any] = {},
+        base_url: Optional[str] = None,
+        api_key: Optional[str] = None,
+        stream: bool = True,
+        user_role: str = "user",
+        cancel_scope: CancelScope | None = None,
+        speculative_turns: SpeculativeTurnTracker | None = None,
+        disable_thinking: bool = True,
+        reasoning_effort: Optional[str] = None,
+        request_timeout_s: float = 20.0,
+        stream_batch_sentences: int = 3,
+        enable_lang_prompt: bool = False,
+        compact_history: bool = False,
+        **_kwargs: Any,
+    ) -> None:
+        self.cancel_scope = cancel_scope
+        self.speculative_turns = speculative_turns
+        self.model_name = model_name
+        self.stream = stream
+        self.stream_batch_sentences = max(1, stream_batch_sentences)
+        self.enable_lang_prompt = enable_lang_prompt
+        self.gen_kwargs = dict(gen_kwargs)
+        self.request_timeout_s = float(request_timeout_s)
+        self.request_timeout = httpx.Timeout(
+            self.request_timeout_s,
+            connect=min(10.0, self.request_timeout_s),
+        )
+
+        self.user_role = user_role
+        self.client = OpenAI(api_key=api_key, base_url=base_url)
+        self._extra_body = self._build_extra_body(base_url, disable_thinking, reasoning_effort)
+        self.compactor = build_compactor(self._build_compaction_generate_fn()) if compact_history else None
+        self.warmup()
+
+    @staticmethod
+    def _is_official_openai(base_url: Optional[str]) -> bool:
+        """Whether ``base_url`` points at the official OpenAI server.
+
+        Normalises a trailing slash so ``https://api.openai.com/v1/`` is also
+        recognised; the official server rejects the provider-specific extra_body
+        keys we send to vLLM / the HF router.
+        """
+        if base_url is None:
+            return False
+        return base_url.rstrip("/") == "https://api.openai.com/v1"
+
+    @classmethod
+    def _build_extra_body(
+        cls,
+        base_url: Optional[str],
+        disable_thinking: bool,
+        reasoning_effort: Optional[str],
+    ) -> Optional[dict[str, Any]]:
+        """Build the provider-specific ``extra_body`` used to disable reasoning.
+
+        Providers differ in how reasoning is turned off: vLLM/Qwen honour
+        ``chat_template_kwargs.enable_thinking=false``, while others (e.g. GLM via
+        the HF router) ignore that and require ``reasoning_effort='none'``. A
+        non-empty ``reasoning_effort`` therefore takes precedence; otherwise we fall
+        back to the chat-template flag. None of this applies to the official
+        OpenAI server, which rejects unknown extra_body keys.
+        """
+        if base_url is None or cls._is_official_openai(base_url):
+            return None
+        if reasoning_effort:
+            return {"reasoning_effort": reasoning_effort}
+        if disable_thinking:
+            return {"chat_template_kwargs": {"enable_thinking": False}}
+        return None
+
+    # ── subclass hooks ──────────────────────────────────────────────────────--
+
+    @abstractmethod
+    def warmup(self) -> None:
+        """Issue a cheap request so the model/connection is ready before serving."""
+        ...
+
+    @abstractmethod
+    def _build_compaction_generate_fn(self) -> CompactGenerateFn:
+        """Return a ``(system, user) -> text`` fn used to compact long histories."""
+        ...
+
+    @abstractmethod
+    def _serialize(self, active_chat: Chat) -> Any:
+        """Serialise the chat to the backend's request payload (input/messages)."""
+        ...
+
+    @abstractmethod
+    def _request(self, api_input: Any, optional_kwargs: dict[str, Any]) -> Any:
+        """Issue the create() call and return the response or stream."""
+        ...
+
+    @abstractmethod
+    def _iter_events(self, api_response: Any) -> Iterator[ProviderEvent]:
+        """Map the backend response/stream to normalised :data:`ProviderEvent`s."""
+        ...
+
+    @abstractmethod
+    def _build_optional_kwargs(self, req_tools: Any, req_tool_choice: Any) -> dict[str, Any]:
+        """Build the per-request tools/tool_choice kwargs in the backend's shape."""
+        ...
+
+    # ── speculative-turn / cancellation gating ─────────────────────────────────
+
+    def _turn_is_latest(self, turn_id: str | None, turn_revision: int | None) -> bool:
+        return self.speculative_turns is None or self.speculative_turns.is_latest(turn_id, turn_revision)
+
+    def _generation_is_stale(self, gen: int | None) -> bool:
+        return gen is not None and self.cancel_scope is not None and self.cancel_scope.is_stale(gen)
+
+    def _turn_output_allowed(self, turn_id: str | None, turn_revision: int | None) -> bool:
+        if self.speculative_turns is None:
+            return True
+        return self.speculative_turns.is_latest_after_reopen_grace(turn_id, turn_revision)
+
+    def _apply_config(
+        self,
+        chat: Chat,
+        instructions: Optional[str],
+        wants_audio: bool = True,
+    ) -> None:
+        if instructions:
+            builder = build_voice_system_prompt if wants_audio else build_text_system_prompt
+            full_instructions = builder(instructions)
+            chat.add_item(make_system_message(full_instructions))
+
+    # ── output helpers ──────────────────────────────────────────────────────--
+
+    def _chunk(
+        self,
+        turn: _Turn,
+        *,
+        text: str = "",
+        tools: list[ResponseFunctionToolCall] | None = None,
+        language_code: Optional[str] = None,
+    ) -> LLMResponseChunk:
+        return LLMResponseChunk(
+            text=text,
+            language_code=language_code if language_code is not None else turn.language_code,
+            tools=tools or [],
+            runtime_config=turn.runtime_config,
+            response=turn.response,
+            turn_id=turn.turn_id,
+            turn_revision=turn.turn_revision,
+            speech_stopped_at_s=turn.speech_stopped_at_s,
+            cancel_generation=turn.gen,
+        )
+
+    def _record_tool_call(self, state: _GenState, turn: _Turn, item: ResponseFunctionToolCall) -> Iterator[LLMOut]:
+        """Append a tool call to history + the tools list, and emit it (unless the
+        turn went stale, in which case it is recorded but not spoken)."""
+        state.tools.append(item)
+        state.pending.append(
+            RealtimeConversationItemFunctionCall(
+                type="function_call",
+                name=item.name,
+                arguments=item.arguments,
+                call_id=item.call_id,
+                id=item.id,
+                status=item.status,
+            )
+        )
+        if self._generation_is_stale(turn.gen) or not self._turn_output_allowed(turn.turn_id, turn.turn_revision):
+            logger.info("LLM generation cancelled (stale speculative turn)")
+            return
+        yield self._chunk(turn, tools=[item])
+
+    # ── consumption ─────────────────────────────────────────────────────────--
+
+    def _consume_streaming(self, events: Iterator[ProviderEvent], state: _GenState, turn: _Turn) -> Iterator[LLMOut]:
+        cancelled = False
+        printable_text = ""
+        sentence_batch: list[str] = []
+
+        def _flush(batch: list[str]) -> Iterator[LLMOut]:
+            if not batch:
+                return
+            if not self._turn_output_allowed(turn.turn_id, turn.turn_revision):
+                logger.info("LLM generation cancelled (stale speculative turn)")
+                return
+            yield self._chunk(turn, text=" ".join(batch))
+
+        for event in events:
+            if self._generation_is_stale(turn.gen) or not self._turn_is_latest(turn.turn_id, turn.turn_revision):
+                logger.info("LLM generation cancelled (interruption)")
+                cancelled = True
+                break
+
+            if isinstance(event, Usage):
+                state.input_tokens = event.input_tokens
+                state.output_tokens = event.output_tokens
+            elif isinstance(event, AssistantMessage):
+                state.pending.append(
+                    RealtimeConversationItemAssistantMessage(type="message", role="assistant", content=event.content)
+                )
+            elif isinstance(event, ToolCall):
+                # Flush any pending spoken text before emitting the tool call.
+                if printable_text.strip():
+                    sentence_batch.append(printable_text.strip())
+                    printable_text = ""
+                if sentence_batch:
+                    if not self._turn_output_allowed(turn.turn_id, turn.turn_revision):
+                        logger.info("LLM generation cancelled (stale speculative turn)")
+                        cancelled = True
+                        break
+                    yield from _flush(sentence_batch)
+                    sentence_batch = []
+                yield from self._record_tool_call(state, turn, event.item)
+            elif isinstance(event, TextDelta):
+                if not turn.wants_audio:
+                    # Text-only: forward verbatim. Keep every character (no
+                    # remove_unspeechable, which strips TTS-unfriendly symbols) and
+                    # don't sentence-split (sent_tokenize collapses newlines/markdown).
+                    state.clean_text += event.text
+                    if event.text:
+                        if not self._turn_output_allowed(turn.turn_id, turn.turn_revision):
+                            logger.info("LLM generation cancelled (stale speculative turn)")
+                            cancelled = True
+                            break
+                        yield self._chunk(turn, text=event.text)
+                    continue
+                new_text = remove_unspeechable(event.text)
+                state.clean_text += new_text
+                printable_text += new_text
+                sentences = sent_tokenize(printable_text)
+                if len(sentences) > 1:
+                    for s in sentences[:-1]:
+                        sentence_batch.append(s)
+                        if len(sentence_batch) >= self.stream_batch_sentences:
+                            if not self._turn_output_allowed(turn.turn_id, turn.turn_revision):
+                                logger.info("LLM generation cancelled (stale speculative turn)")
+                                cancelled = True
+                                break
+                            yield from _flush(sentence_batch)
+                            sentence_batch = []
+                    if cancelled:
+                        break
+                    printable_text = sentences[-1]
+
+        if not cancelled:
+            if printable_text.strip():
+                sentence_batch.append(printable_text.strip())
+            if sentence_batch:
+                if self._generation_is_stale(turn.gen):
+                    logger.info("LLM generation cancelled (interruption)")
+                else:
+                    logger.debug(f"Clean text: {state.clean_text}")
+                    yield from _flush(sentence_batch)
+            logger.info(f"Tools: {state.tools}")
+
+    def _consume_nonstreaming(self, events: Iterator[ProviderEvent], state: _GenState, turn: _Turn) -> Iterator[LLMOut]:
+        if self._generation_is_stale(turn.gen) or not self._turn_is_latest(turn.turn_id, turn.turn_revision):
+            logger.info("LLM generation cancelled (interruption)")
+            return
+        for event in events:
+            if isinstance(event, Usage):
+                state.input_tokens = event.input_tokens
+                state.output_tokens = event.output_tokens
+            elif isinstance(event, AssistantMessage):
+                state.pending.append(
+                    RealtimeConversationItemAssistantMessage(type="message", role="assistant", content=event.content)
+                )
+            elif isinstance(event, ToolCall):
+                yield from self._record_tool_call(state, turn, event.item)
+            elif isinstance(event, TextDelta):
+                # Text-only keeps every character verbatim; audio strips
+                # TTS-unfriendly symbols via remove_unspeechable.
+                spoken = event.text if not turn.wants_audio else remove_unspeechable(event.text)
+                state.clean_text += spoken
+                out = spoken if not turn.wants_audio else spoken.strip()
+                if (
+                    out
+                    and not self._generation_is_stale(turn.gen)
+                    and self._turn_output_allowed(turn.turn_id, turn.turn_revision)
+                ):
+                    yield self._chunk(turn, text=out)
+        logger.debug(f"Clean text: {state.clean_text}")
+        logger.info(f"Tools: {state.tools}")
+
+    # ── orchestration ─────────────────────────────────────────────────────────
+
+    def _generate(
+        self,
+        active_chat: Chat,
+        original_chat: Chat,
+        turn: _Turn,
+        optional_kwargs: dict[str, Any],
+    ) -> Iterator[LLMOut]:
+        api_response: Any = None
+        state = _GenState()
+        error_message: str | None = None
+        api_input = self._serialize(active_chat)
+        if not api_input:
+            # Nothing to send: empty `instructions` and no `input` (in the response,
+            # the default conversation, or the out-of-band context). The provider
+            # would reject this; fail with a clear message instead of an opaque error.
+            error_message = "Cannot generate a response: no instructions and no input were provided."
+
+        try:
+            if error_message is None:
+                api_response = self._request(api_input, optional_kwargs)
+            if api_response is not None:
+                events = self._iter_events(api_response)
+                if self.stream:
+                    yield from self._consume_streaming(events, state, turn)
+                else:
+                    yield from self._consume_nonstreaming(events, state, turn)
+        except httpx.ReadTimeout:
+            logger.warning(
+                "OpenAI API read timed out after %.1fs; ending the current response",
+                self.request_timeout_s,
+            )
+            if not self._generation_is_stale(turn.gen) and self._turn_output_allowed(turn.turn_id, turn.turn_revision):
+                # Canned apology carries no language_code (mirrors the prior handlers).
+                yield LLMResponseChunk(
+                    text="Wow I'm a bit slow today, could you repeat that?",
+                    runtime_config=turn.runtime_config,
+                    response=turn.response,
+                    turn_id=turn.turn_id,
+                    turn_revision=turn.turn_revision,
+                    speech_stopped_at_s=turn.speech_stopped_at_s,
+                    cancel_generation=turn.gen,
+                )
+        except Exception as exc:
+            # Any other generation failure must still terminate the response: record
+            # the error and fall through to the EndOfResponse below. Without this the
+            # exception would escape process() and no EndOfResponse would be emitted,
+            # leaving st.in_response stuck and locking every subsequent response.
+            logger.exception("LLM generation failed; ending the current response")
+            if error_message is None:
+                error_message = f"Language model generation failed: {exc}"
+        finally:
+            if api_response is not None and hasattr(api_response, "close"):
+                try:
+                    api_response.close()
+                except Exception:
+                    pass
+
+        if (
+            error_message is None
+            and not self._generation_is_stale(turn.gen)
+            and self._turn_output_allowed(turn.turn_id, turn.turn_revision)
+        ):
+            # Out-of-band responses emit output and usage but never write back to the
+            # default conversation (their context was a throwaway chat).
+            if not is_out_of_band(turn.response):
+                for item in state.pending:
+                    original_chat.add_item(item)
+                original_chat.strip_images()
+                original_chat.trim_if_needed(self.compactor)
+            if state.input_tokens or state.output_tokens:
+                yield TokenUsage(
+                    input_tokens=state.input_tokens,
+                    output_tokens=state.output_tokens,
+                    turn_id=turn.turn_id,
+                    turn_revision=turn.turn_revision,
+                )
+        yield EndOfResponse(
+            turn_id=turn.turn_id, turn_revision=turn.turn_revision, cancel_generation=turn.gen, error=error_message
+        )
+
+    def process(self, request: LLMIn) -> Iterator[LLMOut]:
+        """Process a language model request and yield LLMResponseChunks."""
+        runtime_config = request.runtime_config
+        response = request.response
+        turn_id = request.turn_id
+        turn_revision = request.turn_revision
+        speech_stopped_at_s = request.speech_stopped_at_s
+        if not self._turn_is_latest(turn_id, turn_revision):
+            logger.info("Skipping stale LLM request for turn=%s rev=%s", turn_id, turn_revision)
+            yield EndOfResponse(turn_id=turn_id, turn_revision=turn_revision)
+            return
+
+        original_chat = runtime_config.chat
+        if is_out_of_band(response):
+            try:
+                active_chat = build_active_chat(original_chat, response)
+            except ChatItemError as exc:
+                logger.info("Out-of-band response rejected: %s", exc)
+                yield EndOfResponse(turn_id=turn_id, turn_revision=turn_revision, error=str(exc))
+                return
+        else:
+            active_chat = original_chat.copy()
+        language_code = request.language_code
+        instructions = (
+            response.instructions if response and response.instructions else runtime_config.session.instructions
+        ) or ""
+        req_tools = response.tools if response and response.tools else runtime_config.session.tools
+        req_tool_choice = (
+            response.tool_choice if response and response.tool_choice else runtime_config.session.tool_choice
+        )
+        wants_audio = response_wants_audio(response)
+        self._apply_config(active_chat, instructions, wants_audio)
+        language_code, lang_name = resolve_auto_language(language_code)
+        if lang_name and self.enable_lang_prompt:
+            active_chat.add_item(make_user_message(f"Please reply to my message in {lang_name}."))
+
+        optional_kwargs = self._build_optional_kwargs(req_tools, req_tool_choice)
+
+        # CancelScope.is_stale(gen) is checked when the stream iterator advances; a
+        # blocked read inside httpx cannot be aborted by cancel_scope.cancel() from
+        # the websocket router. Mitigations: request_timeout_s / ReadTimeout.
+        gen = self.cancel_scope.generation if self.cancel_scope else None
+
+        turn = _Turn(
+            language_code=language_code,
+            gen=gen,
+            runtime_config=runtime_config,
+            response=response,
+            turn_id=turn_id,
+            turn_revision=turn_revision,
+            speech_stopped_at_s=speech_stopped_at_s,
+            wants_audio=wants_audio,
+        )
+        yield from self._generate(active_chat, original_chat, turn, optional_kwargs)
+
+    @property
+    def timing_log_level(self) -> int:
+        return logging.INFO
+
+    def should_log_timing(self, output: LLMOut) -> bool:
+        return isinstance(output, LLMResponseChunk) and self.last_time > self.min_time_to_debug

--- a/src/speech_to_speech/LLM/base_openai_compatible_language_model.py
+++ b/src/speech_to_speech/LLM/base_openai_compatible_language_model.py
@@ -219,9 +219,23 @@ class BaseOpenAICompatibleHandler(BaseHandler[LLMIn, LLMOut], ABC):
         ...
 
     @abstractmethod
-    def _iter_events(self, api_response: Any) -> Iterator[ProviderEvent]:
-        """Map the backend response/stream to normalised :data:`ProviderEvent`s."""
+    def _iter_stream_events(self, api_response: Any) -> Iterator[ProviderEvent]:
+        """Map a streaming response to normalised :data:`ProviderEvent`s."""
         ...
+
+    @abstractmethod
+    def _iter_response_events(self, api_response: Any) -> Iterator[ProviderEvent]:
+        """Map a non-streaming response to normalised :data:`ProviderEvent`s."""
+        ...
+
+    def _iter_events(self, api_response: Any) -> Iterator[ProviderEvent]:
+        """Dispatch to the stream/non-stream mapper. ``self.stream`` is the single
+        source of truth (it set the request's ``stream=`` flag), so the response
+        type always matches it."""
+        if self.stream:
+            yield from self._iter_stream_events(api_response)
+        else:
+            yield from self._iter_response_events(api_response)
 
     @abstractmethod
     def _build_optional_kwargs(self, req_tools: Any, req_tool_choice: Any) -> dict[str, Any]:

--- a/src/speech_to_speech/LLM/base_openai_compatible_language_model.py
+++ b/src/speech_to_speech/LLM/base_openai_compatible_language_model.py
@@ -3,7 +3,6 @@ from __future__ import annotations
 import logging
 from abc import ABC, abstractmethod
 from collections.abc import Iterator
-from dataclasses import dataclass, field
 from typing import Any, Optional
 
 import httpx
@@ -17,6 +16,7 @@ from openai.types.realtime.realtime_conversation_item_assistant_message import (
     Content as AssistantContent,
 )
 from openai.types.responses import ResponseFunctionToolCall
+from pydantic import BaseModel, ConfigDict, Field
 
 from speech_to_speech.baseHandler import BaseHandler
 from speech_to_speech.LLM.chat import (
@@ -50,30 +50,26 @@ logger = logging.getLogger(__name__)
 # lives in one place. Subclasses differ only in how they produce these events.
 
 
-@dataclass
-class TextDelta:
+class TextDelta(BaseModel):
     """Incremental assistant text. Always RAW (unfiltered); the base applies
     ``remove_unspeechable`` for the audio path."""
 
     text: str
 
 
-@dataclass
-class AssistantMessage:
+class AssistantMessage(BaseModel):
     """A complete assistant turn to write back to history."""
 
     content: list[AssistantContent]
 
 
-@dataclass
-class ToolCall:
+class ToolCall(BaseModel):
     """A complete function tool call (``call_id`` / ``id`` already regenerated)."""
 
     item: ResponseFunctionToolCall
 
 
-@dataclass
-class Usage:
+class Usage(BaseModel):
     """Token accounting for the turn."""
 
     input_tokens: int
@@ -83,9 +79,10 @@ class Usage:
 ProviderEvent = TextDelta | AssistantMessage | ToolCall | Usage
 
 
-@dataclass
-class _Turn:
+class _Turn(BaseModel):
     """Per-request context threaded through generation (immutable for the turn)."""
+
+    model_config = ConfigDict(arbitrary_types_allowed=True)
 
     language_code: Optional[str]
     gen: int | None
@@ -97,12 +94,13 @@ class _Turn:
     wants_audio: bool
 
 
-@dataclass
-class _GenState:
+class _GenState(BaseModel):
     """Mutable accumulators collected while consuming a turn's events."""
 
-    tools: list[ResponseFunctionToolCall] = field(default_factory=list)
-    pending: list[SupportedItem] = field(default_factory=list)
+    model_config = ConfigDict(arbitrary_types_allowed=True)
+
+    tools: list[ResponseFunctionToolCall] = Field(default_factory=list)
+    pending: list[SupportedItem] = Field(default_factory=list)
     clean_text: str = ""  # filtered text, kept only for the debug log
     input_tokens: int = 0
     output_tokens: int = 0

--- a/src/speech_to_speech/LLM/chat_completions_language_model.py
+++ b/src/speech_to_speech/LLM/chat_completions_language_model.py
@@ -181,12 +181,6 @@ class ChatCompletionsApiModelHandler(BaseOpenAICompatibleHandler):
             **create_kwargs,
         )
 
-    def _iter_events(self, api_response: Stream[ChatCompletionChunk] | Any) -> Iterator[ProviderEvent]:
-        if isinstance(api_response, Stream):
-            yield from self._iter_stream_events(api_response)
-        else:
-            yield from self._iter_response_events(api_response)
-
     def _iter_stream_events(self, api_response: Stream[ChatCompletionChunk]) -> Iterator[ProviderEvent]:
         # Accumulate streamed tool-call deltas, keyed by their stream index, and the
         # raw assistant text, then emit assistant message + tool calls + usage once

--- a/src/speech_to_speech/LLM/chat_completions_language_model.py
+++ b/src/speech_to_speech/LLM/chat_completions_language_model.py
@@ -283,10 +283,12 @@ class ChatCompletionsApiModelHandler(BaseHandler[LLMIn, LLMOut]):
         api_response: Stream[ChatCompletionChunk] | Any = None
         tools: list[ResponseFunctionToolCall] = []
         pending_chat_items: list[SupportedItem] = []
+        # clean_text accumulates the filtered (TTS-ready) text purely for the
+        # debug log; the text actually spoken is yielded per sentence batch.
         clean_text = ""
-        # Raw (unfiltered) assistant text written back to history; clean_text is the
-        # TTS-ready string sent to the speaker. Storing the filtered text would show
-        # the model a degraded view of its own past turns and cause multi-turn drift.
+        # Raw (unfiltered) assistant text written back to history. Storing the
+        # filtered text would show the model a degraded view of its own past turns
+        # and cause multi-turn drift, so history uses raw_text, not clean_text.
         raw_text = ""
         input_tokens = 0
         output_tokens = 0

--- a/src/speech_to_speech/LLM/chat_completions_language_model.py
+++ b/src/speech_to_speech/LLM/chat_completions_language_model.py
@@ -4,43 +4,26 @@ import json
 import logging
 import time
 from collections.abc import Iterator
-from typing import Any, Optional
+from typing import Any
 
-import httpx
-from nltk import sent_tokenize
-from openai import OpenAI, Stream
+from openai import Stream
 from openai.types.chat import ChatCompletionChunk
-from openai.types.realtime.conversation_item import (
-    RealtimeConversationItemAssistantMessage,
-    RealtimeConversationItemFunctionCall,
-)
 from openai.types.realtime.realtime_conversation_item_assistant_message import (
     Content as AssistantContent,
 )
 from openai.types.responses import ResponseFunctionToolCall
 
-from speech_to_speech.baseHandler import BaseHandler
-from speech_to_speech.LLM.chat import (
-    Chat,
-    ChatItemError,
-    SupportedItem,
-    build_active_chat,
-    make_system_message,
-    make_user_message,
+from speech_to_speech.LLM.base_openai_compatible_language_model import (
+    AssistantMessage,
+    BaseOpenAICompatibleHandler,
+    ProviderEvent,
+    TextDelta,
+    ToolCall,
+    Usage,
 )
-from speech_to_speech.LLM.compaction_prompt import CompactGenerateFn, build_compactor
-from speech_to_speech.LLM.text_prompt import build_text_system_prompt
-from speech_to_speech.LLM.utils import remove_unspeechable, resolve_auto_language
-from speech_to_speech.LLM.voice_prompt import build_voice_system_prompt
-from speech_to_speech.pipeline.cancel_scope import CancelScope
-from speech_to_speech.pipeline.handler_types import LLMIn, LLMOut
-from speech_to_speech.pipeline.messages import (
-    EndOfResponse,
-    LLMResponseChunk,
-    TokenUsage,
-)
-from speech_to_speech.pipeline.speculative_turns import SpeculativeTurnTracker
-from speech_to_speech.utils.utils import _generate_id, is_out_of_band, response_wants_audio
+from speech_to_speech.LLM.chat import Chat
+from speech_to_speech.LLM.compaction_prompt import CompactGenerateFn
+from speech_to_speech.utils.utils import _generate_id
 
 logger = logging.getLogger(__name__)
 
@@ -81,7 +64,7 @@ def _to_chat_tool_choice(tool_choice: Any) -> Any:
     return tool_choice
 
 
-class ChatCompletionsApiModelHandler(BaseHandler[LLMIn, LLMOut]):
+class ChatCompletionsApiModelHandler(BaseOpenAICompatibleHandler):
     """LLM handler that talks to an OpenAI-compatible ``/v1/chat/completions`` server.
 
     Functionally mirrors :class:`ResponsesApiModelHandler` but uses the mature
@@ -90,91 +73,6 @@ class ChatCompletionsApiModelHandler(BaseHandler[LLMIn, LLMOut]):
     calling. The conversation is serialised with :meth:`Chat.to_transformers_chat`,
     which already emits OpenAI chat messages including ``tool_calls``/``tool`` roles.
     """
-
-    def setup(
-        self,
-        model_name: str = "gpt-5.4-mini",
-        device: str = "cuda",
-        gen_kwargs: dict[str, Any] = {},
-        base_url: Optional[str] = None,
-        api_key: Optional[str] = None,
-        stream: bool = True,
-        user_role: str = "user",
-        cancel_scope: CancelScope | None = None,
-        speculative_turns: SpeculativeTurnTracker | None = None,
-        disable_thinking: bool = True,
-        reasoning_effort: Optional[str] = None,
-        request_timeout_s: float = 20.0,
-        stream_batch_sentences: int = 3,
-        enable_lang_prompt: bool = False,
-        compact_history: bool = False,
-        **_kwargs: Any,
-    ) -> None:
-        self.cancel_scope = cancel_scope
-        self.speculative_turns = speculative_turns
-        self.model_name = model_name
-        self.stream = stream
-        self.stream_batch_sentences = max(1, stream_batch_sentences)
-        self.enable_lang_prompt = enable_lang_prompt
-        self.gen_kwargs = dict(gen_kwargs)
-        self.request_timeout_s = float(request_timeout_s)
-        self.request_timeout = httpx.Timeout(
-            self.request_timeout_s,
-            connect=min(10.0, self.request_timeout_s),
-        )
-
-        self.user_role = user_role
-        self.client = OpenAI(api_key=api_key, base_url=base_url)
-        self._extra_body = self._build_extra_body(base_url, disable_thinking, reasoning_effort)
-        self.compactor = build_compactor(self._build_compaction_generate_fn()) if compact_history else None
-        self.warmup()
-
-    @staticmethod
-    def _is_official_openai(base_url: Optional[str]) -> bool:
-        """Whether ``base_url`` points at the official OpenAI server.
-
-        Normalises a trailing slash so ``https://api.openai.com/v1/`` is also
-        recognised; the official server rejects the provider-specific extra_body
-        keys we send to vLLM / the HF router.
-        """
-        if base_url is None:
-            return False
-        return base_url.rstrip("/") == "https://api.openai.com/v1"
-
-    @classmethod
-    def _build_extra_body(
-        cls,
-        base_url: Optional[str],
-        disable_thinking: bool,
-        reasoning_effort: Optional[str],
-    ) -> Optional[dict[str, Any]]:
-        """Build the provider-specific ``extra_body`` used to disable reasoning.
-
-        Providers differ in how reasoning is turned off: vLLM/Qwen honour
-        ``chat_template_kwargs.enable_thinking=false``, while others (e.g. GLM via
-        the HF router) ignore that and require ``reasoning_effort='none'``. A
-        non-empty ``reasoning_effort`` therefore takes precedence; otherwise we fall
-        back to the chat-template flag. None of this applies to the official
-        OpenAI server, which rejects unknown extra_body keys.
-        """
-        if base_url is None or cls._is_official_openai(base_url):
-            return None
-        if reasoning_effort:
-            return {"reasoning_effort": reasoning_effort}
-        if disable_thinking:
-            return {"chat_template_kwargs": {"enable_thinking": False}}
-        return None
-
-    def _turn_is_latest(self, turn_id: str | None, turn_revision: int | None) -> bool:
-        return self.speculative_turns is None or self.speculative_turns.is_latest(turn_id, turn_revision)
-
-    def _generation_is_stale(self, gen: int | None) -> bool:
-        return gen is not None and self.cancel_scope is not None and self.cancel_scope.is_stale(gen)
-
-    def _turn_output_allowed(self, turn_id: str | None, turn_revision: int | None) -> bool:
-        if self.speculative_turns is None:
-            return True
-        return self.speculative_turns.is_latest_after_reopen_grace(turn_id, turn_revision)
 
     def warmup(self) -> None:
         logger.info(f"Warming up {self.__class__.__name__}")
@@ -211,17 +109,6 @@ class ChatCompletionsApiModelHandler(BaseHandler[LLMIn, LLMOut]):
             return response.choices[0].message.content or ""
 
         return generate
-
-    def _apply_config(
-        self,
-        chat: Chat,
-        instructions: Optional[str],
-        wants_audio: bool = True,
-    ) -> None:
-        if instructions:
-            builder = build_voice_system_prompt if wants_audio else build_text_system_prompt
-            full_instructions = builder(instructions)
-            chat.add_item(make_system_message(full_instructions))
 
     @staticmethod
     def _to_chat_content_part(part: dict[str, Any]) -> dict[str, Any]:
@@ -267,313 +154,103 @@ class ChatCompletionsApiModelHandler(BaseHandler[LLMIn, LLMOut]):
                 message["content"] = [cls._to_chat_content_part(p) for p in content]
         return messages
 
-    def _generate(
-        self,
-        active_chat: Chat,
-        original_chat: Chat,
-        language_code: Optional[str],
-        gen: int | None,
-        runtime_config: Any,
-        response: Any,
-        optional_kwargs: dict[str, Any],
-        turn_id: str | None,
-        turn_revision: int | None,
-        speech_stopped_at_s: float | None,
-    ) -> Iterator[LLMOut]:
-        api_response: Stream[ChatCompletionChunk] | Any = None
-        tools: list[ResponseFunctionToolCall] = []
-        pending_chat_items: list[SupportedItem] = []
-        # clean_text accumulates the filtered (TTS-ready) text purely for the
-        # debug log; the text actually spoken is yielded per sentence batch.
-        clean_text = ""
-        # Raw (unfiltered) assistant text written back to history. Storing the
-        # filtered text would show the model a degraded view of its own past turns
-        # and cause multi-turn drift, so history uses raw_text, not clean_text.
-        raw_text = ""
-        input_tokens = 0
-        output_tokens = 0
-        error_message: str | None = None
-        wants_audio = response_wants_audio(response)
-        messages = self._chat_messages(active_chat)
-        if not messages:
-            # Nothing to send: empty `instructions` and no `input` (in the response,
-            # the default conversation, or the out-of-band context). The provider
-            # would reject this; fail with a clear message instead of an opaque error.
-            error_message = "Cannot generate a response: no instructions and no input were provided."
+    # ── base hooks ──────────────────────────────────────────────────────────--
 
-        # Accumulate streamed tool-call deltas, keyed by their stream index.
+    def _serialize(self, active_chat: Chat) -> list[dict[str, Any]]:
+        return self._chat_messages(active_chat)
+
+    def _build_optional_kwargs(self, req_tools: Any, req_tool_choice: Any) -> dict[str, Any]:
+        optional_kwargs: dict[str, Any] = {}
+        chat_tools = _to_chat_tools(req_tools)
+        if chat_tools is not None:
+            optional_kwargs["tools"] = chat_tools
+        if req_tool_choice is not None:
+            optional_kwargs["tool_choice"] = _to_chat_tool_choice(req_tool_choice)
+        return optional_kwargs
+
+    def _request(self, api_input: list[dict[str, Any]], optional_kwargs: dict[str, Any]) -> Any:
+        create_kwargs: dict[str, Any] = dict(optional_kwargs)
+        if self.stream:
+            create_kwargs["stream_options"] = {"include_usage": True}
+        return self.client.chat.completions.create(
+            model=self.model_name,
+            messages=api_input,
+            stream=self.stream,
+            extra_body=self._extra_body,
+            timeout=self.request_timeout,
+            **create_kwargs,
+        )
+
+    def _iter_events(self, api_response: Stream[ChatCompletionChunk] | Any) -> Iterator[ProviderEvent]:
+        if isinstance(api_response, Stream):
+            yield from self._iter_stream_events(api_response)
+        else:
+            yield from self._iter_response_events(api_response)
+
+    def _iter_stream_events(self, api_response: Stream[ChatCompletionChunk]) -> Iterator[ProviderEvent]:
+        # Accumulate streamed tool-call deltas, keyed by their stream index, and the
+        # raw assistant text, then emit assistant message + tool calls + usage once
+        # the stream is exhausted.
         tool_accum: dict[int, dict[str, str]] = {}
+        usage: Usage | None = None
+        raw_text = ""
+        for chunk in api_response:
+            # Usage-only trailing chunk (choices == []) when include_usage is set.
+            if chunk.usage is not None:
+                usage = Usage(chunk.usage.prompt_tokens or 0, chunk.usage.completion_tokens or 0)
+            if not chunk.choices:
+                continue
+            delta = chunk.choices[0].delta
+            if delta.tool_calls:
+                for tc in delta.tool_calls:
+                    entry = tool_accum.setdefault(tc.index, {"name": "", "args": "", "id": ""})
+                    if tc.id:
+                        entry["id"] = tc.id
+                    if tc.function is not None:
+                        if tc.function.name:
+                            entry["name"] = tc.function.name
+                        if tc.function.arguments:
+                            entry["args"] += tc.function.arguments
+            # A refusal streams as `delta.refusal` with `delta.content` None;
+            # surface it as assistant text so it is spoken and stored.
+            text_piece = delta.content or getattr(delta, "refusal", None)
+            if text_piece:
+                raw_text += text_piece
+                yield TextDelta(text_piece)
 
-        def _flush_batch(sentence_batch: list[str]) -> Iterator[LLMOut]:
-            if not sentence_batch:
-                return
-            if not self._turn_output_allowed(turn_id, turn_revision):
-                logger.info("LLM generation cancelled (stale speculative turn)")
-                return
-            yield LLMResponseChunk(
-                text=" ".join(sentence_batch),
-                language_code=language_code,
-                runtime_config=runtime_config,
-                response=response,
-                turn_id=turn_id,
-                turn_revision=turn_revision,
-                speech_stopped_at_s=speech_stopped_at_s,
-                cancel_generation=gen,
-            )
+        if raw_text.strip():
+            yield AssistantMessage([AssistantContent(type="output_text", text=raw_text)])
+        yield from self._tool_calls_from_accum(tool_accum)
+        if usage is not None:
+            yield usage
 
-        try:
-            if error_message is None:
-                create_kwargs: dict[str, Any] = dict(optional_kwargs)
-                if self.stream:
-                    create_kwargs["stream_options"] = {"include_usage": True}
-                api_response = self.client.chat.completions.create(
-                    model=self.model_name,
-                    messages=messages,
-                    stream=self.stream,
-                    extra_body=self._extra_body,
-                    timeout=self.request_timeout,
-                    **create_kwargs,
-                )
+    def _iter_response_events(self, api_response: Any) -> Iterator[ProviderEvent]:
+        usage = api_response.usage
+        if usage:
+            yield Usage(usage.prompt_tokens or 0, usage.completion_tokens or 0)
+        # A valid-but-empty response (e.g. content filter) returns no choices;
+        # complete cleanly with no assistant text rather than raising IndexError.
+        message = api_response.choices[0].message if api_response.choices else None
+        if message is None:
+            return
+        # A refusal arrives as `message.refusal` with `message.content` None; treat
+        # it as assistant text so it is spoken and stored.
+        raw_content = message.content or getattr(message, "refusal", None)
+        if raw_content:
+            yield AssistantMessage([AssistantContent(type="output_text", text=raw_content)])
+            yield TextDelta(raw_content)
+        tool_accum: dict[int, dict[str, str]] = {}
+        for tc in message.tool_calls or []:
+            tool_accum[len(tool_accum)] = {
+                "name": tc.function.name or "",
+                "args": tc.function.arguments or "",
+                "id": tc.id or "",
+            }
+        yield from self._tool_calls_from_accum(tool_accum)
 
-            if isinstance(api_response, Stream):
-                cancelled = False
-                printable_text = ""
-                sentence_batch: list[str] = []
-                for chunk in api_response:
-                    if (
-                        gen is not None and self.cancel_scope is not None and self.cancel_scope.is_stale(gen)
-                    ) or not self._turn_is_latest(turn_id, turn_revision):
-                        logger.info("LLM generation cancelled (interruption)")
-                        cancelled = True
-                        break
-
-                    # Usage-only trailing chunk (choices == []) when include_usage is set.
-                    if chunk.usage is not None:
-                        input_tokens = chunk.usage.prompt_tokens or 0
-                        output_tokens = chunk.usage.completion_tokens or 0
-                    if not chunk.choices:
-                        continue
-
-                    delta = chunk.choices[0].delta
-
-                    # Accumulate tool-call deltas first: a single chunk can carry
-                    # both content and tool_calls, and the text-only branch below
-                    # `continue`s, which would otherwise skip this block.
-                    if delta.tool_calls:
-                        for tc in delta.tool_calls:
-                            entry = tool_accum.setdefault(tc.index, {"name": "", "args": "", "id": ""})
-                            if tc.id:
-                                entry["id"] = tc.id
-                            if tc.function is not None:
-                                if tc.function.name:
-                                    entry["name"] = tc.function.name
-                                if tc.function.arguments:
-                                    entry["args"] += tc.function.arguments
-
-                    # A refusal streams as `delta.refusal` with `delta.content`
-                    # None; surface it as assistant text so it is spoken and stored.
-                    text_piece = delta.content or getattr(delta, "refusal", None)
-                    if text_piece:
-                        raw_text += text_piece
-                        if not wants_audio:
-                            # Text-only: forward the delta verbatim. Keep every
-                            # character (no remove_unspeechable, which strips
-                            # TTS-unfriendly symbols) and don't sentence-split
-                            # (sent_tokenize would collapse newlines / markdown).
-                            clean_text += text_piece
-                            if not self._turn_output_allowed(turn_id, turn_revision):
-                                logger.info("LLM generation cancelled (stale speculative turn)")
-                                cancelled = True
-                                break
-                            yield LLMResponseChunk(
-                                text=text_piece,
-                                language_code=language_code,
-                                runtime_config=runtime_config,
-                                response=response,
-                                turn_id=turn_id,
-                                turn_revision=turn_revision,
-                                speech_stopped_at_s=speech_stopped_at_s,
-                                cancel_generation=gen,
-                            )
-                            continue
-                        new_text = remove_unspeechable(text_piece)
-                        clean_text += new_text
-                        printable_text += new_text
-                        sentences = sent_tokenize(printable_text)
-                        if len(sentences) > 1:
-                            for s in sentences[:-1]:
-                                sentence_batch.append(s)
-                                if len(sentence_batch) >= self.stream_batch_sentences:
-                                    if not self._turn_output_allowed(turn_id, turn_revision):
-                                        logger.info("LLM generation cancelled (stale speculative turn)")
-                                        cancelled = True
-                                        break
-                                    yield from _flush_batch(sentence_batch)
-                                    sentence_batch = []
-                            if cancelled:
-                                break
-                            printable_text = sentences[-1]
-
-                if not cancelled:
-                    # Flush any trailing text before emitting tool calls.
-                    if printable_text.strip():
-                        sentence_batch.append(printable_text.strip())
-                    if sentence_batch:
-                        if self._generation_is_stale(gen):
-                            logger.info("LLM generation cancelled (interruption)")
-                        else:
-                            logger.debug(f"Clean text: {clean_text}")
-                            yield from _flush_batch(sentence_batch)
-                    if raw_text.strip():
-                        pending_chat_items.append(
-                            RealtimeConversationItemAssistantMessage(
-                                type="message",
-                                role="assistant",
-                                content=[AssistantContent(type="output_text", text=raw_text)],
-                            )
-                        )
-                    yield from self._emit_tool_calls(
-                        tool_accum,
-                        tools,
-                        pending_chat_items,
-                        language_code,
-                        gen,
-                        runtime_config,
-                        response,
-                        turn_id,
-                        turn_revision,
-                        speech_stopped_at_s,
-                    )
-                    logger.info(f"Tools: {tools}")
-            else:
-                if (
-                    gen is not None and self.cancel_scope is not None and self.cancel_scope.is_stale(gen)
-                ) or not self._turn_is_latest(turn_id, turn_revision):
-                    logger.info("LLM generation cancelled (interruption)")
-                else:
-                    usage = api_response.usage
-                    if usage:
-                        input_tokens = usage.prompt_tokens or 0
-                        output_tokens = usage.completion_tokens or 0
-                    # A valid-but-empty response (e.g. content filter) returns no
-                    # choices; complete cleanly with no assistant text rather than
-                    # raising IndexError.
-                    message = api_response.choices[0].message if api_response.choices else None
-                    # A refusal arrives as `message.refusal` with `message.content`
-                    # None; treat it as assistant text so it is spoken and stored.
-                    raw_content = (message.content or getattr(message, "refusal", None)) if message else None
-                    # Text-only keeps every character verbatim; audio strips
-                    # TTS-unfriendly symbols via remove_unspeechable.
-                    message_text = (raw_content or "") if not wants_audio else remove_unspeechable(raw_content or "")
-                    clean_text += message_text
-                    # Gate history write-back on the raw content so a turn that is
-                    # entirely TTS-unfriendly symbols is still stored, not dropped.
-                    if raw_content:
-                        pending_chat_items.append(
-                            RealtimeConversationItemAssistantMessage(
-                                type="message",
-                                role="assistant",
-                                content=[AssistantContent(type="output_text", text=raw_content)],
-                            )
-                        )
-                    chunk_text = message_text if not wants_audio else message_text.strip()
-                    if chunk_text:
-                        if not self._generation_is_stale(gen) and self._turn_output_allowed(turn_id, turn_revision):
-                            yield LLMResponseChunk(
-                                text=chunk_text,
-                                language_code=language_code,
-                                runtime_config=runtime_config,
-                                response=response,
-                                turn_id=turn_id,
-                                turn_revision=turn_revision,
-                                speech_stopped_at_s=speech_stopped_at_s,
-                                cancel_generation=gen,
-                            )
-                    for tc in (message.tool_calls if message else None) or []:
-                        tool_accum[len(tool_accum)] = {
-                            "name": tc.function.name or "",
-                            "args": tc.function.arguments or "",
-                            "id": tc.id or "",
-                        }
-                    yield from self._emit_tool_calls(
-                        tool_accum,
-                        tools,
-                        pending_chat_items,
-                        language_code,
-                        gen,
-                        runtime_config,
-                        response,
-                        turn_id,
-                        turn_revision,
-                        speech_stopped_at_s,
-                    )
-                    logger.debug(f"Clean text: {clean_text}")
-                    logger.info(f"Tools: {tools}")
-        except httpx.ReadTimeout:
-            logger.warning(
-                "OpenAI API read timed out after %.1fs; ending the current response",
-                self.request_timeout_s,
-            )
-            if not self._generation_is_stale(gen) and self._turn_output_allowed(turn_id, turn_revision):
-                yield LLMResponseChunk(
-                    text="Wow I'm a bit slow today, could you repeat that?",
-                    runtime_config=runtime_config,
-                    response=response,
-                    turn_id=turn_id,
-                    turn_revision=turn_revision,
-                    speech_stopped_at_s=speech_stopped_at_s,
-                    cancel_generation=gen,
-                )
-        except Exception as exc:
-            # Any other generation failure must still terminate the response: record
-            # the error and fall through to the EndOfResponse below. Without this the
-            # exception would escape process() and no EndOfResponse would be emitted,
-            # leaving st.in_response stuck and locking every subsequent response.
-            logger.exception("LLM generation failed; ending the current response")
-            if error_message is None:
-                error_message = f"Language model generation failed: {exc}"
-        finally:
-            if api_response is not None and hasattr(api_response, "close"):
-                try:
-                    api_response.close()
-                except Exception:
-                    pass
-
-        if (
-            error_message is None
-            and not self._generation_is_stale(gen)
-            and self._turn_output_allowed(turn_id, turn_revision)
-        ):
-            # Out-of-band responses emit output and usage but never write back to the
-            # default conversation (their context was a throwaway chat).
-            if not is_out_of_band(response):
-                for item in pending_chat_items:
-                    original_chat.add_item(item)
-                original_chat.strip_images()
-                original_chat.trim_if_needed(self.compactor)
-            if input_tokens or output_tokens:
-                yield TokenUsage(
-                    input_tokens=input_tokens,
-                    output_tokens=output_tokens,
-                    turn_id=turn_id,
-                    turn_revision=turn_revision,
-                )
-        yield EndOfResponse(turn_id=turn_id, turn_revision=turn_revision, cancel_generation=gen, error=error_message)
-
-    def _emit_tool_calls(
-        self,
-        tool_accum: dict[int, dict[str, str]],
-        tools: list[ResponseFunctionToolCall],
-        pending_chat_items: list[SupportedItem],
-        language_code: Optional[str],
-        gen: int | None,
-        runtime_config: Any,
-        response: Any,
-        turn_id: str | None,
-        turn_revision: int | None,
-        speech_stopped_at_s: float | None,
-    ) -> Iterator[LLMOut]:
-        """Turn accumulated tool-call deltas into ResponseFunctionToolCall events.
+    @staticmethod
+    def _tool_calls_from_accum(tool_accum: dict[int, dict[str, str]]) -> Iterator[ToolCall]:
+        """Turn accumulated tool-call deltas into ToolCall events.
 
         IDs are regenerated (mirroring the Responses handler) so the rest of the
         pipeline pairs each call_id with its function_call_output consistently.
@@ -582,106 +259,16 @@ class ChatCompletionsApiModelHandler(BaseHandler[LLMIn, LLMOut]):
             entry = tool_accum[index]
             if not entry["name"]:
                 continue
-            call_id = _generate_id("call")
-            fc_id = _generate_id("fc")
-            item = ResponseFunctionToolCall(
-                type="function_call",
-                name=entry["name"],
-                arguments=entry["args"] or "{}",
-                call_id=call_id,
-                id=fc_id,
-                status="completed",
-            )
-            tools.append(item)
-            pending_chat_items.append(
-                RealtimeConversationItemFunctionCall(
+            yield ToolCall(
+                ResponseFunctionToolCall(
                     type="function_call",
-                    name=item.name,
-                    arguments=item.arguments,
-                    call_id=item.call_id,
-                    id=item.id,
-                    status=item.status,
+                    name=entry["name"],
+                    arguments=entry["args"] or "{}",
+                    call_id=_generate_id("call"),
+                    id=_generate_id("fc"),
+                    status="completed",
                 )
             )
-            if self._generation_is_stale(gen) or not self._turn_output_allowed(turn_id, turn_revision):
-                logger.info("LLM generation cancelled (stale speculative turn)")
-                continue
-            yield LLMResponseChunk(
-                text="",
-                language_code=language_code,
-                tools=[item],
-                runtime_config=runtime_config,
-                response=response,
-                turn_id=turn_id,
-                turn_revision=turn_revision,
-                speech_stopped_at_s=speech_stopped_at_s,
-                cancel_generation=gen,
-            )
-
-    def process(self, request: LLMIn) -> Iterator[LLMOut]:
-        """Process a language model request and yield LLMResponseChunks."""
-        runtime_config = request.runtime_config
-        response = request.response
-        turn_id = request.turn_id
-        turn_revision = request.turn_revision
-        speech_stopped_at_s = request.speech_stopped_at_s
-        if not self._turn_is_latest(turn_id, turn_revision):
-            logger.info("Skipping stale LLM request for turn=%s rev=%s", turn_id, turn_revision)
-            yield EndOfResponse(turn_id=turn_id, turn_revision=turn_revision)
-            return
-
-        original_chat = runtime_config.chat
-        out_of_band = is_out_of_band(response)
-        if out_of_band:
-            try:
-                active_chat = build_active_chat(original_chat, response)
-            except ChatItemError as exc:
-                logger.info("Out-of-band response rejected: %s", exc)
-                yield EndOfResponse(turn_id=turn_id, turn_revision=turn_revision, error=str(exc))
-                return
-        else:
-            active_chat = original_chat.copy()
-        language_code = request.language_code
-        instructions = (
-            response.instructions if response and response.instructions else runtime_config.session.instructions
-        ) or ""
-        req_tools = response.tools if response and response.tools else runtime_config.session.tools
-        req_tool_choice = (
-            response.tool_choice if response and response.tool_choice else runtime_config.session.tool_choice
-        )
-        self._apply_config(active_chat, instructions, response_wants_audio(response))
-        language_code, lang_name = resolve_auto_language(language_code)
-        if lang_name and self.enable_lang_prompt:
-            active_chat.add_item(make_user_message(f"Please reply to my message in {lang_name}."))
-
-        optional_kwargs: dict[str, Any] = {}
-        chat_tools = _to_chat_tools(req_tools)
-        if chat_tools is not None:
-            optional_kwargs["tools"] = chat_tools
-        if req_tool_choice is not None:
-            optional_kwargs["tool_choice"] = _to_chat_tool_choice(req_tool_choice)
-
-        gen = self.cancel_scope.generation if self.cancel_scope else None
-
-        yield from self._generate(
-            active_chat,
-            original_chat,
-            language_code,
-            gen,
-            runtime_config,
-            response,
-            optional_kwargs,
-            turn_id,
-            turn_revision,
-            speech_stopped_at_s,
-        )
 
     def on_session_end(self) -> None:
         logger.debug("Chat Completions API language model session state reset")
-
-    @property
-    def timing_log_level(self) -> int:
-        return logging.INFO
-
-    def should_log_timing(self, output: LLMOut) -> bool:
-        return isinstance(output, LLMResponseChunk) and self.last_time > self.min_time_to_debug

--- a/src/speech_to_speech/LLM/chat_completions_language_model.py
+++ b/src/speech_to_speech/LLM/chat_completions_language_model.py
@@ -4,10 +4,17 @@ import json
 import logging
 import time
 from collections.abc import Iterator
-from typing import Any
+from typing import Any, cast
 
 from openai import Stream
-from openai.types.chat import ChatCompletionChunk
+from openai.types.chat import (
+    ChatCompletionChunk,
+    ChatCompletionContentPartImageParam,
+    ChatCompletionContentPartParam,
+    ChatCompletionContentPartTextParam,
+    ChatCompletionMessageParam,
+)
+from openai.types.chat.chat_completion_content_part_image_param import ImageURL
 from openai.types.realtime.realtime_conversation_item_assistant_message import (
     Content as AssistantContent,
 )
@@ -111,7 +118,7 @@ class ChatCompletionsApiModelHandler(BaseOpenAICompatibleHandler):
         return generate
 
     @staticmethod
-    def _to_chat_content_part(part: dict[str, Any]) -> dict[str, Any]:
+    def _to_chat_content_part(part: dict[str, Any]) -> ChatCompletionContentPartParam:
         """Convert one transformers content part to Chat-Completions shape.
 
         ``to_transformers_chat`` keeps Realtime-style parts (``input_text`` /
@@ -121,19 +128,21 @@ class ChatCompletionsApiModelHandler(BaseOpenAICompatibleHandler):
         """
         ptype = part.get("type")
         if ptype == "input_text":
-            return {"type": "text", "text": part.get("text") or ""}
+            return ChatCompletionContentPartTextParam(type="text", text=part.get("text") or "")
         if ptype == "input_image":
-            image_url = part.get("image_url")
-            if not isinstance(image_url, dict):
-                image_url = {"url": image_url}
+            raw_url = part.get("image_url")
+            if isinstance(raw_url, dict):
+                image_url = cast("ImageURL", raw_url)
+            else:
+                image_url = ImageURL(url=cast("str", raw_url))
                 detail = part.get("detail")
                 if detail is not None:
                     image_url["detail"] = detail
-            return {"type": "image_url", "image_url": image_url}
-        return part
+            return ChatCompletionContentPartImageParam(type="image_url", image_url=image_url)
+        return cast("ChatCompletionContentPartParam", part)
 
     @classmethod
-    def _chat_messages(cls, chat: Chat) -> list[dict[str, Any]]:
+    def _chat_messages(cls, chat: Chat) -> list[ChatCompletionMessageParam]:
         """Serialise the chat for the Chat Completions API.
 
         ``Chat.to_transformers_chat`` targets HuggingFace ``apply_chat_template``,
@@ -142,6 +151,10 @@ class ChatCompletionsApiModelHandler(BaseOpenAICompatibleHandler):
         multimodal ``content`` parts must use the Chat Completions ``text`` /
         ``image_url`` shape rather than the Realtime ``input_text`` /
         ``input_image`` shape.
+
+        ``to_transformers_chat`` returns plain ``dict``s; the cast records that the
+        patched-up shape conforms to ``ChatCompletionMessageParam`` (a TypedDict, so
+        the cast is a no-op at runtime).
         """
         messages = chat.to_transformers_chat()
         for message in messages:
@@ -152,11 +165,11 @@ class ChatCompletionsApiModelHandler(BaseOpenAICompatibleHandler):
             content = message.get("content")
             if isinstance(content, list):
                 message["content"] = [cls._to_chat_content_part(p) for p in content]
-        return messages
+        return cast("list[ChatCompletionMessageParam]", messages)
 
     # ── base hooks ──────────────────────────────────────────────────────────--
 
-    def _serialize(self, active_chat: Chat) -> list[dict[str, Any]]:
+    def _serialize(self, active_chat: Chat) -> list[ChatCompletionMessageParam]:
         return self._chat_messages(active_chat)
 
     def _build_optional_kwargs(self, req_tools: Any, req_tool_choice: Any) -> dict[str, Any]:
@@ -168,13 +181,13 @@ class ChatCompletionsApiModelHandler(BaseOpenAICompatibleHandler):
             optional_kwargs["tool_choice"] = _to_chat_tool_choice(req_tool_choice)
         return optional_kwargs
 
-    def _request(self, api_input: list[dict[str, Any]], optional_kwargs: dict[str, Any]) -> Any:
+    def _request(self, api_input: list[ChatCompletionMessageParam], optional_kwargs: dict[str, Any]) -> Any:
         create_kwargs: dict[str, Any] = dict(optional_kwargs)
         if self.stream:
             create_kwargs["stream_options"] = {"include_usage": True}
         return self.client.chat.completions.create(
             model=self.model_name,
-            messages=api_input,  # type: ignore[arg-type]  # runtime dicts match the Chat Completions message shape
+            messages=api_input,
             stream=self.stream,
             extra_body=self._extra_body,
             timeout=self.request_timeout,

--- a/src/speech_to_speech/LLM/chat_completions_language_model.py
+++ b/src/speech_to_speech/LLM/chat_completions_language_model.py
@@ -1,0 +1,559 @@
+from __future__ import annotations
+
+import json
+import logging
+import time
+from collections.abc import Iterator
+from typing import Any, Optional
+
+import httpx
+from nltk import sent_tokenize
+from openai import OpenAI, Stream
+from openai.types.chat import ChatCompletionChunk
+from openai.types.realtime.conversation_item import (
+    RealtimeConversationItemAssistantMessage,
+    RealtimeConversationItemFunctionCall,
+)
+from openai.types.realtime.realtime_conversation_item_assistant_message import (
+    Content as AssistantContent,
+)
+from openai.types.responses import ResponseFunctionToolCall
+
+from speech_to_speech.baseHandler import BaseHandler
+from speech_to_speech.LLM.chat import Chat, SupportedItem, make_system_message, make_user_message
+from speech_to_speech.LLM.compaction_prompt import CompactGenerateFn, build_compactor
+from speech_to_speech.LLM.utils import remove_unspeechable, resolve_auto_language
+from speech_to_speech.LLM.voice_prompt import build_voice_system_prompt
+from speech_to_speech.pipeline.cancel_scope import CancelScope
+from speech_to_speech.pipeline.handler_types import LLMIn, LLMOut
+from speech_to_speech.pipeline.messages import (
+    EndOfResponse,
+    LLMResponseChunk,
+    TokenUsage,
+)
+from speech_to_speech.pipeline.speculative_turns import SpeculativeTurnTracker
+from speech_to_speech.utils.utils import _generate_id
+
+logger = logging.getLogger(__name__)
+
+
+def _to_chat_tools(req_tools: Any) -> list[dict[str, Any]] | None:
+    """Convert Responses-API function tools to Chat-Completions tool format.
+
+    Responses tools are flat ``{type:"function", name, description, parameters}``;
+    Chat Completions nests them under a ``function`` key. Items already in the
+    nested form (or non-function tools) are passed through untouched.
+    """
+    if not req_tools:
+        return None
+    chat_tools: list[dict[str, Any]] = []
+    for t in req_tools:
+        d = t if isinstance(t, dict) else t.model_dump(exclude_none=True)
+        if d.get("type") == "function" and "function" not in d:
+            fn = {k: d[k] for k in ("name", "description", "parameters") if k in d}
+            chat_tools.append({"type": "function", "function": fn})
+        else:
+            chat_tools.append(d)
+    return chat_tools
+
+
+def _to_chat_tool_choice(tool_choice: Any) -> Any:
+    """Convert a Responses-API tool_choice to Chat-Completions form.
+
+    The string forms ("auto"/"required"/"none") are identical across both APIs;
+    only the forced-function object differs (flat ``name`` vs nested ``function``).
+    """
+    if isinstance(tool_choice, dict) and tool_choice.get("type") == "function" and "name" in tool_choice:
+        return {"type": "function", "function": {"name": tool_choice["name"]}}
+    if tool_choice is not None and not isinstance(tool_choice, (str, dict)):
+        d = tool_choice.model_dump(exclude_none=True)
+        if d.get("type") == "function" and "name" in d:
+            return {"type": "function", "function": {"name": d["name"]}}
+        return d
+    return tool_choice
+
+
+class ChatCompletionsApiModelHandler(BaseHandler[LLMIn, LLMOut]):
+    """LLM handler that talks to an OpenAI-compatible ``/v1/chat/completions`` server.
+
+    Functionally mirrors :class:`ResponsesApiModelHandler` but uses the mature
+    Chat Completions streaming tool-call protocol (``choices[].delta.tool_calls``)
+    instead of ``/v1/responses``. This is the robust path for vLLM + Qwen tool
+    calling. The conversation is serialised with :meth:`Chat.to_transformers_chat`,
+    which already emits OpenAI chat messages including ``tool_calls``/``tool`` roles.
+    """
+
+    def setup(
+        self,
+        model_name: str = "gpt-5.4-mini",
+        device: str = "cuda",
+        gen_kwargs: dict[str, Any] = {},
+        base_url: Optional[str] = None,
+        api_key: Optional[str] = None,
+        stream: bool = True,
+        user_role: str = "user",
+        cancel_scope: CancelScope | None = None,
+        speculative_turns: SpeculativeTurnTracker | None = None,
+        disable_thinking: bool = True,
+        reasoning_effort: Optional[str] = None,
+        request_timeout_s: float = 20.0,
+        stream_batch_sentences: int = 3,
+        enable_lang_prompt: bool = False,
+        compact_history: bool = False,
+        **_kwargs: Any,
+    ) -> None:
+        self.cancel_scope = cancel_scope
+        self.speculative_turns = speculative_turns
+        self.model_name = model_name
+        self.stream = stream
+        self.stream_batch_sentences = max(1, stream_batch_sentences)
+        self.enable_lang_prompt = enable_lang_prompt
+        self.gen_kwargs = dict(gen_kwargs)
+        self.request_timeout_s = float(request_timeout_s)
+        self.request_timeout = httpx.Timeout(
+            self.request_timeout_s,
+            connect=min(10.0, self.request_timeout_s),
+        )
+
+        self.user_role = user_role
+        self.client = OpenAI(api_key=api_key, base_url=base_url)
+        self._extra_body = self._build_extra_body(base_url, disable_thinking, reasoning_effort)
+        self.compactor = build_compactor(self._build_compaction_generate_fn()) if compact_history else None
+        self.warmup()
+
+    @staticmethod
+    def _build_extra_body(
+        base_url: Optional[str],
+        disable_thinking: bool,
+        reasoning_effort: Optional[str],
+    ) -> Optional[dict[str, Any]]:
+        """Build the provider-specific ``extra_body`` used to disable reasoning.
+
+        Providers differ in how reasoning is turned off: vLLM/Qwen honour
+        ``chat_template_kwargs.enable_thinking=false``, while others (e.g. GLM via
+        the HF router) ignore that and require ``reasoning_effort='none'``. An
+        explicit ``reasoning_effort`` therefore takes precedence; otherwise we fall
+        back to the chat-template flag. None of this applies to the official
+        OpenAI server, which rejects unknown extra_body keys.
+        """
+        if base_url is None or base_url == "https://api.openai.com/v1":
+            return None
+        if reasoning_effort is not None:
+            return {"reasoning_effort": reasoning_effort}
+        if disable_thinking:
+            return {"chat_template_kwargs": {"enable_thinking": False}}
+        return None
+
+    def _turn_is_latest(self, turn_id: str | None, turn_revision: int | None) -> bool:
+        return self.speculative_turns is None or self.speculative_turns.is_latest(turn_id, turn_revision)
+
+    def _generation_is_stale(self, gen: int | None) -> bool:
+        return gen is not None and self.cancel_scope is not None and self.cancel_scope.is_stale(gen)
+
+    def _turn_output_allowed(self, turn_id: str | None, turn_revision: int | None) -> bool:
+        if self.speculative_turns is None:
+            return True
+        return self.speculative_turns.is_latest_after_reopen_grace(turn_id, turn_revision)
+
+    def warmup(self) -> None:
+        logger.info(f"Warming up {self.__class__.__name__}")
+        start = time.time()
+        self.client.chat.completions.create(
+            model=self.model_name,
+            messages=[
+                {"role": "system", "content": "You are a helpful assistant"},
+                {"role": "user", "content": "Hello"},
+            ],
+            extra_body=self._extra_body,
+            timeout=self.request_timeout,
+        )
+        end = time.time()
+        logger.info(f"{self.__class__.__name__}:  warmed up! time: {(end - start):.3f} s")
+
+    def _build_compaction_generate_fn(self) -> CompactGenerateFn:
+        """Return a generate fn that calls Chat Completions for compaction."""
+        client = self.client
+        model_name = self.model_name
+        timeout = self.request_timeout
+        extra_body = self._extra_body
+
+        def generate(system: str, user: str) -> str:
+            response = client.chat.completions.create(
+                model=model_name,
+                messages=[
+                    {"role": "system", "content": system},
+                    {"role": "user", "content": user},
+                ],
+                extra_body=extra_body,
+                timeout=timeout,
+            )
+            return response.choices[0].message.content or ""
+
+        return generate
+
+    def _apply_config(
+        self,
+        chat: Chat,
+        instructions: Optional[str],
+    ) -> None:
+        if instructions:
+            full_instructions = build_voice_system_prompt(instructions)
+            chat.add_item(make_system_message(full_instructions))
+
+    @staticmethod
+    def _chat_messages(chat: Chat) -> list[dict[str, Any]]:
+        """Serialise the chat for the Chat Completions API.
+
+        ``Chat.to_transformers_chat`` targets HuggingFace ``apply_chat_template``,
+        which expects tool-call ``arguments`` as a parsed object. The OpenAI Chat
+        Completions HTTP API instead requires ``arguments`` to be a JSON *string*,
+        so re-encode any object back to a string here.
+        """
+        messages = chat.to_transformers_chat()
+        for message in messages:
+            for tool_call in message.get("tool_calls") or []:
+                fn = tool_call.get("function")
+                if fn is not None and not isinstance(fn.get("arguments"), str):
+                    fn["arguments"] = json.dumps(fn.get("arguments") or {}, ensure_ascii=False)
+        return messages
+
+    def _generate(
+        self,
+        active_chat: Chat,
+        original_chat: Chat,
+        language_code: Optional[str],
+        gen: int | None,
+        runtime_config: Any,
+        response: Any,
+        optional_kwargs: dict[str, Any],
+        turn_id: str | None,
+        turn_revision: int | None,
+        speech_stopped_at_s: float | None,
+    ) -> Iterator[LLMOut]:
+        api_response: Stream[ChatCompletionChunk] | Any = None
+        tools: list[ResponseFunctionToolCall] = []
+        pending_chat_items: list[SupportedItem] = []
+        clean_text = ""
+        input_tokens = 0
+        output_tokens = 0
+
+        # Accumulate streamed tool-call deltas, keyed by their stream index.
+        tool_accum: dict[int, dict[str, str]] = {}
+
+        def _flush_batch(sentence_batch: list[str]) -> Iterator[LLMOut]:
+            if not sentence_batch:
+                return
+            if not self._turn_output_allowed(turn_id, turn_revision):
+                return
+            yield LLMResponseChunk(
+                text=" ".join(sentence_batch),
+                language_code=language_code,
+                runtime_config=runtime_config,
+                response=response,
+                turn_id=turn_id,
+                turn_revision=turn_revision,
+                speech_stopped_at_s=speech_stopped_at_s,
+                cancel_generation=gen,
+            )
+
+        try:
+            create_kwargs: dict[str, Any] = dict(optional_kwargs)
+            if self.stream:
+                create_kwargs["stream_options"] = {"include_usage": True}
+            api_response = self.client.chat.completions.create(
+                model=self.model_name,
+                messages=self._chat_messages(active_chat),
+                stream=self.stream,
+                extra_body=self._extra_body,
+                timeout=self.request_timeout,
+                **create_kwargs,
+            )
+
+            if isinstance(api_response, Stream):
+                cancelled = False
+                printable_text = ""
+                sentence_batch: list[str] = []
+                for chunk in api_response:
+                    if (
+                        gen is not None and self.cancel_scope is not None and self.cancel_scope.is_stale(gen)
+                    ) or not self._turn_is_latest(turn_id, turn_revision):
+                        logger.info("LLM generation cancelled (interruption)")
+                        cancelled = True
+                        break
+
+                    # Usage-only trailing chunk (choices == []) when include_usage is set.
+                    if chunk.usage is not None:
+                        input_tokens = chunk.usage.prompt_tokens or 0
+                        output_tokens = chunk.usage.completion_tokens or 0
+                    if not chunk.choices:
+                        continue
+
+                    delta = chunk.choices[0].delta
+
+                    if delta.content:
+                        new_text = remove_unspeechable(delta.content)
+                        clean_text += new_text
+                        printable_text += new_text
+                        sentences = sent_tokenize(printable_text)
+                        if len(sentences) > 1:
+                            for s in sentences[:-1]:
+                                sentence_batch.append(s)
+                                if len(sentence_batch) >= self.stream_batch_sentences:
+                                    if not self._turn_output_allowed(turn_id, turn_revision):
+                                        logger.info("LLM generation cancelled (stale speculative turn)")
+                                        cancelled = True
+                                        break
+                                    yield from _flush_batch(sentence_batch)
+                                    sentence_batch = []
+                            if cancelled:
+                                break
+                            printable_text = sentences[-1]
+
+                    if delta.tool_calls:
+                        for tc in delta.tool_calls:
+                            entry = tool_accum.setdefault(tc.index, {"name": "", "args": "", "id": ""})
+                            if tc.id:
+                                entry["id"] = tc.id
+                            if tc.function is not None:
+                                if tc.function.name:
+                                    entry["name"] = tc.function.name
+                                if tc.function.arguments:
+                                    entry["args"] += tc.function.arguments
+
+                if not cancelled:
+                    # Flush any trailing text before emitting tool calls.
+                    if printable_text.strip():
+                        sentence_batch.append(printable_text.strip())
+                    if sentence_batch:
+                        if self._generation_is_stale(gen):
+                            logger.info("LLM generation cancelled (interruption)")
+                        else:
+                            logger.debug(f"Clean text: {clean_text}")
+                            yield from _flush_batch(sentence_batch)
+                    if clean_text.strip():
+                        pending_chat_items.append(
+                            RealtimeConversationItemAssistantMessage(
+                                type="message",
+                                role="assistant",
+                                content=[AssistantContent(type="output_text", text=clean_text)],
+                            )
+                        )
+                    yield from self._emit_tool_calls(
+                        tool_accum,
+                        tools,
+                        pending_chat_items,
+                        language_code,
+                        gen,
+                        runtime_config,
+                        response,
+                        turn_id,
+                        turn_revision,
+                        speech_stopped_at_s,
+                    )
+                    if tools:
+                        logger.info(f"Tools: {tools}")
+            else:
+                if (
+                    gen is not None and self.cancel_scope is not None and self.cancel_scope.is_stale(gen)
+                ) or not self._turn_is_latest(turn_id, turn_revision):
+                    logger.info("LLM generation cancelled (interruption)")
+                else:
+                    usage = api_response.usage
+                    if usage:
+                        input_tokens = usage.prompt_tokens or 0
+                        output_tokens = usage.completion_tokens or 0
+                    message = api_response.choices[0].message
+                    message_text = remove_unspeechable(message.content or "")
+                    clean_text += message_text
+                    if message_text.strip():
+                        pending_chat_items.append(
+                            RealtimeConversationItemAssistantMessage(
+                                type="message",
+                                role="assistant",
+                                content=[AssistantContent(type="output_text", text=message.content or "")],
+                            )
+                        )
+                        if not self._generation_is_stale(gen) and self._turn_output_allowed(turn_id, turn_revision):
+                            yield LLMResponseChunk(
+                                text=message_text.strip(),
+                                language_code=language_code,
+                                runtime_config=runtime_config,
+                                response=response,
+                                turn_id=turn_id,
+                                turn_revision=turn_revision,
+                                speech_stopped_at_s=speech_stopped_at_s,
+                                cancel_generation=gen,
+                            )
+                    for tc in message.tool_calls or []:
+                        tool_accum[len(tool_accum)] = {
+                            "name": tc.function.name or "",
+                            "args": tc.function.arguments or "",
+                            "id": tc.id or "",
+                        }
+                    yield from self._emit_tool_calls(
+                        tool_accum,
+                        tools,
+                        pending_chat_items,
+                        language_code,
+                        gen,
+                        runtime_config,
+                        response,
+                        turn_id,
+                        turn_revision,
+                        speech_stopped_at_s,
+                    )
+                    logger.debug(f"Clean text: {clean_text}")
+                    if tools:
+                        logger.info(f"Tools: {tools}")
+        except httpx.ReadTimeout:
+            logger.warning(
+                "OpenAI API read timed out after %.1fs; ending the current response",
+                self.request_timeout_s,
+            )
+            if not self._generation_is_stale(gen) and self._turn_output_allowed(turn_id, turn_revision):
+                yield LLMResponseChunk(
+                    text="Wow I'm a bit slow today, could you repeat that?",
+                    runtime_config=runtime_config,
+                    response=response,
+                    turn_id=turn_id,
+                    turn_revision=turn_revision,
+                    speech_stopped_at_s=speech_stopped_at_s,
+                    cancel_generation=gen,
+                )
+        finally:
+            if api_response is not None and hasattr(api_response, "close"):
+                try:
+                    api_response.close()
+                except Exception:
+                    pass
+
+        if not self._generation_is_stale(gen) and self._turn_output_allowed(turn_id, turn_revision):
+            for item in pending_chat_items:
+                original_chat.add_item(item)
+            original_chat.strip_images()
+            original_chat.trim_if_needed(self.compactor)
+            if input_tokens or output_tokens:
+                yield TokenUsage(
+                    input_tokens=input_tokens,
+                    output_tokens=output_tokens,
+                    turn_id=turn_id,
+                    turn_revision=turn_revision,
+                )
+        yield EndOfResponse(turn_id=turn_id, turn_revision=turn_revision, cancel_generation=gen)
+
+    def _emit_tool_calls(
+        self,
+        tool_accum: dict[int, dict[str, str]],
+        tools: list[ResponseFunctionToolCall],
+        pending_chat_items: list[SupportedItem],
+        language_code: Optional[str],
+        gen: int | None,
+        runtime_config: Any,
+        response: Any,
+        turn_id: str | None,
+        turn_revision: int | None,
+        speech_stopped_at_s: float | None,
+    ) -> Iterator[LLMOut]:
+        """Turn accumulated tool-call deltas into ResponseFunctionToolCall events.
+
+        IDs are regenerated (mirroring the Responses handler) so the rest of the
+        pipeline pairs each call_id with its function_call_output consistently.
+        """
+        for index in sorted(tool_accum):
+            entry = tool_accum[index]
+            if not entry["name"]:
+                continue
+            call_id = _generate_id("call")
+            fc_id = _generate_id("fc")
+            item = ResponseFunctionToolCall(
+                type="function_call",
+                name=entry["name"],
+                arguments=entry["args"] or "{}",
+                call_id=call_id,
+                id=fc_id,
+                status="completed",
+            )
+            tools.append(item)
+            pending_chat_items.append(
+                RealtimeConversationItemFunctionCall(
+                    type="function_call",
+                    name=item.name,
+                    arguments=item.arguments,
+                    call_id=item.call_id,
+                    id=item.id,
+                    status=item.status,
+                )
+            )
+            if self._generation_is_stale(gen) or not self._turn_output_allowed(turn_id, turn_revision):
+                logger.info("LLM generation cancelled (stale speculative turn)")
+                continue
+            yield LLMResponseChunk(
+                text="",
+                language_code=language_code,
+                tools=[item],
+                runtime_config=runtime_config,
+                response=response,
+                turn_id=turn_id,
+                turn_revision=turn_revision,
+                speech_stopped_at_s=speech_stopped_at_s,
+                cancel_generation=gen,
+            )
+
+    def process(self, request: LLMIn) -> Iterator[LLMOut]:
+        """Process a language model request and yield LLMResponseChunks."""
+        runtime_config = request.runtime_config
+        response = request.response
+        turn_id = request.turn_id
+        turn_revision = request.turn_revision
+        speech_stopped_at_s = request.speech_stopped_at_s
+        if not self._turn_is_latest(turn_id, turn_revision):
+            logger.info("Skipping stale LLM request for turn=%s rev=%s", turn_id, turn_revision)
+            yield EndOfResponse(turn_id=turn_id, turn_revision=turn_revision)
+            return
+
+        original_chat = runtime_config.chat
+        active_chat = original_chat.copy()
+        language_code = request.language_code
+        instructions = (
+            response.instructions if response and response.instructions else runtime_config.session.instructions
+        ) or ""
+        req_tools = response.tools if response and response.tools else runtime_config.session.tools
+        req_tool_choice = (
+            response.tool_choice if response and response.tool_choice else runtime_config.session.tool_choice
+        )
+        self._apply_config(active_chat, instructions)
+        language_code, lang_name = resolve_auto_language(language_code)
+        if lang_name and self.enable_lang_prompt:
+            active_chat.add_item(make_user_message(f"Please reply to my message in {lang_name}."))
+
+        optional_kwargs: dict[str, Any] = {}
+        chat_tools = _to_chat_tools(req_tools)
+        if chat_tools is not None:
+            optional_kwargs["tools"] = chat_tools
+            if req_tool_choice is not None:
+                optional_kwargs["tool_choice"] = _to_chat_tool_choice(req_tool_choice)
+
+        gen = self.cancel_scope.generation if self.cancel_scope else None
+
+        yield from self._generate(
+            active_chat,
+            original_chat,
+            language_code,
+            gen,
+            runtime_config,
+            response,
+            optional_kwargs,
+            turn_id,
+            turn_revision,
+            speech_stopped_at_s,
+        )
+
+    def on_session_end(self) -> None:
+        logger.debug("Chat Completions API language model session state reset")
+
+    @property
+    def timing_log_level(self) -> int:
+        return logging.INFO
+
+    def should_log_timing(self, output: LLMOut) -> bool:
+        return isinstance(output, LLMResponseChunk) and self.last_time > self.min_time_to_debug

--- a/src/speech_to_speech/LLM/chat_completions_language_model.py
+++ b/src/speech_to_speech/LLM/chat_completions_language_model.py
@@ -171,6 +171,8 @@ class ChatCompletionsApiModelHandler(BaseOpenAICompatibleHandler):
             content = message.get("content")
             if isinstance(content, list):
                 message["content"] = [cls._to_chat_content_part(p) for p in content]
+            if message.get("role") == "tool":
+                message.pop("name", None)
         return messages
 
     # ── base hooks ──────────────────────────────────────────────────────────--

--- a/src/speech_to_speech/LLM/chat_completions_language_model.py
+++ b/src/speech_to_speech/LLM/chat_completions_language_model.py
@@ -12,13 +12,17 @@ from openai.types.chat import (
     ChatCompletionContentPartImageParam,
     ChatCompletionContentPartParam,
     ChatCompletionContentPartTextParam,
-    ChatCompletionMessageParam,
+    ChatCompletionNamedToolChoiceParam,
+    ChatCompletionToolChoiceOptionParam,
+    ChatCompletionToolParam,
 )
 from openai.types.chat.chat_completion_content_part_image_param import ImageURL
+from openai.types.chat.chat_completion_named_tool_choice_param import Function as NamedToolChoiceFunction
 from openai.types.realtime.realtime_conversation_item_assistant_message import (
     Content as AssistantContent,
 )
 from openai.types.responses import ResponseFunctionToolCall
+from openai.types.shared_params import FunctionDefinition
 
 from speech_to_speech.LLM.base_openai_compatible_language_model import (
     AssistantMessage,
@@ -35,7 +39,7 @@ from speech_to_speech.utils.utils import _generate_id
 logger = logging.getLogger(__name__)
 
 
-def _to_chat_tools(req_tools: Any) -> list[dict[str, Any]] | None:
+def _to_chat_tools(req_tools: Any) -> list[ChatCompletionToolParam] | None:
     """Convert Responses-API function tools to Chat-Completions tool format.
 
     Responses tools are flat ``{type:"function", name, description, parameters}``;
@@ -44,31 +48,37 @@ def _to_chat_tools(req_tools: Any) -> list[dict[str, Any]] | None:
     """
     if not req_tools:
         return None
-    chat_tools: list[dict[str, Any]] = []
+    chat_tools: list[ChatCompletionToolParam] = []
     for t in req_tools:
         d = t if isinstance(t, dict) else t.model_dump(exclude_none=True)
         if d.get("type") == "function" and "function" not in d:
-            fn = {k: d[k] for k in ("name", "description", "parameters") if k in d}
-            chat_tools.append({"type": "function", "function": fn})
+            fn = FunctionDefinition(name=d["name"])
+            if d.get("description") is not None:
+                fn["description"] = d["description"]
+            if d.get("parameters") is not None:
+                fn["parameters"] = d["parameters"]
+            chat_tools.append(ChatCompletionToolParam(type="function", function=fn))
         else:
-            chat_tools.append(d)
+            chat_tools.append(cast("ChatCompletionToolParam", d))
     return chat_tools
 
 
-def _to_chat_tool_choice(tool_choice: Any) -> Any:
+def _to_chat_tool_choice(tool_choice: Any) -> ChatCompletionToolChoiceOptionParam:
     """Convert a Responses-API tool_choice to Chat-Completions form.
 
     The string forms ("auto"/"required"/"none") are identical across both APIs;
     only the forced-function object differs (flat ``name`` vs nested ``function``).
     """
     if isinstance(tool_choice, dict) and tool_choice.get("type") == "function" and "name" in tool_choice:
-        return {"type": "function", "function": {"name": tool_choice["name"]}}
+        return ChatCompletionNamedToolChoiceParam(
+            type="function", function=NamedToolChoiceFunction(name=tool_choice["name"])
+        )
     if tool_choice is not None and not isinstance(tool_choice, (str, dict)):
         d = tool_choice.model_dump(exclude_none=True)
         if d.get("type") == "function" and "name" in d:
-            return {"type": "function", "function": {"name": d["name"]}}
-        return d
-    return tool_choice
+            return ChatCompletionNamedToolChoiceParam(type="function", function=NamedToolChoiceFunction(name=d["name"]))
+        return cast("ChatCompletionToolChoiceOptionParam", d)
+    return cast("ChatCompletionToolChoiceOptionParam", tool_choice)
 
 
 class ChatCompletionsApiModelHandler(BaseOpenAICompatibleHandler):
@@ -130,11 +140,11 @@ class ChatCompletionsApiModelHandler(BaseOpenAICompatibleHandler):
         if ptype == "input_text":
             return ChatCompletionContentPartTextParam(type="text", text=part.get("text") or "")
         if ptype == "input_image":
-            raw_url = part.get("image_url")
+            raw_url: Any = part.get("image_url")
             if isinstance(raw_url, dict):
                 image_url = cast("ImageURL", raw_url)
             else:
-                image_url = ImageURL(url=cast("str", raw_url))
+                image_url = ImageURL(url=raw_url)
                 detail = part.get("detail")
                 if detail is not None:
                     image_url["detail"] = detail
@@ -142,7 +152,7 @@ class ChatCompletionsApiModelHandler(BaseOpenAICompatibleHandler):
         return cast("ChatCompletionContentPartParam", part)
 
     @classmethod
-    def _chat_messages(cls, chat: Chat) -> list[ChatCompletionMessageParam]:
+    def _chat_messages(cls, chat: Chat) -> list[dict[str, Any]]:
         """Serialise the chat for the Chat Completions API.
 
         ``Chat.to_transformers_chat`` targets HuggingFace ``apply_chat_template``,
@@ -151,10 +161,6 @@ class ChatCompletionsApiModelHandler(BaseOpenAICompatibleHandler):
         multimodal ``content`` parts must use the Chat Completions ``text`` /
         ``image_url`` shape rather than the Realtime ``input_text`` /
         ``input_image`` shape.
-
-        ``to_transformers_chat`` returns plain ``dict``s; the cast records that the
-        patched-up shape conforms to ``ChatCompletionMessageParam`` (a TypedDict, so
-        the cast is a no-op at runtime).
         """
         messages = chat.to_transformers_chat()
         for message in messages:
@@ -165,11 +171,11 @@ class ChatCompletionsApiModelHandler(BaseOpenAICompatibleHandler):
             content = message.get("content")
             if isinstance(content, list):
                 message["content"] = [cls._to_chat_content_part(p) for p in content]
-        return cast("list[ChatCompletionMessageParam]", messages)
+        return messages
 
     # ── base hooks ──────────────────────────────────────────────────────────--
 
-    def _serialize(self, active_chat: Chat) -> list[ChatCompletionMessageParam]:
+    def _serialize(self, active_chat: Chat) -> list[dict[str, Any]]:
         return self._chat_messages(active_chat)
 
     def _build_optional_kwargs(self, req_tools: Any, req_tool_choice: Any) -> dict[str, Any]:
@@ -181,13 +187,13 @@ class ChatCompletionsApiModelHandler(BaseOpenAICompatibleHandler):
             optional_kwargs["tool_choice"] = _to_chat_tool_choice(req_tool_choice)
         return optional_kwargs
 
-    def _request(self, api_input: list[ChatCompletionMessageParam], optional_kwargs: dict[str, Any]) -> Any:
+    def _request(self, api_input: list[dict[str, Any]], optional_kwargs: dict[str, Any]) -> Any:
         create_kwargs: dict[str, Any] = dict(optional_kwargs)
         if self.stream:
             create_kwargs["stream_options"] = {"include_usage": True}
         return self.client.chat.completions.create(
             model=self.model_name,
-            messages=api_input,
+            messages=api_input,  # type: ignore[arg-type]  # runtime dicts match the Chat Completions message shape
             stream=self.stream,
             extra_body=self._extra_body,
             timeout=self.request_timeout,

--- a/src/speech_to_speech/LLM/chat_completions_language_model.py
+++ b/src/speech_to_speech/LLM/chat_completions_language_model.py
@@ -20,8 +20,16 @@ from openai.types.realtime.realtime_conversation_item_assistant_message import (
 from openai.types.responses import ResponseFunctionToolCall
 
 from speech_to_speech.baseHandler import BaseHandler
-from speech_to_speech.LLM.chat import Chat, SupportedItem, make_system_message, make_user_message
+from speech_to_speech.LLM.chat import (
+    Chat,
+    ChatItemError,
+    SupportedItem,
+    build_active_chat,
+    make_system_message,
+    make_user_message,
+)
 from speech_to_speech.LLM.compaction_prompt import CompactGenerateFn, build_compactor
+from speech_to_speech.LLM.text_prompt import build_text_system_prompt
 from speech_to_speech.LLM.utils import remove_unspeechable, resolve_auto_language
 from speech_to_speech.LLM.voice_prompt import build_voice_system_prompt
 from speech_to_speech.pipeline.cancel_scope import CancelScope
@@ -32,7 +40,7 @@ from speech_to_speech.pipeline.messages import (
     TokenUsage,
 )
 from speech_to_speech.pipeline.speculative_turns import SpeculativeTurnTracker
-from speech_to_speech.utils.utils import _generate_id
+from speech_to_speech.utils.utils import _generate_id, is_out_of_band, response_wants_audio
 
 logger = logging.getLogger(__name__)
 
@@ -195,9 +203,11 @@ class ChatCompletionsApiModelHandler(BaseHandler[LLMIn, LLMOut]):
         self,
         chat: Chat,
         instructions: Optional[str],
+        wants_audio: bool = True,
     ) -> None:
         if instructions:
-            full_instructions = build_voice_system_prompt(instructions)
+            builder = build_voice_system_prompt if wants_audio else build_text_system_prompt
+            full_instructions = builder(instructions)
             chat.add_item(make_system_message(full_instructions))
 
     @staticmethod
@@ -234,8 +244,20 @@ class ChatCompletionsApiModelHandler(BaseHandler[LLMIn, LLMOut]):
         tools: list[ResponseFunctionToolCall] = []
         pending_chat_items: list[SupportedItem] = []
         clean_text = ""
+        # Raw (unfiltered) assistant text written back to history; clean_text is the
+        # TTS-ready string sent to the speaker. Storing the filtered text would show
+        # the model a degraded view of its own past turns and cause multi-turn drift.
+        raw_text = ""
         input_tokens = 0
         output_tokens = 0
+        error_message: str | None = None
+        wants_audio = response_wants_audio(response)
+        messages = self._chat_messages(active_chat)
+        if not messages:
+            # Nothing to send: empty `instructions` and no `input` (in the response,
+            # the default conversation, or the out-of-band context). The provider
+            # would reject this; fail with a clear message instead of an opaque error.
+            error_message = "Cannot generate a response: no instructions and no input were provided."
 
         # Accumulate streamed tool-call deltas, keyed by their stream index.
         tool_accum: dict[int, dict[str, str]] = {}
@@ -244,6 +266,7 @@ class ChatCompletionsApiModelHandler(BaseHandler[LLMIn, LLMOut]):
             if not sentence_batch:
                 return
             if not self._turn_output_allowed(turn_id, turn_revision):
+                logger.info("LLM generation cancelled (stale speculative turn)")
                 return
             yield LLMResponseChunk(
                 text=" ".join(sentence_batch),
@@ -257,17 +280,18 @@ class ChatCompletionsApiModelHandler(BaseHandler[LLMIn, LLMOut]):
             )
 
         try:
-            create_kwargs: dict[str, Any] = dict(optional_kwargs)
-            if self.stream:
-                create_kwargs["stream_options"] = {"include_usage": True}
-            api_response = self.client.chat.completions.create(
-                model=self.model_name,
-                messages=self._chat_messages(active_chat),
-                stream=self.stream,
-                extra_body=self._extra_body,
-                timeout=self.request_timeout,
-                **create_kwargs,
-            )
+            if error_message is None:
+                create_kwargs: dict[str, Any] = dict(optional_kwargs)
+                if self.stream:
+                    create_kwargs["stream_options"] = {"include_usage": True}
+                api_response = self.client.chat.completions.create(
+                    model=self.model_name,
+                    messages=messages,
+                    stream=self.stream,
+                    extra_body=self._extra_body,
+                    timeout=self.request_timeout,
+                    **create_kwargs,
+                )
 
             if isinstance(api_response, Stream):
                 cancelled = False
@@ -291,6 +315,28 @@ class ChatCompletionsApiModelHandler(BaseHandler[LLMIn, LLMOut]):
                     delta = chunk.choices[0].delta
 
                     if delta.content:
+                        raw_text += delta.content
+                        if not wants_audio:
+                            # Text-only: forward the delta verbatim. Keep every
+                            # character (no remove_unspeechable, which strips
+                            # TTS-unfriendly symbols) and don't sentence-split
+                            # (sent_tokenize would collapse newlines / markdown).
+                            clean_text += delta.content
+                            if not self._turn_output_allowed(turn_id, turn_revision):
+                                logger.info("LLM generation cancelled (stale speculative turn)")
+                                cancelled = True
+                                break
+                            yield LLMResponseChunk(
+                                text=delta.content,
+                                language_code=language_code,
+                                runtime_config=runtime_config,
+                                response=response,
+                                turn_id=turn_id,
+                                turn_revision=turn_revision,
+                                speech_stopped_at_s=speech_stopped_at_s,
+                                cancel_generation=gen,
+                            )
+                            continue
                         new_text = remove_unspeechable(delta.content)
                         clean_text += new_text
                         printable_text += new_text
@@ -330,12 +376,12 @@ class ChatCompletionsApiModelHandler(BaseHandler[LLMIn, LLMOut]):
                         else:
                             logger.debug(f"Clean text: {clean_text}")
                             yield from _flush_batch(sentence_batch)
-                    if clean_text.strip():
+                    if raw_text.strip():
                         pending_chat_items.append(
                             RealtimeConversationItemAssistantMessage(
                                 type="message",
                                 role="assistant",
-                                content=[AssistantContent(type="output_text", text=clean_text)],
+                                content=[AssistantContent(type="output_text", text=raw_text)],
                             )
                         )
                     yield from self._emit_tool_calls(
@@ -350,8 +396,7 @@ class ChatCompletionsApiModelHandler(BaseHandler[LLMIn, LLMOut]):
                         turn_revision,
                         speech_stopped_at_s,
                     )
-                    if tools:
-                        logger.info(f"Tools: {tools}")
+                    logger.info(f"Tools: {tools}")
             else:
                 if (
                     gen is not None and self.cancel_scope is not None and self.cancel_scope.is_stale(gen)
@@ -363,19 +408,27 @@ class ChatCompletionsApiModelHandler(BaseHandler[LLMIn, LLMOut]):
                         input_tokens = usage.prompt_tokens or 0
                         output_tokens = usage.completion_tokens or 0
                     message = api_response.choices[0].message
-                    message_text = remove_unspeechable(message.content or "")
+                    # Text-only keeps every character verbatim; audio strips
+                    # TTS-unfriendly symbols via remove_unspeechable.
+                    message_text = (
+                        (message.content or "") if not wants_audio else remove_unspeechable(message.content or "")
+                    )
                     clean_text += message_text
-                    if message_text.strip():
+                    # Gate history write-back on the raw content so a turn that is
+                    # entirely TTS-unfriendly symbols is still stored, not dropped.
+                    if message.content:
                         pending_chat_items.append(
                             RealtimeConversationItemAssistantMessage(
                                 type="message",
                                 role="assistant",
-                                content=[AssistantContent(type="output_text", text=message.content or "")],
+                                content=[AssistantContent(type="output_text", text=message.content)],
                             )
                         )
+                    chunk_text = message_text if not wants_audio else message_text.strip()
+                    if chunk_text:
                         if not self._generation_is_stale(gen) and self._turn_output_allowed(turn_id, turn_revision):
                             yield LLMResponseChunk(
-                                text=message_text.strip(),
+                                text=chunk_text,
                                 language_code=language_code,
                                 runtime_config=runtime_config,
                                 response=response,
@@ -403,8 +456,7 @@ class ChatCompletionsApiModelHandler(BaseHandler[LLMIn, LLMOut]):
                         speech_stopped_at_s,
                     )
                     logger.debug(f"Clean text: {clean_text}")
-                    if tools:
-                        logger.info(f"Tools: {tools}")
+                    logger.info(f"Tools: {tools}")
         except httpx.ReadTimeout:
             logger.warning(
                 "OpenAI API read timed out after %.1fs; ending the current response",
@@ -420,6 +472,14 @@ class ChatCompletionsApiModelHandler(BaseHandler[LLMIn, LLMOut]):
                     speech_stopped_at_s=speech_stopped_at_s,
                     cancel_generation=gen,
                 )
+        except Exception as exc:
+            # Any other generation failure must still terminate the response: record
+            # the error and fall through to the EndOfResponse below. Without this the
+            # exception would escape process() and no EndOfResponse would be emitted,
+            # leaving st.in_response stuck and locking every subsequent response.
+            logger.exception("LLM generation failed; ending the current response")
+            if error_message is None:
+                error_message = f"Language model generation failed: {exc}"
         finally:
             if api_response is not None and hasattr(api_response, "close"):
                 try:
@@ -427,11 +487,18 @@ class ChatCompletionsApiModelHandler(BaseHandler[LLMIn, LLMOut]):
                 except Exception:
                     pass
 
-        if not self._generation_is_stale(gen) and self._turn_output_allowed(turn_id, turn_revision):
-            for item in pending_chat_items:
-                original_chat.add_item(item)
-            original_chat.strip_images()
-            original_chat.trim_if_needed(self.compactor)
+        if (
+            error_message is None
+            and not self._generation_is_stale(gen)
+            and self._turn_output_allowed(turn_id, turn_revision)
+        ):
+            # Out-of-band responses emit output and usage but never write back to the
+            # default conversation (their context was a throwaway chat).
+            if not is_out_of_band(response):
+                for item in pending_chat_items:
+                    original_chat.add_item(item)
+                original_chat.strip_images()
+                original_chat.trim_if_needed(self.compactor)
             if input_tokens or output_tokens:
                 yield TokenUsage(
                     input_tokens=input_tokens,
@@ -439,7 +506,7 @@ class ChatCompletionsApiModelHandler(BaseHandler[LLMIn, LLMOut]):
                     turn_id=turn_id,
                     turn_revision=turn_revision,
                 )
-        yield EndOfResponse(turn_id=turn_id, turn_revision=turn_revision, cancel_generation=gen)
+        yield EndOfResponse(turn_id=turn_id, turn_revision=turn_revision, cancel_generation=gen, error=error_message)
 
     def _emit_tool_calls(
         self,
@@ -512,7 +579,16 @@ class ChatCompletionsApiModelHandler(BaseHandler[LLMIn, LLMOut]):
             return
 
         original_chat = runtime_config.chat
-        active_chat = original_chat.copy()
+        out_of_band = is_out_of_band(response)
+        if out_of_band:
+            try:
+                active_chat = build_active_chat(original_chat, response)
+            except ChatItemError as exc:
+                logger.info("Out-of-band response rejected: %s", exc)
+                yield EndOfResponse(turn_id=turn_id, turn_revision=turn_revision, error=str(exc))
+                return
+        else:
+            active_chat = original_chat.copy()
         language_code = request.language_code
         instructions = (
             response.instructions if response and response.instructions else runtime_config.session.instructions
@@ -521,7 +597,7 @@ class ChatCompletionsApiModelHandler(BaseHandler[LLMIn, LLMOut]):
         req_tool_choice = (
             response.tool_choice if response and response.tool_choice else runtime_config.session.tool_choice
         )
-        self._apply_config(active_chat, instructions)
+        self._apply_config(active_chat, instructions, response_wants_audio(response))
         language_code, lang_name = resolve_auto_language(language_code)
         if lang_name and self.enable_lang_prompt:
             active_chat.add_item(make_user_message(f"Please reply to my message in {lang_name}."))
@@ -530,8 +606,8 @@ class ChatCompletionsApiModelHandler(BaseHandler[LLMIn, LLMOut]):
         chat_tools = _to_chat_tools(req_tools)
         if chat_tools is not None:
             optional_kwargs["tools"] = chat_tools
-            if req_tool_choice is not None:
-                optional_kwargs["tool_choice"] = _to_chat_tool_choice(req_tool_choice)
+        if req_tool_choice is not None:
+            optional_kwargs["tool_choice"] = _to_chat_tool_choice(req_tool_choice)
 
         gen = self.cancel_scope.generation if self.cancel_scope else None
 

--- a/src/speech_to_speech/LLM/chat_completions_language_model.py
+++ b/src/speech_to_speech/LLM/chat_completions_language_model.py
@@ -130,7 +130,20 @@ class ChatCompletionsApiModelHandler(BaseHandler[LLMIn, LLMOut]):
         self.warmup()
 
     @staticmethod
+    def _is_official_openai(base_url: Optional[str]) -> bool:
+        """Whether ``base_url`` points at the official OpenAI server.
+
+        Normalises a trailing slash so ``https://api.openai.com/v1/`` is also
+        recognised; the official server rejects the provider-specific extra_body
+        keys we send to vLLM / the HF router.
+        """
+        if base_url is None:
+            return False
+        return base_url.rstrip("/") == "https://api.openai.com/v1"
+
+    @classmethod
     def _build_extra_body(
+        cls,
         base_url: Optional[str],
         disable_thinking: bool,
         reasoning_effort: Optional[str],
@@ -139,14 +152,14 @@ class ChatCompletionsApiModelHandler(BaseHandler[LLMIn, LLMOut]):
 
         Providers differ in how reasoning is turned off: vLLM/Qwen honour
         ``chat_template_kwargs.enable_thinking=false``, while others (e.g. GLM via
-        the HF router) ignore that and require ``reasoning_effort='none'``. An
-        explicit ``reasoning_effort`` therefore takes precedence; otherwise we fall
+        the HF router) ignore that and require ``reasoning_effort='none'``. A
+        non-empty ``reasoning_effort`` therefore takes precedence; otherwise we fall
         back to the chat-template flag. None of this applies to the official
         OpenAI server, which rejects unknown extra_body keys.
         """
-        if base_url is None or base_url == "https://api.openai.com/v1":
+        if base_url is None or cls._is_official_openai(base_url):
             return None
-        if reasoning_effort is not None:
+        if reasoning_effort:
             return {"reasoning_effort": reasoning_effort}
         if disable_thinking:
             return {"chat_template_kwargs": {"enable_thinking": False}}
@@ -211,13 +224,37 @@ class ChatCompletionsApiModelHandler(BaseHandler[LLMIn, LLMOut]):
             chat.add_item(make_system_message(full_instructions))
 
     @staticmethod
-    def _chat_messages(chat: Chat) -> list[dict[str, Any]]:
+    def _to_chat_content_part(part: dict[str, Any]) -> dict[str, Any]:
+        """Convert one transformers content part to Chat-Completions shape.
+
+        ``to_transformers_chat`` keeps Realtime-style parts (``input_text`` /
+        ``input_image`` with a bare-string ``image_url``). The Chat Completions
+        HTTP API instead wants ``{type:"text", text}`` and
+        ``{type:"image_url", image_url:{url, detail}}``. Unknown parts pass through.
+        """
+        ptype = part.get("type")
+        if ptype == "input_text":
+            return {"type": "text", "text": part.get("text") or ""}
+        if ptype == "input_image":
+            image_url = part.get("image_url")
+            if not isinstance(image_url, dict):
+                image_url = {"url": image_url}
+                detail = part.get("detail")
+                if detail is not None:
+                    image_url["detail"] = detail
+            return {"type": "image_url", "image_url": image_url}
+        return part
+
+    @classmethod
+    def _chat_messages(cls, chat: Chat) -> list[dict[str, Any]]:
         """Serialise the chat for the Chat Completions API.
 
         ``Chat.to_transformers_chat`` targets HuggingFace ``apply_chat_template``,
-        which expects tool-call ``arguments`` as a parsed object. The OpenAI Chat
-        Completions HTTP API instead requires ``arguments`` to be a JSON *string*,
-        so re-encode any object back to a string here.
+        so two shapes need fixing up for the OpenAI Chat Completions HTTP API:
+        tool-call ``arguments`` must be a JSON *string* (not a parsed object), and
+        multimodal ``content`` parts must use the Chat Completions ``text`` /
+        ``image_url`` shape rather than the Realtime ``input_text`` /
+        ``input_image`` shape.
         """
         messages = chat.to_transformers_chat()
         for message in messages:
@@ -225,6 +262,9 @@ class ChatCompletionsApiModelHandler(BaseHandler[LLMIn, LLMOut]):
                 fn = tool_call.get("function")
                 if fn is not None and not isinstance(fn.get("arguments"), str):
                     fn["arguments"] = json.dumps(fn.get("arguments") or {}, ensure_ascii=False)
+            content = message.get("content")
+            if isinstance(content, list):
+                message["content"] = [cls._to_chat_content_part(p) for p in content]
         return messages
 
     def _generate(
@@ -314,20 +354,37 @@ class ChatCompletionsApiModelHandler(BaseHandler[LLMIn, LLMOut]):
 
                     delta = chunk.choices[0].delta
 
-                    if delta.content:
-                        raw_text += delta.content
+                    # Accumulate tool-call deltas first: a single chunk can carry
+                    # both content and tool_calls, and the text-only branch below
+                    # `continue`s, which would otherwise skip this block.
+                    if delta.tool_calls:
+                        for tc in delta.tool_calls:
+                            entry = tool_accum.setdefault(tc.index, {"name": "", "args": "", "id": ""})
+                            if tc.id:
+                                entry["id"] = tc.id
+                            if tc.function is not None:
+                                if tc.function.name:
+                                    entry["name"] = tc.function.name
+                                if tc.function.arguments:
+                                    entry["args"] += tc.function.arguments
+
+                    # A refusal streams as `delta.refusal` with `delta.content`
+                    # None; surface it as assistant text so it is spoken and stored.
+                    text_piece = delta.content or getattr(delta, "refusal", None)
+                    if text_piece:
+                        raw_text += text_piece
                         if not wants_audio:
                             # Text-only: forward the delta verbatim. Keep every
                             # character (no remove_unspeechable, which strips
                             # TTS-unfriendly symbols) and don't sentence-split
                             # (sent_tokenize would collapse newlines / markdown).
-                            clean_text += delta.content
+                            clean_text += text_piece
                             if not self._turn_output_allowed(turn_id, turn_revision):
                                 logger.info("LLM generation cancelled (stale speculative turn)")
                                 cancelled = True
                                 break
                             yield LLMResponseChunk(
-                                text=delta.content,
+                                text=text_piece,
                                 language_code=language_code,
                                 runtime_config=runtime_config,
                                 response=response,
@@ -337,7 +394,7 @@ class ChatCompletionsApiModelHandler(BaseHandler[LLMIn, LLMOut]):
                                 cancel_generation=gen,
                             )
                             continue
-                        new_text = remove_unspeechable(delta.content)
+                        new_text = remove_unspeechable(text_piece)
                         clean_text += new_text
                         printable_text += new_text
                         sentences = sent_tokenize(printable_text)
@@ -354,17 +411,6 @@ class ChatCompletionsApiModelHandler(BaseHandler[LLMIn, LLMOut]):
                             if cancelled:
                                 break
                             printable_text = sentences[-1]
-
-                    if delta.tool_calls:
-                        for tc in delta.tool_calls:
-                            entry = tool_accum.setdefault(tc.index, {"name": "", "args": "", "id": ""})
-                            if tc.id:
-                                entry["id"] = tc.id
-                            if tc.function is not None:
-                                if tc.function.name:
-                                    entry["name"] = tc.function.name
-                                if tc.function.arguments:
-                                    entry["args"] += tc.function.arguments
 
                 if not cancelled:
                     # Flush any trailing text before emitting tool calls.
@@ -407,21 +453,25 @@ class ChatCompletionsApiModelHandler(BaseHandler[LLMIn, LLMOut]):
                     if usage:
                         input_tokens = usage.prompt_tokens or 0
                         output_tokens = usage.completion_tokens or 0
-                    message = api_response.choices[0].message
+                    # A valid-but-empty response (e.g. content filter) returns no
+                    # choices; complete cleanly with no assistant text rather than
+                    # raising IndexError.
+                    message = api_response.choices[0].message if api_response.choices else None
+                    # A refusal arrives as `message.refusal` with `message.content`
+                    # None; treat it as assistant text so it is spoken and stored.
+                    raw_content = (message.content or getattr(message, "refusal", None)) if message else None
                     # Text-only keeps every character verbatim; audio strips
                     # TTS-unfriendly symbols via remove_unspeechable.
-                    message_text = (
-                        (message.content or "") if not wants_audio else remove_unspeechable(message.content or "")
-                    )
+                    message_text = (raw_content or "") if not wants_audio else remove_unspeechable(raw_content or "")
                     clean_text += message_text
                     # Gate history write-back on the raw content so a turn that is
                     # entirely TTS-unfriendly symbols is still stored, not dropped.
-                    if message.content:
+                    if raw_content:
                         pending_chat_items.append(
                             RealtimeConversationItemAssistantMessage(
                                 type="message",
                                 role="assistant",
-                                content=[AssistantContent(type="output_text", text=message.content)],
+                                content=[AssistantContent(type="output_text", text=raw_content)],
                             )
                         )
                     chunk_text = message_text if not wants_audio else message_text.strip()
@@ -437,7 +487,7 @@ class ChatCompletionsApiModelHandler(BaseHandler[LLMIn, LLMOut]):
                                 speech_stopped_at_s=speech_stopped_at_s,
                                 cancel_generation=gen,
                             )
-                    for tc in message.tool_calls or []:
+                    for tc in (message.tool_calls if message else None) or []:
                         tool_accum[len(tool_accum)] = {
                             "name": tc.function.name or "",
                             "args": tc.function.arguments or "",

--- a/src/speech_to_speech/LLM/chat_completions_language_model.py
+++ b/src/speech_to_speech/LLM/chat_completions_language_model.py
@@ -191,7 +191,9 @@ class ChatCompletionsApiModelHandler(BaseOpenAICompatibleHandler):
         for chunk in api_response:
             # Usage-only trailing chunk (choices == []) when include_usage is set.
             if chunk.usage is not None:
-                usage = Usage(chunk.usage.prompt_tokens or 0, chunk.usage.completion_tokens or 0)
+                usage = Usage(
+                    input_tokens=chunk.usage.prompt_tokens or 0, output_tokens=chunk.usage.completion_tokens or 0
+                )
             if not chunk.choices:
                 continue
             delta = chunk.choices[0].delta
@@ -210,10 +212,10 @@ class ChatCompletionsApiModelHandler(BaseOpenAICompatibleHandler):
             text_piece = delta.content or getattr(delta, "refusal", None)
             if text_piece:
                 raw_text += text_piece
-                yield TextDelta(text_piece)
+                yield TextDelta(text=text_piece)
 
         if raw_text.strip():
-            yield AssistantMessage([AssistantContent(type="output_text", text=raw_text)])
+            yield AssistantMessage(content=[AssistantContent(type="output_text", text=raw_text)])
         yield from self._tool_calls_from_accum(tool_accum)
         if usage is not None:
             yield usage
@@ -221,7 +223,7 @@ class ChatCompletionsApiModelHandler(BaseOpenAICompatibleHandler):
     def _iter_response_events(self, api_response: Any) -> Iterator[ProviderEvent]:
         usage = api_response.usage
         if usage:
-            yield Usage(usage.prompt_tokens or 0, usage.completion_tokens or 0)
+            yield Usage(input_tokens=usage.prompt_tokens or 0, output_tokens=usage.completion_tokens or 0)
         # A valid-but-empty response (e.g. content filter) returns no choices;
         # complete cleanly with no assistant text rather than raising IndexError.
         message = api_response.choices[0].message if api_response.choices else None
@@ -231,8 +233,8 @@ class ChatCompletionsApiModelHandler(BaseOpenAICompatibleHandler):
         # it as assistant text so it is spoken and stored.
         raw_content = message.content or getattr(message, "refusal", None)
         if raw_content:
-            yield AssistantMessage([AssistantContent(type="output_text", text=raw_content)])
-            yield TextDelta(raw_content)
+            yield AssistantMessage(content=[AssistantContent(type="output_text", text=raw_content)])
+            yield TextDelta(text=raw_content)
         tool_accum: dict[int, dict[str, str]] = {}
         for tc in message.tool_calls or []:
             tool_accum[len(tool_accum)] = {
@@ -254,7 +256,7 @@ class ChatCompletionsApiModelHandler(BaseOpenAICompatibleHandler):
             if not entry["name"]:
                 continue
             yield ToolCall(
-                ResponseFunctionToolCall(
+                item=ResponseFunctionToolCall(
                     type="function_call",
                     name=entry["name"],
                     arguments=entry["args"] or "{}",

--- a/src/speech_to_speech/LLM/chat_completions_language_model.py
+++ b/src/speech_to_speech/LLM/chat_completions_language_model.py
@@ -174,7 +174,7 @@ class ChatCompletionsApiModelHandler(BaseOpenAICompatibleHandler):
             create_kwargs["stream_options"] = {"include_usage": True}
         return self.client.chat.completions.create(
             model=self.model_name,
-            messages=api_input,
+            messages=api_input,  # type: ignore[arg-type]  # runtime dicts match the Chat Completions message shape
             stream=self.stream,
             extra_body=self._extra_body,
             timeout=self.request_timeout,

--- a/src/speech_to_speech/LLM/responses_api_language_model.py
+++ b/src/speech_to_speech/LLM/responses_api_language_model.py
@@ -109,12 +109,6 @@ class ResponsesApiModelHandler(BaseOpenAICompatibleHandler):
             AssistantContent(type="output_text", text=c.text if c.type == "output_text" else c.refusal) for c in content
         ]
 
-    def _iter_events(self, api_response: Any) -> Iterator[ProviderEvent]:
-        if isinstance(api_response, Stream):
-            yield from self._iter_stream_events(api_response)
-        else:
-            yield from self._iter_response_events(api_response)
-
     def _iter_stream_events(self, api_response: Stream) -> Iterator[ProviderEvent]:
         for raw_event in api_response:
             if isinstance(raw_event, ResponseTextDeltaEvent):

--- a/src/speech_to_speech/LLM/responses_api_language_model.py
+++ b/src/speech_to_speech/LLM/responses_api_language_model.py
@@ -3,112 +3,37 @@ from __future__ import annotations
 import logging
 import time
 from collections.abc import Iterator
-from typing import Any, Optional
+from typing import Any
 
-import httpx
-from nltk import sent_tokenize
-from openai import OpenAI, Stream
-from openai.types.realtime.conversation_item import (
-    RealtimeConversationItemAssistantMessage,
-    RealtimeConversationItemFunctionCall,
-)
+from openai import Stream
 from openai.types.realtime.realtime_conversation_item_assistant_message import (
     Content as AssistantContent,
 )
 from openai.types.responses import (
-    Response,
     ResponseCompletedEvent,
     ResponseFunctionToolCall,
     ResponseOutputItemDoneEvent,
     ResponseOutputMessage,
-    ResponseStreamEvent,
     ResponseTextDeltaEvent,
 )
 
-from speech_to_speech.baseHandler import BaseHandler
-from speech_to_speech.LLM.chat import (
-    Chat,
-    ChatItemError,
-    SupportedItem,
-    build_active_chat,
-    make_system_message,
-    make_user_message,
+from speech_to_speech.LLM.base_openai_compatible_language_model import (
+    AssistantMessage,
+    BaseOpenAICompatibleHandler,
+    ProviderEvent,
+    TextDelta,
+    ToolCall,
+    Usage,
 )
-from speech_to_speech.LLM.compaction_prompt import CompactGenerateFn, build_compactor
-from speech_to_speech.LLM.text_prompt import build_text_system_prompt
-from speech_to_speech.LLM.utils import remove_unspeechable, resolve_auto_language
-from speech_to_speech.LLM.voice_prompt import build_voice_system_prompt
-from speech_to_speech.pipeline.cancel_scope import CancelScope
-from speech_to_speech.pipeline.handler_types import LLMIn, LLMOut
-from speech_to_speech.pipeline.messages import (
-    EndOfResponse,
-    LLMResponseChunk,
-    TokenUsage,
-)
-from speech_to_speech.pipeline.speculative_turns import SpeculativeTurnTracker
-from speech_to_speech.utils.utils import _generate_id, is_out_of_band, response_wants_audio
+from speech_to_speech.LLM.chat import Chat
+from speech_to_speech.LLM.compaction_prompt import CompactGenerateFn
+from speech_to_speech.utils.utils import _generate_id
 
 logger = logging.getLogger(__name__)
 
 
-class ResponsesApiModelHandler(BaseHandler[LLMIn, LLMOut]):
-    """
-    Handles the language model part.
-    """
-
-    def setup(
-        self,
-        model_name: str = "gpt-5.4-mini",
-        device: str = "cuda",
-        gen_kwargs: dict[str, Any] = {},
-        base_url: Optional[str] = None,
-        api_key: Optional[str] = None,
-        stream: bool = True,
-        user_role: str = "user",
-        cancel_scope: CancelScope | None = None,
-        speculative_turns: SpeculativeTurnTracker | None = None,
-        disable_thinking: bool = True,
-        request_timeout_s: float = 20.0,
-        stream_batch_sentences: int = 3,
-        enable_lang_prompt: bool = False,
-        compact_history: bool = False,
-        **_kwargs: Any,
-    ) -> None:
-        self.cancel_scope = cancel_scope
-        self.speculative_turns = speculative_turns
-        self.model_name = model_name
-        self.stream = stream
-        self.stream_batch_sentences = max(1, stream_batch_sentences)
-        self.enable_lang_prompt = enable_lang_prompt
-        self.gen_kwargs = dict(gen_kwargs)
-        self.request_timeout_s = float(request_timeout_s)
-        self.request_timeout = httpx.Timeout(
-            self.request_timeout_s,
-            connect=min(10.0, self.request_timeout_s),
-        )
-
-        self.user_role = user_role
-        self.client = OpenAI(api_key=api_key, base_url=base_url)
-        self._extra_body = (
-            {"chat_template_kwargs": {"enable_thinking": False}}
-            if disable_thinking
-            and base_url is not None
-            and base_url != "https://api.openai.com/v1"  # Only for other than OpenAI Official Server
-            else None
-        )
-        self.compactor = build_compactor(self._build_compaction_generate_fn()) if compact_history else None
-        self.warmup()
-
-    def _turn_is_latest(self, turn_id: str | None, turn_revision: int | None) -> bool:
-        return self.speculative_turns is None or self.speculative_turns.is_latest(turn_id, turn_revision)
-
-    def _generation_is_stale(self, gen: int | None) -> bool:
-        return gen is not None and self.cancel_scope is not None and self.cancel_scope.is_stale(gen)
-
-    def _turn_output_allowed(self, turn_id: str | None, turn_revision: int | None) -> bool:
-        if self.speculative_turns is None:
-            return True
-        return self.speculative_turns.is_latest_after_reopen_grace(turn_id, turn_revision)
+class ResponsesApiModelHandler(BaseOpenAICompatibleHandler):
+    """LLM handler that talks to an OpenAI ``/v1/responses`` server."""
 
     def warmup(self) -> None:
         logger.info(f"Warming up {self.__class__.__name__}")
@@ -155,413 +80,75 @@ class ResponsesApiModelHandler(BaseHandler[LLMIn, LLMOut]):
 
         return generate
 
-    def _apply_config(
-        self,
-        chat: Chat,
-        instructions: Optional[str],
-        wants_audio: bool = True,
-    ) -> None:
-        if instructions:
-            builder = build_voice_system_prompt if wants_audio else build_text_system_prompt
-            full_instructions = builder(instructions)
-            chat.add_item(make_system_message(full_instructions))
+    # ── base hooks ──────────────────────────────────────────────────────────--
 
-    def _generate(
-        self,
-        active_chat: Chat,
-        original_chat: Chat,
-        language_code: Optional[str],
-        gen: int | None,
-        runtime_config: Any,
-        response: Any,
-        optional_kwargs: dict[str, Any],
-        turn_id: str | None,
-        turn_revision: int | None,
-        speech_stopped_at_s: float | None,
-    ) -> Iterator[LLMOut]:
-        api_response: Response | Stream[ResponseStreamEvent] | None = None
-        tools: list[ResponseFunctionToolCall] = []
-        pending_chat_items: list[SupportedItem] = []
-        clean_text = ""
-        input_tokens = 0
-        output_tokens = 0
-        error_message: str | None = None
-        wants_audio = response_wants_audio(response)
-        api_input = active_chat.to_responses_api_chat()
-        if not api_input:
-            # Nothing to send: empty `instructions` and no `input` (in the response,
-            # the default conversation, or the out-of-band context). The provider
-            # would reject this; fail with a clear message instead of an opaque error.
-            error_message = "Cannot generate a response: no instructions and no input were provided."
-        try:
-            if error_message is None:
-                api_response = self.client.responses.create(
-                    model=self.model_name,
-                    input=api_input,
-                    stream=self.stream,
-                    extra_body=self._extra_body,
-                    timeout=self.request_timeout,
-                    **optional_kwargs,
-                )
-            if isinstance(api_response, Stream):
-                cancelled = False
-                printable_text = ""
-                sentence_batch: list[str] = []
-                for raw_event in api_response:
-                    if (
-                        gen is not None and self.cancel_scope is not None and self.cancel_scope.is_stale(gen)
-                    ) or not self._turn_is_latest(turn_id, turn_revision):
-                        logger.info("LLM generation cancelled (interruption)")
-                        cancelled = True
-                        break
-                    if isinstance(raw_event, ResponseTextDeltaEvent):
-                        if not wants_audio:
-                            # Text-only: forward the delta verbatim. Keep every
-                            # character (no remove_unspeechable, which strips
-                            # TTS-unfriendly symbols) and don't sentence-split
-                            # (sent_tokenize would collapse newlines / markdown).
-                            delta = raw_event.delta
-                            clean_text += delta
-                            if delta:
-                                if not self._turn_output_allowed(turn_id, turn_revision):
-                                    logger.info("LLM generation cancelled (stale speculative turn)")
-                                    cancelled = True
-                                    break
-                                yield LLMResponseChunk(
-                                    text=delta,
-                                    language_code=language_code,
-                                    runtime_config=runtime_config,
-                                    response=response,
-                                    turn_id=turn_id,
-                                    turn_revision=turn_revision,
-                                    speech_stopped_at_s=speech_stopped_at_s,
-                                    cancel_generation=gen,
-                                )
-                            continue
-                        new_text = remove_unspeechable(raw_event.delta)
-                        clean_text += new_text
-                        printable_text += new_text
-                        sentences = sent_tokenize(printable_text)
-                        if len(sentences) > 1:
-                            for s in sentences[:-1]:
-                                sentence_batch.append(s)
-                                if len(sentence_batch) >= self.stream_batch_sentences:
-                                    if not self._turn_output_allowed(turn_id, turn_revision):
-                                        logger.info("LLM generation cancelled (stale speculative turn)")
-                                        cancelled = True
-                                        break
-                                    yield LLMResponseChunk(
-                                        text=" ".join(sentence_batch),
-                                        language_code=language_code,
-                                        runtime_config=runtime_config,
-                                        response=response,
-                                        turn_id=turn_id,
-                                        turn_revision=turn_revision,
-                                        speech_stopped_at_s=speech_stopped_at_s,
-                                        cancel_generation=gen,
-                                    )
-                                    sentence_batch = []
-                            if cancelled:
-                                break
-                            printable_text = sentences[-1]
-                    elif isinstance(raw_event, ResponseOutputItemDoneEvent):
-                        if isinstance(raw_event.item, ResponseFunctionToolCall):
-                            if printable_text.strip():
-                                sentence_batch.append(printable_text.strip())
-                                printable_text = ""
-                            if sentence_batch:
-                                if not self._turn_output_allowed(turn_id, turn_revision):
-                                    logger.info("LLM generation cancelled (stale speculative turn)")
-                                    cancelled = True
-                                    break
-                                yield LLMResponseChunk(
-                                    text=" ".join(sentence_batch),
-                                    language_code=language_code,
-                                    runtime_config=runtime_config,
-                                    response=response,
-                                    turn_id=turn_id,
-                                    turn_revision=turn_revision,
-                                    speech_stopped_at_s=speech_stopped_at_s,
-                                    cancel_generation=gen,
-                                )
-                                sentence_batch = []
-                            raw_event.item.call_id = _generate_id("call")
-                            raw_event.item.id = _generate_id("fc")
-                            tools.append(raw_event.item)
-                            pending_chat_items.append(
-                                RealtimeConversationItemFunctionCall(
-                                    type="function_call",
-                                    name=raw_event.item.name,
-                                    arguments=raw_event.item.arguments,
-                                    call_id=raw_event.item.call_id,
-                                    id=raw_event.item.id,
-                                    status=raw_event.item.status,
-                                )
-                            )
-                            if not self._turn_output_allowed(turn_id, turn_revision):
-                                logger.info("LLM generation cancelled (stale speculative turn)")
-                                cancelled = True
-                                break
-                            yield LLMResponseChunk(
-                                text="",
-                                language_code=language_code,
-                                tools=[raw_event.item],
-                                runtime_config=runtime_config,
-                                response=response,
-                                turn_id=turn_id,
-                                turn_revision=turn_revision,
-                                speech_stopped_at_s=speech_stopped_at_s,
-                                cancel_generation=gen,
-                            )
-                        elif isinstance(raw_event.item, ResponseOutputMessage):
-                            content = [
-                                AssistantContent(
-                                    type="output_text",
-                                    text=c.text if c.type == "output_text" else c.refusal,
-                                )
-                                for c in raw_event.item.content
-                            ]
-                            pending_chat_items.append(
-                                RealtimeConversationItemAssistantMessage(
-                                    type="message", role="assistant", content=content
-                                )
-                            )
-                    elif isinstance(raw_event, ResponseCompletedEvent):
-                        usage = getattr(raw_event.response, "usage", None)
-                        if usage:
-                            input_tokens = usage.input_tokens or 0
-                            output_tokens = usage.output_tokens or 0
-                if not cancelled:
-                    if printable_text.strip():
-                        sentence_batch.append(printable_text.strip())
-                    remaining = " ".join(sentence_batch)
-                    if remaining:
-                        if self._generation_is_stale(gen):
-                            logger.info("LLM generation cancelled (interruption)")
-                        elif not self._turn_output_allowed(turn_id, turn_revision):
-                            logger.info("LLM generation cancelled (stale speculative turn)")
-                        else:
-                            logger.debug(f"Clean text: {clean_text}")
-                            logger.info(f"Tools: {tools}")
-                            yield LLMResponseChunk(
-                                text=remaining,
-                                language_code=language_code,
-                                runtime_config=runtime_config,
-                                response=response,
-                                turn_id=turn_id,
-                                turn_revision=turn_revision,
-                                speech_stopped_at_s=speech_stopped_at_s,
-                                cancel_generation=gen,
-                            )
-            elif isinstance(api_response, Response):
-                if (
-                    gen is not None and self.cancel_scope is not None and self.cancel_scope.is_stale(gen)
-                ) or not self._turn_is_latest(turn_id, turn_revision):
-                    logger.info("LLM generation cancelled (interruption)")
-                else:
-                    usage = api_response.usage
-                    if usage:
-                        input_tokens = usage.input_tokens or 0
-                        output_tokens = usage.output_tokens or 0
-                    for message in api_response.output:
-                        if isinstance(message, ResponseFunctionToolCall):
-                            message.call_id = _generate_id("call")
-                            message.id = _generate_id("fc")
-                            pending_chat_items.append(
-                                RealtimeConversationItemFunctionCall(
-                                    type="function_call",
-                                    name=message.name,
-                                    arguments=message.arguments,
-                                    call_id=message.call_id,
-                                    id=message.id,
-                                    status="in_progress",
-                                )
-                            )
-                            tools.append(message)
-                            if self._generation_is_stale(gen):
-                                logger.info("LLM generation cancelled (interruption)")
-                            elif not self._turn_output_allowed(turn_id, turn_revision):
-                                logger.info("LLM generation cancelled (stale speculative turn)")
-                            else:
-                                yield LLMResponseChunk(
-                                    text="",
-                                    language_code=language_code,
-                                    tools=[message],
-                                    runtime_config=runtime_config,
-                                    response=response,
-                                    turn_id=turn_id,
-                                    turn_revision=turn_revision,
-                                    speech_stopped_at_s=speech_stopped_at_s,
-                                    cancel_generation=gen,
-                                )
-                        elif isinstance(message, ResponseOutputMessage):
-                            content = [
-                                AssistantContent(
-                                    type="output_text",
-                                    text=c.text if c.type == "output_text" else c.refusal,
-                                )
-                                for c in message.content
-                            ]
-                            pending_chat_items.append(
-                                RealtimeConversationItemAssistantMessage(
-                                    type="message", role="assistant", content=content
-                                )
-                            )
-                            # Text-only keeps every character verbatim; audio strips
-                            # TTS-unfriendly symbols via remove_unspeechable.
-                            message_text = ""
-                            for chunk in message.content:
-                                if chunk.type == "output_text":
-                                    message_text += chunk.text if not wants_audio else remove_unspeechable(chunk.text)
-                            clean_text += message_text
-                            chunk_text = message_text if not wants_audio else message_text.strip()
-                            if chunk_text:
-                                if self._generation_is_stale(gen):
-                                    logger.info("LLM generation cancelled (interruption)")
-                                elif not self._turn_output_allowed(turn_id, turn_revision):
-                                    logger.info("LLM generation cancelled (stale speculative turn)")
-                                else:
-                                    yield LLMResponseChunk(
-                                        text=chunk_text,
-                                        language_code=language_code,
-                                        runtime_config=runtime_config,
-                                        response=response,
-                                        turn_id=turn_id,
-                                        turn_revision=turn_revision,
-                                        speech_stopped_at_s=speech_stopped_at_s,
-                                        cancel_generation=gen,
-                                    )
-                        else:
-                            logger.warning(f"Not supported message type: {message.type}")
-                    logger.debug(f"Clean text: {clean_text}")
-                    logger.info(f"Tools: {tools}")
-        except httpx.ReadTimeout:
-            logger.warning(
-                "OpenAI API read timed out after %.1fs; ending the current response",
-                self.request_timeout_s,
-            )
-            if not self._generation_is_stale(gen) and self._turn_output_allowed(turn_id, turn_revision):
-                yield LLMResponseChunk(
-                    text="Wow I'm a bit slow today, could you repeat that?",
-                    runtime_config=runtime_config,
-                    response=response,
-                    turn_id=turn_id,
-                    turn_revision=turn_revision,
-                    speech_stopped_at_s=speech_stopped_at_s,
-                    cancel_generation=gen,
-                )
-        except Exception as exc:
-            # Any other generation failure must still terminate the response: record
-            # the error and fall through to the EndOfResponse below. Without this the
-            # exception would escape process() and no EndOfResponse would be emitted,
-            # leaving st.in_response stuck and locking every subsequent response.
-            logger.exception("LLM generation failed; ending the current response")
-            if error_message is None:
-                error_message = f"Language model generation failed: {exc}"
-        finally:
-            if api_response is not None and hasattr(api_response, "close"):
-                try:
-                    api_response.close()
-                except Exception:
-                    pass
+    def _serialize(self, active_chat: Chat) -> Any:
+        return active_chat.to_responses_api_chat()
 
-        if (
-            error_message is None
-            and not self._generation_is_stale(gen)
-            and self._turn_output_allowed(turn_id, turn_revision)
-        ):
-            # Out-of-band responses emit output and usage but never write back to the
-            # default conversation (their context was a throwaway chat).
-            if not is_out_of_band(response):
-                for item in pending_chat_items:
-                    original_chat.add_item(item)
-                original_chat.strip_images()
-                original_chat.trim_if_needed(self.compactor)
-            if input_tokens or output_tokens:
-                yield TokenUsage(
-                    input_tokens=input_tokens,
-                    output_tokens=output_tokens,
-                    turn_id=turn_id,
-                    turn_revision=turn_revision,
-                )
-        yield EndOfResponse(turn_id=turn_id, turn_revision=turn_revision, cancel_generation=gen, error=error_message)
-
-    def process(self, request: LLMIn) -> Iterator[LLMOut]:
-        """
-        Process a language model request and yield LLMResponseChunks.
-
-        Args:
-            request: The LLMIn request containing runtime configuration and response parameters.
-
-        Yields:
-            LLMResponseChunk: Chunks of text and tools from the language model response.
-        """
-        runtime_config = request.runtime_config
-        response = request.response
-        turn_id = request.turn_id
-        turn_revision = request.turn_revision
-        speech_stopped_at_s = request.speech_stopped_at_s
-        if not self._turn_is_latest(turn_id, turn_revision):
-            logger.info("Skipping stale LLM request for turn=%s rev=%s", turn_id, turn_revision)
-            yield EndOfResponse(turn_id=turn_id, turn_revision=turn_revision)
-            return
-
-        original_chat = runtime_config.chat
-        out_of_band = is_out_of_band(response)
-        if out_of_band:
-            try:
-                active_chat = build_active_chat(original_chat, response)
-            except ChatItemError as exc:
-                logger.info("Out-of-band response rejected: %s", exc)
-                yield EndOfResponse(turn_id=turn_id, turn_revision=turn_revision, error=str(exc))
-                return
-        else:
-            active_chat = original_chat.copy()
-        language_code = request.language_code
-        instructions = (
-            response.instructions if response and response.instructions else runtime_config.session.instructions
-        ) or ""
-        req_tools = response.tools if response and response.tools else runtime_config.session.tools
-        req_tool_choice = (
-            response.tool_choice if response and response.tool_choice else runtime_config.session.tool_choice
-        )
-        self._apply_config(active_chat, instructions, response_wants_audio(response))
-        language_code, lang_name = resolve_auto_language(language_code)
-        if lang_name and self.enable_lang_prompt:
-            active_chat.add_item(make_user_message(f"Please reply to my message in {lang_name}."))
-
+    def _build_optional_kwargs(self, req_tools: Any, req_tool_choice: Any) -> dict[str, Any]:
         optional_kwargs: dict[str, Any] = {}
         if req_tools is not None:
             optional_kwargs["tools"] = req_tools
         if req_tool_choice is not None:
             optional_kwargs["tool_choice"] = req_tool_choice
+        return optional_kwargs
 
-        # CancelScope.is_stale(gen) is checked when the stream iterator advances; a
-        # blocked read inside httpx cannot be aborted by cancel_scope.cancel() from
-        # the websocket router. Mitigations: request_timeout_s / ReadTimeout. A future
-        # option is to run this API call in a child process and terminate() on session
-        # end (IPC and lifecycle cost).
-        gen = self.cancel_scope.generation if self.cancel_scope else None
-
-        yield from self._generate(
-            active_chat,
-            original_chat,
-            language_code,
-            gen,
-            runtime_config,
-            response,
-            optional_kwargs,
-            turn_id,
-            turn_revision,
-            speech_stopped_at_s,
+    def _request(self, api_input: Any, optional_kwargs: dict[str, Any]) -> Any:
+        return self.client.responses.create(
+            model=self.model_name,
+            input=api_input,
+            stream=self.stream,
+            extra_body=self._extra_body,
+            timeout=self.request_timeout,
+            **optional_kwargs,
         )
+
+    @staticmethod
+    def _assistant_content(content: Any) -> list[AssistantContent]:
+        return [
+            AssistantContent(type="output_text", text=c.text if c.type == "output_text" else c.refusal) for c in content
+        ]
+
+    def _iter_events(self, api_response: Any) -> Iterator[ProviderEvent]:
+        if isinstance(api_response, Stream):
+            yield from self._iter_stream_events(api_response)
+        else:
+            yield from self._iter_response_events(api_response)
+
+    def _iter_stream_events(self, api_response: Stream) -> Iterator[ProviderEvent]:
+        for raw_event in api_response:
+            if isinstance(raw_event, ResponseTextDeltaEvent):
+                yield TextDelta(raw_event.delta)
+            elif isinstance(raw_event, ResponseOutputItemDoneEvent):
+                item = raw_event.item
+                if isinstance(item, ResponseFunctionToolCall):
+                    item.call_id = _generate_id("call")
+                    item.id = _generate_id("fc")
+                    yield ToolCall(item)
+                elif isinstance(item, ResponseOutputMessage):
+                    yield AssistantMessage(self._assistant_content(item.content))
+            elif isinstance(raw_event, ResponseCompletedEvent):
+                usage = getattr(raw_event.response, "usage", None)
+                if usage:
+                    yield Usage(usage.input_tokens or 0, usage.output_tokens or 0)
+
+    def _iter_response_events(self, api_response: Any) -> Iterator[ProviderEvent]:
+        usage = api_response.usage
+        if usage:
+            yield Usage(usage.input_tokens or 0, usage.output_tokens or 0)
+        for message in api_response.output:
+            if isinstance(message, ResponseFunctionToolCall):
+                message.call_id = _generate_id("call")
+                message.id = _generate_id("fc")
+                yield ToolCall(message)
+            elif isinstance(message, ResponseOutputMessage):
+                yield AssistantMessage(self._assistant_content(message.content))
+                # Text-only keeps every character; the base applies remove_unspeechable
+                # for audio. Only output_text parts are spoken (refusals are stored).
+                raw = "".join(c.text for c in message.content if c.type == "output_text")
+                yield TextDelta(raw)
+            else:
+                logger.warning(f"Not supported message type: {message.type}")
 
     def on_session_end(self) -> None:
         logger.debug("OpenAI API language model session state reset")
-
-    @property
-    def timing_log_level(self) -> int:
-        return logging.INFO
-
-    def should_log_timing(self, output: LLMOut) -> bool:
-        return isinstance(output, LLMResponseChunk) and self.last_time > self.min_time_to_debug

--- a/src/speech_to_speech/LLM/responses_api_language_model.py
+++ b/src/speech_to_speech/LLM/responses_api_language_model.py
@@ -112,35 +112,35 @@ class ResponsesApiModelHandler(BaseOpenAICompatibleHandler):
     def _iter_stream_events(self, api_response: Stream) -> Iterator[ProviderEvent]:
         for raw_event in api_response:
             if isinstance(raw_event, ResponseTextDeltaEvent):
-                yield TextDelta(raw_event.delta)
+                yield TextDelta(text=raw_event.delta)
             elif isinstance(raw_event, ResponseOutputItemDoneEvent):
                 item = raw_event.item
                 if isinstance(item, ResponseFunctionToolCall):
                     item.call_id = _generate_id("call")
                     item.id = _generate_id("fc")
-                    yield ToolCall(item)
+                    yield ToolCall(item=item)
                 elif isinstance(item, ResponseOutputMessage):
-                    yield AssistantMessage(self._assistant_content(item.content))
+                    yield AssistantMessage(content=self._assistant_content(item.content))
             elif isinstance(raw_event, ResponseCompletedEvent):
                 usage = getattr(raw_event.response, "usage", None)
                 if usage:
-                    yield Usage(usage.input_tokens or 0, usage.output_tokens or 0)
+                    yield Usage(input_tokens=usage.input_tokens or 0, output_tokens=usage.output_tokens or 0)
 
     def _iter_response_events(self, api_response: Any) -> Iterator[ProviderEvent]:
         usage = api_response.usage
         if usage:
-            yield Usage(usage.input_tokens or 0, usage.output_tokens or 0)
+            yield Usage(input_tokens=usage.input_tokens or 0, output_tokens=usage.output_tokens or 0)
         for message in api_response.output:
             if isinstance(message, ResponseFunctionToolCall):
                 message.call_id = _generate_id("call")
                 message.id = _generate_id("fc")
-                yield ToolCall(message)
+                yield ToolCall(item=message)
             elif isinstance(message, ResponseOutputMessage):
-                yield AssistantMessage(self._assistant_content(message.content))
+                yield AssistantMessage(content=self._assistant_content(message.content))
                 # Text-only keeps every character; the base applies remove_unspeechable
                 # for audio. Only output_text parts are spoken (refusals are stored).
                 raw = "".join(c.text for c in message.content if c.type == "output_text")
-                yield TextDelta(raw)
+                yield TextDelta(text=raw)
             else:
                 logger.warning(f"Not supported message type: {message.type}")
 

--- a/src/speech_to_speech/arguments_classes/chat_completions_language_model_arguments.py
+++ b/src/speech_to_speech/arguments_classes/chat_completions_language_model_arguments.py
@@ -1,0 +1,28 @@
+from dataclasses import dataclass, field
+from typing import Optional
+
+from speech_to_speech.arguments_classes.responses_api_language_model_arguments import (
+    ResponsesApiLanguageModelHandlerArguments,
+)
+
+
+@dataclass
+class ChatCompletionsLanguageModelHandlerArguments(ResponsesApiLanguageModelHandlerArguments):
+    """Arguments for the ``chat-completions`` LLM backend.
+
+    Inherits the OpenAI-compatible connection fields from the Responses-API
+    arguments (``responses_api_base_url`` / ``responses_api_api_key`` /
+    ``responses_api_stream`` / ``responses_api_disable_thinking``) so the same
+    CLI flags and launcher env vars drive both backends, and adds the
+    Chat-Completions-only ``reasoning_effort`` knob.
+    """
+
+    responses_api_reasoning_effort: Optional[str] = field(
+        default=None,
+        metadata={
+            "help": "Provider-specific reasoning level sent as extra_body={'reasoning_effort': <value>} on the "
+            "Chat Completions request. Use to disable reasoning on providers where "
+            "chat_template_kwargs.enable_thinking is ignored (e.g. 'none' / 'low'). When unset, falls back to "
+            "the disable_thinking behaviour (chat_template_kwargs.enable_thinking=false). Default is None."
+        },
+    )

--- a/src/speech_to_speech/arguments_classes/module_arguments.py
+++ b/src/speech_to_speech/arguments_classes/module_arguments.py
@@ -28,10 +28,11 @@ class ModuleArguments:
             "help": "The STT to use. Either 'whisper', 'whisper-mlx', 'mlx-audio-whisper', 'faster-whisper', 'parakeet-tdt', or 'paraformer'. Default is 'parakeet-tdt'."
         },
     )
-    llm_backend: Optional[Literal["transformers", "mlx-lm", "responses-api"]] = field(
+    llm_backend: Optional[Literal["transformers", "mlx-lm", "responses-api", "chat-completions"]] = field(
         default="responses-api",
         metadata={
-            "help": "The LLM backend to use. Either 'transformers', 'mlx-lm', or 'responses-api'. Default is 'responses-api'."
+            "help": "The LLM backend to use. Either 'transformers', 'mlx-lm', 'responses-api', or "
+            "'chat-completions' (OpenAI-compatible /v1/chat/completions). Default is 'responses-api'."
         },
     )
     tts: Optional[Literal["melo", "chatTTS", "facebookMMS", "pocket", "kokoro", "qwen3"]] = field(

--- a/src/speech_to_speech/s2s_pipeline.py
+++ b/src/speech_to_speech/s2s_pipeline.py
@@ -21,6 +21,9 @@ from transformers import HfArgumentParser
 
 from speech_to_speech.api.openai_realtime.pipeline_unit import PipelineUnit
 from speech_to_speech.api.openai_realtime.runtime_config import RuntimeConfig
+from speech_to_speech.arguments_classes.chat_completions_language_model_arguments import (
+    ChatCompletionsLanguageModelHandlerArguments,
+)
 from speech_to_speech.arguments_classes.chat_tts_arguments import ChatTTSHandlerArguments
 from speech_to_speech.arguments_classes.facebookmms_tts_arguments import FacebookMMSTTSHandlerArguments
 from speech_to_speech.arguments_classes.faster_whisper_stt_arguments import (
@@ -38,9 +41,6 @@ from speech_to_speech.arguments_classes.parakeet_tdt_arguments import (
 )
 from speech_to_speech.arguments_classes.pocket_tts_arguments import PocketTTSHandlerArguments
 from speech_to_speech.arguments_classes.qwen3_tts_arguments import Qwen3TTSHandlerArguments
-from speech_to_speech.arguments_classes.chat_completions_language_model_arguments import (
-    ChatCompletionsLanguageModelHandlerArguments,
-)
 from speech_to_speech.arguments_classes.responses_api_language_model_arguments import (
     ResponsesApiLanguageModelHandlerArguments,
 )

--- a/src/speech_to_speech/s2s_pipeline.py
+++ b/src/speech_to_speech/s2s_pipeline.py
@@ -38,6 +38,9 @@ from speech_to_speech.arguments_classes.parakeet_tdt_arguments import (
 )
 from speech_to_speech.arguments_classes.pocket_tts_arguments import PocketTTSHandlerArguments
 from speech_to_speech.arguments_classes.qwen3_tts_arguments import Qwen3TTSHandlerArguments
+from speech_to_speech.arguments_classes.chat_completions_language_model_arguments import (
+    ChatCompletionsLanguageModelHandlerArguments,
+)
 from speech_to_speech.arguments_classes.responses_api_language_model_arguments import (
     ResponsesApiLanguageModelHandlerArguments,
 )
@@ -124,20 +127,25 @@ def rename_args(args: Any, prefix: str) -> None:
 
 
 def parse_arguments() -> ParsedArguments:
-    # Pre-parse to determine which LM backend is selected, so only one of the two
+    # Pre-parse to determine which LM backend is selected, so only one of the
     # mutually exclusive LM argument classes is registered with HfArgumentParser
     # (avoids duplicate field names from the shared LanguageModelBaseArguments base).
+    # chat-completions reuses the responses-api connection fields via subclassing.
+    _backend_lm_class = {
+        "responses-api": ResponsesApiLanguageModelHandlerArguments,
+        "chat-completions": ChatCompletionsLanguageModelHandlerArguments,
+    }
     _is_json = len(sys.argv) == 2 and sys.argv[1].endswith(".json")
     if _is_json:
         with open(sys.argv[1]) as _f:
-            _use_responses_api = json.load(_f).get("llm_backend") == "responses-api"
+            _backend = json.load(_f).get("llm_backend")
     else:
         _pre = argparse.ArgumentParser(add_help=False)
         _pre.add_argument("--llm_backend", default="responses-api")
-        _use_responses_api = _pre.parse_known_args()[0].llm_backend == "responses-api"
+        _backend = _pre.parse_known_args()[0].llm_backend
 
-    _lm_class = ResponsesApiLanguageModelHandlerArguments if _use_responses_api else LanguageModelHandlerArguments
-    logger.debug("LLM backend pre-parse: use_responses_api=%s, registering %s", _use_responses_api, _lm_class.__name__)
+    _lm_class = _backend_lm_class.get(_backend, LanguageModelHandlerArguments)
+    logger.debug("LLM backend pre-parse: backend=%s, registering %s", _backend, _lm_class.__name__)
 
     parser = HfArgumentParser(
         (  # type: ignore[arg-type]
@@ -181,8 +189,11 @@ def parse_arguments() -> ParsedArguments:
         mlx_audio_whisper_stt_handler_kwargs=by_type[MLXAudioWhisperSTTHandlerArguments],
         parakeet_tdt_stt_handler_kwargs=by_type[ParakeetTDTSTTHandlerArguments],
         language_model_handler_kwargs=by_type.get(LanguageModelHandlerArguments, LanguageModelHandlerArguments()),
+        # The OpenAI-compatible slot holds whichever class was registered:
+        # ChatCompletions... (a subclass) for chat-completions, else ResponsesApi....
         responses_api_language_model_handler_kwargs=by_type.get(
-            ResponsesApiLanguageModelHandlerArguments, ResponsesApiLanguageModelHandlerArguments()
+            ChatCompletionsLanguageModelHandlerArguments,
+            by_type.get(ResponsesApiLanguageModelHandlerArguments, ResponsesApiLanguageModelHandlerArguments()),
         ),
         chat_tts_handler_kwargs=by_type[ChatTTSHandlerArguments],
         facebook_mms_tts_handler_kwargs=by_type[FacebookMMSTTSHandlerArguments],
@@ -503,7 +514,7 @@ def _build_realtime_pipeline_unit(
         vars(kw)["cancel_scope"] = cancel_scope
         vars(kw)["speculative_turns"] = speculative_turns
 
-    if module_kwargs.llm_backend == "responses-api":
+    if module_kwargs.llm_backend in ("responses-api", "chat-completions"):
         chat_size = vars(responses_api_kw).get("chat_size", 10)
     else:
         chat_size = vars(lm_kw).get("chat_size", 10)
@@ -689,7 +700,7 @@ def build_pipeline(
         vad_handler_kwargs.enable_realtime_transcription = True
         vad_handler_kwargs.realtime_processing_pause = module_kwargs.live_transcription_update_interval
 
-    if module_kwargs.llm_backend == "responses-api":
+    if module_kwargs.llm_backend in ("responses-api", "chat-completions"):
         _lm_vars = vars(responses_api_language_model_handler_kwargs)
     else:
         _lm_vars = vars(language_model_handler_kwargs)
@@ -854,6 +865,18 @@ def get_llm_handler(
             setup_kwargs=vars(responses_api_language_model_handler_kwargs),
         )
 
+    if module_kwargs.llm_backend == "chat-completions":
+        from speech_to_speech.LLM.chat_completions_language_model import ChatCompletionsApiModelHandler
+
+        # Reuses the responses-api argument class (identical fields: model_name,
+        # base_url, api_key, stream, disable_thinking, ...).
+        return ChatCompletionsApiModelHandler(
+            stop_event,
+            queue_in=text_prompt_queue,
+            queue_out=lm_response_queue,
+            setup_kwargs=vars(responses_api_language_model_handler_kwargs),
+        )
+
     if module_kwargs.llm_backend in ("transformers", "mlx-lm"):
         lm_kwargs = vars(language_model_handler_kwargs)
         is_vlm = lm_kwargs.pop("is_vlm", False)
@@ -878,7 +901,7 @@ def get_llm_handler(
             setup_kwargs=lm_kwargs,
         )
 
-    raise ValueError("The LLM should be either transformers, mlx-lm or responses-api")
+    raise ValueError("The LLM should be either transformers, mlx-lm, responses-api or chat-completions")
 
 
 def get_tts_handler(

--- a/tests/test_chat_completions_backend.py
+++ b/tests/test_chat_completions_backend.py
@@ -24,6 +24,7 @@ from openai.types.realtime.realtime_response_create_params import RealtimeRespon
 from openai.types.realtime.realtime_session_create_request import RealtimeSessionCreateRequest
 from openai.types.responses import ResponseFunctionToolCall
 
+import speech_to_speech.LLM.base_openai_compatible_language_model as base_mod
 import speech_to_speech.LLM.chat_completions_language_model as ccm
 from speech_to_speech.api.openai_realtime.runtime_config import RuntimeConfig
 from speech_to_speech.LLM.chat import Chat, make_user_message
@@ -86,8 +87,8 @@ class _FakeClient:
 
 def _make_handler(stream=True):
     """Build a handler whose warmup hits the fake client (no network)."""
-    orig_openai = ccm.OpenAI
-    ccm.OpenAI = _FakeClient
+    orig_openai = base_mod.OpenAI
+    base_mod.OpenAI = _FakeClient
     try:
         h = ChatCompletionsApiModelHandler(
             threading.Event(),
@@ -103,7 +104,7 @@ def _make_handler(stream=True):
             ),
         )
     finally:
-        ccm.OpenAI = orig_openai
+        base_mod.OpenAI = orig_openai
     return h
 
 

--- a/tests/test_chat_completions_backend.py
+++ b/tests/test_chat_completions_backend.py
@@ -14,26 +14,28 @@ import queue
 import threading
 from types import SimpleNamespace
 
-import speech_to_speech.LLM.chat_completions_language_model as ccm
-from speech_to_speech.LLM.chat_completions_language_model import (
-    ChatCompletionsApiModelHandler,
-    _to_chat_tools,
-    _to_chat_tool_choice,
-)
-from speech_to_speech.LLM.chat import Chat, make_user_message
-from speech_to_speech.api.openai_realtime.runtime_config import RuntimeConfig
-from speech_to_speech.pipeline.messages import (
-    GenerateResponseRequest,
-    LLMResponseChunk,
-    TokenUsage,
-)
-from openai.types.realtime.realtime_session_create_request import RealtimeSessionCreateRequest
 from openai.types.realtime.conversation_item import (
     RealtimeConversationItemFunctionCall,
     RealtimeConversationItemFunctionCallOutput,
 )
+from openai.types.realtime.realtime_response_create_params import RealtimeResponseCreateParams
+from openai.types.realtime.realtime_session_create_request import RealtimeSessionCreateRequest
 from openai.types.responses import ResponseFunctionToolCall
 
+import speech_to_speech.LLM.chat_completions_language_model as ccm
+from speech_to_speech.api.openai_realtime.runtime_config import RuntimeConfig
+from speech_to_speech.LLM.chat import Chat, make_user_message
+from speech_to_speech.LLM.chat_completions_language_model import (
+    ChatCompletionsApiModelHandler,
+    _to_chat_tool_choice,
+    _to_chat_tools,
+)
+from speech_to_speech.pipeline.messages import (
+    EndOfResponse,
+    GenerateResponseRequest,
+    LLMResponseChunk,
+    TokenUsage,
+)
 
 # ── Fakes ────────────────────────────────────────────────────────────────────
 
@@ -114,26 +116,38 @@ def _tc_delta(index, id=None, name=None, arguments=None):
     return SimpleNamespace(index=index, id=id, function=SimpleNamespace(name=name, arguments=arguments))
 
 
-def _drive(handler, *, tools=None, tool_choice=None, user="Hallo", chat=None):
+def _drive(
+    handler,
+    *,
+    tools=None,
+    tool_choice=None,
+    user="Hallo",
+    chat=None,
+    response=None,
+    instructions="Du bist ein Roboter.",
+):
     chat = chat or Chat(10)
-    chat.add_item(make_user_message(user))
-    session = RealtimeSessionCreateRequest(type="realtime", instructions="Du bist ein Roboter.")
+    if user:
+        chat.add_item(make_user_message(user))
+    session = RealtimeSessionCreateRequest(type="realtime", instructions=instructions)
     if tools is not None:
         session.tools = tools
     if tool_choice is not None:
         session.tool_choice = tool_choice
     rc = RuntimeConfig(chat=chat, session=session)
     req = GenerateResponseRequest(
-        runtime_config=rc, response=None, language_code="de", turn_id="t", turn_revision=0
+        runtime_config=rc, response=response, language_code="de", turn_id="t", turn_revision=0
     )
-    text, tools_out, usage = "", [], None
+    text, tools_out, usage, end = "", [], None, None
     for out in handler.process(req):
         if isinstance(out, LLMResponseChunk):
             text += out.text
             tools_out += list(out.tools)
         elif isinstance(out, TokenUsage):
             usage = (out.input_tokens, out.output_tokens)
-    return text, tools_out, usage, chat
+        elif isinstance(out, EndOfResponse):
+            end = out
+    return text, tools_out, usage, chat, end
 
 
 # ── Converter tests ──────────────────────────────────────────────────────────
@@ -141,7 +155,9 @@ def _drive(handler, *, tools=None, tool_choice=None, user="Hallo", chat=None):
 
 def test_to_chat_tools_flat_to_nested():
     out = _to_chat_tools([{"type": "function", "name": "f", "description": "d", "parameters": {"type": "object"}}])
-    assert out == [{"type": "function", "function": {"name": "f", "description": "d", "parameters": {"type": "object"}}}]
+    assert out == [
+        {"type": "function", "function": {"name": "f", "description": "d", "parameters": {"type": "object"}}}
+    ]
 
 
 def test_to_chat_tools_passthrough_and_none():
@@ -198,7 +214,7 @@ def test_streaming_text_and_usage():
             _chunk(usage=SimpleNamespace(prompt_tokens=12, completion_tokens=5)),
         ]
     )
-    text, tools, usage, chat = _drive(h)
+    text, tools, usage, chat, _end = _drive(h)
     assert "Hallo" in text and "Wie geht es dir" in text
     assert usage == (12, 5)
     assert tools == []
@@ -216,7 +232,7 @@ def test_streaming_tool_call_accumulates_arguments():
             _chunk(usage=SimpleNamespace(prompt_tokens=20, completion_tokens=8)),
         ]
     )
-    text, tools, usage, chat = _drive(
+    text, tools, usage, chat, _end = _drive(
         h,
         tools=[{"type": "function", "name": "move_head", "parameters": {"type": "object"}}],
         tool_choice="required",
@@ -249,7 +265,7 @@ def test_non_streaming_tool_call():
         ],
         usage=SimpleNamespace(prompt_tokens=7, completion_tokens=3),
     )
-    text, tools, usage, chat = _drive(
+    text, tools, usage, chat, _end = _drive(
         h,
         tools=[{"type": "function", "name": "move_head", "parameters": {"type": "object"}}],
         tool_choice="required",
@@ -274,6 +290,111 @@ def test_tools_converted_to_chat_format_on_request():
     assert captured["tool_choice"] == "auto"
     assert captured["stream"] is True
     assert captured["stream_options"] == {"include_usage": True}
+
+
+# ── Text-only (output_modalities=["text"]) ────────────────────────────────────
+
+
+def test_text_only_streaming_preserves_raw_deltas():
+    """With output_modalities=["text"], deltas are forwarded verbatim: no
+    remove_unspeechable (emoji/markdown survive) and no sentence batching."""
+    h = _make_handler(stream=True)
+    h.client.chat.completions.create = lambda **k: _FakeStream(
+        [
+            _chunk(content="# Title 🎉\n"),
+            _chunk(content="- one\n- two 😀\n"),
+            _chunk(usage=SimpleNamespace(prompt_tokens=3, completion_tokens=4)),
+        ]
+    )
+    text, tools, usage, chat, end = _drive(h, response=RealtimeResponseCreateParams(output_modalities=["text"]))
+    # Raw markdown layout and emoji preserved end-to-end.
+    assert text == "# Title 🎉\n- one\n- two 😀\n"
+    assert tools == []
+    assert usage == (3, 4)
+    # Raw assistant text is committed to history (not the filtered TTS string).
+    assert any(getattr(i, "role", None) == "assistant" for i in chat.buffer), "assistant turn should be stored"
+
+
+def test_non_streaming_text_only_preserves_symbols():
+    h = _make_handler(stream=False)
+    h.client.chat.completions.create = lambda **k: SimpleNamespace(
+        choices=[SimpleNamespace(message=SimpleNamespace(content="**bold** 🎉", tool_calls=[]))],
+        usage=SimpleNamespace(prompt_tokens=2, completion_tokens=2),
+    )
+    text, tools, usage, chat, end = _drive(h, response=RealtimeResponseCreateParams(output_modalities=["text"]))
+    assert text == "**bold** 🎉"  # symbols not stripped
+
+
+# ── tool_choice decoupled from tools ──────────────────────────────────────────
+
+
+def test_tool_choice_sent_without_tools():
+    """A session-level tool_choice must reach the server even when no tools list
+    is supplied (e.g. tool_choice="none" to suppress tool use)."""
+    h = _make_handler(stream=True)
+    captured = {}
+
+    def fake_create(**kwargs):
+        captured.update(kwargs)
+        return _FakeStream([_chunk(content="ok.")])
+
+    h.client.chat.completions.create = fake_create
+    _drive(h, tool_choice="none")
+    assert "tools" not in captured
+    assert captured["tool_choice"] == "none"
+
+
+# ── Error propagation ─────────────────────────────────────────────────────────
+
+
+def test_empty_input_emits_failed_end_of_response():
+    """No instructions and no conversation input → terminating EndOfResponse with
+    an error, instead of an opaque provider 400."""
+    h = _make_handler(stream=True)
+    called = {"n": 0}
+
+    def fake_create(**kwargs):
+        called["n"] += 1
+        return _FakeStream([_chunk(content="should not happen")])
+
+    h.client.chat.completions.create = fake_create
+    # Empty chat + empty instructions => nothing to send.
+    text, tools, usage, chat, end = _drive(h, user="", instructions="", chat=Chat(10))
+    assert called["n"] == 0, "no API call should be made when there is nothing to send"
+    assert end is not None and end.error is not None
+    assert text == ""
+
+
+def test_generation_error_emits_failed_end_of_response():
+    """An exception during generation is caught and surfaced on EndOfResponse.error
+    so the response is closed instead of leaving the pipeline stuck."""
+    h = _make_handler(stream=True)
+
+    def boom(**kwargs):
+        raise RuntimeError("kaboom")
+
+    h.client.chat.completions.create = boom
+    text, tools, usage, chat, end = _drive(h)
+    assert end is not None and end.error is not None
+    assert "kaboom" in end.error
+
+
+# ── Out-of-band (conversation="none") responses ───────────────────────────────
+
+
+def test_out_of_band_does_not_commit_to_default_conversation():
+    """Out-of-band output is emitted but never written back to the default chat."""
+    h = _make_handler(stream=True)
+    h.client.chat.completions.create = lambda **k: _FakeStream(
+        [_chunk(content="Background note."), _chunk(usage=SimpleNamespace(prompt_tokens=1, completion_tokens=1))]
+    )
+    chat = Chat(10)
+    text, tools, usage, chat, end = _drive(
+        h, chat=chat, response=RealtimeResponseCreateParams(conversation="none", output_modalities=["text"])
+    )
+    assert "Background note." in text
+    # Default conversation keeps only the seeded user turn — no assistant commit.
+    assert not any(getattr(i, "role", None) == "assistant" for i in chat.buffer)
 
 
 # ── Standalone runner (no pytest required) ────────────────────────────────────

--- a/tests/test_chat_completions_backend.py
+++ b/tests/test_chat_completions_backend.py
@@ -207,6 +207,30 @@ def test_chat_messages_encodes_tool_arguments_as_string():
     assert json.loads(args) == {"direction": "left"}
 
 
+def test_chat_messages_strips_tool_output_name():
+    """to_transformers_chat adds a tool name for HF templates; Chat Completions
+    tool messages only accept role/tool_call_id/content."""
+    chat = Chat(10)
+    chat.add_item(make_user_message("Search for x"))
+    chat.add_item(
+        RealtimeConversationItemFunctionCall(
+            type="function_call",
+            name="search",
+            arguments='{"q": "x"}',
+            call_id="call_1",
+            id="fc_1",
+            status="completed",
+        )
+    )
+    chat.add_item(
+        RealtimeConversationItemFunctionCallOutput(type="function_call_output", call_id="call_1", output="found")
+    )
+
+    messages = ChatCompletionsApiModelHandler._chat_messages(chat)
+    tool_message = [m for m in messages if m.get("role") == "tool"][0]
+    assert tool_message == {"role": "tool", "tool_call_id": "call_1", "content": "found"}
+
+
 def test_chat_messages_converts_image_and_text_parts_to_chat_shape():
     """to_transformers_chat emits Realtime-shaped parts (input_text / input_image
     with a bare-string image_url); the Chat Completions API needs text / image_url

--- a/tests/test_chat_completions_backend.py
+++ b/tests/test_chat_completions_backend.py
@@ -17,7 +17,9 @@ from types import SimpleNamespace
 from openai.types.realtime.conversation_item import (
     RealtimeConversationItemFunctionCall,
     RealtimeConversationItemFunctionCallOutput,
+    RealtimeConversationItemUserMessage,
 )
+from openai.types.realtime.realtime_conversation_item_user_message import Content as UserContent
 from openai.types.realtime.realtime_response_create_params import RealtimeResponseCreateParams
 from openai.types.realtime.realtime_session_create_request import RealtimeSessionCreateRequest
 from openai.types.responses import ResponseFunctionToolCall
@@ -178,6 +180,8 @@ def test_build_extra_body_variants():
     assert f("http://x/v1", True, None) == {"chat_template_kwargs": {"enable_thinking": False}}
     assert f("http://x/v1", True, "none") == {"reasoning_effort": "none"}  # explicit effort wins
     assert f("https://api.openai.com/v1", True, "none") is None  # official OpenAI: no extra_body
+    assert f("https://api.openai.com/v1/", True, "none") is None  # trailing slash still official
+    assert f("http://x/v1", True, "") == {"chat_template_kwargs": {"enable_thinking": False}}  # empty effort ignored
     assert f("http://x/v1", False, None) is None
     assert f(None, True, None) is None
 
@@ -200,6 +204,31 @@ def test_chat_messages_encodes_tool_arguments_as_string():
     args = tool_call_msgs[0]["tool_calls"][0]["function"]["arguments"]
     assert isinstance(args, str), f"arguments must be a JSON string, got {type(args)}"
     assert json.loads(args) == {"direction": "left"}
+
+
+def test_chat_messages_converts_image_and_text_parts_to_chat_shape():
+    """to_transformers_chat emits Realtime-shaped parts (input_text / input_image
+    with a bare-string image_url); the Chat Completions API needs text / image_url
+    with a nested object."""
+    chat = Chat(10)
+    chat.add_item(
+        RealtimeConversationItemUserMessage(
+            type="message",
+            role="user",
+            content=[
+                UserContent(type="input_text", text="What is this?"),
+                UserContent(type="input_image", image_url="https://example.com/img.png", detail="auto"),
+            ],
+        )
+    )
+    messages = ChatCompletionsApiModelHandler._chat_messages(chat)
+    user = [m for m in messages if m.get("role") == "user"][0]
+    assert isinstance(user["content"], list)
+    parts = {p["type"]: p for p in user["content"]}
+    assert parts["text"]["text"] == "What is this?"
+    assert parts["image_url"]["image_url"] == {"url": "https://example.com/img.png", "detail": "auto"}
+    # No Realtime-shaped parts leak through.
+    assert all(p["type"] not in ("input_text", "input_image") for p in user["content"])
 
 
 # ── Streaming / non-streaming parse tests ─────────────────────────────────────
@@ -275,6 +304,53 @@ def test_non_streaming_tool_call():
     assert usage == (7, 3)
 
 
+def test_streaming_refusal_is_spoken_and_stored():
+    """A refusal streams as delta.refusal (content None); it must be surfaced as
+    assistant text and written to history, not silently dropped."""
+    h = _make_handler(stream=True)
+    h.client.chat.completions.create = lambda **k: _FakeStream(
+        [
+            SimpleNamespace(
+                choices=[
+                    SimpleNamespace(
+                        delta=SimpleNamespace(content=None, refusal="I cannot help with that.", tool_calls=None),
+                        finish_reason=None,
+                    )
+                ],
+                usage=None,
+            ),
+            _chunk(usage=SimpleNamespace(prompt_tokens=4, completion_tokens=6)),
+        ]
+    )
+    text, tools, usage, chat, _end = _drive(h)
+    assert "I cannot help with that." in text
+    assert any(getattr(i, "role", None) == "assistant" for i in chat.buffer)
+
+
+def test_non_streaming_refusal_is_spoken_and_stored():
+    h = _make_handler(stream=False)
+    h.client.chat.completions.create = lambda **k: SimpleNamespace(
+        choices=[SimpleNamespace(message=SimpleNamespace(content=None, refusal="No can do.", tool_calls=[]))],
+        usage=SimpleNamespace(prompt_tokens=2, completion_tokens=2),
+    )
+    text, tools, usage, chat, _end = _drive(h)
+    assert text == "No can do."
+    assert any(getattr(i, "role", None) == "assistant" for i in chat.buffer)
+
+
+def test_non_streaming_empty_choices_completes_cleanly():
+    """A valid response with no choices (e.g. content filter) completes with no
+    assistant text and no error, instead of raising IndexError."""
+    h = _make_handler(stream=False)
+    h.client.chat.completions.create = lambda **k: SimpleNamespace(
+        choices=[], usage=SimpleNamespace(prompt_tokens=1, completion_tokens=0)
+    )
+    text, tools, usage, chat, end = _drive(h)
+    assert text == ""
+    assert tools == []
+    assert end is not None and end.error is None  # clean end, not a generation failure
+
+
 def test_tools_converted_to_chat_format_on_request():
     """The request sent to the server must carry Chat-Completions-shaped tools."""
     h = _make_handler(stream=True)
@@ -313,6 +389,37 @@ def test_text_only_streaming_preserves_raw_deltas():
     assert usage == (3, 4)
     # Raw assistant text is committed to history (not the filtered TTS string).
     assert any(getattr(i, "role", None) == "assistant" for i in chat.buffer), "assistant turn should be stored"
+
+
+def test_text_only_tool_call_in_same_delta_not_dropped():
+    """In text-only mode a delta can carry both content and a tool_call fragment;
+    the tool_call must still be accumulated despite the verbatim-forward `continue`."""
+    h = _make_handler(stream=True)
+    h.client.chat.completions.create = lambda **k: _FakeStream(
+        [
+            SimpleNamespace(
+                choices=[
+                    SimpleNamespace(
+                        delta=SimpleNamespace(
+                            content="Looking it up. ",
+                            tool_calls=[_tc_delta(0, id="srv_1", name="search", arguments='{"q":"x"}')],
+                        ),
+                        finish_reason=None,
+                    )
+                ],
+                usage=None,
+            ),
+            _chunk(usage=SimpleNamespace(prompt_tokens=5, completion_tokens=5)),
+        ]
+    )
+    text, tools, usage, chat, _end = _drive(
+        h,
+        tools=[{"type": "function", "name": "search", "parameters": {"type": "object"}}],
+        response=RealtimeResponseCreateParams(output_modalities=["text"]),
+    )
+    assert "Looking it up." in text
+    assert len(tools) == 1 and tools[0].name == "search"  # not dropped by the text-only continue
+    assert json.loads(tools[0].arguments) == {"q": "x"}
 
 
 def test_non_streaming_text_only_preserves_symbols():

--- a/tests/test_chat_completions_backend.py
+++ b/tests/test_chat_completions_backend.py
@@ -1,0 +1,292 @@
+"""Unit tests for the chat-completions LLM backend.
+
+These run without a GPU or a live server: the OpenAI client is faked at the
+module level, so the streaming/non-streaming parse logic and the format
+converters are exercised purely in-process.
+
+Run with pytest, or standalone:  python tests/test_chat_completions_backend.py
+"""
+
+from __future__ import annotations
+
+import json
+import queue
+import threading
+from types import SimpleNamespace
+
+import speech_to_speech.LLM.chat_completions_language_model as ccm
+from speech_to_speech.LLM.chat_completions_language_model import (
+    ChatCompletionsApiModelHandler,
+    _to_chat_tools,
+    _to_chat_tool_choice,
+)
+from speech_to_speech.LLM.chat import Chat, make_user_message
+from speech_to_speech.api.openai_realtime.runtime_config import RuntimeConfig
+from speech_to_speech.pipeline.messages import (
+    GenerateResponseRequest,
+    LLMResponseChunk,
+    TokenUsage,
+)
+from openai.types.realtime.realtime_session_create_request import RealtimeSessionCreateRequest
+from openai.types.realtime.conversation_item import (
+    RealtimeConversationItemFunctionCall,
+    RealtimeConversationItemFunctionCallOutput,
+)
+from openai.types.responses import ResponseFunctionToolCall
+
+
+# ── Fakes ────────────────────────────────────────────────────────────────────
+
+
+class _FakeStream:
+    """Iterable stand-in for openai.Stream; yields preset chunks."""
+
+    def __init__(self, chunks):
+        self._chunks = chunks
+
+    def __iter__(self):
+        return iter(self._chunks)
+
+    def close(self):
+        pass
+
+
+# Make the handler's ``isinstance(resp, Stream)`` check recognise our fake as a
+# stream. Non-streaming fakes stay plain SimpleNamespace, so they still take the
+# non-stream branch.
+ccm.Stream = _FakeStream
+
+
+class _FakeCompletions:
+    def __init__(self):
+        self.next_result = SimpleNamespace(
+            choices=[SimpleNamespace(message=SimpleNamespace(content="ok", tool_calls=[]))],
+            usage=SimpleNamespace(prompt_tokens=1, completion_tokens=1),
+        )
+        self.last_kwargs = None
+
+    def create(self, **kwargs):
+        self.last_kwargs = kwargs
+        return self.next_result
+
+
+class _FakeChat:
+    def __init__(self):
+        self.completions = _FakeCompletions()
+
+
+class _FakeClient:
+    def __init__(self, *a, **k):
+        self.chat = _FakeChat()
+
+
+def _make_handler(stream=True):
+    """Build a handler whose warmup hits the fake client (no network)."""
+    orig_openai = ccm.OpenAI
+    ccm.OpenAI = _FakeClient
+    try:
+        h = ChatCompletionsApiModelHandler(
+            threading.Event(),
+            queue.Queue(),
+            queue.Queue(),
+            setup_kwargs=dict(
+                model_name="test-model",
+                base_url="http://fake/v1",
+                api_key="k",
+                stream=stream,
+                disable_thinking=True,
+                compact_history=False,
+            ),
+        )
+    finally:
+        ccm.OpenAI = orig_openai
+    return h
+
+
+def _chunk(content=None, tool_calls=None, usage=None):
+    choices = []
+    if content is not None or tool_calls is not None:
+        choices = [SimpleNamespace(delta=SimpleNamespace(content=content, tool_calls=tool_calls), finish_reason=None)]
+    return SimpleNamespace(choices=choices, usage=usage)
+
+
+def _tc_delta(index, id=None, name=None, arguments=None):
+    return SimpleNamespace(index=index, id=id, function=SimpleNamespace(name=name, arguments=arguments))
+
+
+def _drive(handler, *, tools=None, tool_choice=None, user="Hallo", chat=None):
+    chat = chat or Chat(10)
+    chat.add_item(make_user_message(user))
+    session = RealtimeSessionCreateRequest(type="realtime", instructions="Du bist ein Roboter.")
+    if tools is not None:
+        session.tools = tools
+    if tool_choice is not None:
+        session.tool_choice = tool_choice
+    rc = RuntimeConfig(chat=chat, session=session)
+    req = GenerateResponseRequest(
+        runtime_config=rc, response=None, language_code="de", turn_id="t", turn_revision=0
+    )
+    text, tools_out, usage = "", [], None
+    for out in handler.process(req):
+        if isinstance(out, LLMResponseChunk):
+            text += out.text
+            tools_out += list(out.tools)
+        elif isinstance(out, TokenUsage):
+            usage = (out.input_tokens, out.output_tokens)
+    return text, tools_out, usage, chat
+
+
+# ── Converter tests ──────────────────────────────────────────────────────────
+
+
+def test_to_chat_tools_flat_to_nested():
+    out = _to_chat_tools([{"type": "function", "name": "f", "description": "d", "parameters": {"type": "object"}}])
+    assert out == [{"type": "function", "function": {"name": "f", "description": "d", "parameters": {"type": "object"}}}]
+
+
+def test_to_chat_tools_passthrough_and_none():
+    nested = [{"type": "function", "function": {"name": "f"}}]
+    assert _to_chat_tools(nested) == nested
+    assert _to_chat_tools(None) is None
+    assert _to_chat_tools([]) is None
+
+
+def test_to_chat_tool_choice():
+    assert _to_chat_tool_choice("auto") == "auto"
+    assert _to_chat_tool_choice("required") == "required"
+    assert _to_chat_tool_choice({"type": "function", "name": "f"}) == {"type": "function", "function": {"name": "f"}}
+
+
+def test_build_extra_body_variants():
+    f = ChatCompletionsApiModelHandler._build_extra_body
+    assert f("http://x/v1", True, None) == {"chat_template_kwargs": {"enable_thinking": False}}
+    assert f("http://x/v1", True, "none") == {"reasoning_effort": "none"}  # explicit effort wins
+    assert f("https://api.openai.com/v1", True, "none") is None  # official OpenAI: no extra_body
+    assert f("http://x/v1", False, None) is None
+    assert f(None, True, None) is None
+
+
+def test_chat_messages_encodes_tool_arguments_as_string():
+    """to_transformers_chat emits arguments as a dict; the chat API needs a string."""
+    chat = Chat(10)
+    chat.add_item(make_user_message("Kopf links"))
+    chat.add_item(
+        RealtimeConversationItemFunctionCall(
+            type="function_call", name="move_head", arguments='{"direction": "left"}', call_id="call_1", id="fc_1"
+        )
+    )
+    chat.add_item(
+        RealtimeConversationItemFunctionCallOutput(type="function_call_output", call_id="call_1", output="ok")
+    )
+    messages = ChatCompletionsApiModelHandler._chat_messages(chat)
+    tool_call_msgs = [m for m in messages if m.get("tool_calls")]
+    assert tool_call_msgs, "expected an assistant message carrying tool_calls"
+    args = tool_call_msgs[0]["tool_calls"][0]["function"]["arguments"]
+    assert isinstance(args, str), f"arguments must be a JSON string, got {type(args)}"
+    assert json.loads(args) == {"direction": "left"}
+
+
+# ── Streaming / non-streaming parse tests ─────────────────────────────────────
+
+
+def test_streaming_text_and_usage():
+    h = _make_handler(stream=True)
+    h.client.chat.completions.create = lambda **k: _FakeStream(
+        [
+            _chunk(content="Hallo. "),
+            _chunk(content="Wie geht es dir?"),
+            _chunk(usage=SimpleNamespace(prompt_tokens=12, completion_tokens=5)),
+        ]
+    )
+    text, tools, usage, chat = _drive(h)
+    assert "Hallo" in text and "Wie geht es dir" in text
+    assert usage == (12, 5)
+    assert tools == []
+    # assistant text was stored back into the conversation history
+    assert any(getattr(i, "role", None) == "assistant" for i in chat.buffer)
+
+
+def test_streaming_tool_call_accumulates_arguments():
+    h = _make_handler(stream=True)
+    # Arguments arrive split across deltas, as real servers stream them.
+    h.client.chat.completions.create = lambda **k: _FakeStream(
+        [
+            _chunk(tool_calls=[_tc_delta(0, id="srv_1", name="move_head", arguments='{"direction"')]),
+            _chunk(tool_calls=[_tc_delta(0, arguments=': "left"}')]),
+            _chunk(usage=SimpleNamespace(prompt_tokens=20, completion_tokens=8)),
+        ]
+    )
+    text, tools, usage, chat = _drive(
+        h,
+        tools=[{"type": "function", "name": "move_head", "parameters": {"type": "object"}}],
+        tool_choice="required",
+    )
+    assert len(tools) == 1
+    tc = tools[0]
+    assert isinstance(tc, ResponseFunctionToolCall)
+    assert tc.name == "move_head"
+    assert json.loads(tc.arguments) == {"direction": "left"}  # reassembled from two deltas
+    assert usage == (20, 8)
+    # the function_call was stored in history with a freshly minted call_id
+    assert chat._pending_tool_calls, "tool call should be recorded in chat history"
+
+
+def test_non_streaming_tool_call():
+    h = _make_handler(stream=False)
+    h.client.chat.completions.create = lambda **k: SimpleNamespace(
+        choices=[
+            SimpleNamespace(
+                message=SimpleNamespace(
+                    content="",
+                    tool_calls=[
+                        SimpleNamespace(
+                            id="srv_9",
+                            function=SimpleNamespace(name="move_head", arguments='{"direction": "right"}'),
+                        )
+                    ],
+                )
+            )
+        ],
+        usage=SimpleNamespace(prompt_tokens=7, completion_tokens=3),
+    )
+    text, tools, usage, chat = _drive(
+        h,
+        tools=[{"type": "function", "name": "move_head", "parameters": {"type": "object"}}],
+        tool_choice="required",
+    )
+    assert len(tools) == 1 and tools[0].name == "move_head"
+    assert json.loads(tools[0].arguments) == {"direction": "right"}
+    assert usage == (7, 3)
+
+
+def test_tools_converted_to_chat_format_on_request():
+    """The request sent to the server must carry Chat-Completions-shaped tools."""
+    h = _make_handler(stream=True)
+    captured = {}
+
+    def fake_create(**kwargs):
+        captured.update(kwargs)
+        return _FakeStream([_chunk(content="ok.")])
+
+    h.client.chat.completions.create = fake_create
+    _drive(h, tools=[{"type": "function", "name": "f", "parameters": {"type": "object"}}], tool_choice="auto")
+    assert captured["tools"] == [{"type": "function", "function": {"name": "f", "parameters": {"type": "object"}}}]
+    assert captured["tool_choice"] == "auto"
+    assert captured["stream"] is True
+    assert captured["stream_options"] == {"include_usage": True}
+
+
+# ── Standalone runner (no pytest required) ────────────────────────────────────
+
+if __name__ == "__main__":
+    tests = [v for k, v in sorted(globals().items()) if k.startswith("test_") and callable(v)]
+    failed = 0
+    for t in tests:
+        try:
+            t()
+            print(f"PASS  {t.__name__}")
+        except Exception as e:  # noqa: BLE001
+            failed += 1
+            print(f"FAIL  {t.__name__}: {type(e).__name__}: {e}")
+    print(f"\n{len(tests) - failed}/{len(tests)} passed")
+    raise SystemExit(1 if failed else 0)


### PR DESCRIPTION
## Summary

Adds a fourth `--llm_backend` value, `chat-completions`, that drives the
OpenAI-compatible `/v1/chat/completions` endpoint instead of `/v1/responses`.
It mirrors the existing `responses-api` handler (streaming, tool calls, token
usage, history, compaction, cancellation, text-only and out-of-band responses)
but uses the Chat Completions streaming protocol (`choices[].delta.tool_calls`).

Originally contributed in #320 (closes #312); merged here and brought up to
parity with the latest `responses_api_language_model.py` before merging to `main`.

## Motivation

Two independent problems with the Responses path on some OpenAI-compatible
servers, both fixed by using Chat Completions:

1. **Reasoning cannot be disabled.** For some providers (e.g. `zai-org/GLM-4.7:cerebras`
   via the HF router) neither `reasoning.effort` nor `chat_template_kwargs.enable_thinking=false`
   reliably suppresses reasoning on `/v1/responses`, so speakable text is delayed
   or never produced within the output-token budget. Chat Completions with
   `extra_body={"reasoning_effort": "none"}` returns visible text immediately.
2. **Responses streaming tool calls are unreliable on some vLLM builds.** With
   auto tool choice + streaming, vLLM's `responses_stream_generator` can raise a
   pydantic `ValidationError` and kill the stream; replayed tool-call arguments
   can also arrive duplicated. The Chat Completions streaming tool-call path is
   unaffected.

## What changed

- `LLM/chat_completions_language_model.py` — new `ChatCompletionsApiModelHandler`.
  Serialises the conversation with `Chat.to_transformers_chat()` and re-encodes
  tool-call `arguments` from object back to a JSON string.
- `arguments_classes/chat_completions_language_model_arguments.py` — new
  `ChatCompletionsLanguageModelHandlerArguments`, subclassing the responses-api
  arguments (shared connection flags) and adding `responses_api_reasoning_effort`.
- `arguments_classes/module_arguments.py` — `chat-completions` added to the
  `llm_backend` literal.
- `s2s_pipeline.py` — backend→argument-class selection, handler factory branch,
  shared chat-size / runtime-config wiring.
- `README.md` — documents the new backend and `reasoning_effort`.
- `tests/test_chat_completions_backend.py` — mock-based unit tests (no GPU/server).

## Review fixes applied on top of #320

The #320 review flagged places where `responses_api_language_model.py` had grown
features the new handler did not yet reflect. All are now closed:

- **Out-of-band** (`conversation="none"`) responses build a throwaway active chat
  via `build_active_chat` (invalid input → `EndOfResponse.error`) and are never
  written back into the default conversation.
- **Text-only** (`output_modalities=["text"]`) responses forward deltas verbatim
  (no `remove_unspeechable`, no sentence-splitting) in both streaming and
  non-streaming paths, and select `build_text_system_prompt`.
- **`error_message` tracking**: empty-input guard + catch-all `except`, history
  write-back gated on `error_message is None`, and `error=error_message`
  propagated on `EndOfResponse`.
- **History stores raw text** (not the TTS-filtered `clean_text`), preventing
  multi-turn drift; non-streaming write gated on raw `message.content`.
- **`tool_choice` sent independently of `tools`**, so `tool_choice="none"`
  survives with no tools list.
- **Observability parity**: stale-turn cancellation logged in `_flush_batch`;
  `Tools:` logged unconditionally.

## Testing

`pytest tests/test_chat_completions_backend.py` — 15 tests, no network. Covers the
tool/tool_choice converters, `arguments` string re-encoding, `extra_body`
precedence, streaming + non-streaming parse, plus the new text-only, decoupled
`tool_choice`, empty-input / generation-error, and out-of-band behaviours.
`responses_api` and `chat` suites remain green.
