### PR TITLE
Strip Markdown syntax before TTS (#338)

### DIFF
--- a/src/speech_to_speech/LLM/utils.py
+++ b/src/speech_to_speech/LLM/utils.py
@@ -21,10 +21,27 @@ SPEECHABLE_PATTERN = re.compile(
 )
 
 
+_MARKDOWN_PATTERNS = [
+    (re.compile(r"```.*?```", re.DOTALL), ""),       # fenced code blocks
+    (re.compile(r"\*\*(.+?)\*\*"), r"\1"),            # bold
+    (re.compile(r"__(.+?)__"), r"\1"),               # bold (underscore)
+    (re.compile(r"`([^`]+?)`"), r"\1"),               # inline code
+    (re.compile(r"\*(.+?)\*"), r"\1"),               # italic
+    (re.compile(r"_(.+?)_"), r"\1"),                 # italic (underscore)
+    (re.compile(r"(?m)^\s{0,3}#{1,6}\s+"), ""),       # headings
+    (re.compile(r"(?m)^\s{0,3}[-*+]\s+"), ""),        # bullet markers
+]
+
+
 def remove_unspeechable(text: str) -> str:
     """Keep only speechable characters: letters, digits, punctuation, whitespace.
-    support unicode characters (english, arabic, chinese, japanese, korean, etc.)
+
+    Markdown formatting is stripped first (keeping the enclosed text) so the TTS
+    engine does not voice formatting symbols such as asterisks, hashes, or backticks.
+    Supports unicode characters (english, arabic, chinese, japanese, korean, etc.)
     """
+    for pattern, replacement in _MARKDOWN_PATTERNS:
+        text = pattern.sub(replacement, text)
     text = text.translate(SMART_PUNCT_TRANSLATION)
     return SPEECHABLE_PATTERN.sub("", text)
 

--- a/tests/test_llm_utils.py
+++ b/tests/test_llm_utils.py
@@ -7,3 +7,31 @@ def test_remove_unspeechable_normalizes_smart_apostrophes() -> None:
 
 def test_remove_unspeechable_keeps_text_and_drops_emoji() -> None:
     assert remove_unspeechable("Hello 👋 lobster 🦞") == "Hello  lobster "
+
+
+def test_remove_unspeechable_strips_bold():
+    assert remove_unspeechable("**bold**") == "bold"
+
+
+def test_remove_unspeechable_strips_italic():
+    assert remove_unspeechable("*italic*") == "italic"
+
+
+def test_remove_unspeechable_strips_inline_code():
+    assert remove_unspeechable("`code`") == "code"
+
+
+def test_remove_unspeechable_strips_heading():
+    assert remove_unspeechable("# Heading") == "Heading"
+
+
+def test_remove_unspeechable_strips_bullets():
+    assert remove_unspeechable("- item one\n- item two") == "item one\nitem two"
+
+
+def test_remove_unspeechable_mixed_markdown():
+    assert remove_unspeechable("**Hello** world and `code` here") == "Hello world and code here"
+
+
+def test_remove_unspeechable_strips_fenced_code():
+    assert remove_unspeechable("```python\nprint(1)\n```") == ""


### PR DESCRIPTION
LLM responses often contain Markdown (**bold**, # headings, `code`,
- bullets). These symbols were voiced literally by the TTS engine.

remove_unspeechable now strips common Markdown constructs while keeping the enclosed text, so spoken output sounds natural.

Fixes #338.