### PR TITLE
Make star history updates manual

### DIFF
--- a/.github/workflows/star-history.yml
+++ b/.github/workflows/star-history.yml
@@ -1,8 +1,6 @@
 name: Update star history chart
 
 on:
-  schedule:
-    - cron: "17 3 * * 1"  # Mondays 03:17 UTC
   workflow_dispatch:
 
 permissions:
@@ -13,20 +11,28 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
+        with:
+          ref: ${{ github.event.repository.default_branch }}
 
       - name: Generate chart
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: python3 .github/scripts/star_history.py "${{ github.repository }}" assets/star-history.svg
 
-      - name: Commit if changed
+      - name: Commit to update branch if changed
+        env:
+          BASE_BRANCH: ${{ github.event.repository.default_branch }}
+          UPDATE_BRANCH: star-history-update-${{ github.run_id }}-${{ github.run_attempt }}
         run: |
           git config user.name "github-actions[bot]"
           git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
           git add assets/star-history.svg
           if ! git diff --cached --quiet; then
             git commit -m "chore: update star history chart [skip ci]"
-            git push
+            git push origin "HEAD:refs/heads/${UPDATE_BRANCH}"
+            pr_url="https://github.com/${{ github.repository }}/compare/${BASE_BRANCH}...${UPDATE_BRANCH}?expand=1"
+            echo "Open a PR: ${pr_url}"
+            echo "Open a PR: [${UPDATE_BRANCH}](${pr_url})" >> "$GITHUB_STEP_SUMMARY"
           else
             echo "No changes"
           fi


### PR DESCRIPTION
## Summary

- removes the weekly star-history schedule so updates run only through `workflow_dispatch`
- checks out the default branch for each manual run
- pushes the generated SVG commit to a unique update branch instead of protected `main`
- writes a compare link to the workflow summary so a maintainer can open the update PR manually
- keeps workflow permissions limited to `contents: write`

## Why

The repository ruleset requires changes to `main` through pull requests, so the automatic token cannot push the generated SVG directly.

## Validation

- `python3 -m py_compile .github/scripts/star_history.py`
- `python3 -c "import yaml,sys; yaml.safe_load(open('.github/workflows/star-history.yml'))"`
- `git diff --check`