### PR TITLE
Handle Cerebras chat-completions routing

### DIFF
--- a/README.md
+++ b/README.md
@@ -331,6 +331,12 @@ Prefer it when:
 Add `--responses_api_reasoning_effort none` (chat-completions only) to disable reasoning
 on providers where the chat-template flag has no effect:
 
+For Hugging Face Router models pinned to the Cerebras provider with a `:cerebras`
+suffix, the backend skips `chat_template_kwargs.enable_thinking=false`
+automatically because Cerebras rejects that request field. You can still pass
+`--responses_api_reasoning_effort none` when you want to set the provider's
+reasoning control explicitly.
+
 ```bash
 # vLLM (local) serving a Qwen model with tool calling
 speech-to-speech \

--- a/src/speech_to_speech/LLM/base_openai_compatible_language_model.py
+++ b/src/speech_to_speech/LLM/base_openai_compatible_language_model.py
@@ -154,7 +154,7 @@ class BaseOpenAICompatibleHandler(BaseHandler[LLMIn, LLMOut], ABC):
 
         self.user_role = user_role
         self.client = OpenAI(api_key=api_key, base_url=base_url)
-        self._extra_body = self._build_extra_body(base_url, disable_thinking, reasoning_effort)
+        self._extra_body = self._build_extra_body(base_url, disable_thinking, reasoning_effort, self.model_name)
         self.compactor = build_compactor(self._build_compaction_generate_fn()) if compact_history else None
         self.warmup()
 
@@ -176,6 +176,7 @@ class BaseOpenAICompatibleHandler(BaseHandler[LLMIn, LLMOut], ABC):
         base_url: Optional[str],
         disable_thinking: bool,
         reasoning_effort: Optional[str],
+        model_name: Optional[str] = None,
     ) -> Optional[dict[str, Any]]:
         """Build the provider-specific ``extra_body`` used to disable reasoning.
 
@@ -190,9 +191,22 @@ class BaseOpenAICompatibleHandler(BaseHandler[LLMIn, LLMOut], ABC):
             return None
         if reasoning_effort:
             return {"reasoning_effort": reasoning_effort}
+        if cls._is_cerebras_endpoint(base_url, model_name):
+            return None
         if disable_thinking:
             return {"chat_template_kwargs": {"enable_thinking": False}}
         return None
+
+    @staticmethod
+    def _is_cerebras_endpoint(base_url: Optional[str], model_name: Optional[str]) -> bool:
+        if base_url is None:
+            return False
+        normalized_base_url = base_url.rstrip("/")
+        if normalized_base_url == "https://api.cerebras.ai/v1":
+            return True
+        return normalized_base_url == "https://router.huggingface.co/v1" and bool(
+            model_name and model_name.lower().endswith(":cerebras")
+        )
 
     # ── subclass hooks ──────────────────────────────────────────────────────--
 

--- a/tests/test_chat_completions_backend.py
+++ b/tests/test_chat_completions_backend.py
@@ -182,6 +182,14 @@ def test_build_extra_body_variants():
     assert f("http://x/v1", True, "none") == {"reasoning_effort": "none"}  # explicit effort wins
     assert f("https://api.openai.com/v1", True, "none") is None  # official OpenAI: no extra_body
     assert f("https://api.openai.com/v1/", True, "none") is None  # trailing slash still official
+    assert f("https://api.cerebras.ai/v1", True, None, "gemma-4-31b-trial") is None
+    assert f("https://api.cerebras.ai/v1/", True, None, "gemma-4-31b-trial") is None
+    assert f("https://api.cerebras.ai/v1", True, "none", "gemma-4-31b-trial") == {"reasoning_effort": "none"}
+    assert f("https://router.huggingface.co/v1", True, None, "google/gemma-4-31B-it:cerebras") is None
+    assert f("https://router.huggingface.co/v1/", True, None, "zai-org/GLM-4.7:cerebras") is None
+    assert f("https://router.huggingface.co/v1", True, "none", "google/gemma-4-31B-it:cerebras") == {
+        "reasoning_effort": "none"
+    }
     assert f("http://x/v1", True, "") == {"chat_template_kwargs": {"enable_thinking": False}}  # empty effort ignored
     assert f("http://x/v1", False, None) is None
     assert f(None, True, None) is None


### PR DESCRIPTION
## Summary

Handle Cerebras-backed Chat Completions routes that reject `chat_template_kwargs.enable_thinking=false`.

The new `chat-completions` backend automatically sends that provider-specific body for non-OpenAI endpoints when `disable_thinking` is enabled. HF Router models pinned to Cerebras with a `:cerebras` suffix, and direct Cerebras endpoints, reject that request field. This change skips the chat-template fallback for Cerebras routes while preserving explicit `reasoning_effort` support.

## Impact

This lets models such as `google/gemma-4-31B-it:cerebras` work through HF Router with the default chat-completions backend settings. Users can still set `--responses_api_reasoning_effort none` when they want to explicitly control reasoning.

## Validation

- `.venv/bin/python -m pytest tests/test_chat_completions_backend.py tests/test_responses_api_language_model.py -q`
- `.venv/bin/python -m ruff check src/speech_to_speech/LLM/base_openai_compatible_language_model.py tests/test_chat_completions_backend.py README.md`
- Live smoke: `google/gemma-4-31B-it:cerebras` through HF Router with default `disable_thinking=True`, no explicit reasoning flag
- Live smoke: native tool call with `google/gemma-4-31B-it:cerebras` through HF Router
