### PR TITLE
Fix Docker image build

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,5 +1,16 @@
 tmp
 cache
+.venv
+.git
+.mypy_cache
+.pytest_cache
+.ruff_cache
+__pycache__
+**/__pycache__
+*.py[cod]
+*.egg-info
+dist
+build
 Dockerfile
 docker-compose.yml
 .dockerignore

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,16 +1,27 @@
-FROM pytorch/pytorch:2.4.0-cuda12.1-cudnn9-devel
+FROM nvidia/cuda:12.8.1-cudnn-runtime-ubuntu24.04
 
-ENV PYTHONUNBUFFERED 1
+ENV DEBIAN_FRONTEND=noninteractive
+ENV PYTHONUNBUFFERED=1
 ENV PATH="/usr/src/app/.venv/bin:${PATH}"
 
 WORKDIR /usr/src/app
 
 # Install packages
-RUN apt-get update && apt-get install -y git && rm -rf /var/lib/apt/lists/*
-RUN pip install --no-cache-dir uv
+RUN apt-get update \
+    && apt-get install -y --no-install-recommends \
+        ca-certificates \
+        git \
+        libportaudio2 \
+        libsndfile1 \
+        python3 \
+        python3-pip \
+        python3-venv \
+    && rm -rf /var/lib/apt/lists/*
+RUN python3 -m pip install --no-cache-dir --break-system-packages uv
 
-COPY pyproject.toml ./
-RUN uv sync --no-install-project --no-dev
+COPY pyproject.toml README.md LICENSE MANIFEST.in ./
+RUN uv sync --python /usr/bin/python3 --no-install-project --no-dev
 
 COPY . .
-RUN uv sync --no-dev
+RUN uv sync --python /usr/bin/python3 --no-dev
+RUN python -c "import nltk; nltk.download('punkt_tab'); nltk.download('averaged_perceptron_tagger_eng')"

--- a/Dockerfile.arm64
+++ b/Dockerfile.arm64
@@ -1,16 +1,28 @@
-FROM nvcr.io/nvidia/l4t-pytorch:r35.2.1-pth2.0-py3
+ARG BASE_PLATFORM=linux/arm64
+FROM --platform=$BASE_PLATFORM nvidia/cuda:12.8.1-cudnn-runtime-ubuntu24.04
 
-ENV PYTHONUNBUFFERED 1
+ENV DEBIAN_FRONTEND=noninteractive
+ENV PYTHONUNBUFFERED=1
 ENV PATH="/usr/src/app/.venv/bin:${PATH}"
 
 WORKDIR /usr/src/app
 
 # Install packages
-RUN apt-get update && apt-get install -y git && rm -rf /var/lib/apt/lists/*
-RUN pip install --no-cache-dir uv
+RUN apt-get update \
+    && apt-get install -y --no-install-recommends \
+        ca-certificates \
+        git \
+        libportaudio2 \
+        libsndfile1 \
+        python3 \
+        python3-pip \
+        python3-venv \
+    && rm -rf /var/lib/apt/lists/*
+RUN python3 -m pip install --no-cache-dir --break-system-packages uv
 
-COPY pyproject.toml ./
-RUN uv sync --no-install-project --no-dev
+COPY pyproject.toml README.md LICENSE MANIFEST.in ./
+RUN uv sync --python /usr/bin/python3 --no-install-project --no-dev
 
 COPY . .
-RUN uv sync --no-dev
+RUN uv sync --python /usr/bin/python3 --no-dev
+RUN python -c "import nltk; nltk.download('punkt_tab'); nltk.download('averaged_perceptron_tagger_eng')"


### PR DESCRIPTION
## Summary
- Switch the Docker images to a multi-arch CUDA 12.8 Ubuntu 24.04 runtime and install the required Python, uv, and audio system packages.
- Tighten `.dockerignore` so local virtualenvs, caches, git metadata, and build artifacts are not sent to Docker.
- Bake the required NLTK resources into the image and fix the tagger lookup path used by the pipeline.

## Root Cause
- The previous CUDA 12.1 PyTorch base image is amd64-only on this ARM host, which caused the build to run under emulation and fail during dependency installation.
- `qwentts-cpp-python==0.3.0` depends on wheels requiring `manylinux_2_39`; Ubuntu 22.04 ships glibc 2.35, while Ubuntu 24.04 ships glibc 2.39.

## Validation
- `docker compose build pipeline`
- `docker compose build --check pipeline`
- `docker buildx build --check -f Dockerfile.arm64 .`
- `docker run --rm speech-to-speech-pipeline speech-to-speech --help`
- Container smoke import for `speech_to_speech`, `torch`, and `qwentts_cpp`
- `uv run pytest tests/test_cli_defaults.py -q`

Note: the resulting image is large because it includes CUDA runtime components and PyTorch wheels.