### PR TITLE
Defer client conversation items during an active response

### DIFF
--- a/src/speech_to_speech/api/openai_realtime/handlers/conversation.py
+++ b/src/speech_to_speech/api/openai_realtime/handlers/conversation.py
@@ -37,27 +37,55 @@ class ConversationHandler(RealtimeBaseHandler):
         Items are added to the LLM chat context but do NOT trigger response
         generation on their own.  A subsequent ``response.create`` event is
         required to trigger the model.
-        """
-        events: list[ServerEvent] = []
-        item = event.item
 
+        While a response is generating, the item is *deferred*: applying it now
+        would race the LLM handler's end-of-turn chat write-back, which runs on
+        the pipeline thread (e.g. a ``function_call_output`` arriving before its
+        ``function_call`` is recorded, or an image stripped before the next
+        turn reads it). Deferred items are flushed, in order, once the response
+        completes — see :meth:`flush_deferred_items`.
+        """
+        st = self._state(conn_id)
+        if st.in_response:
+            st.deferred_items.append(event.item)
+            logger.debug("Deferred conversation item until the active response completes")
+            return []
+        return self._apply_item(conn_id, event.item)
+
+    def _apply_item(self, conn_id: str, item: ConversationItem) -> list[ServerEvent]:
+        """Add one item to the chat and build its ``conversation.item.created``."""
         try:
             self._append_item(conn_id, item)
         except ChatItemError as exc:
             return [self.make_error(str(exc), "invalid_conversation_item")]
 
-        if item:
-            st = self._state(conn_id)
-            events.append(
-                ConversationItemCreatedEvent(
-                    type="conversation.item.created",
-                    event_id=self._next_event_id(),
-                    previous_item_id=st.last_item_id,
-                    item=item,
-                )
-            )
-            st.last_item_id = item.id
+        if not item:
+            return []
+        st = self._state(conn_id)
+        event = ConversationItemCreatedEvent(
+            type="conversation.item.created",
+            event_id=self._next_event_id(),
+            previous_item_id=st.last_item_id,
+            item=item,
+        )
+        st.last_item_id = item.id
+        return [event]
 
+    def flush_deferred_items(self, conn_id: str) -> list[ServerEvent]:
+        """Apply items buffered during a response, in arrival order.
+
+        Called at response completion (after the generation's own write-back),
+        so a ``function_call_output`` pairs with its now-recorded ``function_call``
+        and an image survives the just-finished response's ``strip_images``.
+        """
+        st = self._state(conn_id)
+        if not st.deferred_items:
+            return []
+        items = st.deferred_items
+        st.deferred_items = []
+        events: list[ServerEvent] = []
+        for item in items:
+            events.extend(self._apply_item(conn_id, item))
         return events
 
     def _append_item(self, conn_id: str, item: ConversationItem) -> None:

--- a/src/speech_to_speech/api/openai_realtime/handlers/response.py
+++ b/src/speech_to_speech/api/openai_realtime/handlers/response.py
@@ -252,6 +252,10 @@ class ResponseHandler(RealtimeBaseHandler):
                 )
             )
             self._end_response(conn_id, status)
+        # Apply any client items that arrived mid-generation now that in_response
+        # is cleared and the generation's own write-back has landed. Done outside
+        # the in_response guard so a stray terminal call still drains the buffer.
+        events.extend(self._service.conversation.flush_deferred_items(conn_id))
         return events
 
     # ── Pipeline event handlers ───────────────────

--- a/src/speech_to_speech/api/openai_realtime/service.py
+++ b/src/speech_to_speech/api/openai_realtime/service.py
@@ -5,6 +5,7 @@ from threading import Event as ThreadingEvent
 from typing import Any, Callable, Literal, Optional, TypeVar, Union
 
 from openai.types.realtime import (
+    ConversationItem,
     ConversationItemCreatedEvent,
     ConversationItemCreateEvent,
     ConversationItemInputAudioTranscriptionCompletedEvent,
@@ -174,6 +175,11 @@ class ConnState(BaseModel):
     speculative_user_item_id: Optional[str] = None
     speculative_input_item_id: Optional[str] = None
     speculative_audio_duration_s: float = 0.0
+    # Client conversation.item.create items that arrived while a response was
+    # generating. Applying them mid-generation races the LLM handler's chat
+    # write-back (cross-thread), so they are buffered here and flushed in order
+    # once the response completes. See ConversationHandler.flush_deferred_items.
+    deferred_items: list[ConversationItem] = Field(default_factory=list)
 
 
 class RealtimeService:

--- a/tests/openai_realtime/test_realtime_service.py
+++ b/tests/openai_realtime/test_realtime_service.py
@@ -379,6 +379,87 @@ class TestHandleConversationItemCreate:
         assert last.content[1].image_url == "data:image/png;base64,abc123"
 
 
+class TestDeferConversationItemsDuringResponse:
+    """conversation.item.create is buffered while a response is generating and
+    flushed, in order, once it completes — so a client item never races the LLM
+    handler's chat write-back (which runs on the pipeline thread)."""
+
+    def _text_event(self, text: str, item_id: str = "msg_x") -> ConversationItemCreateEvent:
+        return ConversationItemCreateEvent(
+            type="conversation.item.create",
+            item={  # type: ignore[arg-type]
+                "id": item_id,
+                "type": "message",
+                "role": "user",
+                "content": [{"type": "input_text", "text": text}],
+            },
+        )
+
+    def _user_texts(self, chat) -> list[str]:
+        return [i.content[0].text for i in chat.buffer if getattr(i, "role", None) == "user"]
+
+    def test_applied_immediately_when_no_active_response(self, service, conn_id):
+        st = service._state(conn_id)
+        assert st.in_response is False
+        events = service.handle_conversation_item_create(conn_id, self._text_event("hi"))
+        assert len(events) == 1
+        assert isinstance(events[0], ConversationItemCreatedEvent)
+        assert self._user_texts(st.runtime_config.chat) == ["hi"]
+        assert st.deferred_items == []
+
+    def test_item_deferred_while_in_response(self, service, conn_id):
+        st = service._state(conn_id)
+        st.in_response = True
+        events = service.handle_conversation_item_create(conn_id, self._text_event("hi"))
+        assert events == []  # ack deferred too
+        assert len(st.deferred_items) == 1
+        assert self._user_texts(st.runtime_config.chat) == []  # not yet in chat
+
+    def test_deferred_items_flushed_in_order_on_finish(self, service, conn_id):
+        st = service._state(conn_id)
+        st.in_response = True
+        service.handle_conversation_item_create(conn_id, self._text_event("a", "msg_1"))
+        service.handle_conversation_item_create(conn_id, self._text_event("b", "msg_2"))
+        assert self._user_texts(st.runtime_config.chat) == []
+
+        events = service.finish_response(conn_id)
+
+        assert st.in_response is False
+        assert st.deferred_items == []
+        assert self._user_texts(st.runtime_config.chat) == ["a", "b"]  # arrival order preserved
+        created = [e for e in events if isinstance(e, ConversationItemCreatedEvent)]
+        assert len(created) == 2
+
+    def test_function_call_output_deferred_then_pairs_after_response(self, service, conn_id):
+        from openai.types.realtime.realtime_conversation_item_function_call import (
+            RealtimeConversationItemFunctionCall,
+        )
+
+        st = service._state(conn_id)
+        chat = st.runtime_config.chat
+        # The function_call the generation produced (held in _pending_tool_calls).
+        chat.add_item(
+            RealtimeConversationItemFunctionCall(
+                type="function_call", call_id="call_1", name="camera_snapshot", arguments="{}"
+            )
+        )
+        st.in_response = True
+        evt = ConversationItemCreateEvent(
+            type="conversation.item.create",
+            item={"type": "function_call_output", "output": "ok", "call_id": "call_1"},
+        )
+        # Output arrives mid-response: deferred (applying now could race), no error.
+        assert service.handle_conversation_item_create(conn_id, evt) == []
+        assert len(st.deferred_items) == 1
+
+        finish_events = service.finish_response(conn_id)
+
+        # Flushed after completion → pairs cleanly, no invalid_conversation_item error.
+        assert not any(isinstance(e, RealtimeErrorEvent) for e in finish_events)
+        assert chat._has_call_id_in_buffer("call_1")
+        assert chat.buffer[-1].type == "function_call_output"
+
+
 # ===================================================================
 # Audio commit
 # ===================================================================


### PR DESCRIPTION
## Why

`conversation.item.create` (tool outputs, images, text) is applied on the asyncio/router thread, while a response *generates* and writes the chat on the pipeline thread. `Chat._lock` makes each operation atomic, but a generation's whole *serialize → generate → write-back* cycle is not — so a client item applied mid-generation races the write-back. This is the **root cause** behind the two races fixed in #326 (tool call not yet recorded when the output returns; image stripped before the next turn reads it).

## What

Serialize all client conversation mutations to response boundaries:

- `ConnState.deferred_items` — items that arrived while `in_response` is set.
- `ConversationHandler.handle_conversation_item_create` — if a response is active, **buffer** the item (defer its `conversation.item.created` ack too); otherwise apply immediately as before.
- `ConversationHandler.flush_deferred_items` — apply buffered items in arrival order.
- `ResponseHandler.finish_response` — flush after `_end_response` (so `in_response` is cleared and the generation's own write-back has already landed).

Because buffering, flushing, and the `in_response` flag are all managed on the single asyncio thread, this adds no new cross-thread race; the pipeline's write-back is already ordered before `finish_response` via the output queue. The flush completes synchronously before `response.done` is sent, so the next `response.create` always sees the applied items.

Result: a `function_call_output` pairs with its now-recorded `function_call`, and an image survives the just-finished response's `strip_images` — by construction, not by per-site defenses.

## Relationship to #326

Complementary. #326 makes the two known consumers robust at the source (eager tool-call recording, consumed-image-id stripping). This PR removes the *whole class* of mid-generation interleaving. Both are worth keeping as layered defense; this PR is additive and independent (touches only the protocol layer).

## Tests
- `TestDeferConversationItemsDuringResponse`: immediate apply when idle; defer while `in_response`; in-order flush on finish; `function_call_output` deferred then pairs cleanly after completion (no `invalid_conversation_item` error).
- Full suite: **561 passing**; ruff + `ruff format` clean; mypy clean.

## Note to reviewers
The `conversation.item.created` ack for a deferred item now arrives at response-done rather than immediately. Compliant clients gate `response.create` on `response.done` (so it's masked), but worth confirming for any client that blocks on the ack mid-turn.