### PR TITLE
Add WebRTC transport for the OpenAI Realtime API

### DIFF
--- a/demo/README.md
+++ b/demo/README.md
@@ -55,6 +55,24 @@ backend, speaking the OpenAI Realtime **GA** protocol over **WebSocket**
    docker run -p 7860:7860 -e SPEECH_TO_SPEECH_URL=ws://host.docker.internal:8765/v1/realtime s2s-demo
    ```
 
+   > **Docker + host backend: WebSocket and WebRTC need different hostnames.**
+   > The two transports dial the backend from different network namespaces:
+   >
+   > - **WebRTC** is dialed **server-side** — the browser POSTs its SDP offer to
+   >   the demo's `/api/calls` proxy, which forwards it from *inside the
+   >   container*. There `host.docker.internal` resolves to your host, so the
+   >   command above works.
+   > - **WebSocket** is dialed **client-side** — the demo hands the URL straight
+   >   to the browser, which opens the socket itself. The browser runs on your
+   >   *host*, where `host.docker.internal` is not a real DNS name, so the
+   >   connection never reaches the backend and the server logs nothing.
+   >
+   > A single Docker `SPEECH_TO_SPEECH_URL` can therefore only make one transport
+   > work at a time (`localhost:8765` for WebSocket, `host.docker.internal:8765`
+   > for WebRTC). To exercise **both** without swapping the env, run the demo
+   > **without Docker** (the `uvicorn` command above) so host and container
+   > namespaces collapse — then `ws://localhost:8765/v1/realtime` works for both.
+
 3. Open <http://localhost:7860/>, click the orb, allow the mic, talk.
 
 > Browsers require **HTTPS or `localhost`** for `getUserMedia()` (mic + camera).

--- a/demo/README.md
+++ b/demo/README.md
@@ -10,12 +10,13 @@ short_description: Voice chat over WebSocket against a HF speech-to-speech
 hf_oauth: true
 ---
 
-# Realtime Voice Demo (WebSocket transport)
+# Realtime Voice Demo
 
 Browser voice-chat UI for the
 [huggingface/speech-to-speech](https://github.com/huggingface/speech-to-speech)
-backend. The browser streams mic audio over a WebSocket using the OpenAI
-Realtime **GA** protocol and plays back the assistant's audio as it arrives.
+backend, speaking the OpenAI Realtime **GA** protocol over **WebSocket**
+(default) or **WebRTC** (Settings → Transport, env-pinned deploys only — see
+[WebRTC transport](#webrtc-transport)).
 
 ## Quick start (local)
 
@@ -80,6 +81,46 @@ websocat ws://localhost:8765/v1/realtime
 The backend exposes one concurrent session per pipeline unit
 (`--num_pipelines` to serve more).
 
+## WebRTC transport
+
+With `SPEECH_TO_SPEECH_URL` set, **Settings → Transport** offers WebRTC as an
+alternative to the WebSocket. Same conversation, different plumbing:
+
+1. The browser adds its mic track and an `oai-events` data channel to an
+   `RTCPeerConnection` and POSTs the SDP offer to the same-origin
+   `/api/calls` proxy, which forwards it to the backend's
+   `POST /v1/realtime/calls` (the OpenAI GA handshake). The proxy exists
+   because the s2s server has no CORS middleware — and it forwards **only**
+   to the env-pinned URL, never to a client-supplied one, so it can't be used
+   as an open proxy. That's why the toggle is locked to WebSocket when the
+   URL isn't pinned (user-typed URLs, LB mode).
+2. Only the handshake goes through the proxy: the negotiated audio (Opus RTP
+   both ways) and the data channel flow directly browser ↔ backend.
+3. JSON events on the data channel are the same GA protocol as the WebSocket,
+   minus the audio: mic audio rides the media track (never
+   `input_audio_buffer.append`, which the backend rejects over WebRTC), and
+   the assistant's voice arrives as a remote audio track (never
+   `response.output_audio.delta`). Barge-in flushing is server-side.
+
+Backend requirement: the `webrtc` extra
+(`pip install "speech-to-speech[webrtc]"`), otherwise `/v1/realtime/calls`
+answers 501 and the handshake fails with a clear message.
+
+Caveats vs. WebSocket:
+
+- **NAT**: host ICE candidates only by default — fine when browser and backend
+  are on the same machine/LAN. Across the internet, set `RTC_ICE_SERVERS` on
+  *this* app (a JSON list of `RTCIceServer` dicts, or comma-separated
+  STUN/TURN URLs; served to the browser via `/api/config`) and
+  `SPEECH_TO_SPEECH_ICE_SERVERS` on the backend. There is no TURN relay
+  fallback, so symmetric-NAT setups may still not connect.
+- **Noise gate**: implemented in the WebSocket capture worklet, so it's
+  hidden on WebRTC — the raw mic track (with the browser's own
+  `noiseSuppression`) is sent instead.
+- **Camera snapshots** are re-encoded to fit one data-channel message
+  (~60 KB), so the model may see a smaller frame than over WebSocket.
+- **Load-balancer mode is WebSocket-only** for now.
+
 ## Connecting to a backend
 
 Three modes, picked by env (`/api/config` tells the client which one is active):
@@ -98,12 +139,12 @@ Three modes, picked by env (`/api/config` tells the client which one is active):
   and the browser dials the per-session compute URL the LB hands back. The LB
   address never reaches the browser; the Settings URL field is hidden.
 
-| `SPEECH_TO_SPEECH_URL` | `LOAD_BALANCER_URL` | `SPACE_ID` | Connection | URL field | Metering |
-|:---:|:---:|:---:|---|---|---|
-| ✅ | any | any | direct → pinned URL | visible, locked | off |
-| – | – | any | direct → user URL | editable | off |
-| – | ✅ | ✅ | LB proxy | hidden | **on** |
-| – | ✅ | – | LB proxy | hidden | off |
+| `SPEECH_TO_SPEECH_URL` | `LOAD_BALANCER_URL` | `SPACE_ID` | Connection | URL field | Transport | Metering |
+|:---:|:---:|:---:|---|---|---|---|
+| ✅ | any | any | direct → pinned URL | visible, locked | WS or WebRTC | off |
+| – | – | any | direct → user URL | editable | WS only | off |
+| – | ✅ | ✅ | LB proxy | hidden | WS only | **on** |
+| – | ✅ | – | LB proxy | hidden | WS only | off |
 
 **Settings → Restart** reconnects with the current voice, instructions and URL.
 
@@ -145,11 +186,12 @@ case-insensitively against the user's organisations from HF OAuth.
 | Key | What |
 |-----|------|
 | Speech-to-speech server URL | Direct realtime WebSocket URL (hidden/locked when pinned by env) |
+| Transport | WebSocket (default) or WebRTC; selectable only with an env-pinned URL |
 | Voice | Qwen3-TTS speaker name (Aiden, Ryan, Dylan, Eric, Ono_Anna, Serena, Sohee, Uncle_Fu, Vivian) |
-| Instructions | System prompt sent in `session.update` once the WS opens |
+| Instructions | System prompt sent in `session.update` once the connection opens |
 
-LocalStorage keys are namespaced `s2s.ws.*` so this app's settings do
-NOT collide with the WebRTC variant.
+LocalStorage keys are namespaced `s2s.ws.*` (plus `s2s.transport` for the
+transport pick).
 
 ## Files
 
@@ -163,6 +205,7 @@ NOT collide with the WebRTC variant.
 | `auth.py` | HF OAuth + per-request identity (tier, hashed keys) |
 | `limiter.py` | SQLite per-day talk-time budget (chunked server-clock reservation) |
 | `ws/s2s-ws-client.js` | WebSocket handshake + OpenAI Realtime GA protocol |
+| `rtc/s2s-rtc-client.js` | WebRTC sibling: SDP handshake via `/api/calls`, events over the data channel, track audio |
 | `ws/codec.js` | base64 <-> PCM helpers + transcript extraction (pure) |
 | `ws/orb-visualizer.js` | `OrbVisualiser`: FFT bands -> orb CSS custom properties |
 | `worklets/mic-capture.js` | AudioWorklet: 48 kHz Float32 -> 16 kHz Int16 PCM, posts ~40 ms chunks |

--- a/demo/index.html
+++ b/demo/index.html
@@ -3,7 +3,7 @@
   <head>
     <meta charset="UTF-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0, viewport-fit=cover" />
-    <title>Minimal Conversation · S2S backend (WebSocket)</title>
+    <title>Minimal Conversation · S2S backend</title>
     <link rel="preconnect" href="https://fonts.googleapis.com" />
     <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />
     <link
@@ -241,6 +241,21 @@
               </small>
             </label>
 
+            <!-- Transport picker. Hidden in LB mode; disabled (locked to
+                 WebSocket) unless the deploy pins SPEECH_TO_SPEECH_URL — the
+                 WebRTC handshake goes through the server-side /api/calls
+                 proxy, which only forwards to the pinned URL. -->
+            <label class="field" id="transport-field" hidden>
+              <span>Transport</span>
+              <select id="transport">
+                <option value="ws" selected>WebSocket</option>
+                <option value="webrtc">WebRTC</option>
+              </select>
+              <small id="transport-hint">
+                How audio travels to the server. Applies on the next conversation.
+              </small>
+            </label>
+
             <div class="field-row">
               <label class="field">
                 <span>Voice</span>
@@ -258,7 +273,9 @@
               </label>
             </div>
 
-            <div class="field">
+            <!-- WS-only: the gate runs in the WebSocket capture worklet; the
+                 WebRTC mic path sends the raw track, so this hides there. -->
+            <div class="field" id="gate-field">
               <span class="field-head">
                 Noise gate
                 <span id="gate-value" class="field-value">Off</span>

--- a/demo/main.js
+++ b/demo/main.js
@@ -1,22 +1,24 @@
 // @ts-check
 /**
  * Minimal voice conversation app, talking to a Hugging Face speech-to-speech
- * backend over **WebSocket** (drop-in alternative to the WebRTC variant).
+ * backend over **WebSocket** or **WebRTC**.
  *
- * Click the orb -> we ask for the mic, POST a session on the LB, open a
- * WebSocket on the routed compute endpoint, push session.update + mic
- * audio, play back the TTS audio. The orb visually reflects the live
- * state (idle, connecting, listening, user-speaking, processing,
- * ai-speaking).
+ * Click the orb -> we ask for the mic, connect (WS dial, or SDP handshake via
+ * the /api/calls proxy), push session.update + mic audio, play back the TTS
+ * audio. The orb visually reflects the live state (idle, connecting,
+ * listening, user-speaking, processing, ai-speaking).
  *
- * The only meaningful difference vs. the WebRTC main.js is that the
- * client owns its own AudioContext (no `attachOutputTrack`), so we hand
- * it the MediaStream directly.
+ * The two client classes expose the same events and methods, so everything
+ * below except the constructor pick is transport-agnostic. WebRTC is offered
+ * only in env-pinned direct mode (the /api/calls proxy forwards exclusively
+ * to SPEECH_TO_SPEECH_URL); LB mode and user-typed URLs stay on WebSocket.
  *
  * @typedef {"idle" | "connecting" | "queued" | "your-turn" | "listening" | "user-speaking" | "processing" | "ai-speaking" | "error"} AppState
+ * @typedef {S2sWsRealtimeClient | S2sRtcRealtimeClient} RealtimeClient
  */
 
 import { S2sWsRealtimeClient } from "./ws/s2s-ws-client.js";
+import { S2sRtcRealtimeClient } from "./rtc/s2s-rtc-client.js";
 import { $, truncateError, DEBUG } from "./ui/dom.js";
 import { ChatView } from "./ui/chat.js";
 import { Account } from "./ui/account.js";
@@ -44,6 +46,9 @@ const STORAGE_KEYS = {
   tools: "s2s.ws.tools",
   searchKey: "s2s.ws.searchKey",
   noiseGate: "s2s.ws.noiseGate",
+  // "ws" | "webrtc". Not under the historical "s2s.ws." prefix — it selects
+  // between the transports rather than configuring the WS one.
+  transport: "s2s.transport",
 };
 
 // ── Noise gate ──────────────────────────────────────────────────────────────
@@ -95,6 +100,21 @@ const TOOL_DEFS = {
 /** Longest edge of the snapshot sent to the VLM, in px (keeps payload sane). */
 const SNAPSHOT_MAX_EDGE = 768;
 const SNAPSHOT_QUALITY = 0.7;
+// Over WebRTC the snapshot travels inside ONE data-channel message, and SCTP
+// messages above the negotiated max (64 KiB on the aiortc side) fail to send.
+// Budget for the data-URL portion, leaving headroom for the JSON envelope.
+const SNAPSHOT_DC_BUDGET_CHARS = 60_000;
+// Re-encode ladder walked until the frame fits the budget: quality first
+// (cheap wins), then resolution. The last rung is ~15–25 KB for any content,
+// so a frame that "fits" is deterministic, not content-dependent luck.
+const SNAPSHOT_LADDER = /** @type {[number, number][]} */ ([
+  [SNAPSHOT_MAX_EDGE, SNAPSHOT_QUALITY],
+  [SNAPSHOT_MAX_EDGE, 0.5],
+  [640, 0.45],
+  [512, 0.4],
+  [448, 0.35],
+  [384, 0.3],
+]);
 
 function loadSettings() {
   return {
@@ -102,6 +122,8 @@ function loadSettings() {
     voice: localStorage.getItem(STORAGE_KEYS.voice) || DEFAULT_VOICE,
     instructions: localStorage.getItem(STORAGE_KEYS.instructions) || DEFAULT_INSTRUCTIONS,
     noiseGate: loadGateThreshold(),
+    // Default WebSocket: the proven path stays the first-run experience.
+    transport: localStorage.getItem(STORAGE_KEYS.transport) === "webrtc" ? "webrtc" : "ws",
   };
 }
 
@@ -124,6 +146,7 @@ function saveSettings(s) {
   localStorage.setItem(STORAGE_KEYS.voice, s.voice);
   localStorage.setItem(STORAGE_KEYS.instructions, s.instructions);
   localStorage.setItem(STORAGE_KEYS.noiseGate, String(s.noiseGate));
+  localStorage.setItem(STORAGE_KEYS.transport, s.transport);
 }
 
 /** @returns {{ web_search: boolean, camera_snapshot: boolean }} */
@@ -236,6 +259,14 @@ const inputLbUrl = $("#lb-url");
 const connField = $("#conn-field");
 /** @type {HTMLElement} */
 const connHint = $("#conn-hint");
+/** @type {HTMLElement} */
+const transportField = $("#transport-field");
+/** @type {HTMLSelectElement} */
+const inputTransport = $("#transport");
+/** @type {HTMLElement} */
+const transportHint = $("#transport-hint");
+/** @type {HTMLElement} */
+const gateField = $("#gate-field");
 /** @type {HTMLSelectElement} */
 const inputVoice = $("#voice");
 /** @type {HTMLTextAreaElement} */
@@ -280,6 +311,17 @@ let allowDirect = true;
 // Deploy-pinned s2s URL (SPEECH_TO_SPEECH_URL). Non-empty -> locked direct
 // mode: the field displays it read-only and the saved user URL is untouched.
 let pinnedUrl = "";
+// Whether the deploy offers the WebRTC transport (/api/config `rtc`; true
+// exactly when the URL is env-pinned, since /api/calls only forwards there).
+let rtcAvailable = false;
+/** @type {RTCIceServer[]} STUN/TURN servers for the browser peer connection
+ * (deploy-provided via RTC_ICE_SERVERS; empty -> host candidates only). */
+let iceServers = [];
+// Transport of the LIVE (or starting) conversation — as opposed to
+// `settings.transport`, which is what the NEXT one will use. Drives the
+// camera-snapshot size budget while a call is running.
+/** @type {"ws" | "webrtc"} */
+let activeTransport = "ws";
 
 // ── Tool state ──────────────────────────────────────────────────────────────
 let toolsEnabled = loadTools();
@@ -336,7 +378,7 @@ let trackedTier = "";
 // queue on teardown / tab-close so we don't hold a phantom place.
 let queuedTicketId = "";
 
-/** @type {S2sWsRealtimeClient | null} */
+/** @type {RealtimeClient | null} */
 let client = null;
 /** @type {MediaStream | null} */
 let micStream = null;
@@ -709,22 +751,44 @@ async function watchCameraPermission() {
  * Grab the current webcam frame as a downscaled JPEG data URL. The preview is
  * mirrored in CSS for a natural self-view, but we draw the raw (un-mirrored)
  * video here so the model sees the scene in its true orientation.
+ *
+ * Over WebRTC the frame must fit one data-channel message, so it's re-encoded
+ * down the SNAPSHOT_LADDER until it's under SNAPSHOT_DC_BUDGET_CHARS; over
+ * WebSocket the first (full-quality) rung is used as before.
  * @returns {string | null}
  */
 function captureSnapshot() {
   if (!cameraStream || !camVideo.videoWidth) return null;
   const vw = camVideo.videoWidth;
   const vh = camVideo.videoHeight;
-  const scale = Math.min(1, SNAPSHOT_MAX_EDGE / Math.max(vw, vh));
-  const w = Math.max(1, Math.round(vw * scale));
-  const h = Math.max(1, Math.round(vh * scale));
-  const canvas = document.createElement("canvas");
-  canvas.width = w;
-  canvas.height = h;
-  const ctx = canvas.getContext("2d");
-  if (!ctx) return null;
-  ctx.drawImage(camVideo, 0, 0, w, h);
-  return canvas.toDataURL("image/jpeg", SNAPSHOT_QUALITY);
+
+  /** @param {number} maxEdge @param {number} quality @returns {string | null} */
+  const encode = (maxEdge, quality) => {
+    const scale = Math.min(1, maxEdge / Math.max(vw, vh));
+    const w = Math.max(1, Math.round(vw * scale));
+    const h = Math.max(1, Math.round(vh * scale));
+    const canvas = document.createElement("canvas");
+    canvas.width = w;
+    canvas.height = h;
+    const ctx = canvas.getContext("2d");
+    if (!ctx) return null;
+    ctx.drawImage(camVideo, 0, 0, w, h);
+    return canvas.toDataURL("image/jpeg", quality);
+  };
+
+  if (activeTransport !== "webrtc") {
+    return encode(SNAPSHOT_MAX_EDGE, SNAPSHOT_QUALITY);
+  }
+  let dataUrl = null;
+  for (const [edge, quality] of SNAPSHOT_LADDER) {
+    dataUrl = encode(edge, quality);
+    if (!dataUrl) return null;
+    if (dataUrl.length <= SNAPSHOT_DC_BUDGET_CHARS) return dataUrl;
+  }
+  // Even the last rung overflowed (shouldn't happen in practice) — send it
+  // anyway; the client logs the failed send rather than killing the session.
+  console.warn(`[tool] snapshot exceeds the data-channel budget after the full ladder (${dataUrl?.length} chars)`);
+  return dataUrl;
 }
 
 /** Brief shutter flash on the preview so the user sees a snapshot was taken. */
@@ -837,6 +901,10 @@ async function fetchConfig() {
       allowDirect = json.allowDirect ?? !lbMode;
       // Deploy-pinned direct URL (overrides the LB server-side already).
       pinnedUrl = (json.s2sUrl || "").trim();
+      // WebRTC transport: offered only when the deploy pins the URL (the
+      // /api/calls proxy refuses to forward anywhere else).
+      rtcAvailable = !!json.rtc;
+      iceServers = Array.isArray(json.iceServers) ? json.iceServers : [];
       // The conversation-time limiter rides on the LB being present.
       limiterOn = lbMode;
     }
@@ -913,13 +981,20 @@ function createResumedAudioContext() {
 
 /** Read the editable settings out of the form. The URL field is only honoured
  *  in free direct mode — in LB mode it's hidden, and when the deploy pins a
- *  URL it's read-only, so the user's saved URL survives either way. */
+ *  URL it's read-only, so the user's saved URL survives either way. The
+ *  transport select is only honoured while selectable, so a saved "webrtc"
+ *  survives a visit to a deploy that can't offer it. */
 function readSettingsFromForm() {
   return {
     directUrl: allowDirect && !pinnedUrl ? inputLbUrl.value.trim() : settings.directUrl,
     voice: inputVoice.value || DEFAULT_VOICE,
     instructions: inputInstructions.value.trim() || DEFAULT_INSTRUCTIONS,
     noiseGate: readGateThreshold(),
+    transport: /** @type {"ws" | "webrtc"} */ (
+      transportSelectable()
+        ? (inputTransport.value === "webrtc" ? "webrtc" : "ws")
+        : settings.transport
+    ),
   };
 }
 
@@ -930,8 +1005,37 @@ function readGateThreshold() {
   return Math.min(GATE_MAX_DB, Math.max(GATE_OFF_DB, v));
 }
 
+/** Whether the transport picker is live: env-pinned direct mode only. The
+ *  /api/calls proxy forwards exclusively to SPEECH_TO_SPEECH_URL, so without
+ *  the pin there is nowhere safe to send a WebRTC offer. */
+function transportSelectable() {
+  return allowDirect && !!pinnedUrl && rtcAvailable;
+}
+
+/** The transport the next conversation will actually use. */
+function effectiveTransport() {
+  return transportSelectable() && settings.transport === "webrtc" ? "webrtc" : "ws";
+}
+
+/** Reflect transport availability + selection into Settings, and hide the
+ *  noise gate when WebRTC is picked (the gate lives in the WS capture
+ *  worklet; the WebRTC mic path sends the raw track). */
+function syncTransportUi() {
+  // Hidden in LB mode (nothing to choose); visible-but-locked in un-pinned
+  // direct mode so the option is discoverable along with what unlocks it.
+  transportField.hidden = !allowDirect;
+  const selectable = transportSelectable();
+  inputTransport.disabled = !selectable;
+  inputTransport.value = selectable && settings.transport === "webrtc" ? "webrtc" : "ws";
+  transportHint.textContent = selectable
+    ? "How audio travels to the server. Applies on the next conversation."
+    : "WebRTC needs a server URL pinned by the deployment (SPEECH_TO_SPEECH_URL).";
+  gateField.hidden = effectiveTransport() === "webrtc";
+}
+
 /** Adapt the connection field to the mode learned from /api/config. */
 function syncConnectionUi() {
+  syncTransportUi();
   if (pinnedUrl) {
     // Deploy-pinned URL: show it, but locked — the deployment owns it.
     connField.hidden = false;
@@ -988,6 +1092,15 @@ settingsForm.addEventListener("submit", (event) => {
 // update the label/marker, persist, and push straight to the running client.
 inputNoiseGate.addEventListener("input", () => {
   setGateThreshold(readGateThreshold());
+});
+
+// Transport persists on change (like the gate) and takes effect on the next
+// conversation; the gate field previews its WS-only availability right away.
+inputTransport.addEventListener("change", () => {
+  if (!transportSelectable()) return;
+  settings.transport = inputTransport.value === "webrtc" ? "webrtc" : "ws";
+  localStorage.setItem(STORAGE_KEYS.transport, settings.transport);
+  syncTransportUi();
 });
 
 restartBtn.addEventListener("click", async () => {
@@ -1150,9 +1263,16 @@ function stopJoinCountdown() {
  * @param {AudioContext | null} [audioContext]
  */
 async function doStart(audioContext = null) {
+  const transport = effectiveTransport();
   // Resolve the target before touching mic/audio so a misconfiguration (e.g.
-  // direct mode with no URL) fails fast with a clear message.
-  const target = connectionTarget();
+  // direct mode with no URL) fails fast with a clear message. Over WebRTC the
+  // browser never dials the s2s server itself — the offer goes to the
+  // same-origin /api/calls proxy — so there is no target to resolve.
+  const target = transport === "webrtc" ? null : connectionTarget();
+  activeTransport = transport;
+  // The radial gate arc (threshold handle around the mic button) is a WS
+  // feature; over WebRTC only the mute button remains.
+  document.body.classList.toggle("rtc-live", transport === "webrtc");
 
   chat.clear();
   chat.reset();
@@ -1179,15 +1299,24 @@ async function doStart(audioContext = null) {
   // The webcam is started on arrival (autoStartCamera), so nothing to do here;
   // a still-pending grant just means the snapshot tool isn't ready yet.
 
-  const c = new S2sWsRealtimeClient({
-    ...target,
+  const common = {
     voice: settings.voice,
     instructions: effectiveInstructions(),
     acquireMic: acquireMicStream,
     tools: activeToolDefs(),
-    noiseGate: gateParams(settings.noiseGate),
     ...(audioContext ? { audioContext } : {}),
-  });
+  };
+  const c = target === null
+    ? new S2sRtcRealtimeClient({
+        callsUrl: "api/calls",
+        iceServers,
+        ...common,
+      })
+    : new S2sWsRealtimeClient({
+        ...target,
+        noiseGate: gateParams(settings.noiseGate),
+        ...common,
+      });
   client = c;
 
   c.addEventListener("queue", (e) => {
@@ -1406,6 +1535,7 @@ async function teardown() {
   // on the page), so we leave it on here — only the camera toggle stops it.
   micMuted = false;
   micBtn.classList.remove("muted");
+  document.body.classList.remove("rtc-live");
   setState("idle");
   // Refresh the chip's remaining-today after the budget moved.
   if (limiterOn) void account.refresh();

--- a/demo/rtc/s2s-rtc-client.js
+++ b/demo/rtc/s2s-rtc-client.js
@@ -1,0 +1,809 @@
+// @ts-check
+/**
+ * Minimal WebRTC client for a speech-to-speech realtime endpoint.
+ *
+ * Sibling of `ws/s2s-ws-client.js` with the SAME public surface (constructor
+ * options subset, methods, dispatched events), so `main.js` can pick either
+ * class from the transport setting and wire it identically. Direct mode only:
+ * there is no load-balancer/queue path over WebRTC yet.
+ *
+ * Handshake (OpenAI Realtime GA "calls" endpoint, via the same-origin proxy):
+ *
+ *   1. getUserMedia -> add the mic track + create the `oai-events` data
+ *      channel on an RTCPeerConnection, `createOffer`, wait for ICE gathering.
+ *   2. POST the offer SDP (Content-Type: application/sdp) to `callsUrl`
+ *      (usually the same-origin `api/calls` proxy, which forwards it to the
+ *      s2s server's /v1/realtime/calls) -> 201 + answer SDP.
+ *   3. `setRemoteDescription(answer)`; once the data channel opens the server
+ *      pushes `session.created` and we reply with `session.update`.
+ *
+ * After that the JSON protocol on the data channel is the one the WebSocket
+ * transport speaks, with the audio moved out of it:
+ *
+ *   - Mic audio rides the RTP media track (Opus), NOT
+ *     `input_audio_buffer.append` — the server rejects `append` over WebRTC.
+ *   - Assistant audio arrives as a remote media track, NOT as
+ *     `response.output_audio.delta` events. There is no client playback
+ *     buffer: barge-in flushing happens server-side, so `speech_started`
+ *     only needs to flip the UI state here.
+ *
+ * Because no audio events exist, "the assistant is audibly speaking" is
+ * detected from the output analyser's RMS (with a short hang time), and
+ * `response.done` / `speech_started` remain the authoritative exits — the
+ * same status contract the WS client exposes.
+ *
+ * @typedef {"idle" | "connecting" | "connected" | "user-speaking" |
+ *           "processing" | "ai-speaking" | "closed" | "error"
+ * } RtcStatus
+ *
+ * @typedef {Object} RtcClientOptions
+ * @property {string} callsUrl URL to POST the SDP offer to (same-origin proxy
+ *   like `api/calls`, or a direct `/v1/realtime/calls` URL when CORS allows).
+ * @property {RTCIceServer[]} [iceServers] STUN/TURN servers for the peer
+ *   connection (from /api/config). Empty/absent -> browser defaults (host
+ *   candidates only — fine locally, may not traverse NATs).
+ * @property {string} voice
+ * @property {string} instructions
+ * @property {MediaStream} [micStream] Live mic stream. Provide this OR `acquireMic`.
+ * @property {() => Promise<MediaStream>} [acquireMic] Lazily obtain the mic
+ *   stream once connect() actually runs (same contract as the WS client).
+ * @property {AudioContext} [audioContext] Pre-created (and resumed) context —
+ *   created inside the tap gesture so iOS lets it start.
+ * @property {import("../ws/s2s-ws-client.js").ToolDef[]} [tools] Function tools
+ *   declared in the initial `session.update`.
+ */
+
+import { extractResponseTranscript } from "../ws/codec.js";
+import { OrbVisualiser, VIS_FFT_SIZE } from "../ws/orb-visualizer.js";
+
+// The server's data channel label (aiortc side ignores any other label).
+const DATA_CHANNEL_LABEL = "oai-events";
+// Give up on the handshake if the data channel hasn't opened this long after
+// the SDP answer was applied (ICE failed silently, e.g. NAT without STUN).
+// The server holds its slot behind a 30 s watchdog; stay under it.
+const DC_OPEN_TIMEOUT_MS = 20_000;
+// Don't wait forever for ICE gathering before POSTing the offer — host
+// candidates land near-instantly; STUN answers within a couple of seconds.
+const ICE_GATHERING_TIMEOUT_MS = 3_000;
+// Output-RMS gate for "the assistant is audibly speaking": open above the
+// threshold, and hang on briefly so inter-word gaps don't flap the status.
+const SPEAKING_OPEN_DB = -50;
+const SPEAKING_HANG_MS = 250;
+const LEVEL_POLL_MS = 50;
+
+/** Build an Error carrying a `code` so callers can branch on the failure kind.
+ *  @param {string} message @param {string} code */
+function _codedError(message, code) {
+  const err = /** @type {Error & { code?: string }} */ (new Error(message));
+  err.code = code;
+  return err;
+}
+
+export class S2sRtcRealtimeClient extends EventTarget {
+  /** @param {RtcClientOptions} options */
+  constructor(options) {
+    super();
+    /** @type {RtcClientOptions} */
+    this.options = options;
+    /** @type {import("../ws/s2s-ws-client.js").ToolDef[]} */
+    this._tools = options.tools ?? [];
+    /** @type {(() => Promise<MediaStream>) | null} */
+    this._acquireMic = options.acquireMic ?? null;
+    /** @type {boolean} Set by close() so late async steps unwind quietly. */
+    this._closed = false;
+    /** @type {RTCPeerConnection | null} */
+    this._pc = null;
+    /** @type {RTCDataChannel | null} */
+    this._dc = null;
+    /** @type {AudioContext | null} */
+    this._ctx = null;
+    /** @type {MediaStreamAudioSourceNode | null} */
+    this._micSrc = null;
+    /** @type {MediaStreamAudioSourceNode | null} */
+    this._remoteSrc = null;
+    /** @type {HTMLAudioElement | null} Muted sink for the Chrome quirk: a
+     * remote WebRTC track stays silent in WebAudio unless the stream is ALSO
+     * attached to an <audio> element. Never added to the DOM. */
+    this._quirkAudio = null;
+    /** @type {AnalyserNode | null} */
+    this._micAnalyser = null;
+    /** @type {AnalyserNode | null} */
+    this._outAnalyser = null;
+    /** @type {OrbVisualiser | null} */
+    this._visualiser = null;
+    /** @type {number} Level/status poll timer (setInterval id). */
+    this._levelTimer = 0;
+    /** @type {Uint8Array} Scratch buffer for time-domain RMS reads. */
+    this._levelBuf = new Uint8Array(VIS_FFT_SIZE);
+    /** @type {number} Last time the output RMS was above the speaking gate. */
+    this._lastAudibleAt = 0;
+    /** @type {RtcStatus} */
+    this._status = "idle";
+    this._aiSpeaking = false;
+    /** @type {string} The response currently holding the backend slot (from
+     * response.created), so RMS-detected audio can be attributed to it. */
+    this._activeResponseId = "";
+    /** @type {Set<string>} response_ids that audibly played, so the UI can
+     * tell a barge-in cut (keep it) from a never-heard speculative response
+     * (drop it). Attribution is by "RMS opened while this response was
+     * active" — sound can't be tied to a response id without audio events. */
+    this._audibleResponses = new Set();
+    /** @type {Map<string, string>} CURRENT assistant transcript segment per
+     * response, accumulated from streamed deltas (reset on segment done). */
+    this._asstTranscriptByResp = new Map();
+    /** @type {Map<string, string>} Completed segments per response, joined. */
+    this._asstFullByResp = new Map();
+    this._muted = false;
+    // ── Response lock ────────────────────────────────────────────────────
+    // Same scheme as the WS client: the backend allows ONE response in
+    // flight, so response.create is serialized. `_openResponses` counts
+    // confirmed-but-unfinished responses; `_createInFlight` covers the window
+    // between our create and its response.created echo; extra creates queue.
+    this._openResponses = 0;
+    this._createInFlight = false;
+    /** @type {{ image?: string }[]} */
+    this._createQueue = [];
+    this._sessionConfigured = false;
+    this._debug = (() => { try { return localStorage.getItem("s2s.debug") === "1"; } catch { return false; } })();
+  }
+
+  get status() {
+    return this._status;
+  }
+
+  /** @param {RtcStatus} status */
+  _setStatus(status) {
+    if (this._status === status) return;
+    this._status = status;
+    this.dispatchEvent(new CustomEvent("status", { detail: { status } }));
+  }
+
+  /** Full assistant transcript so far for a response: completed segments plus
+   *  the in-progress one. @param {string} rid @returns {string} */
+  _asstDisplay(rid) {
+    const full = this._asstFullByResp.get(rid) || "";
+    const seg = this._asstTranscriptByResp.get(rid) || "";
+    if (!seg) return full;
+    return full ? `${full} ${seg}` : seg;
+  }
+
+  _markAudible() {
+    if (this._status === "ai-speaking") return;
+    if (this._status === "closed" || this._status === "error") return;
+    this._setStatus("ai-speaking");
+  }
+
+  /**
+   * Full handshake. Resolves once the data channel is open AND the audio
+   * graph is wired (mic track sending, remote track feeding the analysers).
+   * @returns {Promise<void>}
+   */
+  async connect() {
+    if (this._pc) throw new Error("Already connected");
+    this._setStatus("connecting");
+
+    if (!this.options.micStream && this._acquireMic) {
+      this.options.micStream = await this._acquireMic();
+    }
+    if (this._closed) throw _codedError("connect aborted", "aborted");
+
+    this._setupAudioGraph();
+
+    const pc = new RTCPeerConnection(
+      this.options.iceServers?.length ? { iceServers: this.options.iceServers } : {},
+    );
+    this._pc = pc;
+
+    pc.addEventListener("track", (e) => this._onRemoteTrack(e));
+    pc.addEventListener("connectionstatechange", () => this._onConnectionState());
+
+    const micTrack = this.options.micStream?.getAudioTracks()[0];
+    if (!micTrack) throw new Error("No microphone track available");
+    micTrack.enabled = !this._muted;
+    pc.addTrack(micTrack, /** @type {MediaStream} */ (this.options.micStream));
+
+    // The client opens the events channel (OpenAI convention); the server
+    // waits for it and ignores channels with any other label.
+    const dc = pc.createDataChannel(DATA_CHANNEL_LABEL, { ordered: true });
+    this._dc = dc;
+    dc.addEventListener("message", (e) => this._onDcMessage(e.data));
+    dc.addEventListener("close", () => this._onDcClose());
+
+    await pc.setLocalDescription(await pc.createOffer());
+    // No trickle ICE over the one-shot HTTP handshake: the offer must carry
+    // our candidates, so wait for gathering (bounded — host candidates are
+    // near-instant, and a STUN timeout shouldn't stall the connect).
+    await this._waitIceGathering(pc);
+    if (this._closed) throw _codedError("connect aborted", "aborted");
+
+    const answerSdp = await this._postOffer(pc.localDescription?.sdp ?? "");
+    if (this._closed) throw _codedError("connect aborted", "aborted");
+    await pc.setRemoteDescription({ type: "answer", sdp: answerSdp });
+
+    await this._waitDataChannelOpen(dc);
+    this._startLevelLoop();
+    // The server pushes session.created once it sees the channel open; the
+    // session.update reply is sent from that handler (mirrors the WS client).
+  }
+
+  /** @param {RTCPeerConnection} pc */
+  _waitIceGathering(pc) {
+    if (pc.iceGatheringState === "complete") return Promise.resolve();
+    return new Promise((resolve) => {
+      const done = () => {
+        pc.removeEventListener("icegatheringstatechange", check);
+        clearTimeout(timer);
+        resolve(undefined);
+      };
+      const check = () => {
+        if (pc.iceGatheringState === "complete") done();
+      };
+      const timer = setTimeout(() => {
+        console.warn("[rtc] ICE gathering timed out; sending offer with partial candidates");
+        done();
+      }, ICE_GATHERING_TIMEOUT_MS);
+      pc.addEventListener("icegatheringstatechange", check);
+    });
+  }
+
+  /**
+   * POST the SDP offer, return the answer SDP. Non-2xx bodies are surfaced as
+   * errors ("all slots in use" arrives as a JSON error event with a 503).
+   * @param {string} offerSdp @returns {Promise<string>}
+   */
+  async _postOffer(offerSdp) {
+    console.log("[rtc] POST", this.options.callsUrl);
+    const response = await fetch(this.options.callsUrl, {
+      method: "POST",
+      headers: { "Content-Type": "application/sdp" },
+      body: offerSdp,
+    });
+    if (!response.ok) {
+      const text = await response.text().catch(() => "");
+      if (response.status === 503) {
+        // The s2s server rejects with a JSON error event when the pool is full.
+        try {
+          const j = JSON.parse(text);
+          const msg = j?.error?.message;
+          if (msg) throw _codedError(msg, "busy");
+        } catch (err) {
+          if (err instanceof Error && /** @type {any} */ (err).code === "busy") throw err;
+        }
+        throw _codedError("The speech service is busy — try again shortly.", "busy");
+      }
+      throw new Error(`WebRTC handshake failed (${response.status}): ${text.slice(0, 200)}`);
+    }
+    return response.text();
+  }
+
+  /** @param {RTCDataChannel} dc */
+  _waitDataChannelOpen(dc) {
+    if (dc.readyState === "open") return Promise.resolve();
+    return new Promise((resolve, reject) => {
+      const cleanup = () => {
+        clearTimeout(timer);
+        dc.removeEventListener("open", onOpen);
+        dc.removeEventListener("close", onClose);
+        dc.removeEventListener("error", onClose);
+      };
+      const onOpen = () => {
+        cleanup();
+        resolve(undefined);
+      };
+      const onClose = () => {
+        cleanup();
+        reject(new Error("WebRTC data channel closed before opening"));
+      };
+      const timer = setTimeout(() => {
+        cleanup();
+        reject(new Error(
+          "WebRTC connection timed out. If the server is remote, it may need a STUN/TURN server (RTC_ICE_SERVERS).",
+        ));
+      }, DC_OPEN_TIMEOUT_MS);
+      dc.addEventListener("open", onOpen);
+      dc.addEventListener("close", onClose);
+      dc.addEventListener("error", onClose);
+    });
+  }
+
+  // ── Audio graph ───────────────────────────────────────────────────────────
+  // Mic:    micStream ─→ micAnalyser (orb bars + level meter; the track itself
+  //         goes to the peer connection untouched).
+  // Output: remote track ─→ remoteSrc ─→ outAnalyser ─→ destination, plus the
+  //         hidden muted <audio> that makes Chrome actually run the track.
+
+  _setupAudioGraph() {
+    const ctx = this.options.audioContext ?? new AudioContext({ latencyHint: "interactive" });
+    this._ctx = ctx;
+    if (ctx.state === "suspended") {
+      // Best-effort here — on iOS the resume that counts happened in the tap.
+      void ctx.resume().catch((err) => console.warn("[rtc] AudioContext resume failed:", err));
+    }
+
+    const micAnalyser = ctx.createAnalyser();
+    micAnalyser.fftSize = VIS_FFT_SIZE;
+    micAnalyser.smoothingTimeConstant = 0;
+    const micSrc = ctx.createMediaStreamSource(/** @type {MediaStream} */ (this.options.micStream));
+    micSrc.connect(micAnalyser);
+    this._micSrc = micSrc;
+    this._micAnalyser = micAnalyser;
+
+    const outAnalyser = ctx.createAnalyser();
+    outAnalyser.fftSize = VIS_FFT_SIZE;
+    outAnalyser.smoothingTimeConstant = 0.3;
+    outAnalyser.connect(ctx.destination);
+    this._outAnalyser = outAnalyser;
+
+    this._visualiser = new OrbVisualiser(micAnalyser, outAnalyser, () => this._aiSpeaking);
+    this._visualiser.start();
+  }
+
+  /** @param {RTCTrackEvent} e */
+  _onRemoteTrack(e) {
+    if (e.track.kind !== "audio" || !this._ctx || !this._outAnalyser) return;
+    const stream = e.streams[0] ?? new MediaStream([e.track]);
+    // Chrome quirk: without an <audio> sink the remote track produces silence
+    // in WebAudio. Muted so playback happens once, through the analyser path.
+    const quirk = new Audio();
+    quirk.muted = true;
+    quirk.srcObject = stream;
+    this._quirkAudio = quirk;
+    this._remoteSrc?.disconnect();
+    this._remoteSrc = this._ctx.createMediaStreamSource(stream);
+    this._remoteSrc.connect(this._outAnalyser);
+    if (this._debug) console.debug("[rtc] remote audio track attached");
+  }
+
+  // ── Output-RMS status + mic level ─────────────────────────────────────────
+
+  _startLevelLoop() {
+    if (this._levelTimer) return;
+    this._levelTimer = window.setInterval(() => this._pollLevels(), LEVEL_POLL_MS);
+  }
+
+  /** RMS (0..1) of an analyser's current time-domain buffer.
+   *  @param {AnalyserNode} analyser */
+  _rmsOf(analyser) {
+    analyser.getByteTimeDomainData(this._levelBuf);
+    let sum = 0;
+    for (let i = 0; i < this._levelBuf.length; i++) {
+      const s = (this._levelBuf[i] - 128) / 128;
+      sum += s * s;
+    }
+    return Math.sqrt(sum / this._levelBuf.length);
+  }
+
+  _pollLevels() {
+    if (!this._micAnalyser || !this._outAnalyser) return;
+
+    // Mic level for the Settings meter / gate arc (raw, pre-mute).
+    this.dispatchEvent(
+      new CustomEvent("input-level", { detail: { rms: this._rmsOf(this._micAnalyser) } }),
+    );
+
+    // Speaking gate on the output: RMS opens the state; `response.done` and
+    // `speech_started` (the protocol's authoritative signals) close it.
+    const rms = this._rmsOf(this._outAnalyser);
+    const db = rms > 0 ? 20 * Math.log10(rms) : -Infinity;
+    const now = performance.now();
+    if (db > SPEAKING_OPEN_DB) this._lastAudibleAt = now;
+    const audible = now - this._lastAudibleAt < SPEAKING_HANG_MS;
+    if (audible && !this._aiSpeaking) {
+      this._aiSpeaking = true;
+      if (this._activeResponseId) this._audibleResponses.add(this._activeResponseId);
+      this._markAudible();
+    }
+  }
+
+  // ── Data channel protocol ─────────────────────────────────────────────────
+
+  /** @param {unknown} raw */
+  _onDcMessage(raw) {
+    if (typeof raw !== "string") return;
+    let event;
+    try {
+      event = JSON.parse(raw);
+    } catch {
+      return;
+    }
+
+    const type = event?.type;
+    if (typeof type !== "string") return;
+    if (this._debug) {
+      const extra = type.startsWith("conversation.item.input_audio_transcription")
+        ? ` item=${event.item_id} ${event.delta ?? event.transcript ?? ""}`
+        : type.startsWith("response.")
+          ? ` resp=${event.response_id ?? event.response?.id ?? ""} status=${event.response?.status ?? ""}`
+          : "";
+      console.debug(`[rtc] ${type}${extra}`);
+    }
+
+    switch (type) {
+      case "session.created":
+        // Server-side defaults are already what we want; push only the
+        // user-tunable bits (voice, instructions, tools) — same as WS.
+        this._sendSessionUpdate();
+        this._sessionConfigured = true;
+        if (this._status === "connecting") this._setStatus("connected");
+        break;
+
+      case "session.updated":
+        break;
+
+      case "input_audio_buffer.speech_started":
+        // Barge-in: unlike WS there is no client playback buffer to clear —
+        // the server flushes its track buffer — so this is UI state only.
+        this._aiSpeaking = false;
+        this._lastAudibleAt = 0;
+        this._setStatus("user-speaking");
+        break;
+
+      case "input_audio_buffer.speech_stopped":
+        if (this._status === "user-speaking") this._setStatus("processing");
+        break;
+
+      case "response.created":
+        this._openResponses++;
+        this._createInFlight = false;
+        this._activeResponseId = event.response?.id ?? "";
+        if (this._status === "connected" || this._status === "user-speaking") {
+          this._setStatus("processing");
+        }
+        break;
+
+      case "response.output_item.added":
+        if (this._status === "connected" || this._status === "user-speaking") {
+          this._setStatus("processing");
+        }
+        break;
+
+      case "response.done": {
+        this._aiSpeaking = false;
+        this._lastAudibleAt = 0;
+        this._openResponses = Math.max(0, this._openResponses - 1);
+        if (this._status === "ai-speaking" || this._status === "processing") {
+          this._setStatus("connected");
+        }
+        // Completion AND cancellation both arrive as response.done (status
+        // "cancelled") — same contract the WS client documents.
+        const status = event.response?.status ?? "completed";
+        const responseId = event.response?.id ?? "";
+        if (this._activeResponseId === responseId) this._activeResponseId = "";
+        const audible = responseId ? this._audibleResponses.has(responseId) : false;
+        this._audibleResponses.delete(responseId);
+        const transcript =
+          extractResponseTranscript(event.response) ||
+          this._asstDisplay(responseId) ||
+          "";
+        this._asstTranscriptByResp.delete(responseId);
+        this._asstFullByResp.delete(responseId);
+        this.dispatchEvent(new CustomEvent("response-finished", {
+          detail: { responseId, status, audible, transcript },
+        }));
+        this._flushQueuedCreate();
+        break;
+      }
+
+      case "response.function_call_arguments.done": {
+        const name = typeof event.name === "string" ? event.name : "";
+        const args = typeof event.arguments === "string" ? event.arguments : "{}";
+        const callId = typeof event.call_id === "string" ? event.call_id : "";
+        if (name) {
+          this.dispatchEvent(new CustomEvent("toolcall", {
+            detail: { name, arguments: args, callId },
+          }));
+        } else {
+          console.warn(`[rtc] function_call_arguments.done with no name (call_id=${callId}); cannot run tool — turn may stall`);
+        }
+        break;
+      }
+
+      case "conversation.item.input_audio_transcription.delta": {
+        const delta = typeof event.delta === "string" ? event.delta : "";
+        if (delta) {
+          // The delta carries the full cumulative transcript so far; itemId is
+          // reused across a speculative continuation so the UI groups them.
+          this.dispatchEvent(
+            new CustomEvent("transcript", {
+              detail: {
+                role: "user",
+                text: delta,
+                partial: true,
+                itemId: typeof event.item_id === "string" ? event.item_id : "",
+              },
+            }),
+          );
+        }
+        break;
+      }
+
+      case "conversation.item.input_audio_transcription.completed": {
+        const transcript = typeof event.transcript === "string" ? event.transcript : "";
+        if (transcript) {
+          this.dispatchEvent(
+            new CustomEvent("transcript", {
+              detail: {
+                role: "user",
+                text: transcript,
+                partial: false,
+                itemId: typeof event.item_id === "string" ? event.item_id : "",
+              },
+            }),
+          );
+        }
+        break;
+      }
+
+      case "response.audio_transcript.delta":
+      case "response.output_audio_transcript.delta": {
+        this._markAudible();
+        const rid = typeof event.response_id === "string" ? event.response_id : "";
+        const delta = typeof event.delta === "string" ? event.delta : "";
+        if (delta) {
+          this._asstTranscriptByResp.set(rid, (this._asstTranscriptByResp.get(rid) || "") + delta);
+          this.dispatchEvent(
+            new CustomEvent("transcript", {
+              detail: { role: "assistant", text: this._asstDisplay(rid), partial: true, responseId: rid },
+            }),
+          );
+        }
+        break;
+      }
+
+      case "response.audio_transcript.done":
+      case "response.output_audio_transcript.done": {
+        const rid = typeof event.response_id === "string" ? event.response_id : "";
+        // ONE completed segment; a response can emit several — concatenate
+        // until response.done clears the accumulator.
+        const segment =
+          (typeof event.transcript === "string" && event.transcript) ||
+          this._asstTranscriptByResp.get(rid) ||
+          "";
+        this._asstTranscriptByResp.delete(rid);
+        if (segment) {
+          const prev = this._asstFullByResp.get(rid) || "";
+          this._asstFullByResp.set(rid, prev ? `${prev} ${segment}` : segment);
+        }
+        const full = this._asstFullByResp.get(rid) || "";
+        if (full) {
+          this.dispatchEvent(
+            new CustomEvent("transcript", {
+              detail: { role: "assistant", text: full, partial: false, responseId: rid },
+            }),
+          );
+        }
+        break;
+      }
+
+      case "error": {
+        const err = event.error;
+        console.error("[rtc] server error:", err);
+        // Our optimistic create collided with a still-running response: clear
+        // the guard and re-queue for the next response.done (never retried
+        // immediately — that would just collide again).
+        if (err?.type === "conversation_already_has_active_response" ||
+            err?.code === "conversation_already_has_active_response") {
+          if (this._createInFlight) {
+            this._createInFlight = false;
+            this._createQueue.push({});
+          }
+          break;
+        }
+        // Every other server error is non-fatal: surface for logging, keep
+        // the session alive. Transport failures come through their own paths.
+        this.dispatchEvent(
+          new CustomEvent("server-error", { detail: { error: new Error(err?.message ?? "Server error") } }),
+        );
+        break;
+      }
+    }
+  }
+
+  _onDcClose() {
+    if (this._closed) return;
+    if (this._status === "closed" || this._status === "error") return;
+    console.log("[rtc] data channel closed by server");
+    this.dispatchEvent(
+      new CustomEvent("error", { detail: { error: new Error("Connection closed by the server") } }),
+    );
+    this._setStatus("error");
+  }
+
+  _onConnectionState() {
+    const state = this._pc?.connectionState;
+    if (this._debug) console.debug(`[rtc] connection state: ${state}`);
+    if (this._closed) return;
+    if (state === "failed" || state === "disconnected") {
+      if (this._status === "closed" || this._status === "error") return;
+      this.dispatchEvent(
+        new CustomEvent("error", { detail: { error: new Error(`WebRTC connection ${state}`) } }),
+      );
+      this._setStatus("error");
+    }
+  }
+
+  _sendSessionUpdate() {
+    // Minimal payload, exactly like the WS client: the server's pydantic
+    // validator rejects the whole event on unknown sub-field shapes.
+    /** @type {Record<string, any>} */
+    const session = {
+      type: "realtime",
+      instructions: this.options.instructions,
+      audio: {
+        output: { voice: this.options.voice },
+      },
+    };
+    if (this._tools.length) {
+      session.tools = this._tools;
+      session.tool_choice = "auto";
+    }
+    this._send({ type: "session.update", session });
+  }
+
+  /** Update voice/instructions on a live session without tearing down.
+   *  @param {{ voice?: string; instructions?: string }} patch */
+  updateSession(patch) {
+    /** @type {Record<string, any>} */
+    const session = { type: "realtime" };
+    if (patch.instructions) session.instructions = patch.instructions;
+    if (patch.voice) session.audio = { output: { voice: patch.voice } };
+    if (Object.keys(session).length > 1) {
+      this._send({ type: "session.update", session });
+    }
+  }
+
+  /** Replace the declared tool set on a live session. Always sends `tools` —
+   *  an empty array clears them. @param {import("../ws/s2s-ws-client.js").ToolDef[]} tools */
+  setTools(tools) {
+    this._tools = tools;
+    this._send({
+      type: "session.update",
+      session: { type: "realtime", tools, tool_choice: tools.length ? "auto" : "none" },
+    });
+  }
+
+  /** Return a tool's result to the model. @param {string} callId @param {string} output */
+  sendToolOutput(callId, output) {
+    if (!callId) return;
+    this._send({
+      type: "conversation.item.create",
+      item: { type: "function_call_output", call_id: callId, output },
+    });
+  }
+
+  /** Add an image to the conversation as user content (camera tool). The
+   *  caller keeps `dataUrl` under the data-channel message budget — SCTP
+   *  messages above the negotiated max (64 KiB on aiortc) fail to send.
+   *  @param {string} dataUrl */
+  sendUserImage(dataUrl) {
+    this._send({
+      type: "conversation.item.create",
+      item: {
+        type: "message",
+        role: "user",
+        content: [{ type: "input_image", image_url: dataUrl }],
+      },
+    });
+  }
+
+  /** Ask the model to respond now (after tool results). Serialized behind the
+   *  single-response slot, same as the WS client.
+   *  @param {{ image?: string }} [opts] */
+  requestResponse(opts = {}) {
+    if (this._responseActive()) {
+      this._createQueue.push(opts);
+      if (this._debug) console.debug(`[rtc] response.create queued; pending=${this._createQueue.length}`);
+      return;
+    }
+    this._createResponseNow(opts);
+  }
+
+  _responseActive() {
+    return this._openResponses > 0 || this._createInFlight;
+  }
+
+  /** @param {{ image?: string }} [opts] */
+  _createResponseNow(opts = {}) {
+    if (!this._dc || this._dc.readyState !== "open") return;
+    if (opts.image) this.sendUserImage(opts.image);
+    this._createInFlight = true;
+    this._send({ type: "response.create" });
+  }
+
+  _flushQueuedCreate() {
+    if (this._createQueue.length > 0 && !this._responseActive()) {
+      const opts = this._createQueue.shift();
+      if (this._debug) console.debug(`[rtc] replaying queued response.create; remaining=${this._createQueue.length}`);
+      this._createResponseNow(opts);
+    }
+  }
+
+  /** @param {boolean} muted */
+  setMuted(muted) {
+    this._muted = muted;
+    // The caller (main.js) also toggles the shared micStream tracks; doing it
+    // here too keeps the client correct when driven standalone. A disabled
+    // track makes the browser transmit silence — the server VAD stays quiet.
+    for (const track of this.options.micStream?.getAudioTracks() ?? []) {
+      track.enabled = !muted;
+    }
+  }
+
+  /** Noise gate is a WebSocket-transport feature (implemented in its capture
+   *  worklet); the WebRTC mic path sends the raw track, so this is a no-op.
+   *  @param {import("../ws/s2s-ws-client.js").NoiseGate} _gate */
+  setNoiseGate(_gate) {}
+
+  /** Queue "join" gate — LB-mode only, which WebRTC doesn't support. Present
+   *  so the two clients keep the same surface for the caller. */
+  join() {}
+
+  /** @param {Record<string, unknown>} event */
+  _send(event) {
+    if (!this._dc || this._dc.readyState !== "open") return;
+    try {
+      this._dc.send(JSON.stringify(event));
+    } catch (err) {
+      // A message over the SCTP limit (or a racing close) lands here; keep
+      // the session alive and let the caller's flow recover.
+      console.error("[rtc] data channel send failed:", err);
+    }
+  }
+
+  async close() {
+    this._closed = true;
+    if (this._levelTimer) {
+      clearInterval(this._levelTimer);
+      this._levelTimer = 0;
+    }
+    this._visualiser?.stop();
+    this._visualiser = null;
+    try {
+      this._dc?.close();
+    } catch {
+      // ignored
+    }
+    this._dc = null;
+    try {
+      this._pc?.close();
+    } catch {
+      // ignored
+    }
+    this._pc = null;
+    if (this._quirkAudio) {
+      this._quirkAudio.srcObject = null;
+      this._quirkAudio = null;
+    }
+    try {
+      this._remoteSrc?.disconnect();
+    } catch {
+      // ignored
+    }
+    try {
+      this._micSrc?.disconnect();
+    } catch {
+      // ignored
+    }
+    try {
+      this._micAnalyser?.disconnect();
+    } catch {
+      // ignored
+    }
+    try {
+      this._outAnalyser?.disconnect();
+    } catch {
+      // ignored
+    }
+    try {
+      await this._ctx?.close();
+    } catch {
+      // ignored
+    }
+    this._ctx = null;
+    this._remoteSrc = null;
+    this._micSrc = null;
+    this._micAnalyser = null;
+    this._outAnalyser = null;
+    this._setStatus("closed");
+  }
+}

--- a/demo/rtc/s2s-rtc-client.js
+++ b/demo/rtc/s2s-rtc-client.js
@@ -613,7 +613,14 @@ export class S2sRtcRealtimeClient extends EventTarget {
     const state = this._pc?.connectionState;
     if (this._debug) console.debug(`[rtc] connection state: ${state}`);
     if (this._closed) return;
-    if (state === "failed" || state === "disconnected") {
+    if (state === "disconnected") {
+      // Transient: browsers fire this on brief packet loss and usually recover
+      // to "connected" on their own; the terminal state is "failed", which
+      // fires this handler again if recovery doesn't happen.
+      console.warn("[rtc] connection disconnected — waiting for recovery or failure");
+      return;
+    }
+    if (state === "failed") {
       if (this._status === "closed" || this._status === "error") return;
       this.dispatchEvent(
         new CustomEvent("error", { detail: { error: new Error(`WebRTC connection ${state}`) } }),

--- a/demo/server.py
+++ b/demo/server.py
@@ -84,11 +84,11 @@ LIMITER_ENABLED = bool(LOAD_BALANCER_URL) and bool(SPACE_ID)
 def _parse_ice_servers(raw: str) -> list:
     """ICE servers for the browser's RTCPeerConnection, from RTC_ICE_SERVERS.
 
-    Accepts either a JSON list of RTCIceServer dicts (same format as the s2s
+    Accepts a JSON list of RTCIceServer dicts (same format as the s2s
     server's SPEECH_TO_SPEECH_ICE_SERVERS, e.g.
-    ``[{"urls": "turn:t.example.com", "username": "u", "credential": "c"}]``)
-    or a plain comma-separated list of STUN/TURN URLs. Empty when unset —
-    host candidates only, which is fine for local use."""
+    ``[{"urls": "turn:t.example.com", "username": "u", "credential": "c"}]``),
+    a single such dict, or a plain comma-separated list of STUN/TURN URLs.
+    Empty when unset — host candidates only, which is fine for local use."""
     raw = raw.strip()
     if not raw:
         return []
@@ -96,6 +96,8 @@ def _parse_ice_servers(raw: str) -> list:
         data = json.loads(raw)
         if isinstance(data, list):
             return data
+        if isinstance(data, dict):
+            return [data]
     except ValueError:
         pass
     return [{"urls": u.strip()} for u in raw.split(",") if u.strip()]

--- a/demo/server.py
+++ b/demo/server.py
@@ -23,9 +23,10 @@ disabled entirely (no session proxy, no queue, no metering, no sign-in) and the
 browser connects directly to that URL, shown read-only in Settings.
 
 Endpoints:
-  GET  /api/config           -> { search, lb, allowDirect, s2sUrl, auth }
+  GET  /api/config           -> { search, lb, allowDirect, s2sUrl, rtc, iceServers, auth }
   GET  /api/me               -> login + tier + remaining budget (LB mode only)
   POST /api/search           -> { results, answer }  Google via Serper.dev
+  POST /api/calls            -> proxies the WebRTC SDP offer to <s2s>/v1/realtime/calls
   POST /api/session          -> proxies <LB>/session: a grant, or a queue ticket
   GET  /api/queue/{id}       -> proxies <LB>/queue/{id}: position, or a grant on claim
   DELETE /api/queue/{id}     -> leave the queue (explicit "Leave queue" button)
@@ -41,17 +42,18 @@ the moment a slot is actually claimed (a grant), never while queued.
 """
 
 import asyncio
+import json
 import logging
 import os
+from urllib.parse import urlsplit, urlunsplit
 
+import auth
 import httpx
-from fastapi import FastAPI, HTTPException, Request
+import limiter
+from fastapi import FastAPI, HTTPException, Request, Response
 from fastapi.responses import JSONResponse
 from fastapi.staticfiles import StaticFiles
 from pydantic import BaseModel
-
-import auth
-import limiter
 
 logger = logging.getLogger("s2s.search")
 
@@ -77,6 +79,46 @@ if SPEECH_TO_SPEECH_URL:
 # but nothing is metered: no budget, no reservations, no sign-in gating.
 SPACE_ID = os.environ.get("SPACE_ID", "").strip()
 LIMITER_ENABLED = bool(LOAD_BALANCER_URL) and bool(SPACE_ID)
+
+
+def _parse_ice_servers(raw: str) -> list:
+    """ICE servers for the browser's RTCPeerConnection, from RTC_ICE_SERVERS.
+
+    Accepts either a JSON list of RTCIceServer dicts (same format as the s2s
+    server's SPEECH_TO_SPEECH_ICE_SERVERS, e.g.
+    ``[{"urls": "turn:t.example.com", "username": "u", "credential": "c"}]``)
+    or a plain comma-separated list of STUN/TURN URLs. Empty when unset —
+    host candidates only, which is fine for local use."""
+    raw = raw.strip()
+    if not raw:
+        return []
+    try:
+        data = json.loads(raw)
+        if isinstance(data, list):
+            return data
+    except ValueError:
+        pass
+    return [{"urls": u.strip()} for u in raw.split(",") if u.strip()]
+
+
+RTC_ICE_SERVERS = _parse_ice_servers(os.environ.get("RTC_ICE_SERVERS", ""))
+
+
+def _webrtc_calls_url(s2s_url: str) -> str:
+    """Derive the WebRTC handshake URL from the pinned realtime URL.
+
+    ``ws://host:port/v1/realtime`` -> ``http://host:port/v1/realtime/calls``
+    (ws->http, wss->https; a bare host gets the default /v1/realtime path,
+    mirroring the client's buildDirectWsUrl normalisation)."""
+    s = s2s_url.strip()
+    if not s.startswith(("ws://", "wss://", "http://", "https://")):
+        s = "http://" + s
+    parts = urlsplit(s)
+    scheme = {"ws": "http", "wss": "https"}.get(parts.scheme, parts.scheme)
+    path = parts.path if parts.path not in ("", "/") else "/v1/realtime"
+    return urlunsplit((scheme, parts.netloc, path.rstrip("/") + "/calls", parts.query, ""))
+
+
 SERPER_URL = "https://google.serper.dev/search"
 # Cap results so the tool output stays small enough to feed back to the model.
 MAX_RESULTS = 5
@@ -127,6 +169,11 @@ def config():
         # Deploy-pinned direct s2s URL (empty when unset). Not a secret: the
         # browser dials it itself, and Settings shows it locked.
         "s2sUrl": SPEECH_TO_SPEECH_URL,
+        # WebRTC transport availability: the /api/calls proxy only forwards to
+        # the env-pinned URL (never a client-supplied one), so the toggle is
+        # offered exactly when that URL exists.
+        "rtc": bool(SPEECH_TO_SPEECH_URL),
+        "iceServers": RTC_ICE_SERVERS,
         "auth": AUTH_ENABLED,
     }
 
@@ -212,6 +259,46 @@ async def search(req: SearchRequest):
         answer = kg.get("description") or None
 
     return JSONResponse({"query": query, "answer": answer, "results": results})
+
+
+@app.post("/api/calls")
+async def calls(request: Request):
+    """Proxy the WebRTC SDP handshake to the pinned s2s server.
+
+    The browser can't POST /v1/realtime/calls cross-origin (the s2s server has
+    no CORS middleware, and an application/sdp POST is preflighted), so it
+    posts the offer here and we forward it server-side. Only the signaling hop
+    goes through this proxy — the negotiated audio/data-channel media flows
+    directly between the browser and the s2s server.
+
+    Deliberately forwards ONLY to SPEECH_TO_SPEECH_URL: honouring a
+    client-supplied target would make this an open proxy (SSRF). No env pin,
+    no WebRTC — the client keeps such setups on the WebSocket transport."""
+    if not SPEECH_TO_SPEECH_URL:
+        raise HTTPException(status_code=404, detail="Not found.")
+
+    offer = await request.body()
+    url = _webrtc_calls_url(SPEECH_TO_SPEECH_URL)
+    try:
+        # Generous timeout: the s2s server waits for its own ICE gathering
+        # (up to ~5 s) before returning the answer.
+        async with httpx.AsyncClient(timeout=15.0) as http:
+            resp = await http.post(url, headers={"Content-Type": "application/sdp"}, content=offer)
+    except httpx.RequestError as exc:
+        logger.warning("s2s calls endpoint unreachable: %r", exc)
+        raise HTTPException(status_code=502, detail="Speech service unreachable.")
+
+    # Relay the answer (or the error body) as-is; keep the Location header the
+    # s2s server sets on success (the call id, per the OpenAI GA contract).
+    headers = {}
+    if "location" in resp.headers:
+        headers["Location"] = resp.headers["location"]
+    return Response(
+        content=resp.content,
+        status_code=resp.status_code,
+        media_type=resp.headers.get("content-type", "application/sdp"),
+        headers=headers,
+    )
 
 
 @app.post("/api/session")

--- a/demo/style.css
+++ b/demo/style.css
@@ -1009,6 +1009,9 @@ a:hover {
   transition: opacity 0.25s ease;
 }
 .orb-wrap.live .mic-gate-arc { opacity: 1; }
+/* The gate is a WebSocket-transport feature (it lives in the WS capture
+ * worklet). During a WebRTC call only the mute button remains. */
+body.rtc-live .mic-gate-arc { display: none; }
 .mga-track {
   stroke: rgba(255, 255, 255, 0.1); /* hairline; recedes until needed */
   stroke-width: 1.5;

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -89,6 +89,9 @@ paraformer = [
 pocket = [
     "pocket-tts>=0.1.0",
 ]
+webrtc = [
+    "aiortc>=1.9.0",
+]
 websocket = [
     "websockets>=12.0",
 ]
@@ -111,6 +114,7 @@ dev = [
     "pytest",
     "pytest-asyncio",
     "websockets>=12.0",
+    "aiortc>=1.9.0",
 ]
 
 [tool.pytest.ini_options]

--- a/src/speech_to_speech/api/openai_realtime/README.md
+++ b/src/speech_to_speech/api/openai_realtime/README.md
@@ -83,6 +83,34 @@ flowchart LR
 
 ---
 
+## WebRTC Transport
+
+Alongside the WebSocket endpoint, the server supports the OpenAI GA WebRTC handshake (requires the `webrtc` extra: `pip install 'speech-to-speech[webrtc]'`):
+
+```
+POST /v1/realtime/calls        Content-Type: application/sdp
+```
+
+The client POSTs an SDP offer and receives an SDP answer (`201`, with a `Location: /v1/realtime/calls/{call_id}` header). Audio then flows over RTP media tracks (Opus at 48 kHz, resampled to and from the 16 kHz pipeline rate with a stateful resampler), while all JSON events use the same protocol as WebSocket mode, carried on the `oai-events` data channel.
+
+A WebRTC session claims a pipeline unit from the same pool as WebSocket clients; the per-unit send loop stays the sole consumer of the pipeline output queues and hands PCM to the transport, which paces it out as 20 ms RTP frames (silence when idle).
+
+Differences from WebSocket mode:
+
+- `input_audio_buffer.append` is rejected with `invalid_event_for_transport` — audio arrives on the media track.
+- `output_audio_buffer.clear` is supported (WebRTC only): unplayed audio buffers server-side, so barge-in and cancellation flush it there. The server also flushes it automatically on `response.cancel` and VAD interruption.
+- `session.created` is sent when the data channel opens rather than on connection.
+
+ICE servers (STUN/TURN) can be configured via the `SPEECH_TO_SPEECH_ICE_SERVERS` env var, a JSON list of server entries:
+
+```bash
+export SPEECH_TO_SPEECH_ICE_SERVERS='[{"urls": "stun:stun.example.com:3478"}, {"urls": "turn:turn.example.com", "username": "u", "credential": "c"}]'
+```
+
+Without it, aiortc defaults apply (host candidates + Google STUN). Deployments where clients cannot reach the server directly (symmetric NAT, containers without exposed UDP) need a TURN server.
+
+---
+
 ## Tool Calling Design
 
 Tool calling works through two distinct paths depending on the LLM backend, but both converge to the same wire protocol for the client.

--- a/src/speech_to_speech/api/openai_realtime/handlers/audio.py
+++ b/src/speech_to_speech/api/openai_realtime/handlers/audio.py
@@ -60,7 +60,19 @@ class AudioHandler(RealtimeBaseHandler):
             client_in_rate = getattr(audio_cfg.input.format, "rate", None) or PIPELINE_SAMPLE_RATE
         else:
             client_in_rate = PIPELINE_SAMPLE_RATE
-        pcm_bytes = resample(pcm_bytes, client_in_rate, PIPELINE_SAMPLE_RATE)
+        return self.append_pcm(conn_id, pcm_bytes, client_in_rate)
+
+    def append_pcm(self, conn_id: str, pcm_bytes: bytes, src_rate: int) -> list[bytes]:
+        """Resample raw PCM16 to the pipeline rate and split into 512-sample chunks for the VAD.
+
+        Shared by both transports: the WebSocket route feeds it decoded
+        ``input_audio_buffer.append`` payloads, the WebRTC transport feeds it
+        PCM decoded from inbound media-track frames. Keeps the sub-chunk
+        remainder and the commit bookkeeping (``audio_buffer_has_data``) in
+        one place regardless of how audio arrives.
+        """
+        st = self._state(conn_id)
+        pcm_bytes = resample(pcm_bytes, src_rate, PIPELINE_SAMPLE_RATE)
 
         pcm_bytes = st.audio_remainder + pcm_bytes
 
@@ -150,14 +162,19 @@ class AudioHandler(RealtimeBaseHandler):
 
     # ── Outbound audio encoding ──────────────────
 
-    def encode_audio_chunk(self, conn_id: str, audio: bytes) -> list[ServerEvent]:
-        """Encode a raw PCM audio chunk, emitting ResponseCreated on the first chunk.
+    def begin_audio_response(self, conn_id: str) -> tuple[str, str, list[ServerEvent]]:
+        """Ensure a response exists for outbound audio, emitting ResponseCreated once.
 
         When ``handle_response_create`` already allocated the response,
         ``current_response_id`` is set and no duplicate event is emitted.
         For the implicit-response path (VAD -> STT -> LLM -> TTS, no
         ``response.create``), ``current_response_id`` is still ``None``
         and the event is emitted here on the first audio chunk.
+
+        Returns ``(response_id, item_id, events)``. Shared by both
+        transports: the WebSocket path appends the base64 audio delta to the
+        returned events, the WebRTC path sends only the bookkeeping events
+        over the data channel while audio travels on the media track.
         """
         response = self._service.response
         st = self._state(conn_id)
@@ -173,6 +190,14 @@ class AudioHandler(RealtimeBaseHandler):
                     response=response._build_response(conn_id, "in_progress"),
                 )
             )
+        return resp_id, item_id, events
+
+    def encode_audio_chunk(self, conn_id: str, audio: bytes) -> list[ServerEvent]:
+        """Encode a raw PCM audio chunk as a base64 delta event for the WebSocket transport."""
+        response = self._service.response
+        st = self._state(conn_id)
+
+        resp_id, item_id, events = self.begin_audio_response(conn_id)
         rp = st.current_response_params
         client_out_rate = None
         if rp and rp.audio and rp.audio.output and rp.audio.output.format:

--- a/src/speech_to_speech/api/openai_realtime/pipeline_unit.py
+++ b/src/speech_to_speech/api/openai_realtime/pipeline_unit.py
@@ -6,6 +6,7 @@ from typing import Any, Optional
 from pydantic import BaseModel, ConfigDict, Field
 
 from speech_to_speech.api.openai_realtime.service import RealtimeService
+from speech_to_speech.api.openai_realtime.transports import SessionTransport
 from speech_to_speech.pipeline.cancel_scope import CancelScope
 
 
@@ -18,9 +19,9 @@ class SessionState(BaseModel):
     (pending_output_item) here ensures these fields share one lifecycle — a
     stale value can't outlive its session.
 
-    `transport` is a SessionTransport (WebSocketTransport or WebRTCSession);
-    it may briefly be None while a WebRTC claim finishes constructing the
-    session, so the send loop must tolerate a transport-less snapshot.
+    `transport` may briefly be None while a WebRTC claim finishes
+    constructing the session, so the send loop must tolerate a
+    transport-less snapshot.
 
     `drained` is set by the send loop when SESSION_END travels through the handler
     chain back to the output queue; the release path awaits it before clearing
@@ -30,7 +31,7 @@ class SessionState(BaseModel):
 
     model_config = ConfigDict(arbitrary_types_allowed=True)
 
-    transport: Any = None
+    transport: Optional[SessionTransport] = None
     session_id: str = ""
     pending_output_item: Any = None
     drained: asyncio.Event = Field(default_factory=asyncio.Event)

--- a/src/speech_to_speech/api/openai_realtime/pipeline_unit.py
+++ b/src/speech_to_speech/api/openai_realtime/pipeline_unit.py
@@ -10,28 +10,33 @@ from speech_to_speech.pipeline.cancel_scope import CancelScope
 
 
 class SessionState(BaseModel):
-    """Per-websocket ephemeral state.
+    """Per-client ephemeral state.
 
-    Created when the route handler claims a PipelineUnit on `ws.accept()`; dropped
-    when the websocket disconnects. Holding the websocket reference, the service
-    session id, and any send-loop scratch (pending_output_item) here ensures these
-    fields share one lifecycle — a stale value can't outlive its session.
+    Created when a route handler claims a PipelineUnit (WebSocket accept or
+    WebRTC SDP offer); dropped when the client disconnects. Holding the
+    transport reference, the service session id, and any send-loop scratch
+    (pending_output_item) here ensures these fields share one lifecycle — a
+    stale value can't outlive its session.
+
+    `transport` is a SessionTransport (WebSocketTransport or WebRTCSession);
+    it may briefly be None while a WebRTC claim finishes constructing the
+    session, so the send loop must tolerate a transport-less snapshot.
 
     `drained` is set by the send loop when SESSION_END travels through the handler
-    chain back to the output queue; the route handler awaits it before clearing
+    chain back to the output queue; the release path awaits it before clearing
     `PipelineUnit.session`, so a new client cannot claim the unit until in-flight
     work from this session has fully reset.
     """
 
     model_config = ConfigDict(arbitrary_types_allowed=True)
 
-    websocket: Any
+    transport: Any = None
     session_id: str = ""
     pending_output_item: Any = None
     drained: asyncio.Event = Field(default_factory=asyncio.Event)
-    # Wall-clock time when the ws disconnected (route handler released its claim).
-    # `None` while the client is still active. Used by /v1/pool to surface stuck
-    # units (handlers haven't finished propagating SESSION_END).
+    # Wall-clock time when the client disconnected (route handler released its
+    # claim). `None` while the client is still active. Used by /v1/pool to
+    # surface stuck units (handlers haven't finished propagating SESSION_END).
     released_at: Optional[float] = None
 
 

--- a/src/speech_to_speech/api/openai_realtime/service.py
+++ b/src/speech_to_speech/api/openai_realtime/service.py
@@ -11,8 +11,10 @@ from openai.types.realtime import (
     ConversationItemInputAudioTranscriptionCompletedEvent,
     ConversationItemInputAudioTranscriptionDeltaEvent,
     InputAudioBufferAppendEvent,
+    InputAudioBufferCommitEvent,
     InputAudioBufferSpeechStartedEvent,
     InputAudioBufferSpeechStoppedEvent,
+    OutputAudioBufferClearEvent,
     RealtimeError,
     RealtimeErrorEvent,
     ResponseAudioDeltaEvent,
@@ -66,6 +68,8 @@ _StatusReason = Literal["turn_detected", "client_cancelled", "max_output_tokens"
 
 _EVENT_TYPE_TO_MODEL: dict[str, type[BaseModel]] = {
     "input_audio_buffer.append": InputAudioBufferAppendEvent,
+    "input_audio_buffer.commit": InputAudioBufferCommitEvent,
+    "output_audio_buffer.clear": OutputAudioBufferClearEvent,
     "session.update": SessionUpdateEvent,
     "conversation.item.create": ConversationItemCreateEvent,
     "response.create": ResponseCreateEvent,
@@ -74,6 +78,8 @@ _EVENT_TYPE_TO_MODEL: dict[str, type[BaseModel]] = {
 
 ClientEvent = Union[
     InputAudioBufferAppendEvent,
+    InputAudioBufferCommitEvent,
+    OutputAudioBufferClearEvent,
     SessionUpdateEvent,
     ConversationItemCreateEvent,
     ResponseCreateEvent,
@@ -285,8 +291,14 @@ class RealtimeService:
     def handle_audio_append(self, conn_id: str, event: InputAudioBufferAppendEvent) -> list[bytes]:
         return self.audio.handle_audio_append(conn_id, event)
 
+    def append_pcm(self, conn_id: str, pcm_bytes: bytes, src_rate: int) -> list[bytes]:
+        return self.audio.append_pcm(conn_id, pcm_bytes, src_rate)
+
     def handle_audio_commit(self, conn_id: str) -> RealtimeErrorEvent | None:
         return self.audio.handle_audio_commit(conn_id)
+
+    def begin_audio_response(self, conn_id: str) -> tuple[str, str, list[ServerEvent]]:
+        return self.audio.begin_audio_response(conn_id)
 
     def encode_audio_chunk(self, conn_id: str, audio: bytes) -> list[ServerEvent]:
         return self.audio.encode_audio_chunk(conn_id, audio)

--- a/src/speech_to_speech/api/openai_realtime/transports.py
+++ b/src/speech_to_speech/api/openai_realtime/transports.py
@@ -13,7 +13,8 @@ and hands client-visible traffic to the transport attached to the current
 from __future__ import annotations
 
 import logging
-from typing import TYPE_CHECKING, Protocol
+from abc import ABC, abstractmethod
+from typing import TYPE_CHECKING
 
 from fastapi import WebSocket, WebSocketDisconnect
 from starlette.websockets import WebSocketState
@@ -24,15 +25,19 @@ if TYPE_CHECKING:
 logger = logging.getLogger(__name__)
 
 
-class SessionTransport(Protocol):
+class SessionTransport(ABC):
     """What the send loop and client-event dispatch need from a transport."""
 
+    kind: str
+
+    @abstractmethod
     async def send_events(self, events: list[ServerEvent]) -> None: ...
 
+    @abstractmethod
     async def send_audio_chunk(self, service: RealtimeService, session_id: str, pcm: bytes) -> None:
         """Deliver a pipeline-rate PCM16 chunk to the client."""
-        ...
 
+    @abstractmethod
     def discard_pending_audio(self) -> None:
         """Drop transport-buffered audio that has not reached the client yet.
 
@@ -40,8 +45,8 @@ class SessionTransport(Protocol):
         the WebRTC transport paces playback server-side and must flush its
         track buffer for barge-in to actually silence the assistant.
         """
-        ...
 
+    @abstractmethod
     async def close(self) -> None: ...
 
 
@@ -68,7 +73,7 @@ async def send_ws_event(ws: WebSocket, event: ServerEvent) -> None:
         logger.error(f"Failed to send event to client: {e}")
 
 
-class WebSocketTransport:
+class WebSocketTransport(SessionTransport):
     """JSON-over-WebSocket transport: audio is sent as base64 delta events."""
 
     kind = "websocket"

--- a/src/speech_to_speech/api/openai_realtime/transports.py
+++ b/src/speech_to_speech/api/openai_realtime/transports.py
@@ -1,0 +1,95 @@
+"""Session transports: how server events and outbound audio reach a client.
+
+The per-unit send loop in ``websocket_router`` is transport-agnostic: it owns
+the pipeline output queues (sentinels, generation discards, SESSION_END drain)
+and hands client-visible traffic to the transport attached to the current
+``SessionState``. Two implementations exist:
+
+- ``WebSocketTransport`` (here): events and base64 audio deltas as JSON frames.
+- ``WebRTCSession`` (in ``webrtc_session``, requires the ``webrtc`` extra):
+  events over the ``oai-events`` data channel, audio over the RTP media track.
+"""
+
+from __future__ import annotations
+
+import logging
+from typing import TYPE_CHECKING, Protocol
+
+from fastapi import WebSocket, WebSocketDisconnect
+from starlette.websockets import WebSocketState
+
+if TYPE_CHECKING:
+    from speech_to_speech.api.openai_realtime.service import RealtimeService, ServerEvent
+
+logger = logging.getLogger(__name__)
+
+
+class SessionTransport(Protocol):
+    """What the send loop and client-event dispatch need from a transport."""
+
+    async def send_events(self, events: list[ServerEvent]) -> None: ...
+
+    async def send_audio_chunk(self, service: RealtimeService, session_id: str, pcm: bytes) -> None:
+        """Deliver a pipeline-rate PCM16 chunk to the client."""
+        ...
+
+    def discard_pending_audio(self) -> None:
+        """Drop transport-buffered audio that has not reached the client yet.
+
+        WebSocket clients buffer audio on their side, so this is a no-op there;
+        the WebRTC transport paces playback server-side and must flush its
+        track buffer for barge-in to actually silence the assistant.
+        """
+        ...
+
+    async def close(self) -> None: ...
+
+
+async def send_ws_event(ws: WebSocket, event: ServerEvent) -> None:
+    # Skip cleanly when the ws is already closing/closed — happens during Ctrl-C
+    # shutdown, where the lifespan starts closing sockets while the route handler
+    # or send loop is still in flight pushing events.
+    if ws.application_state != WebSocketState.CONNECTED:
+        return
+    try:
+        await ws.send_json(event.model_dump())
+    except WebSocketDisconnect:
+        logger.debug("Skipped event: ws disconnected mid-send")
+    except RuntimeError as e:
+        # Race: ws closed between the state check above and the send. Starlette
+        # raises a plain RuntimeError("Unexpected ASGI message 'websocket.send'
+        # after sending 'websocket.close' ...") — harmless during shutdown.
+        msg = str(e)
+        if "websocket.close" in msg or "websocket.disconnect" in msg or "response already completed" in msg:
+            logger.debug(f"Skipped event: ws already closed ({msg})")
+        else:
+            logger.error(f"Failed to send event to client: {e}")
+    except Exception as e:  # noqa: BLE001
+        logger.error(f"Failed to send event to client: {e}")
+
+
+class WebSocketTransport:
+    """JSON-over-WebSocket transport: audio is sent as base64 delta events."""
+
+    kind = "websocket"
+
+    def __init__(self, websocket: WebSocket) -> None:
+        self.websocket = websocket
+
+    async def send_events(self, events: list[ServerEvent]) -> None:
+        for event in events:
+            await send_ws_event(self.websocket, event)
+
+    async def send_audio_chunk(self, service: RealtimeService, session_id: str, pcm: bytes) -> None:
+        await self.send_events(service.encode_audio_chunk(session_id, pcm))
+
+    def discard_pending_audio(self) -> None:
+        # Unplayed audio lives client-side over WebSocket; truncation is the
+        # client's responsibility.
+        pass
+
+    async def close(self) -> None:
+        try:
+            await self.websocket.close()
+        except Exception:  # noqa: BLE001
+            pass

--- a/src/speech_to_speech/api/openai_realtime/webrtc_session.py
+++ b/src/speech_to_speech/api/openai_realtime/webrtc_session.py
@@ -27,6 +27,7 @@ import numpy as np
 from aiortc import RTCConfiguration, RTCIceServer, RTCPeerConnection, RTCSessionDescription
 from aiortc.mediastreams import MediaStreamError, MediaStreamTrack
 
+from speech_to_speech.api.openai_realtime.service import PIPELINE_SAMPLE_RATE
 from speech_to_speech.api.openai_realtime.transports import SessionTransport
 
 if TYPE_CHECKING:
@@ -34,7 +35,6 @@ if TYPE_CHECKING:
 
 logger = logging.getLogger(__name__)
 
-PIPELINE_SAMPLE_RATE = 16_000
 WEBRTC_SAMPLE_RATE = 48_000
 AUDIO_PTIME = 0.02  # 20 ms frames
 WEBRTC_FRAME_SAMPLES = int(WEBRTC_SAMPLE_RATE * AUDIO_PTIME)

--- a/src/speech_to_speech/api/openai_realtime/webrtc_session.py
+++ b/src/speech_to_speech/api/openai_realtime/webrtc_session.py
@@ -1,0 +1,349 @@
+"""WebRTC transport for the OpenAI Realtime API emulation.
+
+Requires the ``webrtc`` extra (aiortc). Audio travels over RTP media tracks
+(Opus at 48 kHz, resampled to/from the 16 kHz pipeline rate); all JSON events
+use the same protocol as the WebSocket transport, carried on the
+``oai-events`` data channel.
+
+``WebRTCSession`` implements the ``SessionTransport`` protocol from
+``transports``, so the per-unit send loop in ``websocket_router`` drives it
+exactly like a WebSocket session: it stays the sole consumer of the pipeline
+output queues, and this module only turns delivered PCM into paced RTP frames.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import json
+import logging
+import os
+import time
+from collections.abc import Awaitable
+from fractions import Fraction
+from typing import TYPE_CHECKING, Callable, Optional
+
+import av
+import numpy as np
+from aiortc import RTCConfiguration, RTCIceServer, RTCPeerConnection, RTCSessionDescription
+from aiortc.mediastreams import MediaStreamError, MediaStreamTrack
+
+if TYPE_CHECKING:
+    from speech_to_speech.api.openai_realtime.service import RealtimeService, ServerEvent
+
+logger = logging.getLogger(__name__)
+
+PIPELINE_SAMPLE_RATE = 16_000
+WEBRTC_SAMPLE_RATE = 48_000
+AUDIO_PTIME = 0.02  # 20 ms frames
+WEBRTC_FRAME_SAMPLES = int(WEBRTC_SAMPLE_RATE * AUDIO_PTIME)
+DATA_CHANNEL_LABEL = "oai-events"
+ICE_SERVERS_ENV = "SPEECH_TO_SPEECH_ICE_SERVERS"
+ICE_GATHERING_TIMEOUT_S = 5.0
+# How long a negotiated session may sit without the peer connection reaching
+# "connected" before we release its pipeline unit. Without this, a client that
+# receives the SDP answer and never completes ICE would hold the unit forever.
+CONNECT_TIMEOUT_S = 30.0
+
+
+def rtc_configuration_from_env() -> Optional[RTCConfiguration]:
+    """Build an RTCConfiguration from the SPEECH_TO_SPEECH_ICE_SERVERS env var.
+
+    The variable holds a JSON list of RTCIceServer kwargs, e.g.
+    ``[{"urls": "stun:stun.example.com:3478"},
+       {"urls": "turn:turn.example.com", "username": "u", "credential": "c"}]``.
+    Returns None (aiortc defaults) when unset or invalid.
+    """
+    raw = os.environ.get(ICE_SERVERS_ENV)
+    if not raw:
+        return None
+    try:
+        entries = json.loads(raw)
+        servers = [RTCIceServer(**entry) for entry in entries]
+    except (json.JSONDecodeError, TypeError) as e:
+        logger.error(f"Ignoring invalid {ICE_SERVERS_ENV}: {e}")
+        return None
+    return RTCConfiguration(iceServers=servers)
+
+
+class PcmResampler:
+    """Stateful mono/s16 resampler around av.AudioResampler.
+
+    One instance per direction per session: the libswresample filter state
+    carries across calls, so 20 ms frames resample without the boundary
+    artifacts a stateless per-chunk resample would introduce. Also downmixes
+    multi-channel input (browser Opus is typically stereo) to mono.
+    """
+
+    def __init__(self, target_rate: int) -> None:
+        self._resampler = av.AudioResampler(format="s16", layout="mono", rate=target_rate)
+        self._pts = 0
+
+    def resample_frame(self, frame: av.AudioFrame) -> bytes:
+        out = bytearray()
+        for resampled in self._resampler.resample(frame):
+            out += resampled.to_ndarray().tobytes()
+        return bytes(out)
+
+    def resample_pcm(self, pcm: bytes, src_rate: int) -> bytes:
+        samples = np.frombuffer(pcm, dtype=np.int16)
+        frame = av.AudioFrame.from_ndarray(samples[np.newaxis, :], format="s16", layout="mono")
+        frame.sample_rate = src_rate
+        frame.pts = self._pts
+        frame.time_base = Fraction(1, src_rate)
+        self._pts += samples.shape[0]
+        return self.resample_frame(frame)
+
+
+class PipelineAudioTrack(MediaStreamTrack):
+    """Outbound audio track: paced 20 ms 48 kHz frames from a PCM buffer.
+
+    The send loop pushes generated audio in via ``write()`` (faster than
+    real time); ``recv()`` paces delivery against the wall clock like
+    aiortc's built-in AudioStreamTrack, emitting silence when the buffer is
+    empty so the RTP stream stays continuous. ``clear()`` drops unplayed
+    audio — this is the server-side equivalent of the client's speaker
+    buffer, so barge-in must flush it for interruption to be audible.
+    """
+
+    kind = "audio"
+
+    def __init__(self) -> None:
+        super().__init__()
+        self._buffer = bytearray()
+        self._start: Optional[float] = None
+        self._timestamp = 0
+
+    def write(self, pcm: bytes) -> None:
+        self._buffer.extend(pcm)
+
+    def clear(self) -> None:
+        del self._buffer[:]
+
+    @property
+    def buffered_bytes(self) -> int:
+        return len(self._buffer)
+
+    async def recv(self) -> av.AudioFrame:
+        if self.readyState != "live":
+            raise MediaStreamError
+
+        if self._start is None:
+            self._start = time.time()
+            self._timestamp = 0
+        else:
+            self._timestamp += WEBRTC_FRAME_SAMPLES
+            wait = self._start + (self._timestamp / WEBRTC_SAMPLE_RATE) - time.time()
+            if wait > 0:
+                await asyncio.sleep(wait)
+
+        needed = WEBRTC_FRAME_SAMPLES * 2  # bytes of s16 mono
+        payload = bytes(self._buffer[:needed])
+        del self._buffer[: len(payload)]
+        if len(payload) < needed:
+            payload += b"\x00" * (needed - len(payload))
+
+        samples = np.frombuffer(payload, dtype=np.int16)
+        frame = av.AudioFrame.from_ndarray(samples[np.newaxis, :], format="s16", layout="mono")
+        frame.sample_rate = WEBRTC_SAMPLE_RATE
+        frame.pts = self._timestamp
+        frame.time_base = Fraction(1, WEBRTC_SAMPLE_RATE)
+        return frame
+
+
+class WebRTCSession:
+    """One WebRTC peer connection, used as the SessionState transport.
+
+    All pipeline integration arrives through callbacks supplied by the route
+    handler (which owns the PipelineUnit): parsed client events, inbound PCM,
+    channel-open, and close. This module never touches queues or services
+    directly except through the SessionTransport methods the send loop calls.
+    """
+
+    kind = "webrtc"
+
+    def __init__(
+        self,
+        pc: RTCPeerConnection,
+        *,
+        on_client_event: Callable[[dict], Awaitable[None]],
+        on_audio: Callable[[bytes], None],
+        on_open: Callable[[], Awaitable[None]],
+        on_closed: Callable[[], None],
+    ) -> None:
+        self._pc = pc
+        self._on_client_event = on_client_event
+        self._on_audio = on_audio
+        self._on_open = on_open
+        self._on_closed = on_closed
+        self._dc = None
+        self._closed = False
+        self._track = PipelineAudioTrack()
+        self._out_resampler = PcmResampler(WEBRTC_SAMPLE_RATE)
+        self._in_resampler = PcmResampler(PIPELINE_SAMPLE_RATE)
+        # Data-channel messages funnel through one queue + consumer task so
+        # client events apply in arrival order; dispatching each message in
+        # its own task could reorder e.g. session.update vs response.create.
+        self._dc_messages: asyncio.Queue[str] = asyncio.Queue()
+        self._tasks: list[asyncio.Task] = []
+
+    # ── Lifecycle ─────────────────────────────────
+
+    def setup(self) -> None:
+        """Wire aiortc event callbacks. Call before negotiate()."""
+        self._pc.addTrack(self._track)
+
+        @self._pc.on("datachannel")
+        def on_datachannel(dc) -> None:
+            if dc.label != DATA_CHANNEL_LABEL:
+                logger.warning(f"[WebRTC] Ignoring unexpected data channel: {dc.label}")
+                return
+            self._dc = dc
+            self._spawn(self._consume_dc_messages())
+            logger.info(f"[WebRTC] Data channel '{DATA_CHANNEL_LABEL}' received")
+
+            # aiortc may deliver the channel already open, in which case the
+            # "open" event never fires.
+            if dc.readyState == "open":
+                self._spawn(self._on_open())
+            else:
+
+                @dc.on("open")
+                def on_dc_open() -> None:
+                    self._spawn(self._on_open())
+
+            @dc.on("message")
+            def on_message(msg) -> None:
+                if isinstance(msg, str):
+                    self._dc_messages.put_nowait(msg)
+                else:
+                    logger.warning("[WebRTC] Ignoring binary data-channel message")
+
+            @dc.on("close")
+            def on_dc_close() -> None:
+                logger.info("[WebRTC] Data channel closed")
+                self._spawn(self.close())
+
+        @self._pc.on("track")
+        def on_track(track) -> None:
+            if track.kind == "audio":
+                logger.info("[WebRTC] Inbound audio track received")
+                self._spawn(self._consume_inbound_audio(track))
+
+        @self._pc.on("connectionstatechange")
+        async def on_connection_state_change() -> None:
+            state = self._pc.connectionState
+            logger.info(f"[WebRTC] Connection state: {state}")
+            if state in ("failed", "closed"):
+                await self.close()
+
+    async def negotiate(self, offer_sdp: str) -> str:
+        """Apply the client's SDP offer and return the SDP answer.
+
+        Waits for ICE gathering so the answer carries the server's candidates
+        — there is no trickle-ICE channel in the HTTP handshake.
+        """
+        await self._pc.setRemoteDescription(RTCSessionDescription(sdp=offer_sdp, type="offer"))
+        answer = await self._pc.createAnswer()
+        await self._pc.setLocalDescription(answer)
+
+        if self._pc.iceGatheringState != "complete":
+            done: asyncio.Event = asyncio.Event()
+
+            @self._pc.on("icegatheringstatechange")
+            def on_ice_change() -> None:
+                if self._pc.iceGatheringState == "complete":
+                    done.set()
+
+            if self._pc.iceGatheringState == "complete":  # raced to completion
+                done.set()
+            try:
+                await asyncio.wait_for(done.wait(), timeout=ICE_GATHERING_TIMEOUT_S)
+            except asyncio.TimeoutError:
+                logger.warning("[WebRTC] ICE gathering timed out, returning partial SDP")
+
+        self._spawn(self._connect_watchdog())
+        return self._pc.localDescription.sdp
+
+    async def close(self) -> None:
+        if self._closed:
+            return
+        self._closed = True
+        # close() itself often runs as a _spawn()ed task (dc close handler),
+        # so it is in _tasks — cancelling the current task here would abort
+        # this method before the release callback runs.
+        current = asyncio.current_task()
+        for task in self._tasks:
+            if task is not current:
+                task.cancel()
+        self._track.stop()
+        try:
+            await self._pc.close()
+        except Exception as e:  # noqa: BLE001
+            logger.warning(f"[WebRTC] Error closing peer connection: {e}")
+        self._on_closed()
+        logger.info("[WebRTC] Session closed")
+
+    # ── SessionTransport protocol ─────────────────
+
+    async def send_events(self, events: list[ServerEvent]) -> None:
+        dc = self._dc
+        if dc is None or dc.readyState != "open":
+            return
+        for event in events:
+            try:
+                dc.send(json.dumps(event.model_dump()))
+            except Exception as e:  # noqa: BLE001
+                logger.error(f"[WebRTC] Data channel send error: {e}")
+
+    async def send_audio_chunk(self, service: RealtimeService, session_id: str, pcm: bytes) -> None:
+        # Bookkeeping events (response.created on the implicit VAD path) go
+        # over the data channel; the audio itself goes on the media track.
+        _resp_id, _item_id, events = service.begin_audio_response(session_id)
+        if events:
+            await self.send_events(events)
+        self._track.write(self._out_resampler.resample_pcm(pcm, PIPELINE_SAMPLE_RATE))
+
+    def discard_pending_audio(self) -> None:
+        self._track.clear()
+
+    # ── Internals ─────────────────────────────────
+
+    def _spawn(self, coro: Awaitable[None]) -> None:
+        task = asyncio.ensure_future(coro)
+        self._tasks.append(task)
+
+    async def _connect_watchdog(self) -> None:
+        await asyncio.sleep(CONNECT_TIMEOUT_S)
+        if not self._closed and self._pc.connectionState != "connected":
+            logger.warning(
+                f"[WebRTC] Peer not connected after {CONNECT_TIMEOUT_S:.0f}s "
+                f"(state: {self._pc.connectionState}); releasing session"
+            )
+            await self.close()
+
+    async def _consume_dc_messages(self) -> None:
+        while not self._closed:
+            msg = await self._dc_messages.get()
+            try:
+                raw = json.loads(msg)
+            except json.JSONDecodeError:
+                logger.error(f"[WebRTC] Invalid JSON on data channel: {msg!r}")
+                continue
+            if not isinstance(raw, dict):
+                logger.error(f"[WebRTC] Non-object event on data channel: {msg!r}")
+                continue
+            try:
+                await self._on_client_event(raw)
+            except Exception:  # noqa: BLE001
+                logger.exception("[WebRTC] Error handling client event")
+
+    async def _consume_inbound_audio(self, track) -> None:
+        while not self._closed:
+            try:
+                frame = await track.recv()
+            except MediaStreamError:
+                logger.info("[WebRTC] Inbound audio track ended")
+                break
+            pcm = self._in_resampler.resample_frame(frame)
+            if pcm:
+                self._on_audio(pcm)

--- a/src/speech_to_speech/api/openai_realtime/webrtc_session.py
+++ b/src/speech_to_speech/api/openai_realtime/webrtc_session.py
@@ -5,8 +5,8 @@ Requires the ``webrtc`` extra (aiortc). Audio travels over RTP media tracks
 use the same protocol as the WebSocket transport, carried on the
 ``oai-events`` data channel.
 
-``WebRTCSession`` implements the ``SessionTransport`` protocol from
-``transports``, so the per-unit send loop in ``websocket_router`` drives it
+``WebRTCSession`` subclasses ``SessionTransport`` from ``transports``,
+so the per-unit send loop in ``websocket_router`` drives it
 exactly like a WebSocket session: it stays the sole consumer of the pipeline
 output queues, and this module only turns delivered PCM into paced RTP frames.
 """
@@ -26,6 +26,8 @@ import av
 import numpy as np
 from aiortc import RTCConfiguration, RTCIceServer, RTCPeerConnection, RTCSessionDescription
 from aiortc.mediastreams import MediaStreamError, MediaStreamTrack
+
+from speech_to_speech.api.openai_realtime.transports import SessionTransport
 
 if TYPE_CHECKING:
     from speech_to_speech.api.openai_realtime.service import RealtimeService, ServerEvent
@@ -150,7 +152,7 @@ class PipelineAudioTrack(MediaStreamTrack):
         return frame
 
 
-class WebRTCSession:
+class WebRTCSession(SessionTransport):
     """One WebRTC peer connection, used as the SessionState transport.
 
     All pipeline integration arrives through callbacks supplied by the route
@@ -283,7 +285,7 @@ class WebRTCSession:
         self._on_closed()
         logger.info("[WebRTC] Session closed")
 
-    # ── SessionTransport protocol ─────────────────
+    # ── SessionTransport interface ────────────────
 
     async def send_events(self, events: list[ServerEvent]) -> None:
         dc = self._dc

--- a/src/speech_to_speech/api/openai_realtime/websocket_router.py
+++ b/src/speech_to_speech/api/openai_realtime/websocket_router.py
@@ -537,9 +537,6 @@ def create_app(pool: list[PipelineUnit], stop_event: ThreadingEvent) -> FastAPI:
         # previous session that survived SESSION_END propagation doesn't leak.
         _clean_unit(unit)
 
-        config = rtc_configuration_from_env()
-        pc = RTCPeerConnection(configuration=config) if config is not None else RTCPeerConnection()
-
         released = False
 
         def _on_closed() -> None:
@@ -553,6 +550,7 @@ def create_app(pool: list[PipelineUnit], stop_event: ThreadingEvent) -> FastAPI:
             _release_session(unit, session_id)
 
         async def _on_client_event(raw: dict[str, Any]) -> None:
+            assert session is not None  # callbacks only fire after setup()
             await _dispatch_client_event(unit, session_id, raw, session, transport_kind="webrtc")
 
         def _on_audio(pcm: bytes) -> None:
@@ -564,18 +562,33 @@ def create_app(pool: list[PipelineUnit], stop_event: ThreadingEvent) -> FastAPI:
                 unit.input_queue.put((chunk, rt_cfg))
 
         async def _on_open() -> None:
+            assert session is not None  # callbacks only fire after setup()
             await session.send_events([unit.service.build_session_created(session_id)])
             logger.info(f"WebRTC session.created sent (session {session_id})")
 
-        session = WebRTCSession(
-            pc,
-            on_client_event=_on_client_event,
-            on_audio=_on_audio,
-            on_open=_on_open,
-            on_closed=_on_closed,
-        )
-        session.setup()
-        unit.session.transport = session
+        # Any failure between the claim above and a successful negotiate()
+        # must release the unit, or it stays occupied forever with no peer
+        # attached — the connect watchdog only exists once negotiate() ran.
+        session = None
+        try:
+            config = rtc_configuration_from_env()
+            pc = RTCPeerConnection(configuration=config) if config is not None else RTCPeerConnection()
+            session = WebRTCSession(
+                pc,
+                on_client_event=_on_client_event,
+                on_audio=_on_audio,
+                on_open=_on_open,
+                on_closed=_on_closed,
+            )
+            session.setup()
+            unit.session.transport = session
+        except Exception as e:  # noqa: BLE001
+            logger.error(f"WebRTC session setup failed (session {session_id}): {type(e).__name__}: {e}")
+            if session is not None:
+                await session.close()  # fires _on_closed → _release_session
+            else:
+                _on_closed()
+            return Response(content="WebRTC session setup failed", status_code=500, media_type="text/plain")
 
         try:
             answer_sdp = await session.negotiate(offer_sdp)
@@ -631,29 +644,35 @@ def create_app(pool: list[PipelineUnit], stop_event: ThreadingEvent) -> FastAPI:
                         if events:
                             await transport.send_events(events)
 
-                    if is_speech_start and (was_in_response or was_response_pending):
-                        active_cfg = unit.service._state(session_id).runtime_config if session_id else None
-                        if text_msg.interrupt_response and (
+                    if is_speech_start and session_id:
+                        active_cfg = unit.service._state(session_id).runtime_config
+                        interrupt_enabled = text_msg.interrupt_response and (
                             active_cfg is None or active_cfg.interrupt_response_enabled
-                        ):
-                            unit.cancel_scope.cancel()
-                            if session_id:
+                        )
+                        if interrupt_enabled and transport is not None:
+                            # Flush even when no response is active: the WebRTC
+                            # track can still hold unplayed audio from a response
+                            # whose done-sentinel was already observed —
+                            # finish_response() runs on the sentinel, not when
+                            # playback completes. No-op over WebSocket.
+                            transport.discard_pending_audio()
+                        if was_in_response or was_response_pending:
+                            if interrupt_enabled:
+                                unit.cancel_scope.cancel()
                                 unit.service._state(session_id).response_pending = False
-                            _flush_queue(unit.output_queue, preserve=_keep_audio_sentinel)
-                            _flush_queue(unit.text_output_queue, preserve=_keep_user_text_event)
-                            if transport is not None:
-                                transport.discard_pending_audio()
-                            if unit.response_playing.is_set():
-                                unit.response_playing.clear()
-                            logger.info(
-                                "Pipeline %d: speech during %s: cancelled, queue flushed",
-                                unit.index,
-                                "response" if was_in_response else "pending response",
-                            )
-                        else:
-                            logger.info(
-                                f"Pipeline {unit.index}: speech during response: interrupt_response disabled, ignoring"
-                            )
+                                _flush_queue(unit.output_queue, preserve=_keep_audio_sentinel)
+                                _flush_queue(unit.text_output_queue, preserve=_keep_user_text_event)
+                                if unit.response_playing.is_set():
+                                    unit.response_playing.clear()
+                                logger.info(
+                                    "Pipeline %d: speech during %s: cancelled, queue flushed",
+                                    unit.index,
+                                    "response" if was_in_response else "pending response",
+                                )
+                            else:
+                                logger.info(
+                                    f"Pipeline {unit.index}: speech during response: interrupt_response disabled, ignoring"
+                                )
                 except Empty:
                     pass
 

--- a/src/speech_to_speech/api/openai_realtime/websocket_router.py
+++ b/src/speech_to_speech/api/openai_realtime/websocket_router.py
@@ -8,19 +8,27 @@ from threading import Event as ThreadingEvent
 from typing import Any, Callable, TypeVar
 
 import numpy as np
-from fastapi import FastAPI, WebSocket, WebSocketDisconnect
+from fastapi import FastAPI, Request, Response, WebSocket, WebSocketDisconnect
 from openai.types.realtime import (
     ConversationItemCreateEvent,
     InputAudioBufferAppendEvent,
     InputAudioBufferCommitEvent,
+    OutputAudioBufferClearEvent,
     ResponseCancelEvent,
     ResponseCreateEvent,
     SessionUpdateEvent,
 )
-from starlette.websockets import WebSocketState
 
 from speech_to_speech.api.openai_realtime.pipeline_unit import PipelineUnit, SessionState
-from speech_to_speech.api.openai_realtime.service import ServerEvent, build_error_event
+from speech_to_speech.api.openai_realtime.service import (
+    PIPELINE_SAMPLE_RATE,
+    build_error_event,
+)
+from speech_to_speech.api.openai_realtime.transports import (
+    SessionTransport,
+    WebSocketTransport,
+    send_ws_event,
+)
 from speech_to_speech.pipeline.control import SESSION_END, PipelineControlMessage, is_control_message
 from speech_to_speech.pipeline.events import (
     AssistantTextEvent,
@@ -42,34 +50,6 @@ MAX_AUDIO_BATCH_BYTES = 6400
 # real handler chain.
 SESSION_END_DRAIN_TIMEOUT_S = 10.0
 QItem = TypeVar("QItem")
-
-
-async def _send_event(ws: WebSocket, event: ServerEvent) -> None:
-    # Skip cleanly when the ws is already closing/closed — happens during Ctrl-C
-    # shutdown, where the lifespan starts closing sockets while the route handler
-    # or send loop is still in flight pushing events.
-    if ws.application_state != WebSocketState.CONNECTED:
-        return
-    try:
-        await ws.send_json(event.model_dump())
-    except WebSocketDisconnect:
-        logger.debug("Skipped event: ws disconnected mid-send")
-    except RuntimeError as e:
-        # Race: ws closed between the state check above and the send. Starlette
-        # raises a plain RuntimeError("Unexpected ASGI message 'websocket.send'
-        # after sending 'websocket.close' ...") — harmless during shutdown.
-        msg = str(e)
-        if "websocket.close" in msg or "websocket.disconnect" in msg or "response already completed" in msg:
-            logger.debug(f"Skipped event: ws already closed ({msg})")
-        else:
-            logger.error(f"Failed to send event to client: {e}")
-    except Exception as e:  # noqa: BLE001
-        logger.error(f"Failed to send event to client: {e}")
-
-
-async def _send_events(ws: WebSocket, events: list[ServerEvent]) -> None:
-    for event in events:
-        await _send_event(ws, event)
 
 
 def _keep_audio_sentinel(item: Any) -> bool:
@@ -114,7 +94,7 @@ def _flush_queue(q: Queue[QItem], *, preserve: Callable[[QItem], bool] | None = 
 
 
 async def _drain_pending_response_events(
-    ws: WebSocket | None,
+    transport: SessionTransport | None,
     unit: PipelineUnit,
     session_id: str | None,
 ) -> None:
@@ -142,8 +122,8 @@ async def _drain_pending_response_events(
                 if _generation_is_discardable(unit, item.cancel_generation):
                     continue
                 events = unit.service.dispatch_pipeline_event(session_id, item)
-                if ws is not None and events:
-                    await _send_events(ws, events)
+                if transport is not None and events:
+                    await transport.send_events(events)
             else:
                 preserved.append(item)
                 drain_assistant_events = False
@@ -255,6 +235,113 @@ async def _release_unit_after_drain(unit: PipelineUnit, session: Any, session_id
     logger.info(f"Pipeline {unit.index} released (session {session_id} ended)")
 
 
+def _release_session(unit: PipelineUnit, session_id: str) -> None:
+    """Start the release of a unit after its client disconnected.
+
+    Shared by the WebSocket route's finally block and the WebRTC session's
+    close callback. Marks the session as released, resets the unit, enqueues
+    SESSION_END, and spawns the drain-and-release task — the unit stays
+    claimed until SESSION_END propagates back to output_queue.
+    """
+    old_session = unit.session
+    if old_session is None:
+        # Already released (e.g. duplicate close callbacks racing).
+        return
+    old_session.released_at = time.monotonic()
+    _clean_unit(unit)
+    unit.input_queue.put(SESSION_END)
+    asyncio.create_task(_release_unit_after_drain(unit, old_session, session_id))
+
+
+async def _dispatch_client_event(
+    unit: PipelineUnit,
+    session_id: str,
+    raw: dict[str, Any],
+    transport: SessionTransport,
+    *,
+    transport_kind: str = "websocket",
+) -> None:
+    """Parse and apply one client event, replying over *transport*.
+
+    Shared by both transports; ``transport_kind`` gates the events whose
+    validity depends on how audio travels: ``input_audio_buffer.append`` is
+    WebSocket-only (WebRTC audio arrives on the media track), and
+    ``output_audio_buffer.clear`` is WebRTC-only (over WebSocket the unplayed
+    audio sits client-side).
+    """
+    service = unit.service
+    event = service.parse_client_event(raw)
+    if event is None:
+        await transport.send_events(
+            [service.make_error(f"Unknown or invalid event: {raw.get('type')}", "unknown_or_invalid_event")]
+        )
+        return
+
+    if isinstance(event, InputAudioBufferAppendEvent):
+        if transport_kind == "webrtc":
+            await transport.send_events(
+                [
+                    service.make_error(
+                        "In WebRTC mode audio arrives via the media track; input_audio_buffer.append is not supported.",
+                        "invalid_event_for_transport",
+                    )
+                ]
+            )
+            return
+        chunks = service.handle_audio_append(session_id, event)
+        rt_cfg = service._state(session_id).runtime_config
+        for chunk in chunks:
+            unit.input_queue.put((chunk, rt_cfg))
+
+    elif isinstance(event, InputAudioBufferCommitEvent):
+        err = service.handle_audio_commit(session_id)
+        if err:
+            await transport.send_events([err])
+
+    elif isinstance(event, OutputAudioBufferClearEvent):
+        if transport_kind != "webrtc":
+            await transport.send_events(
+                [
+                    service.make_error(
+                        "output_audio_buffer.clear is only supported on the WebRTC transport.",
+                        "invalid_event_for_transport",
+                    )
+                ]
+            )
+            return
+        _flush_queue(unit.output_queue, preserve=_keep_audio_sentinel)
+        transport.discard_pending_audio()
+
+    elif isinstance(event, SessionUpdateEvent):
+        err = service.handle_session_update(session_id, event)
+        if err:
+            await transport.send_events([err])
+
+    elif isinstance(event, ConversationItemCreateEvent):
+        events = service.handle_conversation_item_create(session_id, event)
+        if events:
+            await transport.send_events(events)
+
+    elif isinstance(event, ResponseCreateEvent):
+        result = service.handle_response_create(session_id, event)
+        if result:
+            if result.type != "error":
+                unit.cancel_scope.new_response()
+            await transport.send_events([result])
+
+    elif isinstance(event, ResponseCancelEvent):
+        was_active = service._state(session_id).in_response
+        if was_active:
+            unit.cancel_scope.cancel()
+        _flush_queue(unit.output_queue, preserve=_keep_audio_sentinel)
+        _flush_queue(unit.text_output_queue, preserve=_keep_user_text_event)
+        transport.discard_pending_audio()
+        events = service.handle_response_cancel(session_id)
+        if events:
+            await transport.send_events(events)
+        unit.response_playing.clear()
+
+
 def create_app(pool: list[PipelineUnit], stop_event: ThreadingEvent) -> FastAPI:
     @asynccontextmanager
     async def lifespan(app: FastAPI) -> AsyncIterator[None]:
@@ -271,23 +358,24 @@ def create_app(pool: list[PipelineUnit], stop_event: ThreadingEvent) -> FastAPI:
                 pass
         for unit in pool:
             sess = unit.session
-            if sess is not None:
+            if sess is not None and sess.transport is not None:
                 try:
-                    await sess.websocket.close()
+                    await sess.transport.close()
                 except Exception:
                     pass
 
     app = FastAPI(lifespan=lifespan)
 
-    def _claim_unit(ws: WebSocket) -> PipelineUnit | None:
+    def _claim_unit(transport: SessionTransport | None) -> PipelineUnit | None:
         """Atomically (between asyncio yield points) reserve the first idle unit.
 
         Creates a placeholder SessionState that the caller fills in with the
-        session_id after RealtimeService.register().
+        session_id after RealtimeService.register(). The WebRTC route claims
+        with transport=None and attaches the session object once constructed.
         """
         for unit in pool:
             if unit.session is None:
-                unit.session = SessionState(websocket=ws)
+                unit.session = SessionState(transport=transport)
                 return unit
         return None
 
@@ -295,11 +383,12 @@ def create_app(pool: list[PipelineUnit], stop_event: ThreadingEvent) -> FastAPI:
     async def realtime_endpoint(ws: WebSocket) -> None:
         await ws.accept()
 
-        unit = _claim_unit(ws)
+        transport = WebSocketTransport(ws)
+        unit = _claim_unit(transport)
         if unit is None:
             logger.warning(f"Rejected connection: all {len(pool)} pipeline slots in use")
             # Stateless error event — rejection is not chargeable to any unit's usage metrics.
-            await _send_event(
+            await send_ws_event(
                 ws,
                 build_error_event(
                     f"All {len(pool)} session slots are in use. Disconnect an existing client first.",
@@ -321,7 +410,7 @@ def create_app(pool: list[PipelineUnit], stop_event: ThreadingEvent) -> FastAPI:
         _clean_unit(unit)
 
         try:
-            await _send_event(ws, unit.service.build_session_created(session_id))
+            await send_ws_event(ws, unit.service.build_session_created(session_id))
 
             while not stop_event.is_set():
                 try:
@@ -329,54 +418,7 @@ def create_app(pool: list[PipelineUnit], stop_event: ThreadingEvent) -> FastAPI:
                 except asyncio.TimeoutError:
                     continue
 
-                event = unit.service.parse_client_event(raw)
-                if event is None:
-                    await _send_event(
-                        ws,
-                        unit.service.make_error(
-                            f"Unknown or invalid event: {raw.get('type')}", "unknown_or_invalid_event"
-                        ),
-                    )
-                    continue
-
-                if isinstance(event, InputAudioBufferAppendEvent):
-                    chunks = unit.service.handle_audio_append(session_id, event)
-                    rt_cfg = unit.service._state(session_id).runtime_config
-                    for chunk in chunks:
-                        unit.input_queue.put((chunk, rt_cfg))
-
-                elif isinstance(event, InputAudioBufferCommitEvent):
-                    err = unit.service.handle_audio_commit(session_id)
-                    if err:
-                        await _send_event(ws, err)
-
-                elif isinstance(event, SessionUpdateEvent):
-                    err = unit.service.handle_session_update(session_id, event)
-                    if err:
-                        await _send_event(ws, err)
-
-                elif isinstance(event, ConversationItemCreateEvent):
-                    events = unit.service.handle_conversation_item_create(session_id, event)
-                    if events:
-                        await _send_events(ws, events)
-
-                elif isinstance(event, ResponseCreateEvent):
-                    result = unit.service.handle_response_create(session_id, event)
-                    if result:
-                        if result.type != "error":
-                            unit.cancel_scope.new_response()
-                        await _send_event(ws, result)
-
-                elif isinstance(event, ResponseCancelEvent):
-                    was_active = unit.service._state(session_id).in_response
-                    if was_active:
-                        unit.cancel_scope.cancel()
-                    _flush_queue(unit.output_queue, preserve=_keep_audio_sentinel)
-                    _flush_queue(unit.text_output_queue, preserve=_keep_user_text_event)
-                    events = unit.service.handle_response_cancel(session_id)
-                    if events:
-                        await _send_events(ws, events)
-                    unit.response_playing.clear()
+                await _dispatch_client_event(unit, session_id, raw, transport)
 
         except WebSocketDisconnect:
             logger.info(f"Client {session_id} disconnected from pipeline {unit.index}")
@@ -387,16 +429,11 @@ def create_app(pool: list[PipelineUnit], stop_event: ThreadingEvent) -> FastAPI:
             # to this object until we clear unit.session, so any handler output that
             # arrives during the drain window is sent to the now-closed ws (silently
             # dropped) instead of leaking to whichever client claims this unit next.
-            old_session = unit.session
-            if old_session is not None:
-                old_session.released_at = time.monotonic()
-            _clean_unit(unit)
-            unit.input_queue.put(SESSION_END)
-            # Spawn the drain-and-release as a separate task so the route handler's
-            # finally returns immediately. Awaiting here is unreliable: after
+            # _release_session spawns the drain-and-release as a separate task so
+            # this finally returns immediately. Awaiting here is unreliable: after
             # WebSocketDisconnect propagates, subsequent awaits in the same task
             # can be skipped/cancelled by Starlette's runner and never resume.
-            asyncio.create_task(_release_unit_after_drain(unit, old_session, session_id))
+            _release_session(unit, session_id)
 
     @app.get("/v1/usage")
     async def usage_endpoint() -> dict[str, Any]:
@@ -445,12 +482,122 @@ def create_app(pool: list[PipelineUnit], stop_event: ThreadingEvent) -> FastAPI:
             "units": [_state(u) for u in pool],
         }
 
+    @app.post("/v1/realtime/calls")
+    async def webrtc_calls_endpoint(request: Request) -> Response:
+        """WebRTC SDP handshake (OpenAI GA Realtime 'calls' endpoint).
+
+        The client POSTs an SDP offer with Content-Type: application/sdp and
+        receives an SDP answer. Audio then flows over WebRTC media tracks;
+        events flow over the 'oai-events' data channel using the same JSON
+        protocol as the WebSocket transport.
+        """
+        try:
+            from aiortc import RTCPeerConnection
+
+            from speech_to_speech.api.openai_realtime.webrtc_session import (
+                WebRTCSession,
+                rtc_configuration_from_env,
+            )
+        except ImportError:
+            return Response(
+                content="WebRTC support requires the 'webrtc' extra: pip install 'speech-to-speech[webrtc]'",
+                status_code=501,
+                media_type="text/plain",
+            )
+
+        if "application/sdp" not in request.headers.get("content-type", ""):
+            return Response(
+                content="Content-Type must be application/sdp",
+                status_code=415,
+                media_type="text/plain",
+            )
+        offer_sdp = (await request.body()).decode("utf-8")
+
+        # Claim with a placeholder transport; the send loop tolerates a
+        # transport-less snapshot until the session object below is attached.
+        unit = _claim_unit(None)
+        if unit is None:
+            logger.warning(f"Rejected WebRTC offer: all {len(pool)} pipeline slots in use")
+            return Response(
+                content=build_error_event(
+                    f"All {len(pool)} session slots are in use. Disconnect an existing client first.",
+                    error_type="session_limit_reached",
+                ).model_dump_json(),
+                status_code=503,
+                media_type="application/json",
+            )
+
+        pipeline_log_ctx.set(unit.index)
+        session_id = unit.service.register()
+        assert unit.session is not None
+        unit.session.session_id = session_id
+        logger.info(f"WebRTC client claiming pipeline {unit.index} (session {session_id})")
+
+        # Defensive: drain edge queues and reset events so stale data from a
+        # previous session that survived SESSION_END propagation doesn't leak.
+        _clean_unit(unit)
+
+        config = rtc_configuration_from_env()
+        pc = RTCPeerConnection(configuration=config) if config is not None else RTCPeerConnection()
+
+        released = False
+
+        def _on_closed() -> None:
+            # close() is idempotent but can be reached from several aiortc
+            # callbacks; release the unit exactly once.
+            nonlocal released
+            if released:
+                return
+            released = True
+            logger.info(f"WebRTC client {session_id} disconnected from pipeline {unit.index}")
+            _release_session(unit, session_id)
+
+        async def _on_client_event(raw: dict[str, Any]) -> None:
+            await _dispatch_client_event(unit, session_id, raw, session, transport_kind="webrtc")
+
+        def _on_audio(pcm: bytes) -> None:
+            chunks = unit.service.append_pcm(session_id, pcm, PIPELINE_SAMPLE_RATE)
+            if not chunks:
+                return
+            rt_cfg = unit.service._state(session_id).runtime_config
+            for chunk in chunks:
+                unit.input_queue.put((chunk, rt_cfg))
+
+        async def _on_open() -> None:
+            await session.send_events([unit.service.build_session_created(session_id)])
+            logger.info(f"WebRTC session.created sent (session {session_id})")
+
+        session = WebRTCSession(
+            pc,
+            on_client_event=_on_client_event,
+            on_audio=_on_audio,
+            on_open=_on_open,
+            on_closed=_on_closed,
+        )
+        session.setup()
+        unit.session.transport = session
+
+        try:
+            answer_sdp = await session.negotiate(offer_sdp)
+        except Exception as e:  # noqa: BLE001
+            logger.error(f"WebRTC negotiation failed (session {session_id}): {type(e).__name__}: {e}")
+            await session.close()
+            return Response(content="Invalid SDP offer", status_code=400, media_type="text/plain")
+
+        logger.info(f"WebRTC SDP answer returned (session {session_id})")
+        return Response(
+            content=answer_sdp,
+            status_code=201,
+            media_type="application/sdp",
+            headers={"Location": f"/v1/realtime/calls/{session_id}"},
+        )
+
     async def _send_loop_for(unit: PipelineUnit) -> None:
         """Per-pipeline send loop. Polls this unit's output queues and forwards
-        to the websocket currently attached via unit.session.
+        to the transport currently attached via unit.session.
 
         Per-session scratch (pending_output_item) lives on SessionState, so it
-        disappears together with the websocket when the session is released —
+        disappears together with the transport when the session is released —
         no stale sentinel can leak into the next claim.
         """
         pipeline_log_ctx.set(unit.index)
@@ -458,9 +605,9 @@ def create_app(pool: list[PipelineUnit], stop_event: ThreadingEvent) -> FastAPI:
             try:
                 # Snapshot the session once per iteration; if the route releases the
                 # unit mid-iteration, we continue against the prior snapshot which is
-                # consistent (its websocket is still valid until ws.close() returns).
+                # consistent (its transport is still valid until close() returns).
                 session = unit.session
-                ws = session.websocket if session is not None else None
+                transport = session.transport if session is not None else None
                 session_id = session.session_id if session is not None else None
 
                 # Text events first (speech_started cancels active response).
@@ -479,10 +626,10 @@ def create_app(pool: list[PipelineUnit], stop_event: ThreadingEvent) -> FastAPI:
                         unit, text_msg.cancel_generation
                     ):
                         pass
-                    elif ws is not None and isinstance(text_msg, PipelineEvent) and session_id:
+                    elif transport is not None and isinstance(text_msg, PipelineEvent) and session_id:
                         events = unit.service.dispatch_pipeline_event(session_id, text_msg)
                         if events:
-                            await _send_events(ws, events)
+                            await transport.send_events(events)
 
                     if is_speech_start and (was_in_response or was_response_pending):
                         active_cfg = unit.service._state(session_id).runtime_config if session_id else None
@@ -494,6 +641,8 @@ def create_app(pool: list[PipelineUnit], stop_event: ThreadingEvent) -> FastAPI:
                                 unit.service._state(session_id).response_pending = False
                             _flush_queue(unit.output_queue, preserve=_keep_audio_sentinel)
                             _flush_queue(unit.text_output_queue, preserve=_keep_user_text_event)
+                            if transport is not None:
+                                transport.discard_pending_audio()
                             if unit.response_playing.is_set():
                                 unit.response_playing.clear()
                             logger.info(
@@ -516,9 +665,9 @@ def create_app(pool: list[PipelineUnit], stop_event: ThreadingEvent) -> FastAPI:
                         audio_chunk = unit.output_queue.get_nowait()
 
                     if _is_pipeline_end(audio_chunk):
-                        await _drain_pending_response_events(ws, unit, session_id)
-                        if ws is not None and session_id:
-                            await _send_events(ws, unit.service.finish_response(session_id))
+                        await _drain_pending_response_events(transport, unit, session_id)
+                        if transport is not None and session_id:
+                            await transport.send_events(unit.service.finish_response(session_id))
                         break
 
                     if _is_audio_done(audio_chunk):
@@ -530,9 +679,9 @@ def create_app(pool: list[PipelineUnit], stop_event: ThreadingEvent) -> FastAPI:
                             unit.should_listen.set()
                             logger.info(f"Pipeline {unit.index}: stale response complete, listening re-enabled")
                             continue
-                        await _drain_pending_response_events(ws, unit, session_id)
-                        if ws is not None and session_id:
-                            await _send_events(ws, unit.service.finish_response(session_id))
+                        await _drain_pending_response_events(transport, unit, session_id)
+                        if transport is not None and session_id:
+                            await transport.send_events(unit.service.finish_response(session_id))
                         if session_id:
                             unit.service._state(session_id).response_pending = False
                         unit.response_playing.clear()
@@ -589,8 +738,8 @@ def create_app(pool: list[PipelineUnit], stop_event: ThreadingEvent) -> FastAPI:
                         unit.response_playing.set()
                         unit.should_listen.set()
 
-                    if ws is not None and session_id:
-                        await _send_events(ws, unit.service.encode_audio_chunk(session_id, bytes(audio_batch)))
+                    if transport is not None and session_id:
+                        await transport.send_audio_chunk(unit.service, session_id, bytes(audio_batch))
                 except Empty:
                     pass
 

--- a/src/speech_to_speech/api/openai_realtime/websocket_router.py
+++ b/src/speech_to_speech/api/openai_realtime/websocket_router.py
@@ -42,6 +42,22 @@ from speech_to_speech.pipeline.events import (
 from speech_to_speech.pipeline.log_context import pipeline_log_ctx
 from speech_to_speech.pipeline.messages import AUDIO_RESPONSE_DONE, PIPELINE_END, AudioOutput
 
+# aiortc (the 'webrtc' extra) is optional. Import it here, at module load,
+# rather than lazily in the calls endpoint: the av/cryptography C extensions
+# take up to a second to load cold, which would block the shared event loop —
+# and every live conversation's audio — on the first WebRTC handshake.
+try:
+    from aiortc import RTCPeerConnection
+
+    from speech_to_speech.api.openai_realtime.webrtc_session import (
+        WebRTCSession,
+        rtc_configuration_from_env,
+    )
+
+    WEBRTC_AVAILABLE = True
+except ImportError:
+    WEBRTC_AVAILABLE = False
+
 logger = logging.getLogger(__name__)
 MAX_AUDIO_BATCH_BYTES = 6400
 # How long the release path waits for SESSION_END to propagate through the
@@ -491,14 +507,7 @@ def create_app(pool: list[PipelineUnit], stop_event: ThreadingEvent) -> FastAPI:
         events flow over the 'oai-events' data channel using the same JSON
         protocol as the WebSocket transport.
         """
-        try:
-            from aiortc import RTCPeerConnection
-
-            from speech_to_speech.api.openai_realtime.webrtc_session import (
-                WebRTCSession,
-                rtc_configuration_from_env,
-            )
-        except ImportError:
+        if not WEBRTC_AVAILABLE:
             return Response(
                 content="WebRTC support requires the 'webrtc' extra: pip install 'speech-to-speech[webrtc]'",
                 status_code=501,
@@ -528,14 +537,21 @@ def create_app(pool: list[PipelineUnit], stop_event: ThreadingEvent) -> FastAPI:
             )
 
         pipeline_log_ctx.set(unit.index)
-        session_id = unit.service.register()
-        assert unit.session is not None
-        unit.session.session_id = session_id
-        logger.info(f"WebRTC client claiming pipeline {unit.index} (session {session_id})")
+        try:
+            session_id = unit.service.register()
+            assert unit.session is not None
+            unit.session.session_id = session_id
+            logger.info(f"WebRTC client claiming pipeline {unit.index} (session {session_id})")
 
-        # Defensive: drain edge queues and reset events so stale data from a
-        # previous session that survived SESSION_END propagation doesn't leak.
-        _clean_unit(unit)
+            # Defensive: drain edge queues and reset events so stale data from a
+            # previous session that survived SESSION_END propagation doesn't leak.
+            _clean_unit(unit)
+        except Exception as e:  # noqa: BLE001
+            logger.error(f"WebRTC call setup failed (pipeline {unit.index}): {type(e).__name__}: {e}")
+            # No transport or drain task exists yet, so undoing the claim
+            # directly is the whole release.
+            unit.session = None
+            return Response(content="WebRTC session setup failed", status_code=500, media_type="text/plain")
 
         released = False
 
@@ -604,6 +620,26 @@ def create_app(pool: list[PipelineUnit], stop_event: ThreadingEvent) -> FastAPI:
             media_type="application/sdp",
             headers={"Location": f"/v1/realtime/calls/{session_id}"},
         )
+
+    @app.delete("/v1/realtime/calls/{call_id}")
+    async def webrtc_hangup_endpoint(call_id: str) -> Response:
+        """Hang up a WebRTC call — the Location URL advertised by the POST above."""
+        for unit in pool:
+            session = unit.session
+            if (
+                session is None
+                or session.session_id != call_id
+                or session.released_at is not None
+                or session.transport is None
+                or session.transport.kind != "webrtc"
+            ):
+                continue
+            logger.info(f"WebRTC call {call_id} hung up via DELETE (pipeline {unit.index})")
+            # close() fires the session's on_closed callback, which releases
+            # the unit exactly once (idempotent with aiortc's own callbacks).
+            await session.transport.close()
+            return Response(status_code=200)
+        return Response(content="Unknown call", status_code=404, media_type="text/plain")
 
     async def _send_loop_for(unit: PipelineUnit) -> None:
         """Per-pipeline send loop. Polls this unit's output queues and forwards

--- a/tests/openai_realtime/test_webrtc.py
+++ b/tests/openai_realtime/test_webrtc.py
@@ -500,6 +500,40 @@ class TestWebRTCLoopback:
         finally:
             await pc.close()
 
+    async def test_delete_location_hangs_up(self, server_env):
+        """DELETE on the Location URL advertised by the 201 releases the unit;
+        an unknown call id answers 404."""
+        pc = RTCPeerConnection()
+        try:
+            pc.createDataChannel("oai-events")
+            pc.addTrack(AudioStreamTrack())
+            offer = await pc.createOffer()
+            await pc.setLocalDescription(offer)
+
+            async with httpx.AsyncClient() as client:
+                resp = await client.post(
+                    f"http://127.0.0.1:{server_env.port}/v1/realtime/calls",
+                    content=pc.localDescription.sdp,
+                    headers={"Content-Type": "application/sdp"},
+                    timeout=10.0,
+                )
+                assert resp.status_code == 201
+                location = resp.headers["location"]
+
+                missing = await client.delete(
+                    f"http://127.0.0.1:{server_env.port}/v1/realtime/calls/no-such-call",
+                    timeout=10.0,
+                )
+                assert missing.status_code == 404
+
+                hangup = await client.delete(
+                    f"http://127.0.0.1:{server_env.port}{location}", timeout=10.0
+                )
+                assert hangup.status_code == 200
+        finally:
+            await pc.close()
+        await _wait_for_release(server_env)
+
     async def test_invalid_offer_releases_unit(self, server_env):
         async with httpx.AsyncClient() as client:
             resp = await client.post(
@@ -514,13 +548,14 @@ class TestWebRTCLoopback:
     async def test_setup_failure_releases_unit(self, server_env, monkeypatch):
         """A failure between claiming the unit and negotiate() (e.g. peer
         connection construction) must release the unit, not leak it."""
-        import speech_to_speech.api.openai_realtime.webrtc_session as webrtc_module
+        import speech_to_speech.api.openai_realtime.websocket_router as router_module
 
         def _boom():
             raise RuntimeError("boom")
 
-        # The calls endpoint imports this at request time, so the patch takes.
-        monkeypatch.setattr(webrtc_module, "rtc_configuration_from_env", _boom)
+        # The calls endpoint uses the router's module-level binding (imported
+        # eagerly at load), so that's the name to patch.
+        monkeypatch.setattr(router_module, "rtc_configuration_from_env", _boom)
 
         pc = RTCPeerConnection()
         try:

--- a/tests/openai_realtime/test_webrtc.py
+++ b/tests/openai_realtime/test_webrtc.py
@@ -30,6 +30,7 @@ av = pytest.importorskip("av")
 import httpx  # noqa: E402  (ships with the openai dependency)
 from aiortc import RTCPeerConnection, RTCSessionDescription  # noqa: E402
 from aiortc.mediastreams import AudioStreamTrack, MediaStreamError  # noqa: E402
+from starlette.testclient import TestClient  # noqa: E402
 
 import speech_to_speech.api.openai_realtime.websocket_router as router_module  # noqa: E402
 from speech_to_speech.api.openai_realtime.pipeline_unit import PipelineUnit  # noqa: E402
@@ -41,6 +42,7 @@ from speech_to_speech.api.openai_realtime.webrtc_session import (  # noqa: E402
     PipelineAudioTrack,
 )
 from speech_to_speech.pipeline.cancel_scope import CancelScope  # noqa: E402
+from speech_to_speech.pipeline.events import SpeechStartedEvent  # noqa: E402
 from speech_to_speech.pipeline.messages import AUDIO_RESPONSE_DONE  # noqa: E402
 
 from .test_openai_client import _ServerEnv  # noqa: E402
@@ -295,6 +297,43 @@ class TestWebRTCDispatch:
 
 
 # ---------------------------------------------------------------------------
+# Send-loop barge-in against transport-buffered audio
+# ---------------------------------------------------------------------------
+
+
+class TestBargeInAfterResponseDone:
+    """Speech starting after a response finished must still flush audio the
+    transport buffered but has not played yet: finish_response() runs when the
+    done-sentinel is observed, not when playback completes, so fast TTS can
+    leave seconds of unplayed audio in the WebRTC track with in_response
+    already cleared."""
+
+    def test_speech_start_flushes_buffered_transport_audio(self):
+        unit = _make_unit()
+        stop_event = ThreadingEvent()
+        app = router_module.create_app(pool=[unit], stop_event=stop_event)
+        with TestClient(app) as client:
+            with client.websocket_connect("/v1/realtime") as ws:
+                ws.receive_json()  # session.created
+                # No response is active or pending. Swap in a spy transport so
+                # the send loop's discard call is observable.
+                spy = _FakeTransport()
+                assert unit.session is not None
+                unit.session.transport = spy
+                generation_before = unit.cancel_scope.generation
+
+                unit.text_output_queue.put(SpeechStartedEvent())
+
+                deadline = time.monotonic() + 2.0
+                while time.monotonic() < deadline and spy.discards == 0:
+                    time.sleep(0.02)
+                assert spy.discards == 1
+                # Nothing to cancel: no response was active.
+                assert unit.cancel_scope.generation == generation_before
+        stop_event.set()
+
+
+# ---------------------------------------------------------------------------
 # Loopback integration: real aiortc peer against the served app
 # ---------------------------------------------------------------------------
 
@@ -459,3 +498,55 @@ class TestWebRTCLoopback:
             assert second.json()["error"]["type"] == "session_limit_reached"
         finally:
             await pc.close()
+
+    async def test_invalid_offer_releases_unit(self, server_env):
+        async with httpx.AsyncClient() as client:
+            resp = await client.post(
+                f"http://127.0.0.1:{server_env.port}/v1/realtime/calls",
+                content="not an sdp",
+                headers={"Content-Type": "application/sdp"},
+                timeout=10.0,
+            )
+        assert resp.status_code == 400
+        await _wait_for_release(server_env)
+
+    async def test_setup_failure_releases_unit(self, server_env, monkeypatch):
+        """A failure between claiming the unit and negotiate() (e.g. peer
+        connection construction) must release the unit, not leak it."""
+        import speech_to_speech.api.openai_realtime.webrtc_session as webrtc_module
+
+        def _boom():
+            raise RuntimeError("boom")
+
+        # The calls endpoint imports this at request time, so the patch takes.
+        monkeypatch.setattr(webrtc_module, "rtc_configuration_from_env", _boom)
+
+        pc = RTCPeerConnection()
+        try:
+            pc.createDataChannel("oai-events")
+            pc.addTrack(AudioStreamTrack())
+            offer = await pc.createOffer()
+            await pc.setLocalDescription(offer)
+
+            async with httpx.AsyncClient() as client:
+                resp = await client.post(
+                    f"http://127.0.0.1:{server_env.port}/v1/realtime/calls",
+                    content=pc.localDescription.sdp,
+                    headers={"Content-Type": "application/sdp"},
+                    timeout=10.0,
+                )
+            assert resp.status_code == 500
+        finally:
+            await pc.close()
+        await _wait_for_release(server_env)
+
+
+async def _wait_for_release(server_env, timeout: float = 5.0) -> None:
+    """Assert the unit was released (or is draining) after a failed call."""
+    deadline = time.monotonic() + timeout
+    while time.monotonic() < deadline:
+        session = server_env.unit.session
+        if session is None or session.released_at is not None:
+            return
+        await asyncio.sleep(0.05)
+    raise AssertionError("failed WebRTC call left the pipeline unit claimed")

--- a/tests/openai_realtime/test_webrtc.py
+++ b/tests/openai_realtime/test_webrtc.py
@@ -35,6 +35,7 @@ from starlette.testclient import TestClient  # noqa: E402
 import speech_to_speech.api.openai_realtime.websocket_router as router_module  # noqa: E402
 from speech_to_speech.api.openai_realtime.pipeline_unit import PipelineUnit  # noqa: E402
 from speech_to_speech.api.openai_realtime.service import CHUNK_SIZE_BYTES, RealtimeService  # noqa: E402
+from speech_to_speech.api.openai_realtime.transports import SessionTransport  # noqa: E402
 from speech_to_speech.api.openai_realtime.webrtc_session import (  # noqa: E402
     WEBRTC_FRAME_SAMPLES,
     WEBRTC_SAMPLE_RATE,
@@ -74,7 +75,7 @@ def _make_unit() -> PipelineUnit:
     )
 
 
-class _FakeTransport:
+class _FakeTransport(SessionTransport):
     kind = "webrtc"
 
     def __init__(self):

--- a/tests/openai_realtime/test_webrtc.py
+++ b/tests/openai_realtime/test_webrtc.py
@@ -1,0 +1,461 @@
+"""Tests for the WebRTC transport.
+
+Three layers:
+
+- Pure-unit tests for the shared ``append_pcm`` path, the ``PcmResampler``
+  (stereo downmix, statefulness), and the paced ``PipelineAudioTrack``.
+- Dispatch tests driving ``_dispatch_client_event`` with a fake transport,
+  covering the transport-gated events (append rejected over WebRTC,
+  output_audio_buffer.clear flushing server-side audio).
+- One loopback integration test: a real aiortc peer performs the SDP
+  handshake against the uvicorn-served app (POST /v1/realtime/calls),
+  exchanges events over the 'oai-events' data channel, streams mic audio
+  into the pipeline input queue, and receives paced audio from output_queue.
+
+The whole module is skipped when the ``webrtc`` extra (aiortc) isn't installed.
+"""
+
+import asyncio
+import json
+import time
+from queue import Empty, Queue
+from threading import Event as ThreadingEvent
+
+import numpy as np
+import pytest
+
+aiortc = pytest.importorskip("aiortc")
+av = pytest.importorskip("av")
+
+import httpx  # noqa: E402  (ships with the openai dependency)
+from aiortc import RTCPeerConnection, RTCSessionDescription  # noqa: E402
+from aiortc.mediastreams import AudioStreamTrack, MediaStreamError  # noqa: E402
+
+import speech_to_speech.api.openai_realtime.websocket_router as router_module  # noqa: E402
+from speech_to_speech.api.openai_realtime.pipeline_unit import PipelineUnit  # noqa: E402
+from speech_to_speech.api.openai_realtime.service import CHUNK_SIZE_BYTES, RealtimeService  # noqa: E402
+from speech_to_speech.api.openai_realtime.webrtc_session import (  # noqa: E402
+    WEBRTC_FRAME_SAMPLES,
+    WEBRTC_SAMPLE_RATE,
+    PcmResampler,
+    PipelineAudioTrack,
+)
+from speech_to_speech.pipeline.cancel_scope import CancelScope  # noqa: E402
+from speech_to_speech.pipeline.messages import AUDIO_RESPONSE_DONE  # noqa: E402
+
+from .test_openai_client import _ServerEnv  # noqa: E402
+
+PIPELINE_SAMPLE_RATE = 16_000
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+
+def _make_unit() -> PipelineUnit:
+    text_prompt_queue: Queue = Queue()
+    should_listen = ThreadingEvent()
+    should_listen.set()
+    service = RealtimeService(text_prompt_queue=text_prompt_queue, should_listen=should_listen)
+    return PipelineUnit(
+        index=0,
+        service=service,
+        cancel_scope=CancelScope(),
+        should_listen=should_listen,
+        response_playing=ThreadingEvent(),
+        input_queue=Queue(),
+        output_queue=Queue(),
+        text_output_queue=Queue(),
+        text_prompt_queue=text_prompt_queue,
+        handlers=[],
+    )
+
+
+class _FakeTransport:
+    kind = "webrtc"
+
+    def __init__(self):
+        self.sent: list[dict] = []
+        self.discards = 0
+
+    async def send_events(self, events):
+        self.sent.extend(e.model_dump() for e in events)
+
+    async def send_audio_chunk(self, service, session_id, pcm):
+        raise AssertionError("dispatch tests never send audio")
+
+    def discard_pending_audio(self):
+        self.discards += 1
+
+    async def close(self):
+        pass
+
+
+# ---------------------------------------------------------------------------
+# append_pcm (shared inbound path)
+# ---------------------------------------------------------------------------
+
+
+class TestAppendPcm:
+    def test_chunks_and_remainder_carry_across_calls(self):
+        unit = _make_unit()
+        conn_id = unit.service.register()
+
+        # 700 samples at pipeline rate: one 512-sample chunk + 188 remainder.
+        chunks = unit.service.append_pcm(conn_id, b"\x01\x00" * 700, PIPELINE_SAMPLE_RATE)
+        assert [len(c) for c in chunks] == [CHUNK_SIZE_BYTES]
+
+        # 324 more completes the second chunk exactly (188 + 324 = 512).
+        chunks = unit.service.append_pcm(conn_id, b"\x01\x00" * 324, PIPELINE_SAMPLE_RATE)
+        assert [len(c) for c in chunks] == [CHUNK_SIZE_BYTES]
+        assert unit.service._state(conn_id).audio_remainder == b""
+
+    def test_sets_commit_bookkeeping(self):
+        unit = _make_unit()
+        conn_id = unit.service.register()
+
+        assert unit.service.handle_audio_commit(conn_id) is not None  # empty buffer errors
+
+        unit.service.append_pcm(conn_id, b"\x01\x00" * 512, PIPELINE_SAMPLE_RATE)
+        assert unit.service.handle_audio_commit(conn_id) is None
+
+
+# ---------------------------------------------------------------------------
+# PcmResampler
+# ---------------------------------------------------------------------------
+
+
+class TestPcmResampler:
+    def test_stereo_48k_downmixes_to_mono_16k(self):
+        resampler = PcmResampler(PIPELINE_SAMPLE_RATE)
+        n = WEBRTC_FRAME_SAMPLES
+        stereo = np.zeros((2, n), dtype=np.int16)
+        stereo[0, :] = 1000
+        stereo[1, :] = 3000
+        frame = av.AudioFrame.from_ndarray(stereo, format="s16p", layout="stereo")
+        frame.sample_rate = WEBRTC_SAMPLE_RATE
+        frame.pts = 0
+
+        total = bytearray(resampler.resample_frame(frame))
+        # Push several frames so filter delay flushes through.
+        for i in range(1, 10):
+            f = av.AudioFrame.from_ndarray(stereo, format="s16p", layout="stereo")
+            f.sample_rate = WEBRTC_SAMPLE_RATE
+            f.pts = i * n
+            total += resampler.resample_frame(f)
+
+        samples = np.frombuffer(bytes(total), dtype=np.int16)
+        # 10 frames of 20 ms at 48 kHz → ~200 ms at 16 kHz = ~3200 samples
+        # (minus filter delay). A plane-concatenating flatten bug would give
+        # double that; a channel-dropping bug would average to 1000 or 3000.
+        assert 2800 <= samples.shape[0] <= 3200
+        steady_state = samples[samples.shape[0] // 2 :]
+        assert abs(int(np.mean(steady_state)) - 2000) <= 10  # downmix average
+
+    def test_stateful_across_pcm_chunks(self):
+        resampler = PcmResampler(WEBRTC_SAMPLE_RATE)
+        total = bytearray()
+        for _ in range(10):
+            total += resampler.resample_pcm(b"\x01\x00" * 512, PIPELINE_SAMPLE_RATE)
+        samples = np.frombuffer(bytes(total), dtype=np.int16)
+        # 5120 samples at 16 kHz → ~15360 at 48 kHz, minus filter delay.
+        assert 15000 <= samples.shape[0] <= 15360
+
+
+# ---------------------------------------------------------------------------
+# PipelineAudioTrack
+# ---------------------------------------------------------------------------
+
+
+class TestPipelineAudioTrack:
+    async def test_recv_returns_written_audio_then_silence(self):
+        track = PipelineAudioTrack()
+        payload = (np.ones(WEBRTC_FRAME_SAMPLES, dtype=np.int16) * 5).tobytes()
+        track.write(payload)
+
+        frame = await track.recv()
+        assert frame.sample_rate == WEBRTC_SAMPLE_RATE
+        assert np.all(frame.to_ndarray() == 5)
+
+        frame = await track.recv()  # buffer now empty → silence
+        assert np.all(frame.to_ndarray() == 0)
+        track.stop()
+
+    async def test_recv_paces_to_wall_clock(self):
+        track = PipelineAudioTrack()
+        track.write(b"\x00" * WEBRTC_FRAME_SAMPLES * 2 * 10)  # 10 frames buffered
+
+        start = time.monotonic()
+        for _ in range(5):
+            await track.recv()
+        elapsed = time.monotonic() - start
+        # 5 frames of 20 ms: first is immediate, the rest paced → ≥ ~80 ms.
+        # Without pacing this loop completes in microseconds.
+        assert elapsed >= 0.06
+        track.stop()
+
+    async def test_clear_drops_unplayed_audio(self):
+        track = PipelineAudioTrack()
+        track.write((np.ones(WEBRTC_FRAME_SAMPLES * 4, dtype=np.int16) * 7).tobytes())
+        assert track.buffered_bytes > 0
+
+        track.clear()
+        assert track.buffered_bytes == 0
+        frame = await track.recv()
+        assert np.all(frame.to_ndarray() == 0)
+        track.stop()
+
+    async def test_recv_after_stop_raises(self):
+        track = PipelineAudioTrack()
+        track.stop()
+        with pytest.raises(MediaStreamError):
+            await track.recv()
+
+
+# ---------------------------------------------------------------------------
+# Client-event dispatch over the data channel
+# ---------------------------------------------------------------------------
+
+
+class TestWebRTCDispatch:
+    async def test_append_rejected_over_webrtc(self):
+        unit = _make_unit()
+        conn_id = unit.service.register()
+        transport = _FakeTransport()
+
+        await router_module._dispatch_client_event(
+            unit,
+            conn_id,
+            {"type": "input_audio_buffer.append", "audio": "AAAA"},
+            transport,
+            transport_kind="webrtc",
+        )
+
+        assert len(transport.sent) == 1
+        assert transport.sent[0]["type"] == "error"
+        assert transport.sent[0]["error"]["type"] == "invalid_event_for_transport"
+        assert unit.input_queue.qsize() == 0
+
+    async def test_output_audio_buffer_clear_flushes_audio(self):
+        unit = _make_unit()
+        conn_id = unit.service.register()
+        transport = _FakeTransport()
+
+        unit.output_queue.put(b"\x01\x00" * 512)
+        unit.output_queue.put(AUDIO_RESPONSE_DONE)
+
+        await router_module._dispatch_client_event(
+            unit,
+            conn_id,
+            {"type": "output_audio_buffer.clear"},
+            transport,
+            transport_kind="webrtc",
+        )
+
+        assert transport.sent == []  # no error
+        assert transport.discards == 1
+        # Pending audio flushed, done-sentinel preserved so the response still closes.
+        assert unit.output_queue.get_nowait() == AUDIO_RESPONSE_DONE
+        with pytest.raises(Empty):
+            unit.output_queue.get_nowait()
+
+    async def test_output_audio_buffer_clear_rejected_over_websocket(self):
+        unit = _make_unit()
+        conn_id = unit.service.register()
+        transport = _FakeTransport()
+        transport.kind = "websocket"
+
+        await router_module._dispatch_client_event(
+            unit,
+            conn_id,
+            {"type": "output_audio_buffer.clear"},
+            transport,
+            transport_kind="websocket",
+        )
+
+        assert len(transport.sent) == 1
+        assert transport.sent[0]["type"] == "error"
+        assert transport.sent[0]["error"]["type"] == "invalid_event_for_transport"
+
+    async def test_response_cancel_discards_transport_audio(self):
+        unit = _make_unit()
+        conn_id = unit.service.register()
+        transport = _FakeTransport()
+
+        await router_module._dispatch_client_event(
+            unit,
+            conn_id,
+            {"type": "response.cancel"},
+            transport,
+            transport_kind="webrtc",
+        )
+
+        assert transport.discards == 1
+
+
+# ---------------------------------------------------------------------------
+# Loopback integration: real aiortc peer against the served app
+# ---------------------------------------------------------------------------
+
+
+@pytest.fixture
+def server_env():
+    env = _ServerEnv()
+    env.start()
+    yield env
+    env.stop()
+
+
+class _DataChannelInbox:
+    """Collects data-channel messages and lets tests await specific types."""
+
+    def __init__(self, dc):
+        self.events: list[dict] = []
+        self._new = asyncio.Event()
+
+        @dc.on("message")
+        def on_message(msg):
+            self.events.append(json.loads(msg))
+            self._new.set()
+
+    async def wait_for(self, event_type: str, timeout: float = 5.0) -> dict:
+        deadline = time.monotonic() + timeout
+        while True:
+            for event in self.events:
+                if event["type"] == event_type:
+                    return event
+            remaining = deadline - time.monotonic()
+            if remaining <= 0:
+                raise AssertionError(
+                    f"No '{event_type}' event within {timeout}s; got {[e['type'] for e in self.events]}"
+                )
+            self._new.clear()
+            try:
+                await asyncio.wait_for(self._new.wait(), timeout=remaining)
+            except asyncio.TimeoutError:
+                pass
+
+
+class TestWebRTCLoopback:
+    async def test_handshake_events_and_audio_roundtrip(self, server_env):
+        pc = RTCPeerConnection()
+        try:
+            dc = pc.createDataChannel("oai-events")
+            inbox = _DataChannelInbox(dc)
+            pc.addTrack(AudioStreamTrack())  # silent mic track
+
+            received_frames: list = []
+            track_ready = asyncio.Event()
+
+            @pc.on("track")
+            def on_track(track):
+                async def _consume():
+                    while True:
+                        try:
+                            frame = await track.recv()
+                        except MediaStreamError:
+                            return
+                        received_frames.append(frame)
+                        track_ready.set()
+
+                asyncio.ensure_future(_consume())
+
+            offer = await pc.createOffer()
+            await pc.setLocalDescription(offer)
+
+            async with httpx.AsyncClient() as client:
+                resp = await client.post(
+                    f"http://127.0.0.1:{server_env.port}/v1/realtime/calls",
+                    content=pc.localDescription.sdp,
+                    headers={"Content-Type": "application/sdp"},
+                    timeout=10.0,
+                )
+            assert resp.status_code == 201
+            assert resp.headers["content-type"].startswith("application/sdp")
+            assert resp.headers["location"].startswith("/v1/realtime/calls/")
+
+            await pc.setRemoteDescription(RTCSessionDescription(sdp=resp.text, type="answer"))
+
+            # session.created arrives once the data channel opens.
+            created = await inbox.wait_for("session.created", timeout=10.0)
+            assert "session" in created
+
+            # Client events over the data channel reach the shared dispatch:
+            # append must be rejected as transport-invalid.
+            dc.send(json.dumps({"type": "input_audio_buffer.append", "audio": "AAAA"}))
+            error = await inbox.wait_for("error")
+            assert error["error"]["type"] == "invalid_event_for_transport"
+
+            # Inbound mic audio lands on input_queue as 512-sample chunks.
+            def _wait_for_input_chunk(timeout: float = 10.0):
+                return server_env.input_queue.get(timeout=timeout)
+
+            chunk, _cfg = await asyncio.get_running_loop().run_in_executor(None, _wait_for_input_chunk)
+            assert len(chunk) == CHUNK_SIZE_BYTES
+
+            # Outbound pipeline audio: PCM through output_queue reaches the
+            # client as RTP frames, and the done-sentinel closes the response
+            # over the data channel (response.created was sent implicitly).
+            server_env.output_queue.put(np.ones(4096, dtype=np.int16).tobytes())
+            server_env.output_queue.put(AUDIO_RESPONSE_DONE)
+
+            await inbox.wait_for("response.created", timeout=10.0)
+            done = await inbox.wait_for("response.done", timeout=10.0)
+            assert done["response"]["status"] == "completed"
+
+            await asyncio.wait_for(track_ready.wait(), timeout=10.0)
+            assert received_frames[0].sample_rate == WEBRTC_SAMPLE_RATE
+
+            # Hanging up: closing the data channel signals the server (an
+            # SCTP reset, unlike a bare pc.close() which the server only
+            # notices via ICE consent timeouts). The release path enqueues
+            # SESSION_END and marks the session as draining.
+            dc.close()
+            deadline = time.monotonic() + 5.0
+            while time.monotonic() < deadline:
+                session = server_env.unit.session
+                if session is None or session.released_at is not None:
+                    break
+                await asyncio.sleep(0.05)
+            else:
+                raise AssertionError("WebRTC disconnect did not start the unit release")
+        finally:
+            await pc.close()
+
+    async def test_rejects_wrong_content_type(self, server_env):
+        async with httpx.AsyncClient() as client:
+            resp = await client.post(
+                f"http://127.0.0.1:{server_env.port}/v1/realtime/calls",
+                json={"sdp": "nope"},
+                timeout=10.0,
+            )
+        assert resp.status_code == 415
+
+    async def test_rejects_when_pool_full(self, server_env):
+        pc = RTCPeerConnection()
+        try:
+            pc.createDataChannel("oai-events")
+            pc.addTrack(AudioStreamTrack())
+            offer = await pc.createOffer()
+            await pc.setLocalDescription(offer)
+
+            async with httpx.AsyncClient() as client:
+                first = await client.post(
+                    f"http://127.0.0.1:{server_env.port}/v1/realtime/calls",
+                    content=pc.localDescription.sdp,
+                    headers={"Content-Type": "application/sdp"},
+                    timeout=10.0,
+                )
+                assert first.status_code == 201
+
+                second = await client.post(
+                    f"http://127.0.0.1:{server_env.port}/v1/realtime/calls",
+                    content=pc.localDescription.sdp,
+                    headers={"Content-Type": "application/sdp"},
+                    timeout=10.0,
+                )
+            assert second.status_code == 503
+            assert second.json()["error"]["type"] == "session_limit_reached"
+        finally:
+            await pc.close()

--- a/tests/openai_realtime/test_webrtc.py
+++ b/tests/openai_realtime/test_webrtc.py
@@ -526,9 +526,7 @@ class TestWebRTCLoopback:
                 )
                 assert missing.status_code == 404
 
-                hangup = await client.delete(
-                    f"http://127.0.0.1:{server_env.port}{location}", timeout=10.0
-                )
+                hangup = await client.delete(f"http://127.0.0.1:{server_env.port}{location}", timeout=10.0)
                 assert hangup.status_code == 200
         finally:
             await pc.close()

--- a/tests/openai_realtime/test_websocket_router.py
+++ b/tests/openai_realtime/test_websocket_router.py
@@ -19,6 +19,7 @@ from starlette.websockets import WebSocketState
 import speech_to_speech.api.openai_realtime.websocket_router as router_module
 from speech_to_speech.api.openai_realtime.pipeline_unit import PipelineUnit
 from speech_to_speech.api.openai_realtime.service import CHUNK_SIZE_BYTES, RealtimeService
+from speech_to_speech.api.openai_realtime.transports import WebSocketTransport
 from speech_to_speech.api.openai_realtime.websocket_router import create_app
 from speech_to_speech.pipeline.cancel_scope import CancelScope
 from speech_to_speech.pipeline.control import SESSION_END, PipelineControlMessage, is_control_message
@@ -574,7 +575,7 @@ class TestSendLoop:
         text_output_queue.put(TokenUsageEvent(input_tokens=10, output_tokens=5))
         ws = _FakeWebSocket()
 
-        asyncio.run(router_module._drain_pending_response_events(ws, unit, conn_id))
+        asyncio.run(router_module._drain_pending_response_events(WebSocketTransport(ws), unit, conn_id))
         done_events = service.finish_response(conn_id)
 
         assert [payload["type"] for payload in ws.sent] == ["response.function_call_arguments.done"]
@@ -614,7 +615,7 @@ class TestSendLoop:
         text_output_queue.put(AssistantTextEvent(text="queued after boundary"))
         ws = _FakeWebSocket()
 
-        asyncio.run(router_module._drain_pending_response_events(ws, unit, conn_id))
+        asyncio.run(router_module._drain_pending_response_events(WebSocketTransport(ws), unit, conn_id))
         done_events = service.finish_response(conn_id)
 
         assert [payload["type"] for payload in ws.sent] == ["response.function_call_arguments.done"]


### PR DESCRIPTION
Supersedes #279 — that branch predates the pipeline-pool rework of the realtime router, so this reimplements the transport on top of it rather than rebasing.

## What this adds

A WebRTC transport alongside the WebSocket endpoint, following the OpenAI GA Realtime handshake:

```
POST /v1/realtime/calls        Content-Type: application/sdp
```

The client POSTs an SDP offer and receives an SDP answer (`201`, `Location: /v1/realtime/calls/{call_id}`). Audio flows over RTP media tracks (Opus 48 kHz, resampled to/from the 16 kHz pipeline rate with a stateful `av.AudioResampler` — no per-chunk boundary artifacts, stereo downmixed correctly); all JSON events use the same protocol as WebSocket mode, carried on the `oai-events` data channel. Requires the new optional `webrtc` extra (aiortc); the endpoint answers `501` with install instructions when it is missing.

## Design

- **The send loop stays the sole consumer of the pipeline output queues.** `SessionState` now holds a `SessionTransport` (`WebSocketTransport` or `WebRTCSession`) instead of a raw websocket; the per-unit send loop hands events and PCM to the transport. All generation-staleness discards, sentinel handling, and SESSION_END drain/release logic remain in one place and work identically for both transports.
- **WebRTC sessions claim pipeline units from the same pool** as WebSocket clients (`503` + `session_limit_reached` when full); `/v1/pool` stays accurate, and disconnect goes through the same drain-and-release path (with a connect watchdog so an abandoned handshake can't hold a unit).
- **Shared client-event dispatch** for both transports. Transport-gated events: `input_audio_buffer.append` is rejected over WebRTC (`invalid_event_for_transport` — audio arrives on the media track), and `output_audio_buffer.clear` is WebRTC-only.
- **Interruption flushes server-side audio.** Over WebRTC the unplayed audio buffers in the server's paced track (20 ms frames), not in the client — so barge-in, `response.cancel`, and `output_audio_buffer.clear` all clear that buffer and playback stops within ~one frame.
- **Shared inbound path**: `append_pcm` factored out of `handle_audio_append`, so WebRTC audio keeps the 512-sample chunk alignment and `input_audio_buffer.commit` bookkeeping. `begin_audio_response` factored out of `encode_audio_chunk`, so the implicit VAD path still emits `response.created` over the data channel without encoding base64 deltas nobody reads.
- **ICE configuration** via `SPEECH_TO_SPEECH_ICE_SERVERS` (JSON list of STUN/TURN entries); aiortc defaults otherwise. NAT-restricted deployments need their own TURN — documented in the realtime README.

## Drive-by fix

`input_audio_buffer.commit` was missing from `_EVENT_TYPE_TO_MODEL`, so the WebSocket route's commit branch was unreachable (commits errored as unknown events). Added to the parse map.

## Tests

- Unit tests: stateful resampler (stereo 48 kHz → mono 16 kHz downmix), paced audio track (wall-clock pacing, silence fill, `clear()`), shared dispatch transport gating, `append_pcm` chunk/remainder/commit behavior.
- Loopback integration test with a real aiortc peer against the uvicorn-served app: SDP handshake, `session.created` + error events over the data channel, mic audio landing on `input_queue` as 512-sample chunks, pipeline audio arriving as 48 kHz RTP frames, `response.created`/`response.done` sequencing, and unit release on hangup.
- Module skips cleanly when aiortc isn't installed; aiortc added to the dev group so CI exercises it. Full suite: 582 passed; ruff and mypy clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)