### PR TITLE
chore: remove deprecated melo option from tts arguments

### DIFF
--- a/src/speech_to_speech/arguments_classes/module_arguments.py
+++ b/src/speech_to_speech/arguments_classes/module_arguments.py
@@ -35,7 +35,7 @@ class ModuleArguments:
             "'chat-completions' (OpenAI-compatible /v1/chat/completions). Default is 'responses-api'."
         },
     )
-    tts: Optional[Literal["melo", "chatTTS", "facebookMMS", "pocket", "kokoro", "qwen3"]] = field(
+    tts: Optional[Literal["chatTTS", "facebookMMS", "pocket", "kokoro", "qwen3"]] = field(
         default="qwen3",
         metadata={
             "help": "The TTS to use. Either 'chatTTS', 'facebookMMS', 'pocket', 'kokoro', or 'qwen3'. Default is 'qwen3'."


### PR DESCRIPTION
Remove the deprecated and archived MeloTTS choice from the ModuleArguments class Literal option list to prevent potential runtime ValueErrors.