### PR TITLE
Add native Keenable web search for OpenAI-compatible LLM backends

### DIFF
--- a/README.md
+++ b/README.md
@@ -421,6 +421,39 @@ speech-to-speech \
     --responses_api_stream
 ```
 
+### Live web search with Keenable
+
+The OpenAI-compatible backends (`chat-completions` and `responses-api`) can give the
+assistant native access to the live web via [Keenable](https://docs.keenable.ai): the
+server advertises `web_search` and `fetch_page` tools to the model and executes them
+*inside the pipeline*, feeding results back to the model in the same turn. Clients need
+no tool handling — ask about news, weather, sports or prices and the spoken answer is
+grounded in a fresh search. Fast inference (e.g. Cerebras) is what makes the extra LLM
+round-trip per search comfortable in a voice loop.
+
+```bash
+# The Cerebras voice stack, now with live web answers
+export KEENABLE_API_KEY="keen_..."   # optional: keyless free tier works too
+speech-to-speech \
+    --mode realtime \
+    --stt parakeet-tdt \
+    --llm_backend chat-completions \
+    --tts qwen3 \
+    --model_name "google/gemma-4-31B-it:cerebras" \
+    --responses_api_base_url "https://router.huggingface.co/v1" \
+    --responses_api_api_key "$HF_TOKEN" \
+    --responses_api_reasoning_effort none \
+    --responses_api_stream \
+    --keenable_web_search
+```
+
+Flags: `--keenable_web_search` enables the tools, `--keenable_api_key` (or the
+`KEENABLE_API_KEY` env var) authenticates for higher rate limits, and
+`--tool_call_max_rounds` bounds search→answer rounds per turn (default 3, the last
+round always forces a spoken answer). A client-registered tool with the same name
+takes precedence, so existing clients that implement their own `web_search` keep
+working unchanged.
+
 ### Fully Local
 
 Run the LLM in a separate llama.cpp process for the lowest-friction fully local setup, as shown in the [Reachy Mini local conversation guide](https://huggingface.co/blog/local-reachy-mini-conversation):

--- a/src/speech_to_speech/LLM/README.md
+++ b/src/speech_to_speech/LLM/README.md
@@ -74,6 +74,15 @@ Common options:
 - `--init_chat_prompt`
 - `--user_role`
 
+### Live web search (Keenable, OpenAI-compatible backends only)
+
+Both `responses-api` and `chat-completions` accept `--keenable_web_search`: the handler
+advertises `web_search` / `fetch_page` tools backed by [Keenable](https://docs.keenable.ai)
+and executes them server-side (see `LLM/server_tools.py` and the agentic loop in
+`base_openai_compatible_language_model.py`). Optional `--keenable_api_key` /
+`KEENABLE_API_KEY` for authenticated rate limits, `--tool_call_max_rounds` (default 3)
+to bound search rounds per turn. Client-registered tools with the same name win.
+
 ## LLM Behavior
 
 When STT is set to language auto-detection (`--language auto`), LLM handlers can receive `(text, language_code)` and prepend a language control instruction like:

--- a/src/speech_to_speech/LLM/base_openai_compatible_language_model.py
+++ b/src/speech_to_speech/LLM/base_openai_compatible_language_model.py
@@ -3,7 +3,7 @@ from __future__ import annotations
 import logging
 from abc import ABC, abstractmethod
 from collections.abc import Iterator
-from typing import Any, Optional
+from typing import Any, Optional, cast
 
 import httpx
 from nltk import sent_tokenize
@@ -11,6 +11,7 @@ from openai import OpenAI
 from openai.types.realtime.conversation_item import (
     RealtimeConversationItemAssistantMessage,
     RealtimeConversationItemFunctionCall,
+    RealtimeConversationItemFunctionCallOutput,
 )
 from openai.types.realtime.realtime_conversation_item_assistant_message import (
     Content as AssistantContent,
@@ -28,6 +29,7 @@ from speech_to_speech.LLM.chat import (
     make_user_message,
 )
 from speech_to_speech.LLM.compaction_prompt import CompactGenerateFn, build_compactor
+from speech_to_speech.LLM.server_tools import KeenableWebTools
 from speech_to_speech.LLM.text_prompt import build_text_system_prompt
 from speech_to_speech.LLM.utils import remove_unspeechable, resolve_auto_language
 from speech_to_speech.LLM.voice_prompt import build_voice_system_prompt
@@ -92,6 +94,9 @@ class _Turn(BaseModel):
     turn_revision: int | None
     speech_stopped_at_s: float | None
     wants_audio: bool
+    # Names of server-executed tools active for this turn. A client-registered
+    # tool with the same name wins (its calls are forwarded, not intercepted).
+    server_tool_names: frozenset[str] = frozenset()
 
 
 class _GenState(BaseModel):
@@ -100,6 +105,9 @@ class _GenState(BaseModel):
     model_config = ConfigDict(arbitrary_types_allowed=True)
 
     tools: list[ResponseFunctionToolCall] = Field(default_factory=list)
+    # Tool calls owned by the server-side executor (e.g. Keenable web search);
+    # they are run in-pipeline instead of being forwarded to the client.
+    server_calls: list[ResponseFunctionToolCall] = Field(default_factory=list)
     pending: list[SupportedItem] = Field(default_factory=list)
     clean_text: str = ""  # filtered text, kept only for the debug log
     input_tokens: int = 0
@@ -117,6 +125,11 @@ class BaseOpenAICompatibleHandler(BaseHandler[LLMIn, LLMOut], ABC):
     sentence batching, text-only vs audio handling, history write-back, token
     usage, out-of-band handling and error termination.
     """
+
+    # Class-level defaults so partially-initialised handlers (tests, subclasses
+    # overriding setup) behave as if server tools are disabled.
+    server_tools: KeenableWebTools | None = None
+    tool_call_max_rounds: int = 3
 
     # ── setup ─────────────────────────────────────────────────────────────────
 
@@ -137,6 +150,9 @@ class BaseOpenAICompatibleHandler(BaseHandler[LLMIn, LLMOut], ABC):
         stream_batch_sentences: int = 3,
         enable_lang_prompt: bool = False,
         compact_history: bool = False,
+        keenable_web_search: bool = False,
+        keenable_api_key: Optional[str] = None,
+        tool_call_max_rounds: int = 3,
         **_kwargs: Any,
     ) -> None:
         self.cancel_scope = cancel_scope
@@ -153,6 +169,8 @@ class BaseOpenAICompatibleHandler(BaseHandler[LLMIn, LLMOut], ABC):
         )
 
         self.user_role = user_role
+        self.server_tools = KeenableWebTools(api_key=keenable_api_key) if keenable_web_search else None
+        self.tool_call_max_rounds = max(1, tool_call_max_rounds)
         self.client = OpenAI(api_key=api_key, base_url=base_url)
         self._extra_body = self._build_extra_body(base_url, disable_thinking, reasoning_effort)
         self.compactor = build_compactor(self._build_compaction_generate_fn()) if compact_history else None
@@ -344,8 +362,9 @@ class BaseOpenAICompatibleHandler(BaseHandler[LLMIn, LLMOut], ABC):
                 break
 
             if isinstance(event, Usage):
-                state.input_tokens = event.input_tokens
-                state.output_tokens = event.output_tokens
+                # += so usage accumulates across server-tool follow-up rounds.
+                state.input_tokens += event.input_tokens
+                state.output_tokens += event.output_tokens
             elif isinstance(event, AssistantMessage):
                 state.pending.append(
                     RealtimeConversationItemAssistantMessage(type="message", role="assistant", content=event.content)
@@ -362,7 +381,10 @@ class BaseOpenAICompatibleHandler(BaseHandler[LLMIn, LLMOut], ABC):
                         break
                     yield from _flush(sentence_batch)
                     sentence_batch = []
-                yield from self._record_tool_call(state, turn, event.item)
+                if event.item.name in turn.server_tool_names:
+                    state.server_calls.append(event.item)
+                else:
+                    yield from self._record_tool_call(state, turn, event.item)
             elif isinstance(event, TextDelta):
                 if not turn.wants_audio:
                     # Text-only: forward verbatim. Keep every character (no
@@ -411,14 +433,18 @@ class BaseOpenAICompatibleHandler(BaseHandler[LLMIn, LLMOut], ABC):
             return
         for event in events:
             if isinstance(event, Usage):
-                state.input_tokens = event.input_tokens
-                state.output_tokens = event.output_tokens
+                # += so usage accumulates across server-tool follow-up rounds.
+                state.input_tokens += event.input_tokens
+                state.output_tokens += event.output_tokens
             elif isinstance(event, AssistantMessage):
                 state.pending.append(
                     RealtimeConversationItemAssistantMessage(type="message", role="assistant", content=event.content)
                 )
             elif isinstance(event, ToolCall):
-                yield from self._record_tool_call(state, turn, event.item)
+                if event.item.name in turn.server_tool_names:
+                    state.server_calls.append(event.item)
+                else:
+                    yield from self._record_tool_call(state, turn, event.item)
             elif isinstance(event, TextDelta):
                 # Text-only keeps every character verbatim; audio strips
                 # TTS-unfriendly symbols via remove_unspeechable.
@@ -436,6 +462,50 @@ class BaseOpenAICompatibleHandler(BaseHandler[LLMIn, LLMOut], ABC):
 
     # ── orchestration ─────────────────────────────────────────────────────────
 
+    def _execute_server_tool_calls(
+        self,
+        state: _GenState,
+        turn: _Turn,
+        active_chat: Chat,
+        original_chat: Chat,
+    ) -> None:
+        """Run the round's server-owned tool calls and write the results to history.
+
+        Interim assistant text and each ``function_call``/``function_call_output``
+        pair go into the active chat (so the follow-up request sees them) and,
+        for regular turns, into the original chat (durable history). Out-of-band
+        turns never touch the default conversation.
+        """
+        assert self.server_tools is not None
+
+        def persist(item: SupportedItem) -> None:
+            active_chat.add_item(item)
+            if not is_out_of_band(turn.response):
+                original_chat.add_item(item.model_copy(deep=True))
+
+        for pending_item in state.pending:
+            persist(pending_item)
+        state.pending.clear()
+        for call in state.server_calls:
+            output = self.server_tools.execute(call.name, call.arguments)
+            persist(
+                RealtimeConversationItemFunctionCall(
+                    type="function_call",
+                    name=call.name,
+                    arguments=call.arguments,
+                    call_id=call.call_id,
+                    id=call.id,
+                    status="completed",
+                )
+            )
+            persist(
+                RealtimeConversationItemFunctionCallOutput(
+                    type="function_call_output",
+                    call_id=call.call_id,
+                    output=output,
+                )
+            )
+
     def _generate(
         self,
         active_chat: Chat,
@@ -443,59 +513,90 @@ class BaseOpenAICompatibleHandler(BaseHandler[LLMIn, LLMOut], ABC):
         turn: _Turn,
         optional_kwargs: dict[str, Any],
     ) -> Iterator[LLMOut]:
-        api_response: Any = None
         state = _GenState()
         error_message: str | None = None
-        api_input = self._serialize(active_chat)
         # Images the model actually sees this turn; only these are stripped on
         # write-back, so an image a fast client injects mid-generation for the
         # next turn survives (it is not in this serialized snapshot).
         consumed_image_ids = active_chat.image_message_ids()
-        if not api_input:
-            # Nothing to send: empty `instructions` and no `input` (in the response,
-            # the default conversation, or the out-of-band context). The provider
-            # would reject this; fail with a clear message instead of an opaque error.
-            error_message = "Cannot generate a response: no instructions and no input were provided."
+        # With server tools enabled the turn becomes a bounded agentic loop:
+        # execute the model's server-owned tool calls in-pipeline, feed the
+        # outputs back, and re-request until the model answers in text.
+        max_rounds = self.tool_call_max_rounds if turn.server_tool_names else 1
 
-        try:
-            if error_message is None:
-                api_response = self._request(api_input, optional_kwargs)
-            if api_response is not None:
-                events = self._iter_events(api_response)
-                if self.stream:
-                    yield from self._consume_streaming(events, state, turn)
-                else:
-                    yield from self._consume_nonstreaming(events, state, turn)
-        except httpx.ReadTimeout:
-            logger.warning(
-                "OpenAI API read timed out after %.1fs; ending the current response",
-                self.request_timeout_s,
-            )
-            if not self._generation_is_stale(turn.gen) and self._turn_output_allowed(turn.turn_id, turn.turn_revision):
-                # Canned apology carries no language_code (mirrors the prior handlers).
-                yield LLMResponseChunk(
-                    text="Wow I'm a bit slow today, could you repeat that?",
-                    runtime_config=turn.runtime_config,
-                    response=turn.response,
-                    turn_id=turn.turn_id,
-                    turn_revision=turn.turn_revision,
-                    speech_stopped_at_s=turn.speech_stopped_at_s,
-                    cancel_generation=turn.gen,
+        for round_idx in range(max_rounds):
+            state.server_calls.clear()
+            round_kwargs = optional_kwargs
+            if turn.server_tool_names and max_rounds > 1 and round_idx == max_rounds - 1:
+                # Final permitted round: force a spoken answer over yet another call.
+                round_kwargs = {**optional_kwargs, "tool_choice": "none"}
+            api_response: Any = None
+            timed_out = False
+            api_input = self._serialize(active_chat)
+            if not api_input:
+                # Nothing to send: empty `instructions` and no `input` (in the response,
+                # the default conversation, or the out-of-band context). The provider
+                # would reject this; fail with a clear message instead of an opaque error.
+                error_message = "Cannot generate a response: no instructions and no input were provided."
+
+            try:
+                if error_message is None:
+                    api_response = self._request(api_input, round_kwargs)
+                if api_response is not None:
+                    events = self._iter_events(api_response)
+                    if self.stream:
+                        yield from self._consume_streaming(events, state, turn)
+                    else:
+                        yield from self._consume_nonstreaming(events, state, turn)
+            except httpx.ReadTimeout:
+                logger.warning(
+                    "OpenAI API read timed out after %.1fs; ending the current response",
+                    self.request_timeout_s,
                 )
-        except Exception as exc:
-            # Any other generation failure must still terminate the response: record
-            # the error and fall through to the EndOfResponse below. Without this the
-            # exception would escape process() and no EndOfResponse would be emitted,
-            # leaving st.in_response stuck and locking every subsequent response.
-            logger.exception("LLM generation failed; ending the current response")
-            if error_message is None:
-                error_message = f"Language model generation failed: {exc}"
-        finally:
-            if api_response is not None and hasattr(api_response, "close"):
-                try:
-                    api_response.close()
-                except Exception:
-                    pass
+                timed_out = True
+                if not self._generation_is_stale(turn.gen) and self._turn_output_allowed(
+                    turn.turn_id, turn.turn_revision
+                ):
+                    # Canned apology carries no language_code (mirrors the prior handlers).
+                    yield LLMResponseChunk(
+                        text="Wow I'm a bit slow today, could you repeat that?",
+                        runtime_config=turn.runtime_config,
+                        response=turn.response,
+                        turn_id=turn.turn_id,
+                        turn_revision=turn.turn_revision,
+                        speech_stopped_at_s=turn.speech_stopped_at_s,
+                        cancel_generation=turn.gen,
+                    )
+            except Exception as exc:
+                # Any other generation failure must still terminate the response: record
+                # the error and fall through to the EndOfResponse below. Without this the
+                # exception would escape process() and no EndOfResponse would be emitted,
+                # leaving st.in_response stuck and locking every subsequent response.
+                logger.exception("LLM generation failed; ending the current response")
+                if error_message is None:
+                    error_message = f"Language model generation failed: {exc}"
+            finally:
+                if api_response is not None and hasattr(api_response, "close"):
+                    try:
+                        api_response.close()
+                    except Exception:
+                        pass
+
+            if timed_out or error_message is not None or not state.server_calls or round_idx == max_rounds - 1:
+                # No follow-up request will happen after the final round, so a
+                # tool call the model insists on there is dropped, not executed.
+                break
+            if self._generation_is_stale(turn.gen) or not self._turn_is_latest(turn.turn_id, turn.turn_revision):
+                logger.info("Skipping server tool execution (turn cancelled)")
+                break
+            logger.info(
+                "Executing %d server tool call(s), round %d/%d: %s",
+                len(state.server_calls),
+                round_idx + 1,
+                max_rounds,
+                [c.name for c in state.server_calls],
+            )
+            self._execute_server_tool_calls(state, turn, active_chat, original_chat)
 
         if (
             error_message is None
@@ -552,6 +653,25 @@ class BaseOpenAICompatibleHandler(BaseHandler[LLMIn, LLMOut], ABC):
         req_tool_choice = (
             response.tool_choice if response and response.tool_choice else runtime_config.session.tool_choice
         )
+        server_tool_names: frozenset[str] = frozenset()
+        if self.server_tools is not None:
+            # Advertise the server-executed tools alongside any client tools. A
+            # client-registered tool with the same name wins: it is neither
+            # re-advertised nor intercepted, preserving existing client behaviour.
+            client_tool_names = set()
+            for t in req_tools or []:
+                d = t if isinstance(t, dict) else t.model_dump(exclude_none=True)
+                name = d.get("name") or (d.get("function") or {}).get("name")
+                if name:
+                    client_tool_names.add(name)
+            server_defs = [d for d in self.server_tools.tool_definitions if d["name"] not in client_tool_names]
+            if server_defs:
+                # The session's tool list is a realtime-typed union; the flat dicts
+                # are accepted by both backends' request builders.
+                req_tools = cast("Any", list(req_tools or []) + server_defs)
+                server_tool_names = frozenset(d["name"] for d in server_defs)
+                guidance = self.server_tools.voice_guidance()
+                instructions = f"{instructions}\n\n{guidance}" if instructions else guidance
         wants_audio = response_wants_audio(response)
         self._apply_config(active_chat, instructions, wants_audio)
         language_code, lang_name = resolve_auto_language(language_code)
@@ -574,6 +694,7 @@ class BaseOpenAICompatibleHandler(BaseHandler[LLMIn, LLMOut], ABC):
             turn_revision=turn_revision,
             speech_stopped_at_s=speech_stopped_at_s,
             wants_audio=wants_audio,
+            server_tool_names=server_tool_names,
         )
         yield from self._generate(active_chat, original_chat, turn, optional_kwargs)
 

--- a/src/speech_to_speech/LLM/server_tools.py
+++ b/src/speech_to_speech/LLM/server_tools.py
@@ -1,0 +1,251 @@
+"""Server-executed web tools backed by the Keenable API (https://docs.keenable.ai).
+
+These tools are advertised to the language model alongside any client-registered
+tools, but they are executed *inside* the pipeline by
+:class:`~speech_to_speech.LLM.base_openai_compatible_language_model.BaseOpenAICompatibleHandler`:
+the tool call never reaches the realtime client, its output is written to the
+conversation as a ``function_call_output``, and the model is re-queried in the
+same turn. Any realtime client therefore gets live-web answers with no tool
+handling of its own.
+
+Keenable is keyless by default (rate-limited free tier); an API key
+(``keen_...``, via ``--keenable_api_key`` or the ``KEENABLE_API_KEY`` env var)
+switches to the authenticated endpoints.
+"""
+
+from __future__ import annotations
+
+import ipaddress
+import json
+import logging
+import os
+import time
+from datetime import datetime
+from typing import Any
+from urllib.parse import urlsplit
+
+import httpx
+
+from speech_to_speech.LLM.tool_call.function_tool import FunctionTool
+
+logger = logging.getLogger(__name__)
+
+_DEFAULT_BASE_URL = "https://api.keenable.ai"
+_BASE_URL_ENV = "KEENABLE_API_URL"
+_API_KEY_ENV = "KEENABLE_API_KEY"
+
+WEB_SEARCH_TOOL = FunctionTool(
+    type="function",
+    name="web_search",
+    description=(
+        "Search the live web. Use for anything recent or uncertain: news, current events, "
+        "weather, sports, prices, schedules, releases, or facts that may have changed since "
+        "your training. Returns ranked results with titles, URLs, descriptions and snippets."
+    ),
+    parameters={
+        "type": "object",
+        "properties": {
+            "query": {
+                "type": "string",
+                "description": "The search query. Describe the ideal page in natural language.",
+            },
+            "site": {
+                "type": "string",
+                "description": "Optional: restrict results to one domain, e.g. 'reuters.com'.",
+            },
+            "published_after": {
+                "type": "string",
+                "description": "Optional: only pages published after this date ('YYYY-MM-DD' or relative like '7d').",
+            },
+        },
+        "required": ["query"],
+    },
+)
+
+FETCH_PAGE_TOOL = FunctionTool(
+    type="function",
+    name="fetch_page",
+    description=(
+        "Fetch a web page's main content as markdown. Use after web_search when a snippet "
+        "is not enough and you need to read the page itself."
+    ),
+    parameters={
+        "type": "object",
+        "properties": {
+            "url": {
+                "type": "string",
+                "description": "The http(s) URL of the page to fetch (usually from a web_search result).",
+            },
+        },
+        "required": ["url"],
+    },
+)
+
+
+def _reject_private_fetch_target(url: str) -> str | None:
+    """Return an error message when *url* points at a private/internal target.
+
+    The Keenable backend enforces this server-side too; the client-side guard
+    avoids sending internal hostnames off-box in the first place. Only IP
+    literals and well-known internal names are checked — DNS names fall through
+    to the backend's guard.
+    """
+    parts = urlsplit(url)
+    if parts.scheme not in ("http", "https"):
+        return f"Refusing to fetch a non-http(s) URL: {url!r}"
+    host = (parts.hostname or "").strip().lower().rstrip(".")
+    if not host:
+        return f"Refusing to fetch a URL with no host: {url!r}"
+    if host in ("localhost", "metadata.google.internal"):
+        return f"Refusing to fetch a private/internal host: {host!r}"
+    try:
+        ip = ipaddress.ip_address(host)
+    except ValueError:
+        return None
+    if ip.is_loopback or ip.is_private or ip.is_link_local or ip.is_multicast or ip.is_unspecified:
+        return f"Refusing to fetch a private/internal address: {host!r}"
+    return None
+
+
+class KeenableWebTools:
+    """Keenable-backed ``web_search`` / ``fetch_page`` tools with a shared HTTP client.
+
+    ``execute`` never raises: transport and API failures come back as an
+    ``{"error": ...}`` JSON string so the model can recover conversationally
+    instead of the turn dying.
+    """
+
+    def __init__(
+        self,
+        api_key: str | None = None,
+        timeout_s: float = 10.0,
+        max_results: int = 5,
+        snippet_max_chars: int = 600,
+        fetch_max_chars: int = 6000,
+        transport: httpx.BaseTransport | None = None,
+    ) -> None:
+        self.api_key = api_key or os.environ.get(_API_KEY_ENV) or None
+        self.max_results = max_results
+        self.snippet_max_chars = snippet_max_chars
+        self.fetch_max_chars = fetch_max_chars
+        base_url = (os.environ.get(_BASE_URL_ENV) or _DEFAULT_BASE_URL).rstrip("/")
+        headers = {"User-Agent": "speech-to-speech-keenable/1.0"}
+        if self.api_key:
+            headers["X-API-Key"] = self.api_key
+        # Keyless traffic uses the public endpoints (rate-limited free tier).
+        self._path_suffix = "" if self.api_key else "/public"
+        self._client = httpx.Client(base_url=base_url, headers=headers, timeout=timeout_s, transport=transport)
+        self._handlers = {
+            WEB_SEARCH_TOOL.name: self._web_search,
+            FETCH_PAGE_TOOL.name: self._fetch_page,
+        }
+
+    @property
+    def tool_definitions(self) -> list[dict[str, Any]]:
+        """Flat Responses-API-style function tool dicts, ready to merge into a request."""
+        return [t.model_dump(exclude_none=True) for t in (WEB_SEARCH_TOOL, FETCH_PAGE_TOOL)]
+
+    def voice_guidance(self) -> str:
+        """System-prompt suffix teaching the model when/how to use the tools in a voice chat."""
+        today = datetime.now().strftime("%A, %B %d, %Y")
+        return (
+            f"Today's date is {today}. You can access the live web with the web_search and "
+            "fetch_page tools; they run on the server and return results to you immediately, "
+            "so call them whenever the user asks about news, weather, sports, prices, or any "
+            "fact that may have changed recently. Call the tool immediately and silently: no "
+            "announcements, no permission-asking, no filler like 'Let me check' — results come "
+            "back fast enough to answer right away. When answering from web results, stay "
+            "spoken-friendly: summarize in one or two short sentences, name the source when "
+            "useful, and never read URLs or long lists aloud."
+        )
+
+    def owns(self, name: str) -> bool:
+        return name in self._handlers
+
+    def execute(self, name: str, arguments_json: str) -> str:
+        """Run tool *name* with the model-provided JSON arguments; always returns JSON."""
+        try:
+            arguments = json.loads(arguments_json or "{}")
+            if not isinstance(arguments, dict):
+                raise ValueError("arguments must be a JSON object")
+        except (json.JSONDecodeError, ValueError) as exc:
+            return self._error(f"Invalid tool arguments: {exc}")
+        handler = self._handlers.get(name)
+        if handler is None:
+            return self._error(f"Unknown tool: {name}")
+        try:
+            return handler(arguments)
+        except httpx.TimeoutException:
+            return self._error("The web request timed out.")
+        except httpx.HTTPStatusError as exc:
+            detail = ""
+            try:
+                detail = exc.response.json().get("error") or ""
+            except Exception:
+                pass
+            return self._error(f"Keenable API error {exc.response.status_code}: {detail}".strip())
+        except httpx.HTTPError as exc:
+            return self._error(f"Web request failed: {exc}")
+
+    @staticmethod
+    def _error(message: str) -> str:
+        logger.warning("Keenable tool error: %s", message)
+        return json.dumps({"error": message}, ensure_ascii=False)
+
+    def _web_search(self, arguments: dict[str, Any]) -> str:
+        query = arguments.get("query")
+        if not query or not isinstance(query, str):
+            return self._error("web_search requires a 'query' string argument.")
+        # "realtime" mode trades a little depth for consistent ~200ms responses —
+        # the right point on the curve when a spoken reply is waiting on it.
+        payload: dict[str, Any] = {"query": query, "mode": "realtime"}
+        for key in ("site", "published_after"):
+            value = arguments.get(key)
+            if value and isinstance(value, str):
+                payload[key] = value
+        started = time.perf_counter()
+        response = self._client.post(f"/v1/search{self._path_suffix}", json=payload)
+        took_ms = (time.perf_counter() - started) * 1000
+        response.raise_for_status()
+        results = response.json().get("results") or []
+        compact = [
+            {
+                "title": r.get("title"),
+                "url": r.get("url"),
+                "description": r.get("description"),
+                "snippet": (r.get("snippet") or "")[: self.snippet_max_chars] or None,
+                "published_at": r.get("published_at"),
+            }
+            for r in results[: self.max_results]
+        ]
+        logger.info("Keenable web_search(%r) -> %d results in %.0f ms", query, len(compact), took_ms)
+        return json.dumps({"results": compact}, ensure_ascii=False)
+
+    def _fetch_page(self, arguments: dict[str, Any]) -> str:
+        url = arguments.get("url")
+        if not url or not isinstance(url, str):
+            return self._error("fetch_page requires a 'url' string argument.")
+        rejection = _reject_private_fetch_target(url)
+        if rejection is not None:
+            return self._error(rejection)
+        params: dict[str, Any] = {"url": url, "max_chars": self.fetch_max_chars}
+        started = time.perf_counter()
+        response = self._client.get(f"/v1/fetch{self._path_suffix}", params=params)
+        if response.status_code == 404:
+            # Not in the index yet — retry live from the source.
+            response = self._client.get(f"/v1/fetch{self._path_suffix}", params={**params, "live": True})
+        took_ms = (time.perf_counter() - started) * 1000
+        response.raise_for_status()
+        data = response.json()
+        logger.info("Keenable fetch_page(%r) -> %d chars in %.0f ms", url, len(data.get("content") or ""), took_ms)
+        return json.dumps(
+            {
+                "url": data.get("url"),
+                "title": data.get("title"),
+                "content": data.get("content"),
+            },
+            ensure_ascii=False,
+        )
+
+    def close(self) -> None:
+        self._client.close()

--- a/src/speech_to_speech/arguments_classes/responses_api_language_model_arguments.py
+++ b/src/speech_to_speech/arguments_classes/responses_api_language_model_arguments.py
@@ -32,3 +32,24 @@ class ResponsesApiLanguageModelHandlerArguments(LanguageModelBaseArguments):
             "For Together Qwen3.5 models this sends chat_template_kwargs.enable_thinking=false."
         },
     )
+    keenable_web_search: bool = field(
+        default=False,
+        metadata={
+            "help": "Enable native live web search: the server advertises Keenable web_search/fetch_page tools "
+            "to the model and executes them inside the pipeline, so clients need no tool handling. Default is False."
+        },
+    )
+    keenable_api_key: Optional[str] = field(
+        default=None,
+        metadata={
+            "help": "Keenable API key (keen_...). Falls back to the KEENABLE_API_KEY env var; with no key the "
+            "keyless rate-limited free tier is used. Default is None."
+        },
+    )
+    tool_call_max_rounds: int = field(
+        default=3,
+        metadata={
+            "help": "Maximum LLM rounds per turn when server-executed tools (Keenable web search) are enabled; "
+            "the final round forces a spoken answer. Default is 3."
+        },
+    )

--- a/tests/test_keenable_tool_loop.py
+++ b/tests/test_keenable_tool_loop.py
@@ -1,0 +1,349 @@
+"""Tests for server-side (Keenable) tool execution in the OpenAI-compatible LLM handler.
+
+The OpenAI client is faked with a scripted sequence of responses, and the
+Keenable executor is stubbed, so the agentic loop in ``_generate`` is exercised
+fully in-process: advertise tools -> intercept server-owned calls -> execute ->
+write function_call/function_call_output to history -> re-request -> speak.
+
+Run with pytest, or standalone:  python tests/test_keenable_tool_loop.py
+"""
+
+from __future__ import annotations
+
+import json
+import queue
+import threading
+from types import SimpleNamespace
+
+from openai.types.realtime.conversation_item import (
+    RealtimeConversationItemFunctionCall,
+    RealtimeConversationItemFunctionCallOutput,
+)
+from openai.types.realtime.realtime_session_create_request import RealtimeSessionCreateRequest
+
+import speech_to_speech.LLM.base_openai_compatible_language_model as base_mod
+import speech_to_speech.LLM.chat_completions_language_model as ccm
+from speech_to_speech.api.openai_realtime.runtime_config import RuntimeConfig
+from speech_to_speech.LLM.chat import Chat, make_user_message
+from speech_to_speech.LLM.chat_completions_language_model import ChatCompletionsApiModelHandler
+from speech_to_speech.pipeline.messages import (
+    EndOfResponse,
+    GenerateResponseRequest,
+    LLMResponseChunk,
+    TokenUsage,
+)
+
+# ── Fakes ────────────────────────────────────────────────────────────────────
+
+
+class _FakeStream:
+    """Iterable stand-in for openai.Stream; yields preset chunks."""
+
+    def __init__(self, chunks):
+        self._chunks = chunks
+
+    def __iter__(self):
+        return iter(self._chunks)
+
+    def close(self):
+        pass
+
+
+# Make the handler's ``isinstance(resp, Stream)`` check recognise our fake.
+ccm.Stream = _FakeStream
+
+
+class _StubKeenable:
+    """Stands in for KeenableWebTools: records calls, returns canned output."""
+
+    def __init__(self):
+        self.calls: list[tuple[str, str]] = []
+        self.result = json.dumps({"results": [{"title": "Sunny", "url": "https://w.example"}]})
+
+    @property
+    def tool_definitions(self):
+        return [
+            {"type": "function", "name": "web_search", "description": "d", "parameters": {"type": "object"}},
+            {"type": "function", "name": "fetch_page", "description": "d", "parameters": {"type": "object"}},
+        ]
+
+    def voice_guidance(self):
+        return "GUIDANCE"
+
+    def owns(self, name):
+        return name in ("web_search", "fetch_page")
+
+    def execute(self, name, arguments_json):
+        self.calls.append((name, arguments_json))
+        return self.result
+
+
+class _SeqCompletions:
+    """Fake chat.completions returning a scripted sequence of responses."""
+
+    def __init__(self, results):
+        self.results = list(results)
+        self.calls: list[dict] = []
+
+    def create(self, **kwargs):
+        self.calls.append(kwargs)
+        if not self.results:
+            raise AssertionError("fake client ran out of scripted responses")
+        return self.results.pop(0)
+
+
+class _FakeClient:
+    def __init__(self, *a, **k):
+        self.chat = SimpleNamespace(
+            completions=SimpleNamespace(
+                create=lambda **kw: SimpleNamespace(
+                    choices=[SimpleNamespace(message=SimpleNamespace(content="ok", tool_calls=[]))],
+                    usage=SimpleNamespace(prompt_tokens=1, completion_tokens=1),
+                )
+            )
+        )
+
+
+def _text_response(text, in_tokens=10, out_tokens=5):
+    return SimpleNamespace(
+        choices=[SimpleNamespace(message=SimpleNamespace(content=text, tool_calls=[]))],
+        usage=SimpleNamespace(prompt_tokens=in_tokens, completion_tokens=out_tokens),
+    )
+
+
+def _tool_response(name, arguments, in_tokens=10, out_tokens=5):
+    tc = SimpleNamespace(id="x", function=SimpleNamespace(name=name, arguments=arguments))
+    return SimpleNamespace(
+        choices=[SimpleNamespace(message=SimpleNamespace(content=None, tool_calls=[tc]))],
+        usage=SimpleNamespace(prompt_tokens=in_tokens, completion_tokens=out_tokens),
+    )
+
+
+def _stream_chunk(content=None, tool_calls=None, usage=None):
+    choices = []
+    if content is not None or tool_calls is not None:
+        choices = [SimpleNamespace(delta=SimpleNamespace(content=content, tool_calls=tool_calls), finish_reason=None)]
+    return SimpleNamespace(choices=choices, usage=usage)
+
+
+def _stream_tool_response(name, arguments):
+    tc = SimpleNamespace(index=0, id="x", function=SimpleNamespace(name=name, arguments=arguments))
+    return _FakeStream([_stream_chunk(content="On it. ", tool_calls=None), _stream_chunk(tool_calls=[tc])])
+
+
+def _stream_text_response(text):
+    return _FakeStream([_stream_chunk(content=text)])
+
+
+def _make_handler(max_rounds=3, stream=False):
+    orig_openai = base_mod.OpenAI
+    base_mod.OpenAI = _FakeClient
+    try:
+        handler = ChatCompletionsApiModelHandler(
+            threading.Event(),
+            queue.Queue(),
+            queue.Queue(),
+            setup_kwargs=dict(
+                model_name="test-model",
+                base_url="http://fake/v1",
+                api_key="k",
+                stream=stream,
+                disable_thinking=True,
+                compact_history=False,
+                keenable_web_search=False,  # a stub replaces the real executor below
+                tool_call_max_rounds=max_rounds,
+            ),
+        )
+    finally:
+        base_mod.OpenAI = orig_openai
+    handler.server_tools = _StubKeenable()
+    return handler
+
+
+def _drive(handler, responses, *, tools=None, user="What's the weather in Paris?"):
+    chat = Chat(10)
+    chat.add_item(make_user_message(user))
+    session = RealtimeSessionCreateRequest(type="realtime", instructions="Be brief.")
+    if tools is not None:
+        session.tools = tools
+    completions = _SeqCompletions(responses)
+    handler.client.chat.completions = completions
+    req = GenerateResponseRequest(
+        runtime_config=RuntimeConfig(chat=chat, session=session),
+        response=None,
+        language_code="en",
+        turn_id="t",
+        turn_revision=0,
+    )
+    text, tools_out, usage, end = "", [], None, None
+    for out in handler.process(req):
+        if isinstance(out, LLMResponseChunk):
+            text += out.text
+            tools_out += list(out.tools)
+        elif isinstance(out, TokenUsage):
+            usage = (out.input_tokens, out.output_tokens)
+        elif isinstance(out, EndOfResponse):
+            end = out
+    return SimpleNamespace(text=text, tools_out=tools_out, usage=usage, chat=chat, end=end, completions=completions)
+
+
+# ── Tests ────────────────────────────────────────────────────────────────────
+
+
+def test_server_tool_call_is_executed_and_answer_spoken():
+    handler = _make_handler()
+    r = _drive(
+        handler,
+        [
+            _tool_response("web_search", '{"query": "weather Paris"}'),
+            _text_response("It is sunny in Paris."),
+        ],
+    )
+    assert r.text == "It is sunny in Paris."
+    assert r.tools_out == []  # nothing forwarded to the client
+    assert r.end.error is None
+    assert handler.server_tools.calls == [("web_search", '{"query": "weather Paris"}')]
+    assert len(r.completions.calls) == 2
+
+
+def test_tools_advertised_with_guidance():
+    handler = _make_handler()
+    r = _drive(handler, [_text_response("hi")])
+    request_tools = r.completions.calls[0]["tools"]
+    assert {t["function"]["name"] for t in request_tools} == {"web_search", "fetch_page"}
+    system = r.completions.calls[0]["messages"][0]
+    assert system["role"] == "system"
+    assert "GUIDANCE" in str(system["content"])
+
+
+def test_history_contains_call_and_output_pair():
+    handler = _make_handler()
+    r = _drive(
+        handler,
+        [
+            _tool_response("web_search", '{"query": "q"}'),
+            _text_response("Done."),
+        ],
+    )
+    items = r.chat.buffer
+    fcs = [i for i in items if isinstance(i, RealtimeConversationItemFunctionCall)]
+    fcos = [i for i in items if isinstance(i, RealtimeConversationItemFunctionCallOutput)]
+    assert len(fcs) == 1 and len(fcos) == 1
+    assert fcs[0].name == "web_search"
+    assert fcs[0].call_id == fcos[0].call_id
+    assert fcos[0].output == handler.server_tools.result
+    # The follow-up request saw the pair too.
+    followup_roles = [m["role"] for m in r.completions.calls[1]["messages"]]
+    assert "tool" in followup_roles
+
+
+def test_final_round_forces_tool_choice_none():
+    handler = _make_handler(max_rounds=3)
+    r = _drive(
+        handler,
+        [
+            _tool_response("web_search", '{"query": "a"}'),
+            _tool_response("web_search", '{"query": "b"}'),
+            _tool_response("web_search", '{"query": "c"}'),  # still stubborn on the last round
+        ],
+    )
+    assert len(r.completions.calls) == 3
+    assert "tool_choice" not in r.completions.calls[0]
+    assert "tool_choice" not in r.completions.calls[1]
+    assert r.completions.calls[2]["tool_choice"] == "none"
+    # Only the first two calls were executed; the loop ends after the final round.
+    assert [c[1] for c in handler.server_tools.calls] == ['{"query": "a"}', '{"query": "b"}']
+    assert r.end.error is None
+
+
+def test_usage_accumulates_across_rounds():
+    handler = _make_handler()
+    r = _drive(
+        handler,
+        [
+            _tool_response("web_search", '{"query": "q"}', in_tokens=10, out_tokens=5),
+            _text_response("Done.", in_tokens=30, out_tokens=7),
+        ],
+    )
+    assert r.usage == (40, 12)
+
+
+def test_client_tool_call_still_forwarded():
+    handler = _make_handler()
+    client_tool = {"type": "function", "name": "camera_snapshot", "description": "d", "parameters": {}}
+    r = _drive(
+        handler,
+        [_tool_response("camera_snapshot", "{}")],
+        tools=[client_tool],
+    )
+    assert [t.name for t in r.tools_out] == ["camera_snapshot"]
+    assert handler.server_tools.calls == []
+    assert len(r.completions.calls) == 1  # no follow-up round for client tools
+
+
+def test_client_registered_name_wins_over_server_tool():
+    handler = _make_handler()
+    client_ws = {"type": "function", "name": "web_search", "description": "client", "parameters": {}}
+    r = _drive(
+        handler,
+        [_tool_response("web_search", '{"query": "q"}')],
+        tools=[client_ws],
+    )
+    # web_search advertised once (the client's), fetch_page still added by the server.
+    names = [t["function"]["name"] for t in r.completions.calls[0]["tools"]]
+    assert names.count("web_search") == 1
+    assert "fetch_page" in names
+    # The call went to the client, not the server executor.
+    assert [t.name for t in r.tools_out] == ["web_search"]
+    assert handler.server_tools.calls == []
+
+
+def test_tool_error_output_still_answers():
+    handler = _make_handler()
+    handler.server_tools.result = json.dumps({"error": "Rate limit exceeded"})
+    r = _drive(
+        handler,
+        [
+            _tool_response("web_search", '{"query": "q"}'),
+            _text_response("Sorry, search is unavailable."),
+        ],
+    )
+    assert r.text == "Sorry, search is unavailable."
+    fcos = [i for i in r.chat.buffer if isinstance(i, RealtimeConversationItemFunctionCallOutput)]
+    assert json.loads(fcos[0].output) == {"error": "Rate limit exceeded"}
+    assert r.end.error is None
+
+
+def test_streaming_server_tool_loop_speaks_interim_and_final_text():
+    handler = _make_handler(stream=True)
+    r = _drive(
+        handler,
+        [
+            _stream_tool_response("web_search", '{"query": "q"}'),
+            _stream_text_response("It is sunny."),
+        ],
+    )
+    # The interim acknowledgement streamed before the tool call is spoken too.
+    assert "On it." in r.text and "It is sunny." in r.text
+    assert r.tools_out == []  # server-owned call not forwarded to the client
+    assert handler.server_tools.calls == [("web_search", '{"query": "q"}')]
+    fcos = [i for i in r.chat.buffer if isinstance(i, RealtimeConversationItemFunctionCallOutput)]
+    assert len(fcos) == 1
+    assert r.end.error is None
+
+
+def test_no_server_tools_single_round():
+    handler = _make_handler()
+    handler.server_tools = None
+    r = _drive(handler, [_text_response("plain")])
+    assert r.text == "plain"
+    assert len(r.completions.calls) == 1
+    assert "tools" not in r.completions.calls[0]
+
+
+if __name__ == "__main__":
+    import sys
+
+    import pytest
+
+    sys.exit(pytest.main([__file__, "-v"]))

--- a/tests/test_server_tools.py
+++ b/tests/test_server_tools.py
@@ -1,0 +1,198 @@
+"""Unit tests for the Keenable-backed server tools (LLM/server_tools.py).
+
+No network: httpx.MockTransport stands in for the Keenable API.
+
+Run with pytest, or standalone:  python tests/test_server_tools.py
+"""
+
+from __future__ import annotations
+
+import json
+
+import httpx
+
+from speech_to_speech.LLM.server_tools import (
+    FETCH_PAGE_TOOL,
+    WEB_SEARCH_TOOL,
+    KeenableWebTools,
+)
+
+# ── Helpers ──────────────────────────────────────────────────────────────────
+
+
+def _search_payload(n: int) -> dict:
+    return {
+        "query": "q",
+        "results": [
+            {
+                "title": f"Title {i}",
+                "url": f"https://example.com/{i}",
+                "description": f"Desc {i}",
+                "snippet": "s" * 2000,
+                "published_at": "2026-01-01T00:00:00Z",
+                "acquired_at": "2026-01-02T00:00:00Z",
+            }
+            for i in range(n)
+        ],
+    }
+
+
+def _make_tools(handler_fn, **kwargs) -> tuple[KeenableWebTools, list[httpx.Request]]:
+    requests: list[httpx.Request] = []
+
+    def record(request: httpx.Request) -> httpx.Response:
+        requests.append(request)
+        return handler_fn(request)
+
+    tools = KeenableWebTools(transport=httpx.MockTransport(record), **kwargs)
+    return tools, requests
+
+
+# ── Definitions ──────────────────────────────────────────────────────────────
+
+
+def test_tool_definitions_are_flat_function_dicts():
+    tools, _ = _make_tools(lambda r: httpx.Response(200, json={}), api_key="keen_x")
+    defs = tools.tool_definitions
+    assert [d["name"] for d in defs] == ["web_search", "fetch_page"]
+    for d in defs:
+        assert d["type"] == "function"
+        assert "function" not in d  # flat Responses-API shape, not Chat-Completions nested
+        assert d["parameters"]["type"] == "object"
+    assert WEB_SEARCH_TOOL.parameters["required"] == ["query"]
+    assert FETCH_PAGE_TOOL.parameters["required"] == ["url"]
+
+
+def test_voice_guidance_mentions_tools_and_date():
+    tools, _ = _make_tools(lambda r: httpx.Response(200, json={}), api_key="keen_x")
+    guidance = tools.voice_guidance()
+    assert "web_search" in guidance
+    assert "Today's date" in guidance
+
+
+# ── web_search ───────────────────────────────────────────────────────────────
+
+
+def test_search_uses_keyed_endpoint_and_header():
+    tools, requests = _make_tools(lambda r: httpx.Response(200, json=_search_payload(2)), api_key="keen_secret")
+    out = json.loads(tools.execute("web_search", json.dumps({"query": "ai news"})))
+    assert len(out["results"]) == 2
+    (request,) = requests
+    assert request.url.path == "/v1/search"
+    assert request.headers["X-API-Key"] == "keen_secret"
+    assert json.loads(request.content) == {"query": "ai news", "mode": "realtime"}
+
+
+def test_search_keyless_uses_public_endpoint(monkeypatch):
+    monkeypatch.delenv("KEENABLE_API_KEY", raising=False)
+    tools, requests = _make_tools(lambda r: httpx.Response(200, json=_search_payload(1)))
+    tools.execute("web_search", json.dumps({"query": "x"}))
+    (request,) = requests
+    assert request.url.path == "/v1/search/public"
+    assert "X-API-Key" not in request.headers
+
+
+def test_search_truncates_results_and_snippets():
+    tools, _ = _make_tools(lambda r: httpx.Response(200, json=_search_payload(9)), api_key="keen_x")
+    out = json.loads(tools.execute("web_search", json.dumps({"query": "x"})))
+    assert len(out["results"]) == 5  # max_results default
+    assert all(len(r["snippet"]) <= 600 for r in out["results"])
+    assert out["results"][0]["title"] == "Title 0"
+    assert out["results"][0]["url"] == "https://example.com/0"
+
+
+def test_search_passes_optional_filters_and_drops_unknown():
+    tools, requests = _make_tools(lambda r: httpx.Response(200, json=_search_payload(0)), api_key="keen_x")
+    tools.execute(
+        "web_search",
+        json.dumps({"query": "x", "site": "reuters.com", "published_after": "7d", "bogus": "y"}),
+    )
+    body = json.loads(requests[0].content)
+    assert body == {"query": "x", "mode": "realtime", "site": "reuters.com", "published_after": "7d"}
+
+
+def test_search_requires_query():
+    tools, requests = _make_tools(lambda r: httpx.Response(200, json={}), api_key="keen_x")
+    out = json.loads(tools.execute("web_search", "{}"))
+    assert "error" in out
+    assert not requests  # nothing sent
+
+
+# ── fetch_page ───────────────────────────────────────────────────────────────
+
+
+def test_fetch_page_get_with_params():
+    payload = {"url": "https://example.com/a", "title": "T", "content": "body"}
+    tools, requests = _make_tools(lambda r: httpx.Response(200, json=payload), api_key="keen_x")
+    out = json.loads(tools.execute("fetch_page", json.dumps({"url": "https://example.com/a"})))
+    assert out == {"url": "https://example.com/a", "title": "T", "content": "body"}
+    (request,) = requests
+    assert request.method == "GET"
+    assert request.url.path == "/v1/fetch"
+    assert request.url.params["url"] == "https://example.com/a"
+    assert request.url.params["max_chars"] == "6000"
+
+
+def test_fetch_page_retries_live_on_404():
+    def handler(request: httpx.Request) -> httpx.Response:
+        if request.url.params.get("live") == "true":
+            return httpx.Response(200, json={"url": "u", "title": "T", "content": "live!"})
+        return httpx.Response(404, json={"error": "Not found"})
+
+    tools, requests = _make_tools(handler, api_key="keen_x")
+    out = json.loads(tools.execute("fetch_page", json.dumps({"url": "https://example.com/new"})))
+    assert out["content"] == "live!"
+    assert len(requests) == 2
+    assert requests[1].url.params["live"] == "true"
+
+
+def test_fetch_page_rejects_private_targets():
+    tools, requests = _make_tools(lambda r: httpx.Response(200, json={}), api_key="keen_x")
+    for url in (
+        "ftp://example.com/x",
+        "http://localhost/x",
+        "http://127.0.0.1/x",
+        "http://10.0.0.8/x",
+        "http://[::1]/x",
+        "http://metadata.google.internal/x",
+    ):
+        out = json.loads(tools.execute("fetch_page", json.dumps({"url": url})))
+        assert "error" in out, url
+    assert not requests  # nothing left the box
+
+
+# ── execute error handling ───────────────────────────────────────────────────
+
+
+def test_execute_never_raises():
+    tools, _ = _make_tools(lambda r: httpx.Response(429, json={"error": "Rate limit exceeded"}), api_key="keen_x")
+    out = json.loads(tools.execute("web_search", json.dumps({"query": "x"})))
+    assert "429" in out["error"]
+    assert "Rate limit exceeded" in out["error"]
+
+    assert "error" in json.loads(tools.execute("web_search", "not json"))
+    assert "error" in json.loads(tools.execute("web_search", "[1, 2]"))
+    assert "error" in json.loads(tools.execute("nope", "{}"))
+
+
+def test_execute_timeout_returns_error():
+    def handler(request: httpx.Request) -> httpx.Response:
+        raise httpx.ConnectTimeout("boom")
+
+    tools, _ = _make_tools(handler, api_key="keen_x")
+    out = json.loads(tools.execute("web_search", json.dumps({"query": "x"})))
+    assert out == {"error": "The web request timed out."}
+
+
+def test_owns():
+    tools, _ = _make_tools(lambda r: httpx.Response(200, json={}), api_key="keen_x")
+    assert tools.owns("web_search") and tools.owns("fetch_page")
+    assert not tools.owns("camera_snapshot")
+
+
+if __name__ == "__main__":
+    import sys
+
+    import pytest
+
+    sys.exit(pytest.main([__file__, "-v"]))


### PR DESCRIPTION
## What

Native, server-side web search for the OpenAI-compatible LLM backends (`chat-completions` and `responses-api`), backed by [Keenable](https://docs.keenable.ai) — a low-latency web search API with a keyless free tier.

With `--keenable_web_search`, the handler advertises `web_search` / `fetch_page` tools to the model and executes them **inside the pipeline**: the tool call never reaches the realtime client — the handler runs the search, writes the `function_call` / `function_call_output` pair into the conversation, and re-requests the model in the same turn. Every realtime client (CLI, browser Space, Reachy Mini) gets live-web spoken answers with zero client-side tool handling.

```bash
speech-to-speech --mode realtime --stt parakeet-tdt --llm_backend chat-completions --tts qwen3 \
    --model_name "google/gemma-4-31B-it:cerebras" \
    --responses_api_base_url "https://router.huggingface.co/v1" \
    --responses_api_api_key "$HF_TOKEN" \
    --responses_api_reasoning_effort none --responses_api_stream \
    --keenable_web_search
```

## Why it works in a voice loop

Keenable's `realtime` search mode returns in ~200 ms consistently, and fast LLM inference (e.g. Cerebras, as in the [voice AI blog post](https://huggingface.co/blog/cerebras-gemma4-voice-ai)) makes the extra model round-trip cheap. Measured end-to-end on an L4 Inference Endpoint with the stack above: **speech-end → first spoken words of a web-grounded answer in 1.3 s**, search included:

```
Keenable web_search('current weather in Paris') -> 5 results in 235 ms
Last speech detected to first speech out: 1.296s
```

## Design notes

- **Bounded agentic loop** in `BaseOpenAICompatibleHandler._generate` (`--tool_call_max_rounds`, default 3); the final round forces `tool_choice="none"` so a turn always ends in speech. Cancellation / speculative-turn staleness is re-checked before executing tools and before each round; token usage accumulates across rounds.
- **Client tools take precedence**: a client-registered tool with the same name is neither re-advertised nor intercepted, so existing deployments (e.g. the hf-realtime-voice Space's browser-side `web_search`) keep working unchanged.
- Tool errors return as `{"error": ...}` output so the model recovers conversationally; `fetch_page` has a client-side SSRF guard and retries `live=true` when a page isn't indexed.
- Keyless by default (rate-limited free tier); `--keenable_api_key` / `KEENABLE_API_KEY` for higher limits. No new dependencies (uses `httpx`).

## Tests

22 new unit tests (`tests/test_server_tools.py` with `httpx.MockTransport`, `tests/test_keenable_tool_loop.py` with a scripted OpenAI client): the loop in streaming and non-streaming modes, name-collision precedence, error paths, max-rounds behaviour, usage accounting. `ruff check` / `ruff format` / `mypy` clean; full suite passes.

## Live demo

Identical fork of the hf-realtime-voice Space with search proxied through Keenable, pipeline on an L4 Inference Endpoint: https://huggingface.co/spaces/styskin/keenable-realtime-voice

🤖 Generated with [Claude Code](https://claude.com/claude-code)
