### PR TITLE
Prepare release 0.2.11

### DIFF
--- a/README.md
+++ b/README.md
@@ -104,15 +104,15 @@ On Linux, the Qwen3-TTS GGML backend comes from `faster-qwen3-tts[ggml]`. Its de
 
 ```bash
 # CUDA 13.x
-pip install "qwentts-cpp-python==0.3.0+cu130" \
+pip install "qwentts-cpp-python==0.3.1+cu130" \
   -f https://huggingface.co/datasets/andito/qwentts-cpp-python-wheels/tree/main/whl/cu130
 
 # CUDA 12.4
-pip install "qwentts-cpp-python==0.3.0+cu124" \
+pip install "qwentts-cpp-python==0.3.1+cu124" \
   -f https://huggingface.co/datasets/andito/qwentts-cpp-python-wheels/tree/main/whl/cu124
 
 # CPU-only fallback
-pip install "qwentts-cpp-python==0.3.0+cpu" \
+pip install "qwentts-cpp-python==0.3.1+cpu" \
   -f https://huggingface.co/datasets/andito/qwentts-cpp-python-wheels/tree/main/whl/cpu
 
 pip install speech-to-speech

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "speech-to-speech"
-version = "0.2.10"
+version = "0.2.11"
 description = "Low-latency speech-to-speech pipeline"
 readme = "README.md"
 requires-python = ">=3.10"
@@ -47,8 +47,8 @@ dependencies = [
     "uvicorn>=0.30.0",
     "websockets>=12.0",
     "nano-parakeet>=0.2.0; platform_system != 'Darwin'",
-    "faster-qwen3-tts[ggml]>=0.3.1; platform_system != 'Darwin' and platform_system != 'Windows'",
-    "faster-qwen3-tts>=0.3.1; platform_system == 'Windows'",
+    "faster-qwen3-tts[ggml]>=0.3.2; platform_system != 'Darwin' and platform_system != 'Windows'",
+    "faster-qwen3-tts>=0.3.2; platform_system == 'Windows'",
     "lingua-language-detector>=2.0.2",
     "miniaudio==1.61; platform_system == 'Darwin'",
     "mlx==0.31.1; platform_system == 'Darwin'",

--- a/src/speech_to_speech/TTS/README.md
+++ b/src/speech_to_speech/TTS/README.md
@@ -98,7 +98,7 @@ Install notes for Linux GGML:
 - If that wheel does not match your CUDA runtime, install one of the Hugging Face wheelhouse builds before installing `speech-to-speech`.
 
 ```bash
-pip install "qwentts-cpp-python==0.3.0+cu130" \
+pip install "qwentts-cpp-python==0.3.1+cu130" \
   -f https://huggingface.co/datasets/andito/qwentts-cpp-python-wheels/tree/main/whl/cu130
 pip install speech-to-speech
 ```

--- a/src/speech_to_speech/__init__.py
+++ b/src/speech_to_speech/__init__.py
@@ -1,3 +1,3 @@
 """speech-to-speech: low-latency speech-to-speech pipeline."""
 
-__version__ = "0.2.10"
+__version__ = "0.2.11"


### PR DESCRIPTION
## Summary

- bump `speech-to-speech` from `0.2.10` to `0.2.11`
- require `faster-qwen3-tts>=0.3.2` on supported non-macOS platforms
- update CUDA/CPU qwentts wheel examples from `0.3.0` to `0.3.1`

## Why

`faster-qwen3-tts` 0.3.2 now requires the updated `qwentts-cpp-python` 0.3.1
runtime for its optional GGML backend. This release keeps speech-to-speech's
default Qwen3-TTS dependency and backend-specific installation documentation
aligned with those releases.

## Validation

- confirmed `speech-to-speech` 0.2.11 is not currently published on PyPI
- confirmed `faster-qwen3-tts` 0.3.2 is published on PyPI
- confirmed project and package versions both resolve to `0.2.11`
- `580 passed`
- Ruff check and tracked-file format check pass
- mypy passes for 89 source files
- `git diff --check`

After merge, publishing should use an annotated `v0.2.11` tag.
