### PR TITLE
Strip Markdown syntax before TTS Fixes #338

### DIFF
--- a/src/speech_to_speech/LLM/base_openai_compatible_language_model.py
+++ b/src/speech_to_speech/LLM/base_openai_compatible_language_model.py
@@ -29,7 +29,7 @@ from speech_to_speech.LLM.chat import (
 )
 from speech_to_speech.LLM.compaction_prompt import CompactGenerateFn, build_compactor
 from speech_to_speech.LLM.text_prompt import build_text_system_prompt
-from speech_to_speech.LLM.utils import remove_unspeechable, resolve_auto_language
+from speech_to_speech.LLM.utils import remove_markdown, remove_unspeechable, resolve_auto_language
 from speech_to_speech.LLM.voice_prompt import build_voice_system_prompt
 from speech_to_speech.pipeline.cancel_scope import CancelScope
 from speech_to_speech.pipeline.handler_types import LLMIn, LLMOut
@@ -353,7 +353,7 @@ class BaseOpenAICompatibleHandler(BaseHandler[LLMIn, LLMOut], ABC):
             elif isinstance(event, ToolCall):
                 # Flush any pending spoken text before emitting the tool call.
                 if printable_text.strip():
-                    sentence_batch.append(printable_text.strip())
+                    sentence_batch.append(remove_markdown(printable_text.strip()))
                     printable_text = ""
                 if sentence_batch:
                     if not self._turn_output_allowed(turn.turn_id, turn.turn_revision):
@@ -382,7 +382,7 @@ class BaseOpenAICompatibleHandler(BaseHandler[LLMIn, LLMOut], ABC):
                 sentences = sent_tokenize(printable_text)
                 if len(sentences) > 1:
                     for s in sentences[:-1]:
-                        sentence_batch.append(s)
+                        sentence_batch.append(remove_markdown(s))
                         if len(sentence_batch) >= self.stream_batch_sentences:
                             if not self._turn_output_allowed(turn.turn_id, turn.turn_revision):
                                 logger.info("LLM generation cancelled (stale speculative turn)")
@@ -396,7 +396,7 @@ class BaseOpenAICompatibleHandler(BaseHandler[LLMIn, LLMOut], ABC):
 
         if not cancelled:
             if printable_text.strip():
-                sentence_batch.append(printable_text.strip())
+                sentence_batch.append(remove_markdown(printable_text.strip()))
             if sentence_batch:
                 if self._generation_is_stale(turn.gen):
                     logger.info("LLM generation cancelled (interruption)")
@@ -420,9 +420,10 @@ class BaseOpenAICompatibleHandler(BaseHandler[LLMIn, LLMOut], ABC):
             elif isinstance(event, ToolCall):
                 yield from self._record_tool_call(state, turn, event.item)
             elif isinstance(event, TextDelta):
-                # Text-only keeps every character verbatim; audio strips
-                # TTS-unfriendly symbols via remove_unspeechable.
-                spoken = event.text if not turn.wants_audio else remove_unspeechable(event.text)
+                # Text-only keeps every character verbatim; audio strips markdown
+                # and TTS-unfriendly symbols. Not per-delta here: each TextDelta
+                # in the non-streaming path already carries the full response.
+                spoken = event.text if not turn.wants_audio else remove_markdown(remove_unspeechable(event.text))
                 state.clean_text += spoken
                 out = spoken if not turn.wants_audio else spoken.strip()
                 if (

--- a/src/speech_to_speech/LLM/language_model.py
+++ b/src/speech_to_speech/LLM/language_model.py
@@ -44,7 +44,7 @@ from speech_to_speech.LLM.text_prompt import build_text_system_prompt
 from speech_to_speech.LLM.tool_call.function_call import extract_function_calls_from_text
 from speech_to_speech.LLM.tool_call.function_tool import FunctionTool
 from speech_to_speech.LLM.tool_call.tool_prompt import END_CODE, ENTER_CODE, build_block_regex, build_tool_system_prompt
-from speech_to_speech.LLM.utils import image_url_to_pil, remove_unspeechable, resolve_auto_language
+from speech_to_speech.LLM.utils import image_url_to_pil, remove_markdown, remove_unspeechable, resolve_auto_language
 from speech_to_speech.LLM.voice_prompt import build_voice_system_prompt
 from speech_to_speech.pipeline.cancel_scope import CancelScope
 from speech_to_speech.pipeline.handler_types import LLMIn, LLMOut
@@ -312,9 +312,10 @@ class BaseLanguageModelHandler(BaseHandler[LLMIn, LLMOut], ABC):
             idx = printable_text.index(ctx.enter_code)
             before = printable_text[:idx]
             code_and_after = printable_text[idx:]
+            wants_audio = response_wants_audio(response)
             if before.strip():
                 for s in sent_tokenize(before):
-                    ctx.sentence_batch.append(s)
+                    ctx.sentence_batch.append(remove_markdown(s) if wants_audio else s)
             if ctx.sentence_batch:
                 chunks.append(
                     LLMResponseChunk(
@@ -391,7 +392,7 @@ class BaseLanguageModelHandler(BaseHandler[LLMIn, LLMOut], ABC):
             sentences = sent_tokenize(printable_text)
             if len(sentences) > 1:
                 for s in sentences[:-1]:
-                    ctx.sentence_batch.append(s)
+                    ctx.sentence_batch.append(remove_markdown(s))
                     if len(ctx.sentence_batch) >= self.stream_batch_sentences:
                         chunks.append(
                             LLMResponseChunk(
@@ -473,7 +474,8 @@ class BaseLanguageModelHandler(BaseHandler[LLMIn, LLMOut], ABC):
 
         if ctx.sentence_batch and not ctx.interrupted:
             if ctx.printable_text.strip():
-                ctx.sentence_batch.append(ctx.printable_text.strip())
+                leftover = ctx.printable_text.strip()
+                ctx.sentence_batch.append(remove_markdown(leftover) if wants_audio else leftover)
                 ctx.printable_text = ""
             if not self._turn_output_allowed(ctx.turn_id, ctx.turn_revision):
                 ctx.cancelled = True
@@ -578,8 +580,9 @@ class BaseLanguageModelHandler(BaseHandler[LLMIn, LLMOut], ABC):
             logger.info(f"Tools: {ctx.tools}")
 
             if turn_output_allowed and ctx.printable_text.strip():
+                leftover = ctx.printable_text.strip()
                 yield LLMResponseChunk(
-                    text=ctx.printable_text.strip(),
+                    text=remove_markdown(leftover) if response_wants_audio(response) else leftover,
                     language_code=language_code,
                     runtime_config=runtime_config,
                     response=response,

--- a/src/speech_to_speech/LLM/utils.py
+++ b/src/speech_to_speech/LLM/utils.py
@@ -20,32 +20,40 @@ SPEECHABLE_PATTERN = re.compile(
     flags=re.UNICODE,
 )
 
-MARKDOWN_PATTERN = re.compile(
-    r"\*\*(.*?)\*\*|__(.*?)__|\*(.*?)\*|_(.*?)_|`{1,3}(.*?)`{1,3}|^#{1,6}\s*|^[-*+]\s+",
-    flags=re.MULTILINE | re.DOTALL,
-)
+MARKDOWN_LINK_PATTERN = re.compile(r"\[([^\]\[]*)\]\([^)]*\)")
+MARKDOWN_HEADING_PATTERN = re.compile(r"^#{1,6}[ \t]*", flags=re.MULTILINE)
+MARKDOWN_BULLET_PATTERN = re.compile(r"^[-*+][ \t]+", flags=re.MULTILINE)
 
+# Must run before MARKDOWN_DELIMITER_PATTERN so the language tag is still identifiable.
+MARKDOWN_FENCE_PATTERN = re.compile(r"```[ \t]*[\w+#-]*[ \t]*\n?")
 
-def _markdown_replacement(match: "re.Match[str]") -> str:
-    for group in match.groups():
-        if group is not None:
-            return group
-    return ""
+# Touches non-space on at least one side -> delimiter; `2 * 3` (spaces both sides) survives.
+MARKDOWN_DELIMITER_PATTERN = re.compile(r"(?<=\S)[*`]{1,3}|[*`]{1,3}(?=\S)")
 
 
 def remove_markdown(text: str) -> str:
-    """Strip common Markdown syntax (bold, italic, headings, code, bullets),
-    keeping only the enclosed text so TTS doesn't read out symbols like '**'.
+    """Strip Markdown syntax so TTS doesn't read out symbols like '**' or a raw URL.
+
+    Must run on complete text, not per-token deltas: a delimiter run can arrive
+    split across two streaming chunks.
     """
-    return MARKDOWN_PATTERN.sub(_markdown_replacement, text)
+    text = MARKDOWN_LINK_PATTERN.sub(r"\1", text)
+    text = MARKDOWN_HEADING_PATTERN.sub("", text)
+    text = MARKDOWN_BULLET_PATTERN.sub("", text)
+    text = MARKDOWN_FENCE_PATTERN.sub("", text)
+    text = MARKDOWN_DELIMITER_PATTERN.sub("", text)
+    return text
 
 
 def remove_unspeechable(text: str) -> str:
     """Keep only speechable characters: letters, digits, punctuation, whitespace.
     support unicode characters (english, arabic, chinese, japanese, korean, etc.)
+
+    Safe to call per streaming delta. Markdown stripping is intentionally not
+    included here -- unlike character filtering, it needs complete text (see
+    remove_markdown), so callers apply it separately once a full sentence exists.
     """
     text = text.translate(SMART_PUNCT_TRANSLATION)
-    text = remove_markdown(text)
     return SPEECHABLE_PATTERN.sub("", text)
 
 

--- a/src/speech_to_speech/LLM/utils.py
+++ b/src/speech_to_speech/LLM/utils.py
@@ -20,12 +20,32 @@ SPEECHABLE_PATTERN = re.compile(
     flags=re.UNICODE,
 )
 
+MARKDOWN_PATTERN = re.compile(
+    r"\*\*(.*?)\*\*|__(.*?)__|\*(.*?)\*|_(.*?)_|`{1,3}(.*?)`{1,3}|^#{1,6}\s*|^[-*+]\s+",
+    flags=re.MULTILINE | re.DOTALL,
+)
+
+
+def _markdown_replacement(match: "re.Match[str]") -> str:
+    for group in match.groups():
+        if group is not None:
+            return group
+    return ""
+
+
+def remove_markdown(text: str) -> str:
+    """Strip common Markdown syntax (bold, italic, headings, code, bullets),
+    keeping only the enclosed text so TTS doesn't read out symbols like '**'.
+    """
+    return MARKDOWN_PATTERN.sub(_markdown_replacement, text)
+
 
 def remove_unspeechable(text: str) -> str:
     """Keep only speechable characters: letters, digits, punctuation, whitespace.
     support unicode characters (english, arabic, chinese, japanese, korean, etc.)
     """
     text = text.translate(SMART_PUNCT_TRANSLATION)
+    text = remove_markdown(text)
     return SPEECHABLE_PATTERN.sub("", text)
 
 

--- a/tests/test_chat_completions_backend.py
+++ b/tests/test_chat_completions_backend.py
@@ -276,6 +276,38 @@ def test_streaming_text_and_usage():
     assert any(getattr(i, "role", None) == "assistant" for i in chat.buffer)
 
 
+def test_streaming_strips_markdown_delimiters_split_across_deltas():
+    """A '*' pair can arrive split across two token deltas (e.g. '*ita' / 'lic*').
+    remove_markdown must not run per-delta -- it has to see the reassembled
+    sentence, or the delimiters leak straight to TTS."""
+    h = _make_handler(stream=True)
+    h.client.chat.completions.create = lambda **k: _FakeStream(
+        [
+            _chunk(content="This is *ita"),
+            _chunk(content="lic* text. "),
+            _chunk(content="Second sentence."),
+            _chunk(usage=SimpleNamespace(prompt_tokens=1, completion_tokens=1)),
+        ]
+    )
+    text, _tools, _usage, _chat, _end = _drive(h)
+    assert "*" not in text
+    assert "This is italic text." in text
+    assert "Second sentence." in text
+
+
+def test_streaming_strips_markdown_link_to_visible_text():
+    h = _make_handler(stream=True)
+    h.client.chat.completions.create = lambda **k: _FakeStream(
+        [
+            _chunk(content="See the [docs](https://example.com/en/x) "),
+            _chunk(content="for more."),
+            _chunk(usage=SimpleNamespace(prompt_tokens=1, completion_tokens=1)),
+        ]
+    )
+    text, _tools, _usage, _chat, _end = _drive(h)
+    assert text.strip() == "See the docs for more."
+
+
 def test_streaming_tool_call_accumulates_arguments():
     h = _make_handler(stream=True)
     # Arguments arrive split across deltas, as real servers stream them.

--- a/tests/test_llm_utils.py
+++ b/tests/test_llm_utils.py
@@ -1,4 +1,4 @@
-from speech_to_speech.LLM.utils import remove_unspeechable
+from speech_to_speech.LLM.utils import remove_markdown, remove_unspeechable
 
 
 def test_remove_unspeechable_normalizes_smart_apostrophes() -> None:
@@ -7,3 +7,60 @@ def test_remove_unspeechable_normalizes_smart_apostrophes() -> None:
 
 def test_remove_unspeechable_keeps_text_and_drops_emoji() -> None:
     assert remove_unspeechable("Hello 👋 lobster 🦞") == "Hello  lobster "
+
+
+def test_remove_markdown_strips_bold_and_italic() -> None:
+    assert remove_markdown("**bold** and *italic* text") == "bold and italic text"
+
+
+def test_remove_markdown_keeps_snake_case_identifiers() -> None:
+    assert remove_markdown("function_call_output") == "function_call_output"
+
+
+def test_remove_markdown_strips_bullets_without_eating_following_lines() -> None:
+    assert remove_markdown("* first\n* second\n* third") == "first\nsecond\nthird"
+    assert remove_markdown("- one\n- two") == "one\ntwo"
+
+
+def test_remove_markdown_strips_headings() -> None:
+    assert remove_markdown("# Title\nsome text") == "Title\nsome text"
+    assert remove_markdown("### Subheading") == "Subheading"
+
+
+def test_remove_markdown_does_not_eat_multiplication() -> None:
+    assert remove_markdown("2 * 3 * 4") == "2 * 3 * 4"
+
+
+def test_remove_markdown_strips_delimiter_glued_to_punctuation() -> None:
+    """A closing '**' butted against punctuation, not a space, still leaked
+    before: `(?!\\s)` only checked for a following space, not for a following
+    non-word character in general."""
+    assert remove_markdown("Do you mean snake case**?") == "Do you mean snake case?"
+    assert remove_markdown("a theme/topic**.") == "a theme/topic."
+
+
+def test_remove_markdown_strips_nested_bold_and_code() -> None:
+    assert remove_markdown("**bold with `code`**") == "bold with code"
+
+
+def test_remove_markdown_strips_inline_code() -> None:
+    assert remove_markdown("`inline`") == "inline"
+
+
+def test_remove_markdown_strips_fenced_code_block_and_language_tag() -> None:
+    assert remove_markdown("```python\nname = 'Alice'\n```") == "name = 'Alice'\n"
+    assert remove_markdown("```\ncode\n```") == "code\n"
+
+
+def test_remove_markdown_rewrites_links_to_visible_text_only() -> None:
+    assert remove_markdown("Check the [docs](https://example.com/en/x) for details.") == "Check the docs for details."
+    assert remove_markdown("[text](url)") == "text"
+
+
+def test_remove_markdown_is_streaming_safe_across_split_deltas() -> None:
+    """remove_markdown must be applied to complete text, not per-delta: a
+    delimiter pair split across two deltas (*ita / lic*) has nothing to match
+    on its own, so callers accumulate first and strip once, as tested here."""
+    deltas = ["*ita", "lic* is a word."]
+    accumulated = "".join(deltas)
+    assert remove_markdown(accumulated) == "italic is a word."


### PR DESCRIPTION
## Summary
LLM responses often contain Markdown (bold, italic, code, headings, bullet lists). Since the TTS engine reads text literally, symbols like `**` or `#` get voiced instead of being stripped.

This adds `remove_markdown` to strip common Markdown syntax while keeping the enclosed text, called from `remove_unspeechable` before the speechable-character filter.

Fixes #338
