### PR TITLE
Default Qwen3 TTS to GGML

### DIFF
--- a/README.md
+++ b/README.md
@@ -66,8 +66,33 @@ pip install speech-to-speech
 The default install is scoped to the standard realtime voice-agent path:
 - Parakeet TDT for STT
 - OpenAI-compatible API for the language model
-- Qwen3-TTS for speech output
+- Qwen3-TTS for speech output, using the GGML backend by default on non-macOS platforms
 - local audio and realtime server modes
+
+On Linux, the Qwen3-TTS GGML backend comes from `faster-qwen3-tts[ggml]`.
+Its default `qwentts-cpp-python` wheel on PyPI targets CUDA 12.8. If your
+machine does not have the CUDA 12 runtime that wheel expects, install the
+matching wheel from the Hugging Face wheelhouse before installing
+`speech-to-speech`:
+
+```bash
+# CUDA 13.x
+pip install "qwentts-cpp-python==0.3.0+cu130" \
+  -f https://huggingface.co/datasets/andito/qwentts-cpp-python-wheels/tree/main/whl/cu130
+
+# CUDA 12.4
+pip install "qwentts-cpp-python==0.3.0+cu124" \
+  -f https://huggingface.co/datasets/andito/qwentts-cpp-python-wheels/tree/main/whl/cu124
+
+# CPU-only fallback
+pip install "qwentts-cpp-python==0.3.0+cpu" \
+  -f https://huggingface.co/datasets/andito/qwentts-cpp-python-wheels/tree/main/whl/cpu
+
+pip install speech-to-speech
+```
+
+To use the previous CUDA-graphs implementation instead of GGML, pass
+`--qwen3_tts_backend torch`.
 
 Optional backends are installed with extras:
 ```bash
@@ -131,6 +156,7 @@ speech-to-speech \
     --qwen3_tts_model_name Qwen/Qwen3-TTS-12Hz-1.7B-CustomVoice \
     --qwen3_tts_speaker Aiden \
     --qwen3_tts_language auto \
+    --qwen3_tts_backend ggml \
     --qwen3_tts_non_streaming_mode True \
     --qwen3_tts_mlx_quantization 6bit \
     --model_name gpt-5.4-mini \

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -47,7 +47,7 @@ dependencies = [
     "uvicorn>=0.30.0",
     "websockets>=12.0",
     "nano-parakeet>=0.2.0; platform_system != 'Darwin'",
-    "faster-qwen3-tts>=0.2.6; platform_system != 'Darwin'",
+    "faster-qwen3-tts[ggml]>=0.3.0; platform_system != 'Darwin'",
     "lingua-language-detector>=2.0.2",
     "miniaudio==1.61; platform_system == 'Darwin'",
     "mlx==0.31.1; platform_system == 'Darwin'",

--- a/src/speech_to_speech/TTS/README.md
+++ b/src/speech_to_speech/TTS/README.md
@@ -80,17 +80,30 @@ python s2s_pipeline.py \
   --tts qwen3 \
   --qwen3_tts_model_name Qwen/Qwen3-TTS-12Hz-1.7B-CustomVoice \
   --qwen3_tts_device cuda \
+  --qwen3_tts_backend ggml \
   --qwen3_tts_speaker Aiden \
   --qwen3_tts_language auto \
   --qwen3_tts_non_streaming_mode True
 ```
 
 Behavior:
-- Uses `faster-qwen3-tts` on non-macOS platforms.
+- Uses `faster-qwen3-tts` on non-macOS platforms, defaulting to the GGML backend. Pass `--qwen3_tts_backend torch` to use the CUDA-graphs backend instead.
 - Uses `mlx-audio` on Apple Silicon and auto-maps `Qwen/...` model IDs to `mlx-community/...`, defaulting to the `6bit` MLX variant unless the model name already pins a suffix.
 - Supports MLX quantization overrides on Apple Silicon via `--qwen3_tts_mlx_quantization bf16|4bit|6bit|8bit`.
 - Keeps the existing voice-clone/custom-voice/voice-design handler flow intact.
 - Defaults to the CustomVoice model with speaker `Aiden`, so no reference audio is required. Voice-clone/base models can still use `--qwen3_tts_ref_audio`.
+
+Install notes for Linux GGML:
+- The default PyPI `qwentts-cpp-python` wheel targets CUDA 12.8.
+- If that wheel does not match your CUDA runtime, install one of the Hugging Face wheelhouse builds before installing `speech-to-speech`.
+
+```bash
+pip install "qwentts-cpp-python==0.3.0+cu130" \
+  -f https://huggingface.co/datasets/andito/qwentts-cpp-python-wheels/tree/main/whl/cu130
+pip install speech-to-speech
+```
+
+Available wheelhouse directories include `cu124`, `cu128`, `cu130`, and `cpu`.
 
 Example for Apple Silicon using the default 6-bit MLX variant:
 

--- a/src/speech_to_speech/TTS/qwen3_tts_handler.py
+++ b/src/speech_to_speech/TTS/qwen3_tts_handler.py
@@ -44,6 +44,7 @@ DEFAULT_MLX_STREAMING_CHUNK_SIZE = 4
 DEFAULT_QWEN3_TTS_MAX_NEW_TOKENS = 1536
 MIN_QWEN3_TTS_UTTERANCE_TOKENS = 360
 VALID_MLX_QUANTIZATION_SUFFIXES = ("bf16", "4bit", "6bit", "8bit")
+VALID_FASTER_BACKENDS = ("ggml", "torch")
 MLX_STREAMING_TOKENS_PER_SECOND = 12.5
 PIPELINE_SR = 16000
 ESTIMATED_QWEN3_WORDS_PER_SECOND = 2.6
@@ -96,6 +97,7 @@ class Qwen3TTSHandler(BaseHandler[TTSIn, TTSOut]):
         device: str = "cuda",
         dtype: str | torch.dtype = "auto",
         attn_implementation: str = "eager",
+        backend: str = "ggml",
         ref_audio: str | Path | None = None,
         ref_text: str = DEFAULT_REF_TEXT,
         language: str = "auto",
@@ -124,6 +126,7 @@ class Qwen3TTSHandler(BaseHandler[TTSIn, TTSOut]):
         self.xvec_only = xvec_only
         self.parity_mode = parity_mode
         self.non_streaming_mode = non_streaming_mode
+        self.faster_backend = self._normalize_faster_backend(backend)
         self.mlx_quantization = self._normalize_mlx_quantization(mlx_quantization)
         self.max_new_tokens = max_new_tokens
         self.blocksize = blocksize
@@ -155,11 +158,16 @@ class Qwen3TTSHandler(BaseHandler[TTSIn, TTSOut]):
         else:
             self.device = device
             self.model_name = model_name
-            logger.info(f"Loading Qwen3-TTS model: {self.model_name} via faster-qwen3-tts")
+            logger.info(
+                "Loading Qwen3-TTS model: %s via faster-qwen3-tts (%s backend)",
+                self.model_name,
+                self.faster_backend,
+            )
             self._setup_faster(
                 model_name=self.model_name,
                 dtype=dtype,
                 attn_implementation=attn_implementation,
+                backend=self.faster_backend,
             )
 
         logger.info(
@@ -174,7 +182,7 @@ class Qwen3TTSHandler(BaseHandler[TTSIn, TTSOut]):
 
         self.warmup()
 
-    def _setup_faster(self, model_name: str, dtype: Any, attn_implementation: str) -> None:
+    def _setup_faster(self, model_name: str, dtype: Any, attn_implementation: str, backend: str) -> None:
         try:
             import torch
         except ImportError as e:
@@ -192,7 +200,7 @@ class Qwen3TTSHandler(BaseHandler[TTSIn, TTSOut]):
         except ImportError as e:
             raise ImportError(
                 "faster-qwen3-tts is required for Qwen3 TTS on non-macOS platforms. "
-                "Install with: pip install faster-qwen3-tts"
+                "Install with: pip install 'faster-qwen3-tts[ggml]'"
             ) from e
 
         self.model = FasterQwen3TTS.from_pretrained(
@@ -200,6 +208,7 @@ class Qwen3TTSHandler(BaseHandler[TTSIn, TTSOut]):
             device=self.device,
             dtype=self.dtype,
             attn_implementation=attn_implementation,
+            backend=backend,
         )
         logger.info("Qwen3-TTS model loaded")
 
@@ -229,6 +238,14 @@ class Qwen3TTSHandler(BaseHandler[TTSIn, TTSOut]):
             ) from e
 
         logger.info("MLX Audio Qwen3-TTS model loaded")
+
+    def _normalize_faster_backend(self, backend: Any) -> str:
+        value = str(backend or "ggml").strip().lower()
+        if value not in VALID_FASTER_BACKENDS:
+            raise ValueError(
+                f"Unsupported qwen3_tts_backend value {backend!r}. Supported values: {', '.join(VALID_FASTER_BACKENDS)}"
+            )
+        return value
 
     def _normalize_mlx_quantization(self, mlx_quantization: Any) -> Optional[str]:
         if mlx_quantization is None:

--- a/src/speech_to_speech/arguments_classes/qwen3_tts_arguments.py
+++ b/src/speech_to_speech/arguments_classes/qwen3_tts_arguments.py
@@ -1,5 +1,5 @@
 from dataclasses import dataclass, field
-from typing import Optional
+from typing import Literal, Optional
 
 
 @dataclass
@@ -26,6 +26,12 @@ class Qwen3TTSHandlerArguments:
         default="eager",
         metadata={
             "help": "Attention implementation. Options: 'eager', 'flash_attention_2', 'sdpa'. Use 'eager' on Jetson. Default is 'eager'."
+        },
+    )
+    qwen3_tts_backend: Literal["ggml", "torch"] = field(
+        default="ggml",
+        metadata={
+            "help": "faster-qwen3-tts backend on non-macOS platforms. Options: 'ggml' or 'torch'. Default is 'ggml'. On Apple Silicon, mlx-audio is selected automatically and this option is ignored."
         },
     )
     qwen3_tts_ref_audio: Optional[str] = field(

--- a/tests/install_smoke.py
+++ b/tests/install_smoke.py
@@ -57,6 +57,7 @@ def _validate_package_defaults() -> None:
     assert qwen3_args.qwen3_tts_model_name == "Qwen/Qwen3-TTS-12Hz-1.7B-CustomVoice"
     assert qwen3_args.qwen3_tts_speaker == "Aiden"
     assert qwen3_args.qwen3_tts_language == "auto"
+    assert qwen3_args.qwen3_tts_backend == "ggml"
     assert qwen3_args.qwen3_tts_non_streaming_mode is True
     assert qwen3_args.qwen3_tts_ref_audio is None
     assert qwen3_args.qwen3_tts_mlx_quantization == "6bit"

--- a/tests/test_cli_defaults.py
+++ b/tests/test_cli_defaults.py
@@ -48,6 +48,7 @@ def test_release_defaults_match_responses_api_parakeet_qwen3_realtime_profile():
     assert qwen3_args.qwen3_tts_model_name == "Qwen/Qwen3-TTS-12Hz-1.7B-CustomVoice"
     assert qwen3_args.qwen3_tts_speaker == "Aiden"
     assert qwen3_args.qwen3_tts_language == "auto"
+    assert qwen3_args.qwen3_tts_backend == "ggml"
     assert qwen3_args.qwen3_tts_non_streaming_mode is True
     assert qwen3_args.qwen3_tts_ref_audio is None
     assert qwen3_args.qwen3_tts_mlx_quantization == "6bit"
@@ -102,6 +103,17 @@ def test_parse_arguments_default_backend_returns_openai_api():
     assert isinstance(args.language_model_handler_kwargs, LanguageModelHandlerArguments)
     assert args.responses_api_language_model_handler_kwargs.model_name == "gpt-5.4-mini"
     assert args.module_kwargs.llm_backend == "responses-api"
+
+
+def test_parse_arguments_accepts_qwen3_tts_backend_override():
+    original_argv = sys.argv[:]
+    try:
+        sys.argv = ["speech-to-speech", "--qwen3_tts_backend", "torch"]
+        args = parse_arguments()
+    finally:
+        sys.argv = original_argv
+
+    assert args.qwen3_tts_handler_kwargs.qwen3_tts_backend == "torch"
 
 
 def test_parse_arguments_transformers_backend():

--- a/tests/test_qwen3_tts_handler_backend.py
+++ b/tests/test_qwen3_tts_handler_backend.py
@@ -97,10 +97,11 @@ def test_setup_preserves_faster_backend_off_darwin(monkeypatch):
     def _setup_mlx(self, *args, **kwargs):
         raise AssertionError("Non-Darwin setup should not use the mlx backend")
 
-    def _setup_faster(self, model_name, dtype, attn_implementation):
+    def _setup_faster(self, model_name, dtype, attn_implementation, backend):
         recorded["model_name"] = model_name
         recorded["dtype"] = dtype
         recorded["attn_implementation"] = attn_implementation
+        recorded["backend"] = backend
 
     monkeypatch.setattr(qwen3_tts_module, "platform", "linux")
     monkeypatch.setattr(Qwen3TTSHandler, "_setup_mlx", _setup_mlx)
@@ -117,12 +118,36 @@ def test_setup_preserves_faster_backend_off_darwin(monkeypatch):
     )
 
     assert handler.backend == "faster_qwen3_tts"
+    assert handler.faster_backend == "ggml"
     assert handler.streaming_chunk_size == 8
     assert recorded == {
         "model_name": "Qwen/Qwen3-TTS-12Hz-0.6B-Base",
         "dtype": "float16",
         "attn_implementation": "sdpa",
+        "backend": "ggml",
     }
+
+
+def test_setup_passes_torch_backend_override_off_darwin(monkeypatch):
+    recorded = {}
+
+    def _setup_mlx(self, *args, **kwargs):
+        raise AssertionError("Non-Darwin setup should not use the mlx backend")
+
+    def _setup_faster(self, model_name, dtype, attn_implementation, backend):
+        recorded["backend"] = backend
+
+    monkeypatch.setattr(qwen3_tts_module, "platform", "linux")
+    monkeypatch.setattr(Qwen3TTSHandler, "_setup_mlx", _setup_mlx)
+    monkeypatch.setattr(Qwen3TTSHandler, "_setup_faster", _setup_faster)
+    monkeypatch.setattr(Qwen3TTSHandler, "warmup", lambda self: None)
+
+    handler = object.__new__(Qwen3TTSHandler)
+    handler.setup(Event(), backend="torch")
+
+    assert handler.backend == "faster_qwen3_tts"
+    assert handler.faster_backend == "torch"
+    assert recorded["backend"] == "torch"
 
 
 def test_setup_defaults_to_custom_voice_profile_off_darwin(monkeypatch):
@@ -131,10 +156,11 @@ def test_setup_defaults_to_custom_voice_profile_off_darwin(monkeypatch):
     def _setup_mlx(self, *args, **kwargs):
         raise AssertionError("Non-Darwin setup should not use the mlx backend")
 
-    def _setup_faster(self, model_name, dtype, attn_implementation):
+    def _setup_faster(self, model_name, dtype, attn_implementation, backend):
         recorded["model_name"] = model_name
         recorded["dtype"] = dtype
         recorded["attn_implementation"] = attn_implementation
+        recorded["backend"] = backend
 
     monkeypatch.setattr(qwen3_tts_module, "platform", "linux")
     monkeypatch.setattr(Qwen3TTSHandler, "_setup_mlx", _setup_mlx)
@@ -145,7 +171,9 @@ def test_setup_defaults_to_custom_voice_profile_off_darwin(monkeypatch):
     handler.setup(Event())
 
     assert handler.backend == "faster_qwen3_tts"
+    assert handler.faster_backend == "ggml"
     assert recorded["model_name"] == "Qwen/Qwen3-TTS-12Hz-1.7B-CustomVoice"
+    assert recorded["backend"] == "ggml"
     assert handler.ref_audio is None
     assert handler.speaker == "Aiden"
     assert handler.language == "auto"
@@ -169,7 +197,7 @@ def test_setup_normalizes_qwen3_language_aliases(monkeypatch, language, expected
     def _setup_mlx(self, *args, **kwargs):
         raise AssertionError("Non-Darwin setup should not use the mlx backend")
 
-    def _setup_faster(self, model_name, dtype, attn_implementation):
+    def _setup_faster(self, model_name, dtype, attn_implementation, backend):
         return None
 
     monkeypatch.setattr(qwen3_tts_module, "platform", "linux")
@@ -238,6 +266,16 @@ def test_setup_rejects_invalid_mlx_quantization(monkeypatch):
             model_name="Qwen/Qwen3-TTS-12Hz-0.6B-Base",
             mlx_quantization="5bit",
         )
+
+
+def test_setup_rejects_invalid_faster_backend(monkeypatch):
+    monkeypatch.setattr(qwen3_tts_module, "platform", "linux")
+    monkeypatch.setattr(Qwen3TTSHandler, "warmup", lambda self: None)
+
+    handler = object.__new__(Qwen3TTSHandler)
+
+    with pytest.raises(ValueError, match="Unsupported qwen3_tts_backend"):
+        handler.setup(Event(), backend="cuda")
 
 
 def test_mlx_helper_methods_use_model_config_and_streaming_conversion():


### PR DESCRIPTION
## Summary

- Default Qwen3-TTS on non-macOS platforms to the `faster-qwen3-tts` GGML backend.
- Add `--qwen3_tts_backend {ggml,torch}` so users can still choose the CUDA-graphs backend.
- Install `faster-qwen3-tts[ggml]>=0.3.0` on non-macOS platforms.
- Document the CUDA wheel expectations and the Hugging Face wheelhouse options for CUDA 13.x, CUDA 12.4, and CPU fallback.

## Why

The GGML backend gives faster Qwen3-TTS inference for the default realtime setup, but the default PyPI `qwentts-cpp-python` wheel targets CUDA 12.8. The docs now call out how to preinstall a matching wheel when the host runtime is different.

## Validation

- `uv run pytest tests/test_cli_defaults.py tests/test_qwen3_tts_handler_backend.py`
- `uv run python tests/install_smoke.py`
- `uv run ruff check src/speech_to_speech/TTS/qwen3_tts_handler.py src/speech_to_speech/arguments_classes/qwen3_tts_arguments.py tests/install_smoke.py tests/test_cli_defaults.py tests/test_qwen3_tts_handler_backend.py`
- `git diff --check`
