### PR TITLE
Fix two mid-generation conversation races (tool call & image)

### DIFF
--- a/src/speech_to_speech/LLM/base_openai_compatible_language_model.py
+++ b/src/speech_to_speech/LLM/base_openai_compatible_language_model.py
@@ -287,22 +287,39 @@ class BaseOpenAICompatibleHandler(BaseHandler[LLMIn, LLMOut], ABC):
         )
 
     def _record_tool_call(self, state: _GenState, turn: _Turn, item: ResponseFunctionToolCall) -> Iterator[LLMOut]:
-        """Append a tool call to history + the tools list, and emit it (unless the
-        turn went stale, in which case it is recorded but not spoken)."""
+        """Emit a tool call, persisting it (and any assistant text seen so far)
+        to history *before* it is forwarded to the client.
+
+        The function_call must already exist in the conversation by the time the
+        client returns its ``function_call_output``; otherwise a fast client
+        races ahead of the deferred end-of-turn write-back and the output is
+        rejected ("No function_call with call_id ... found"), which makes the
+        model re-issue the same tool call. The call lands in ``_pending_tool_calls``
+        (not serialized until its output pairs it), so eager recording is safe.
+
+        Out-of-band turns never touch the default conversation, and a stale turn
+        records nothing (it is not forwarded to the client either)."""
         state.tools.append(item)
-        state.pending.append(
-            RealtimeConversationItemFunctionCall(
-                type="function_call",
-                name=item.name,
-                arguments=item.arguments,
-                call_id=item.call_id,
-                id=item.id,
-                status=item.status,
-            )
+        fc_item = RealtimeConversationItemFunctionCall(
+            type="function_call",
+            name=item.name,
+            arguments=item.arguments,
+            call_id=item.call_id,
+            id=item.id,
+            status=item.status,
         )
         if self._generation_is_stale(turn.gen) or not self._turn_output_allowed(turn.turn_id, turn.turn_revision):
             logger.info("LLM generation cancelled (stale speculative turn)")
             return
+        if not is_out_of_band(turn.response):
+            # Flush assistant text accumulated before this call first (so history
+            # order matches what the client received), then persist the call —
+            # all before the chunk leaves for the client.
+            chat = turn.runtime_config.chat
+            for pending_item in state.pending:
+                chat.add_item(pending_item)
+            state.pending.clear()
+            chat.add_item(fc_item)
         yield self._chunk(turn, tools=[item])
 
     # ── consumption ─────────────────────────────────────────────────────────--
@@ -430,6 +447,10 @@ class BaseOpenAICompatibleHandler(BaseHandler[LLMIn, LLMOut], ABC):
         state = _GenState()
         error_message: str | None = None
         api_input = self._serialize(active_chat)
+        # Images the model actually sees this turn; only these are stripped on
+        # write-back, so an image a fast client injects mid-generation for the
+        # next turn survives (it is not in this serialized snapshot).
+        consumed_image_ids = active_chat.image_message_ids()
         if not api_input:
             # Nothing to send: empty `instructions` and no `input` (in the response,
             # the default conversation, or the out-of-band context). The provider
@@ -484,9 +505,11 @@ class BaseOpenAICompatibleHandler(BaseHandler[LLMIn, LLMOut], ABC):
             # Out-of-band responses emit output and usage but never write back to the
             # default conversation (their context was a throwaway chat).
             if not is_out_of_band(turn.response):
+                # Tool calls (and any assistant text preceding them) were already
+                # written eagerly in _record_tool_call; only trailing items remain.
                 for item in state.pending:
                     original_chat.add_item(item)
-                original_chat.strip_images()
+                original_chat.strip_images(consumed_image_ids)
                 original_chat.trim_if_needed(self.compactor)
             if state.input_tokens or state.output_tokens:
                 yield TokenUsage(

--- a/src/speech_to_speech/LLM/chat.py
+++ b/src/speech_to_speech/LLM/chat.py
@@ -458,15 +458,32 @@ class Chat:
             self._gen_counter += 1
             self._compact_in_flight = False
 
-    def strip_images(self) -> None:
-        """Remove all image content parts from user messages in the buffer.
+    def image_message_ids(self) -> set[str]:
+        """IDs of user messages currently carrying ``input_image`` content."""
+        with self._lock:
+            return {
+                item.id
+                for item in self.buffer
+                if isinstance(item, RealtimeConversationItemUserMessage)
+                and item.id is not None
+                and any(p.type == "input_image" for p in item.content)
+            }
+
+    def strip_images(self, only_ids: set[str] | None = None) -> None:
+        """Remove image content parts from user messages in the buffer.
 
         Called after appending the assistant response so images don't persist
-        across turns.
+        across turns. With *only_ids*, strip only those message IDs — the images
+        the just-completed response actually consumed (captured before the
+        request was sent). This leaves intact an image a fast client injected
+        mid-generation for the *next* turn, which the current response never saw.
+        Without *only_ids*, every image is stripped.
         """
         with self._lock:
             for item in self.buffer:
                 if isinstance(item, RealtimeConversationItemUserMessage):
+                    if only_ids is not None and item.id not in only_ids:
+                        continue
                     item.content = [p for p in item.content if p.type != "input_image"]
 
     # ── Compaction internals ──────────────────────────────────

--- a/src/speech_to_speech/LLM/language_model.py
+++ b/src/speech_to_speech/LLM/language_model.py
@@ -542,6 +542,10 @@ class BaseLanguageModelHandler(BaseHandler[LLMIn, LLMOut], ABC):
 
         gen = self.cancel_scope.generation if self.cancel_scope else None
         ctx.cancel_generation = gen
+        # Images the model sees this turn; only these are stripped on write-back,
+        # so an image a fast client injects mid-generation for the next turn
+        # survives (it is not in this serialized snapshot).
+        consumed_image_ids = active_chat.image_message_ids()
 
         try:
             yield from self._generate(active_chat, language_code, gen, ctx, runtime_config, response)
@@ -568,7 +572,7 @@ class BaseLanguageModelHandler(BaseHandler[LLMIn, LLMOut], ABC):
                         )
                     )
             if commit_allowed:
-                original_chat.strip_images()
+                original_chat.strip_images(consumed_image_ids)
                 original_chat.trim_if_needed(self.compactor)
             logger.debug("Clean text: %s", ctx.generated_text)
             logger.info(f"Tools: {ctx.tools}")

--- a/tests/test_chat.py
+++ b/tests/test_chat.py
@@ -837,6 +837,29 @@ class TestStripImages:
         assert chat.buffer[0].content[0].text == "just text"
         assert len(chat.buffer[0].content) == 1
 
+    def test_image_message_ids_reports_only_image_carriers(self):
+        chat = Chat(size=10)
+        chat.add_item(_user("text only"))
+        img_msg = chat.add_item(_user_msg_with_parts(("text", "b"), ("image", "url2")))
+        assert chat.image_message_ids() == {img_msg.id}
+
+    def test_strip_images_only_ids_spares_concurrent_image(self):
+        """Regression: an image injected for the *next* turn (not in the set the
+        finished response consumed) must survive the write-back strip."""
+        chat = Chat(size=10)
+        consumed = chat.add_item(_user_msg_with_parts(("text", "a"), ("image", "old")))
+        # snapshot of what the just-finished response actually saw
+        consumed_ids = chat.image_message_ids()
+        # a fast client injects the next turn's image mid-generation
+        fresh = chat.add_item(_user_msg_with_parts(("text", "b"), ("image", "new")))
+
+        chat.strip_images(consumed_ids)
+
+        consumed_after = next(i for i in chat.buffer if i.id == consumed.id)
+        fresh_after = next(i for i in chat.buffer if i.id == fresh.id)
+        assert all(p.type != "input_image" for p in consumed_after.content)  # consumed → stripped
+        assert any(p.type == "input_image" for p in fresh_after.content)  # next turn's image → kept
+
 
 # ===================================================================
 # 11. TestMarkCallCompleted

--- a/tests/test_chat_completions_backend.py
+++ b/tests/test_chat_completions_backend.py
@@ -301,6 +301,44 @@ def test_streaming_tool_call_accumulates_arguments():
     assert chat._pending_tool_calls, "tool call should be recorded in chat history"
 
 
+def test_tool_call_recorded_before_chunk_is_emitted():
+    """Regression: a fast client can return function_call_output before the
+    deferred end-of-turn write-back runs. The call must already be in history
+    the instant its chunk is yielded, otherwise the output is rejected with
+    'No function_call with call_id ... found' and the model re-issues the call."""
+    h = _make_handler(stream=True)
+    h.client.chat.completions.create = lambda **k: _FakeStream(
+        [
+            _chunk(content="Sure."),
+            _chunk(tool_calls=[_tc_delta(0, id="srv_1", name="camera_snapshot", arguments="{}")]),
+            _chunk(usage=SimpleNamespace(prompt_tokens=5, completion_tokens=2)),
+        ]
+    )
+    chat = Chat(10)
+    chat.add_item(make_user_message("take a photo"))
+    session = RealtimeSessionCreateRequest(type="realtime", instructions="Du bist ein Roboter.")
+    session.tools = [{"type": "function", "name": "camera_snapshot", "parameters": {"type": "object"}}]
+    rc = RuntimeConfig(chat=chat, session=session)
+    req = GenerateResponseRequest(runtime_config=rc, language_code="de", turn_id="t", turn_revision=0)
+
+    emitted_call_id = None
+    for out in h.process(req):
+        if isinstance(out, LLMResponseChunk) and out.tools:
+            emitted_call_id = out.tools[0].call_id
+            # At the moment the client receives the call, it must exist in history.
+            assert emitted_call_id in chat._pending_tool_calls, (
+                "function_call must be recorded BEFORE its chunk is forwarded to the client"
+            )
+            # A fast client returning the output here must pair cleanly (no raise).
+            chat.add_item(
+                RealtimeConversationItemFunctionCallOutput(
+                    type="function_call_output", call_id=emitted_call_id, output="ok"
+                )
+            )
+    assert emitted_call_id is not None, "a tool call should have been emitted"
+    assert chat._has_call_id_in_buffer(emitted_call_id), "call+output should be paired in the buffer"
+
+
 def test_non_streaming_tool_call():
     h = _make_handler(stream=False)
     h.client.chat.completions.create = lambda **k: SimpleNamespace(


### PR DESCRIPTION
## Problem

A client can mutate the conversation **while the LLM handler is still generating**. `conversation.item.create` (tool outputs, images, text) is applied on the asyncio/router thread, while a generation reads and writes the chat on the pipeline thread. `Chat._lock` makes each individual operation atomic, but **not** a generation's whole *serialize → generate → write-back* cycle — so a fast tool/image client reliably lands items in that window.

This surfaced as two concrete failures while testing a `camera_snapshot` round-trip against `/v1/responses`.

## Fixes

### 1. Tool call not in history when the client returns its output
The `function_call` was only recorded in the deferred end-of-turn write-back. A fast client returned its `function_call_output` first, so pairing failed with `No function_call with call_id ... found` and the model **re-issued the same tool call**.

`_record_tool_call` now persists the call (and any preceding assistant text, for correct history order) **before** the chunk is forwarded to the client. The call lands in `_pending_tool_calls` (not serialized until its output pairs it), so eager recording is safe; out-of-band and stale turns still record nothing.

### 2. Image stripped before the response that needed it
`strip_images()` ran in the write-back and removed **every** image in the buffer — including one a fast client injected mid-generation for the *next* turn. Token counts confirmed the model never saw the image and hallucinated a description.

We now capture the image-bearing message ids the request **actually consumed** (`Chat.image_message_ids()` at serialize time) and `strip_images(only_ids)` strips only those, sparing the next turn's image. Applied to both the OpenAI-compatible base handler and the legacy `language_model.py` handler.

## Tests
- `test_tool_call_recorded_before_chunk_is_emitted` — call is in `_pending_tool_calls` at chunk-emit time; a fast `function_call_output` pairs without raising.
- `test_image_message_ids_reports_only_image_carriers`, `test_strip_images_only_ids_spares_concurrent_image`.
- Full suite: **560 passing**; ruff + `ruff format` clean; mypy clean on changed files.

## Follow-up
A separate PR will add a defense-in-depth layer that buffers client `conversation.item.create` items while a response is active and flushes them at response-done, eliminating the whole class of mid-generation interleaving by construction. These targeted fixes remain valuable as layered safety.