### PR TITLE
Fix stuck pipeline units in session teardown

### DIFF
--- a/src/speech_to_speech/api/openai_realtime/pipeline_unit.py
+++ b/src/speech_to_speech/api/openai_realtime/pipeline_unit.py
@@ -33,6 +33,11 @@ class SessionState(BaseModel):
     # `None` while the client is still active. Used by /v1/pool to surface stuck
     # units (handlers haven't finished propagating SESSION_END).
     released_at: Optional[float] = None
+    # Wall-clock time when the drain wait gave up and quarantined the unit
+    # (SESSION_END_QUARANTINE_TIMEOUT_S elapsed). The unit stays unclaimable —
+    # its handlers may still emit this session's output — until SESSION_END
+    # actually drains. Reported as "stuck" by /v1/pool.
+    quarantined_at: Optional[float] = None
 
 
 class PipelineUnit(BaseModel):

--- a/src/speech_to_speech/api/openai_realtime/websocket_router.py
+++ b/src/speech_to_speech/api/openai_realtime/websocket_router.py
@@ -37,10 +37,16 @@ from speech_to_speech.pipeline.messages import AUDIO_RESPONSE_DONE, PIPELINE_END
 logger = logging.getLogger(__name__)
 MAX_AUDIO_BATCH_BYTES = 6400
 # How long the release path waits for SESSION_END to propagate through the
-# handler chain back to output_queue before clearing unit.session. Tests
-# monkeypatch this to a small value since their fixtures usually skip the
-# real handler chain.
+# handler chain back to output_queue before warning that the unit is stuck.
+# Tests monkeypatch this to a small value since their fixtures usually skip
+# the real handler chain.
 SESSION_END_DRAIN_TIMEOUT_S = 10.0
+# Hard ceiling on the drain wait: past this, the unit is force-released even
+# though SESSION_END never came back (e.g. a wedged handler thread), trading
+# a possible leak of stale output into the next session for restored pool
+# capacity. Stale audio tagged with an old cancel generation is still dropped
+# by the send loop's discard checks.
+SESSION_END_FORCE_RELEASE_TIMEOUT_S = 180.0
 QItem = TypeVar("QItem")
 
 
@@ -73,7 +79,9 @@ async def _send_events(ws: WebSocket, events: list[ServerEvent]) -> None:
 
 
 def _keep_audio_sentinel(item: Any) -> bool:
-    return _is_audio_done(item)
+    # SESSION_END must survive barge-in flushes of output_queue: dropping it
+    # would leave the release path waiting forever for the drain signal.
+    return _is_audio_done(item) or is_control_message(item, SESSION_END.kind)
 
 
 def _keep_user_text_event(item: Any) -> bool:
@@ -225,34 +233,49 @@ def _should_discard_audio(unit: PipelineUnit, item: Any) -> bool:
 
 
 async def _release_unit_after_drain(unit: PipelineUnit, session: Any, session_id: str) -> None:
-    """Wait indefinitely for SESSION_END to propagate, then release the unit.
+    """Wait for SESSION_END to propagate, then release the unit.
 
     Runs in its own asyncio task so the route handler's finally block can return
     immediately. The unit stays unavailable for new claims (unit.session != None)
     until SESSION_END travels all the way through the handler chain back to
     output_queue — observed by the send loop, which sets session.drained.
 
-    Intentionally has no timeout-fallback release. If a handler (e.g. an LM HTTP
-    call) is still busy past SESSION_END_DRAIN_TIMEOUT_S, releasing the unit
-    would let a new client claim it while stale output from the previous session
-    is still in flight — that output would be dispatched under the new session.
-    We accept reduced pool capacity over a cross-session leak; operators can see
-    stuck units in `/v1/pool` (long `released_at` age).
+    If the chain is still busy past SESSION_END_FORCE_RELEASE_TIMEOUT_S (e.g. a
+    wedged or dead handler thread), the unit is force-released anyway so the pool
+    doesn't lose capacity permanently. The next claim's _clean_unit flush plus the
+    session_id tag on SESSION_END (the send loop ignores a late one from another
+    session) keep the previous session's leftovers from being mistaken for the
+    new session's state; operators can spot force releases in the logs and slow
+    drains in `/v1/pool` (long `released_at` age).
     """
     elapsed = 0.0
     warned = False
-    while not session.drained.is_set():
-        await asyncio.sleep(0.05)
-        elapsed += 0.05
-        if not warned and elapsed >= SESSION_END_DRAIN_TIMEOUT_S:
-            logger.warning(
-                f"Pipeline {unit.index}: SESSION_END not drained after {elapsed:.1f}s — "
-                f"unit will remain unavailable until handlers finish (session {session_id})"
-            )
-            warned = True
-    unit.service.unregister(session_id)
-    unit.session = None
-    logger.info(f"Pipeline {unit.index} released (session {session_id} ended)")
+    try:
+        while not session.drained.is_set():
+            await asyncio.sleep(0.05)
+            elapsed += 0.05
+            if not warned and elapsed >= SESSION_END_DRAIN_TIMEOUT_S:
+                logger.warning(
+                    f"Pipeline {unit.index}: SESSION_END not drained after {elapsed:.1f}s — "
+                    f"unit will remain unavailable until handlers finish (session {session_id})"
+                )
+                warned = True
+            if elapsed >= SESSION_END_FORCE_RELEASE_TIMEOUT_S:
+                logger.error(
+                    f"Pipeline {unit.index}: SESSION_END still not drained after {elapsed:.0f}s — "
+                    f"force-releasing unit; stale output from session {session_id} may still be in flight"
+                )
+                break
+    finally:
+        # Release unconditionally: even if unregister raises (or the task is
+        # cancelled at shutdown), the unit must not stay claimed forever.
+        try:
+            unit.service.unregister(session_id)
+        except Exception:
+            logger.exception(f"Pipeline {unit.index}: unregister failed for session {session_id}")
+        finally:
+            unit.session = None
+        logger.info(f"Pipeline {unit.index} released (session {session_id} ended)")
 
 
 def create_app(pool: list[PipelineUnit], stop_event: ThreadingEvent) -> FastAPI:
@@ -278,6 +301,10 @@ def create_app(pool: list[PipelineUnit], stop_event: ThreadingEvent) -> FastAPI:
                     pass
 
     app = FastAPI(lifespan=lifespan)
+
+    # Strong references to in-flight drain-and-release tasks (asyncio only
+    # holds tasks weakly); each task removes itself on completion.
+    release_tasks: set[asyncio.Task[None]] = set()
 
     def _claim_unit(ws: WebSocket) -> PipelineUnit | None:
         """Atomically (between asyncio yield points) reserve the first idle unit.
@@ -310,17 +337,20 @@ def create_app(pool: list[PipelineUnit], stop_event: ThreadingEvent) -> FastAPI:
             return
 
         pipeline_log_ctx.set(unit.index)
-        session_id = unit.service.register()
         # _claim_unit guarantees unit.session is not None for the returned unit.
         assert unit.session is not None
-        unit.session.session_id = session_id
-        logger.info(f"Client connected to pipeline {unit.index} (session {session_id})")
-
-        # Defensive: drain edge queues and reset events so stale data from a
-        # previous session that survived SESSION_END propagation doesn't leak.
-        _clean_unit(unit)
-
+        # Everything after the claim runs inside try so the finally below always
+        # releases the unit, even if session setup fails.
+        session_id = ""
         try:
+            session_id = unit.service.register()
+            unit.session.session_id = session_id
+            logger.info(f"Client connected to pipeline {unit.index} (session {session_id})")
+
+            # Defensive: drain edge queues and reset events so stale data from a
+            # previous session that survived SESSION_END propagation doesn't leak.
+            _clean_unit(unit)
+
             await _send_event(ws, unit.service.build_session_created(session_id))
 
             while not stop_event.is_set():
@@ -391,12 +421,17 @@ def create_app(pool: list[PipelineUnit], stop_event: ThreadingEvent) -> FastAPI:
             if old_session is not None:
                 old_session.released_at = time.monotonic()
             _clean_unit(unit)
-            unit.input_queue.put(SESSION_END)
+            # Tag SESSION_END with this session's id so that, after a force
+            # release, a late arrival can't satisfy the next session's drain.
+            unit.input_queue.put(PipelineControlMessage(SESSION_END.kind, session_id=session_id))
             # Spawn the drain-and-release as a separate task so the route handler's
             # finally returns immediately. Awaiting here is unreliable: after
             # WebSocketDisconnect propagates, subsequent awaits in the same task
             # can be skipped/cancelled by Starlette's runner and never resume.
-            asyncio.create_task(_release_unit_after_drain(unit, old_session, session_id))
+            # asyncio holds tasks weakly — keep a reference until it completes.
+            task = asyncio.create_task(_release_unit_after_drain(unit, old_session, session_id))
+            release_tasks.add(task)
+            task.add_done_callback(release_tasks.discard)
 
     @app.get("/v1/usage")
     async def usage_endpoint() -> dict[str, Any]:
@@ -543,9 +578,12 @@ def create_app(pool: list[PipelineUnit], stop_event: ThreadingEvent) -> FastAPI:
 
                     # SESSION_END travels from input_queue through every handler to
                     # output_queue. Observing it here means the chain has fully reset;
-                    # signal the release path so it can clear unit.session.
+                    # signal the release path so it can clear unit.session. A tag from
+                    # another session means the emitting session was force-released —
+                    # its late SESSION_END must not stand in for this session's drain.
                     if is_control_message(audio_chunk, SESSION_END.kind):
-                        if session is not None:
+                        chunk_session_id = getattr(audio_chunk, "session_id", None)
+                        if session is not None and chunk_session_id in (None, session.session_id):
                             session.drained.set()
                             logger.debug(f"Pipeline {unit.index}: SESSION_END drained")
                         continue

--- a/src/speech_to_speech/api/openai_realtime/websocket_router.py
+++ b/src/speech_to_speech/api/openai_realtime/websocket_router.py
@@ -41,12 +41,16 @@ MAX_AUDIO_BATCH_BYTES = 6400
 # Tests monkeypatch this to a small value since their fixtures usually skip
 # the real handler chain.
 SESSION_END_DRAIN_TIMEOUT_S = 10.0
-# Hard ceiling on the drain wait: past this, the unit is force-released even
-# though SESSION_END never came back (e.g. a wedged handler thread), trading
-# a possible leak of stale output into the next session for restored pool
-# capacity. Stale audio tagged with an old cancel generation is still dropped
-# by the send loop's discard checks.
-SESSION_END_FORCE_RELEASE_TIMEOUT_S = 180.0
+# Past this, the unit is quarantined: its service session is unregistered
+# (closing the chat so late handler output can't mutate or bill it), but the
+# unit stays unclaimable. Releasing it instead would let a new client claim a
+# unit whose handlers may still emit the previous session's output (e.g. a
+# transcript, which carries no session identity and would be appended to the
+# new session's conversation) — a cross-session leak. If SESSION_END does
+# eventually drain, the chain has proven itself clean and the unit returns to
+# the pool; a dead handler keeps it quarantined forever, visible in /v1/pool
+# as "stuck".
+SESSION_END_QUARANTINE_TIMEOUT_S = 180.0
 QItem = TypeVar("QItem")
 
 
@@ -232,6 +236,13 @@ def _should_discard_audio(unit: PipelineUnit, item: Any) -> bool:
     return _generation_is_discardable(unit, _audio_generation(item))
 
 
+def _safe_unregister(unit: PipelineUnit, session_id: str) -> None:
+    try:
+        unit.service.unregister(session_id)
+    except Exception:
+        logger.exception(f"Pipeline {unit.index}: unregister failed for session {session_id}")
+
+
 async def _release_unit_after_drain(unit: PipelineUnit, session: Any, session_id: str) -> None:
     """Wait for SESSION_END to propagate, then release the unit.
 
@@ -240,13 +251,14 @@ async def _release_unit_after_drain(unit: PipelineUnit, session: Any, session_id
     until SESSION_END travels all the way through the handler chain back to
     output_queue — observed by the send loop, which sets session.drained.
 
-    If the chain is still busy past SESSION_END_FORCE_RELEASE_TIMEOUT_S (e.g. a
-    wedged or dead handler thread), the unit is force-released anyway so the pool
-    doesn't lose capacity permanently. The next claim's _clean_unit flush plus the
-    session_id tag on SESSION_END (the send loop ignores a late one from another
-    session) keep the previous session's leftovers from being mistaken for the
-    new session's state; operators can spot force releases in the logs and slow
-    drains in `/v1/pool` (long `released_at` age).
+    Past SESSION_END_QUARANTINE_TIMEOUT_S (a wedged or dead handler thread) the
+    unit is quarantined, NOT released: still-running handlers could emit the old
+    session's output (transcripts carry no session identity) into whichever
+    session claimed the unit next, and a dead handler would make the unit accept
+    clients it can never serve. The session is unregistered right away so late
+    output can't mutate or bill the closed conversation; the unit itself only
+    returns to the pool if SESSION_END eventually drains, proving the chain is
+    clean. Operators can spot quarantined units in `/v1/pool` (state "stuck").
     """
     elapsed = 0.0
     warned = False
@@ -260,22 +272,23 @@ async def _release_unit_after_drain(unit: PipelineUnit, session: Any, session_id
                     f"unit will remain unavailable until handlers finish (session {session_id})"
                 )
                 warned = True
-            if elapsed >= SESSION_END_FORCE_RELEASE_TIMEOUT_S:
+            if session.quarantined_at is None and elapsed >= SESSION_END_QUARANTINE_TIMEOUT_S:
+                session.quarantined_at = time.monotonic()
+                _safe_unregister(unit, session_id)
                 logger.error(
                     f"Pipeline {unit.index}: SESSION_END still not drained after {elapsed:.0f}s — "
-                    f"force-releasing unit; stale output from session {session_id} may still be in flight"
+                    f"quarantining unit until the handler chain drains (session {session_id})"
                 )
-                break
     finally:
-        # Release unconditionally: even if unregister raises (or the task is
-        # cancelled at shutdown), the unit must not stay claimed forever.
+        # Runs when the drain completed (chain proven clean) or the task is
+        # cancelled at shutdown. Release unconditionally: even if unregister
+        # raises, the unit must not stay claimed forever.
         try:
-            unit.service.unregister(session_id)
-        except Exception:
-            logger.exception(f"Pipeline {unit.index}: unregister failed for session {session_id}")
+            _safe_unregister(unit, session_id)
         finally:
             unit.session = None
-        logger.info(f"Pipeline {unit.index} released (session {session_id} ended)")
+        recovered = " after quarantine" if session.quarantined_at is not None else ""
+        logger.info(f"Pipeline {unit.index} released{recovered} (session {session_id} ended)")
 
 
 def create_app(pool: list[PipelineUnit], stop_event: ThreadingEvent) -> FastAPI:
@@ -464,6 +477,17 @@ def create_app(pool: list[PipelineUnit], stop_event: ThreadingEvent) -> FastAPI:
                 return {"index": u.index, "state": "idle", "session_id": None}
             if s.released_at is None:
                 return {"index": u.index, "state": "active", "session_id": s.session_id}
+            # Drain wait gave up (quarantine timeout): the unit stays occupied
+            # until SESSION_END actually drains — possibly forever if a handler
+            # thread died. Surfaced distinctly so operators can act on it.
+            if s.quarantined_at is not None:
+                return {
+                    "index": u.index,
+                    "state": "stuck",
+                    "session_id": s.session_id,
+                    "draining_for_s": round(now - s.released_at, 2),
+                    "stuck_for_s": round(now - s.quarantined_at, 2),
+                }
             # released by client but SESSION_END hasn't drained yet → unit
             # is still occupied; surface elapsed time so operators can spot
             # stuck handlers.

--- a/src/speech_to_speech/pipeline/control.py
+++ b/src/speech_to_speech/pipeline/control.py
@@ -13,6 +13,10 @@ class ControlKind(str, Enum):
 @dataclass(frozen=True)
 class PipelineControlMessage:
     kind: ControlKind
+    # Session that enqueued the message, when known. Lets the pooled realtime
+    # send loop ignore a SESSION_END from a force-released session so it can't
+    # satisfy the drain wait of the session that claimed the unit afterwards.
+    session_id: str | None = None
 
 
 SESSION_END = PipelineControlMessage(ControlKind.SESSION_END)

--- a/tests/openai_realtime/test_websocket_router.py
+++ b/tests/openai_realtime/test_websocket_router.py
@@ -760,9 +760,7 @@ class TestDrainRelease:
                 unit.output_queue.put(PipelineControlMessage(SESSION_END.kind, session_id="sess_stale"))
                 time.sleep(0.3)
                 assert not unit.session.drained.is_set()
-                unit.output_queue.put(
-                    PipelineControlMessage(SESSION_END.kind, session_id=unit.session.session_id)
-                )
+                unit.output_queue.put(PipelineControlMessage(SESSION_END.kind, session_id=unit.session.session_id))
                 time.sleep(0.3)
                 assert unit.session.drained.is_set()
 

--- a/tests/openai_realtime/test_websocket_router.py
+++ b/tests/openai_realtime/test_websocket_router.py
@@ -35,8 +35,10 @@ def short_drain_timeout(monkeypatch):
     """Shorten the SESSION_END drain warning threshold so tests don't wait 10s.
 
     The constant only controls when the release task logs a warning about a
-    slow-draining unit — there is no longer a release-anyway timeout, so the
-    unit stays unavailable until SESSION_END actually drains.
+    slow-draining unit. The force-release timeout
+    (SESSION_END_FORCE_RELEASE_TIMEOUT_S) is left at its real value so units
+    stay unavailable until SESSION_END actually drains; tests that exercise the
+    force release shorten it themselves.
     """
     monkeypatch.setattr(router_module, "SESSION_END_DRAIN_TIMEOUT_S", 0.1)
 
@@ -713,6 +715,75 @@ class TestCleanup:
         assert cancel_scope.generation == 2
         assert not response_playing.is_set()
         assert text_output_queue.empty()
+
+
+# ===================================================================
+# Drain / release robustness
+# ===================================================================
+
+
+class TestDrainRelease:
+    def test_barge_in_flush_preserves_session_end(self):
+        """The output_queue flush on barge-in must not swallow an in-flight
+        SESSION_END — losing it would leave the release task waiting forever."""
+        q: Queue = Queue()
+        q.put(_pcm_bytes(10))
+        q.put(PipelineControlMessage(SESSION_END.kind, session_id="sess_a"))
+        q.put(_pcm_bytes(10))
+        router_module._flush_queue(q, preserve=router_module._keep_audio_sentinel)
+        assert is_control_message(q.get_nowait(), SESSION_END.kind)
+        assert q.empty()
+
+    def test_force_release_frees_unit_when_session_end_never_drains(self, setup, monkeypatch):
+        """With no handler chain, SESSION_END never reaches output_queue; the
+        force-release timeout must still free the unit for new claims."""
+        monkeypatch.setattr(router_module, "SESSION_END_FORCE_RELEASE_TIMEOUT_S", 0.2)
+        app, service, *_ = setup
+        with TestClient(app) as client:
+            with client.websocket_connect("/v1/realtime") as ws:
+                ws.receive_json()
+            time.sleep(0.8)
+            assert len(service._conns) == 0
+            assert client.get("/v1/pool").json()["in_use"] == 0
+            with client.websocket_connect("/v1/realtime") as ws2:
+                assert ws2.receive_json()["type"] == "session.created"
+
+    def test_stale_session_end_does_not_satisfy_next_sessions_drain(self):
+        """A SESSION_END tagged with a force-released session's id must not set
+        `drained` for the session that claimed the unit afterwards."""
+        unit = _make_unit(0)
+        app = create_app(pool=[unit], stop_event=ThreadingEvent())
+        with TestClient(app) as client:
+            with client.websocket_connect("/v1/realtime") as ws:
+                ws.receive_json()
+                assert unit.session is not None
+                unit.output_queue.put(PipelineControlMessage(SESSION_END.kind, session_id="sess_stale"))
+                time.sleep(0.3)
+                assert not unit.session.drained.is_set()
+                unit.output_queue.put(
+                    PipelineControlMessage(SESSION_END.kind, session_id=unit.session.session_id)
+                )
+                time.sleep(0.3)
+                assert unit.session.drained.is_set()
+
+    def test_register_failure_still_releases_unit(self, setup, monkeypatch):
+        """An exception during session setup (after the claim) must not leak the
+        slot: the finally still enqueues SESSION_END and spawns the release task."""
+        app, service, input_queue, output_queue, *_ = setup
+
+        def _boom():
+            raise RuntimeError("register failed")
+
+        monkeypatch.setattr(service, "register", _boom)
+        with TestClient(app) as client:
+            try:
+                with client.websocket_connect("/v1/realtime"):
+                    pass
+            except Exception:
+                pass
+            _simulate_session_end_drain(input_queue, output_queue)
+            time.sleep(0.3)
+            assert client.get("/v1/pool").json()["in_use"] == 0
 
 
 # ===================================================================

--- a/tests/openai_realtime/test_websocket_router.py
+++ b/tests/openai_realtime/test_websocket_router.py
@@ -35,10 +35,10 @@ def short_drain_timeout(monkeypatch):
     """Shorten the SESSION_END drain warning threshold so tests don't wait 10s.
 
     The constant only controls when the release task logs a warning about a
-    slow-draining unit. The force-release timeout
-    (SESSION_END_FORCE_RELEASE_TIMEOUT_S) is left at its real value so units
+    slow-draining unit. The quarantine timeout
+    (SESSION_END_QUARANTINE_TIMEOUT_S) is left at its real value so units
     stay unavailable until SESSION_END actually drains; tests that exercise the
-    force release shorten it themselves.
+    quarantine shorten it themselves.
     """
     monkeypatch.setattr(router_module, "SESSION_END_DRAIN_TIMEOUT_S", 0.1)
 
@@ -734,16 +734,40 @@ class TestDrainRelease:
         assert is_control_message(q.get_nowait(), SESSION_END.kind)
         assert q.empty()
 
-    def test_force_release_frees_unit_when_session_end_never_drains(self, setup, monkeypatch):
-        """With no handler chain, SESSION_END never reaches output_queue; the
-        force-release timeout must still free the unit for new claims."""
-        monkeypatch.setattr(router_module, "SESSION_END_FORCE_RELEASE_TIMEOUT_S", 0.2)
+    def test_quarantine_keeps_unit_unclaimable_when_session_end_never_drains(self, setup, monkeypatch):
+        """With no handler chain, SESSION_END never reaches output_queue; past
+        the quarantine timeout the session is unregistered (no more chat
+        mutation or billing) but the unit must NOT become claimable — its
+        handlers could still emit the old session's output."""
+        monkeypatch.setattr(router_module, "SESSION_END_QUARANTINE_TIMEOUT_S", 0.2)
         app, service, *_ = setup
         with TestClient(app) as client:
             with client.websocket_connect("/v1/realtime") as ws:
                 ws.receive_json()
             time.sleep(0.8)
             assert len(service._conns) == 0
+            pool = client.get("/v1/pool").json()
+            assert pool["in_use"] == 1
+            assert pool["units"][0]["state"] == "stuck"
+            assert pool["units"][0]["stuck_for_s"] >= 0
+            with client.websocket_connect("/v1/realtime") as ws2:
+                msg = ws2.receive_json()
+                assert msg["type"] == "error"
+                assert msg["error"]["type"] == "session_limit_reached"
+
+    def test_quarantined_unit_returns_to_pool_after_late_drain(self, setup, monkeypatch):
+        """If SESSION_END eventually drains after the quarantine kicked in, the
+        chain has proven itself clean and the unit becomes claimable again."""
+        monkeypatch.setattr(router_module, "SESSION_END_QUARANTINE_TIMEOUT_S", 0.2)
+        app, service, input_queue, output_queue, *_ = setup
+        with TestClient(app) as client:
+            with client.websocket_connect("/v1/realtime") as ws:
+                ws.receive_json()
+            time.sleep(0.8)
+            assert client.get("/v1/pool").json()["units"][0]["state"] == "stuck"
+            # Late drain: the wedged "handler chain" finally forwards SESSION_END.
+            _simulate_session_end_drain(input_queue, output_queue)
+            time.sleep(0.3)
             assert client.get("/v1/pool").json()["in_use"] == 0
             with client.websocket_connect("/v1/realtime") as ws2:
                 assert ws2.receive_json()["type"] == "session.created"


### PR DESCRIPTION
## Problem

A pipeline unit is only released for new claims after the `SESSION_END` control message travels the whole handler chain back to `output_queue`, where the send loop observes it and sets `session.drained`. A review of this path found several conditions where that never happens, leaving the unit claimed forever — and once every unit in the pool is stuck, all new connections are rejected with `session_limit_reached`:

1. **Barge-in flush could eat SESSION_END.** The send loop's speech-started interrupt flushes `output_queue` preserving only `AUDIO_RESPONSE_DONE`. A trailing `SpeechStartedEvent` (the VAD writes them straight onto `text_output_queue`, possibly mid-teardown) processed while `SESSION_END` was already on `output_queue` would silently discard it — the release task then polls `drained` forever.
2. **Slot leak on setup failure.** `register()` and `_clean_unit()` ran after the claim but *outside* the route's `try/finally`; an exception there left `unit.session` set with no release task ever spawned.
3. **Wedged or dead handler = invisible permanent capacity loss.** The release path waits indefinitely with only a one-shot log warning at 10s; a handler thread that hung (or died — `BaseHandler.run` doesn't emit `PIPELINE_END` on an uncaught error) removed the unit from the pool until restart, kept the dead session registered, and was hard to distinguish from a normal slow drain in `/v1/pool`.
4. **Fire-and-forget release task.** The `asyncio.create_task` result wasn't referenced (asyncio holds tasks weakly), and an exception in `unregister()` would kill the task *after* draining but *before* `unit.session = None`.

## Changes

- `_keep_audio_sentinel` now also preserves `SESSION_END` control messages, so barge-in flushes can't discard the drain signal.
- Session setup runs inside the route's `try`, so the `finally` always enqueues `SESSION_END` and spawns the release task, even when setup fails.
- New `SESSION_END_QUARANTINE_TIMEOUT_S = 180s`: past it, the unit is **quarantined**, not released. Its service session is unregistered immediately — the chat is closed, so late handler output can't mutate or bill the dead conversation — but the unit stays unclaimable until `SESSION_END` actually drains, which is proof the handler chain is clean. This deliberately avoids force-releasing: pipeline output such as transcripts carries no session identity, so handing the unit to a new client while an old handler is still running would leak the previous client's words into the new conversation, and a unit with a dead handler thread must not re-enter the pool as healthy. A permanently wedged unit is surfaced by `/v1/pool` as state `"stuck"` with `stuck_for_s` so operators can act on it. (Per review feedback — an earlier revision force-released after the timeout.)
- `PipelineControlMessage` gained an optional `session_id` tag as defense in depth: the route tags the `SESSION_END` it enqueues and the send loop only sets `drained` on a matching tag (untagged accepted for compatibility), so a stale `SESSION_END` can never satisfy another session's drain wait.
- Release tasks are held in a strong-reference set, and the release runs in a `try/finally` — `unregister()` errors are logged and the unit is still freed.

## Tests

`TestDrainRelease` covers: the flush preserves `SESSION_END`, quarantine keeps the unit unclaimable and rejects new clients while unregistering the dead session, a late drain returns a quarantined unit to the pool, a stale-tagged `SESSION_END` doesn't drain the next session, and a `register()` failure still releases the unit. Full suite: 578 passed, mypy clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)