### PR TITLE
Add an LLM proxy for remote LLM backends

### DIFF
--- a/README.md
+++ b/README.md
@@ -317,6 +317,27 @@ with client.realtime.connect(model="local") as conn:
 
 The server implements the core Realtime event set: `input_audio_buffer.append`, `session.update`, `conversation.item.create`, `response.create`, and `response.cancel` inbound; speech start/stop, streaming transcription, audio deltas, tool calls, and `response.done` outbound. The full event reference, architecture, and design details live in the [Realtime Engine README](./src/speech_to_speech/api/openai_realtime/README.md).
 
+### LLM Proxy
+
+With `--enable_llm_proxy`, the realtime server also exposes the remote LLM it is configured with as a plain OpenAI compatible endpoint, so a client holding an open realtime session can run side tasks (summaries, titles, background agents) with tools and streaming, fully concurrent with the voice conversation and never interrupted by new speech:
+
+* `POST /v1/chat/completions` when running `--llm_backend chat-completions`
+* `POST /v1/responses` when running `--llm_backend responses-api`
+
+The bearer token is the realtime session id. **Read this twice: the session id arrives in the `session.created` event on the realtime connection** (behind a load balancer it is not the session id returned by the session creation call). Point the stock OpenAI SDK at the server and pass the session id as the API key:
+
+```python
+from openai import OpenAI
+
+llm = OpenAI(base_url="http://localhost:8765/v1", api_key=session_id)
+completion = llm.chat.completions.create(
+    model="anything",  # ignored: the server forces its configured --model_name
+    messages=[{"role": "user", "content": "Summarize the conversation so far: ..."}],
+)
+```
+
+Requests are stateless (send the full message list each time) and are proxied to the configured upstream with the key held by the server, which never reaches clients. The `model` field is always overwritten with the server configured `--model_name`. The proxy is off by default, requires a remote backend (`chat-completions` or `responses-api`), and answers 501 with the reason otherwise; a missing or unknown session id answers 401.
+
 ## LLM Backends
 
 The LLM is the most compute-intensive and highest-latency component in the pipeline. A single forward pass through a large model can dominate end-to-end response time, so choosing the right backend for your hardware and latency budget matters. The pipeline supports:

--- a/README.md
+++ b/README.md
@@ -319,24 +319,24 @@ The server implements the core Realtime event set: `input_audio_buffer.append`, 
 
 ### LLM Proxy
 
-With `--enable_llm_proxy`, the realtime server also exposes the remote LLM it is configured with as a plain OpenAI compatible endpoint, so a client holding an open realtime session can run side tasks (summaries, titles, background agents) with tools and streaming, fully concurrent with the voice conversation and never interrupted by new speech:
+With `--enable_llm_proxy`, the realtime server also exposes the remote LLM it is configured with as a plain OpenAI compatible endpoint, so a client can run side tasks (summaries, titles, background agents) with tools and streaming, fully concurrent with the voice conversation and never interrupted by new speech:
 
 * `POST /v1/chat/completions` when running `--llm_backend chat-completions`
 * `POST /v1/responses` when running `--llm_backend responses-api`
 
-The bearer token is the realtime session id. **Read this twice: the session id arrives in the `session.created` event on the realtime connection** (behind a load balancer it is not the session id returned by the session creation call). Point the stock OpenAI SDK at the server and pass the session id as the API key:
+The server performs no authentication and no throttling of its own. Enable the proxy only on a trusted network, or deploy the server behind a gateway that owns access control. The s2s-endpoint compute replica is such a gateway: it opens these paths only to clients that created their session with an HF token, checks the API key against that token, and applies a rate limit per user. Point the stock OpenAI SDK at whichever host you talk to; this server ignores the API key (a gateway in front decides what it must be):
 
 ```python
 from openai import OpenAI
 
-llm = OpenAI(base_url="http://localhost:8765/v1", api_key=session_id)
+llm = OpenAI(base_url="http://localhost:8765/v1", api_key="unused")
 completion = llm.chat.completions.create(
     model="anything",  # ignored: the server forces its configured --model_name
     messages=[{"role": "user", "content": "Summarize the conversation so far: ..."}],
 )
 ```
 
-Requests are stateless (send the full message list each time) and are proxied to the configured upstream with the key held by the server, which never reaches clients. The `model` field is always overwritten with the server configured `--model_name`. The proxy is off by default, requires a remote backend (`chat-completions` or `responses-api`), and answers 501 with the reason otherwise; a missing or unknown session id answers 401.
+Requests are stateless (send the full message list each time) and are proxied to the configured upstream with the key held by the server, which never reaches clients. The `model` field is always overwritten with the server configured `--model_name`. The proxy is off by default, requires a remote backend (`chat-completions` or `responses-api`), and answers 501 with the reason otherwise.
 
 ## LLM Backends
 

--- a/src/speech_to_speech/api/openai_realtime/handlers/session.py
+++ b/src/speech_to_speech/api/openai_realtime/handlers/session.py
@@ -54,7 +54,11 @@ class SessionHandler(RealtimeBaseHandler):
     def build_session_created(self, conn_id: str) -> SessionCreatedEvent:
         """Build a SessionCreatedEvent populated with the current config."""
         cfg = self._state(conn_id).runtime_config
-        session = cfg.session
+        # The OpenAI GA protocol includes the session id in session.created;
+        # clients also need it as the bearer token for the LLM proxy routes.
+        # The SDK model has no `id` field but allows extras, and model_dump()
+        # carries them onto the wire.
+        session = cfg.session.model_copy(update={"id": conn_id})
         return SessionCreatedEvent(
             type="session.created",
             event_id=self._next_event_id(),

--- a/src/speech_to_speech/api/openai_realtime/handlers/session.py
+++ b/src/speech_to_speech/api/openai_realtime/handlers/session.py
@@ -54,8 +54,7 @@ class SessionHandler(RealtimeBaseHandler):
     def build_session_created(self, conn_id: str) -> SessionCreatedEvent:
         """Build a SessionCreatedEvent populated with the current config."""
         cfg = self._state(conn_id).runtime_config
-        # The OpenAI GA protocol includes the session id in session.created;
-        # clients also need it as the bearer token for the LLM proxy routes.
+        # The OpenAI GA protocol includes the session id in session.created.
         # The SDK model has no `id` field but allows extras, and model_dump()
         # carries them onto the wire.
         session = cfg.session.model_copy(update={"id": conn_id})

--- a/src/speech_to_speech/api/openai_realtime/llm_proxy.py
+++ b/src/speech_to_speech/api/openai_realtime/llm_proxy.py
@@ -148,6 +148,10 @@ def _mount_passthrough(app: FastAPI, path: str, pool: list[PipelineUnit], config
         except Exception:
             return _error_response(400, "Request body must be valid JSON.", "invalid_request_error")
         body["model"] = config.model_name
+        if path == _PATHS["responses-api"]:
+            # Session holders are anonymous; forcing store off keeps them from
+            # creating persistent state on the operator's provider account.
+            body["store"] = False
 
         headers = {"Authorization": f"Bearer {config.upstream_api_key}"}
         # Generation can legitimately take minutes, so only the connect

--- a/src/speech_to_speech/api/openai_realtime/llm_proxy.py
+++ b/src/speech_to_speech/api/openai_realtime/llm_proxy.py
@@ -15,6 +15,8 @@ import logging
 import httpx
 from fastapi import FastAPI, Request, Response
 from pydantic import BaseModel
+from starlette.background import BackgroundTask
+from starlette.responses import StreamingResponse
 
 from speech_to_speech.api.openai_realtime.pipeline_unit import PipelineUnit
 
@@ -33,6 +35,7 @@ class LLMProxyConfig(BaseModel):
     upstream_base_url: str | None = None
     upstream_api_key: str | None = None
     model_name: str | None = None
+    connect_timeout_s: float = 10.0
 
 
 class _ErrorDetail(BaseModel):
@@ -51,6 +54,19 @@ def _error_response(status_code: int, message: str, error_type: str) -> Response
         status_code=status_code,
         media_type="application/json",
     )
+
+
+def _verbatim_response(upstream: httpx.Response, content: bytes) -> Response:
+    return Response(
+        content=content,
+        status_code=upstream.status_code,
+        media_type=upstream.headers.get("content-type"),
+    )
+
+
+def _upstream_unreachable(error: httpx.HTTPError) -> Response:
+    logger.warning(f"LLM proxy: upstream request failed: {type(error).__name__}: {error}")
+    return _error_response(502, f"Upstream request failed: {type(error).__name__}", "upstream_unreachable")
 
 
 def _bearer_session_id(request: Request) -> str | None:
@@ -134,10 +150,46 @@ def _mount_passthrough(app: FastAPI, path: str, pool: list[PipelineUnit], config
         body["model"] = config.model_name
 
         headers = {"Authorization": f"Bearer {config.upstream_api_key}"}
-        async with httpx.AsyncClient() as client:
-            upstream = await client.post(upstream_url, json=body, headers=headers)
-        return Response(
-            content=upstream.content,
+        # Generation can legitimately take minutes, so only the connect
+        # phase gets a timeout; reads (streamed or not) have none.
+        timeout = httpx.Timeout(None, connect=config.connect_timeout_s)
+
+        if not body.get("stream"):
+            try:
+                async with httpx.AsyncClient(timeout=timeout) as client:
+                    upstream = await client.post(upstream_url, json=body, headers=headers)
+            except httpx.HTTPError as e:
+                return _upstream_unreachable(e)
+            return _verbatim_response(upstream, upstream.content)
+
+        # Streaming: forward every upstream byte as it arrives. The client
+        # and upstream response stay open for the response's lifetime and are
+        # closed by the background task after the last byte is sent.
+        client = httpx.AsyncClient(timeout=timeout)
+        try:
+            upstream_request = client.build_request("POST", upstream_url, json=body, headers=headers)
+            upstream = await client.send(upstream_request, stream=True)
+        except httpx.HTTPError as e:
+            await client.aclose()
+            return _upstream_unreachable(e)
+        except Exception:
+            await client.aclose()
+            raise
+
+        async def _cleanup() -> None:
+            await upstream.aclose()
+            await client.aclose()
+
+        if upstream.status_code >= 400:
+            # Error before any frame: pass status and body through verbatim,
+            # buffered, exactly as a non-streaming answer would be.
+            content = await upstream.aread()
+            await _cleanup()
+            return _verbatim_response(upstream, content)
+
+        return StreamingResponse(
+            upstream.aiter_raw(),
             status_code=upstream.status_code,
             media_type=upstream.headers.get("content-type"),
+            background=BackgroundTask(_cleanup),
         )

--- a/src/speech_to_speech/api/openai_realtime/llm_proxy.py
+++ b/src/speech_to_speech/api/openai_realtime/llm_proxy.py
@@ -11,6 +11,8 @@ never interrupted by new speech.
 """
 
 import logging
+import time
+from collections import defaultdict, deque
 
 import httpx
 from fastapi import FastAPI, Request, Response
@@ -36,6 +38,37 @@ class LLMProxyConfig(BaseModel):
     upstream_api_key: str | None = None
     model_name: str | None = None
     connect_timeout_s: float = 10.0
+    rate_limit_rpm: int = 20
+
+
+def _now() -> float:
+    # Module-level so tests can monkeypatch the clock instead of sleeping.
+    return time.monotonic()
+
+
+_RATE_LIMIT_WINDOW_S = 60.0
+
+
+class _SessionRateLimiter:
+    """In-memory sliding window, keyed by session id, replica-local."""
+
+    def __init__(self, limit_rpm: int):
+        self.limit_rpm = limit_rpm
+        self._hits: dict[str, deque[float]] = defaultdict(deque)
+
+    def allow(self, session_id: str) -> bool:
+        now = _now()
+        hits = self._hits[session_id]
+        while hits and now - hits[0] >= _RATE_LIMIT_WINDOW_S:
+            hits.popleft()
+        if len(hits) >= self.limit_rpm:
+            return False
+        hits.append(now)
+        # Sessions are short-lived relative to the process; drop fully expired
+        # entries so dead session ids don't accumulate forever.
+        if len(self._hits) > 1024:
+            self._hits = defaultdict(deque, {k: v for k, v in self._hits.items() if v})
+        return True
 
 
 class _ErrorDetail(BaseModel):
@@ -131,6 +164,7 @@ def _mount_unavailable(app: FastAPI, path: str, reason: str) -> None:
 def _mount_passthrough(app: FastAPI, path: str, pool: list[PipelineUnit], config: LLMProxyConfig) -> None:
     base_url = (config.upstream_base_url or DEFAULT_UPSTREAM_BASE_URL).rstrip("/")
     upstream_url = base_url + path.removeprefix("/v1")
+    rate_limiter = _SessionRateLimiter(config.rate_limit_rpm)
 
     @app.post(path)
     async def passthrough_endpoint(request: Request) -> Response:
@@ -141,6 +175,14 @@ def _mount_passthrough(app: FastAPI, path: str, pool: list[PipelineUnit], config
                 "Invalid bearer token: pass the realtime session id of an open session "
                 "(from the session.created event) as the API key.",
                 "invalid_session",
+            )
+
+        if not rate_limiter.allow(session_id):
+            return _error_response(
+                429,
+                f"Rate limit exceeded: this session may make {config.rate_limit_rpm} requests "
+                "per minute. Back off and retry.",
+                "rate_limit_exceeded",
             )
 
         try:

--- a/src/speech_to_speech/api/openai_realtime/llm_proxy.py
+++ b/src/speech_to_speech/api/openai_realtime/llm_proxy.py
@@ -10,9 +10,13 @@ so proxied generations run fully concurrent with the speech pipeline and are
 never interrupted by new speech.
 """
 
+import json
 import logging
+import re
 import time
 from collections import defaultdict, deque
+from collections.abc import AsyncIterator
+from typing import Any
 
 import httpx
 from fastapi import FastAPI, Request, Response
@@ -39,6 +43,70 @@ class LLMProxyConfig(BaseModel):
     model_name: str | None = None
     connect_timeout_s: float = 10.0
     rate_limit_rpm: int = 20
+
+
+class LLMProxyUsage(BaseModel):
+    """Replica-local proxy counters, reset with the process.
+
+    Surfaced as the additive ``llm_proxy`` section of the usage endpoint.
+    429 is its own bucket (not double-counted under 4xx) so a melting
+    client is visible at a glance.
+    """
+
+    requests: int = 0
+    responses_2xx: int = 0
+    responses_4xx: int = 0
+    responses_429: int = 0
+    responses_5xx: int = 0
+    input_tokens: int = 0
+    output_tokens: int = 0
+
+    def record_status(self, status: int) -> None:
+        self.requests += 1
+        if status == 429:
+            self.responses_429 += 1
+        elif 200 <= status < 300:
+            self.responses_2xx += 1
+        elif 400 <= status < 500:
+            self.responses_4xx += 1
+        elif status >= 500:
+            self.responses_5xx += 1
+
+    def record_token_payload(self, payload: Any) -> None:
+        """Accumulate tokens from any upstream JSON payload that carries usage.
+
+        Handles the three shapes the proxy sees: chat completions bodies and
+        stream chunks (``usage`` at the top level, prompt/completion keys),
+        Responses bodies (``usage`` at the top level, input/output keys), and
+        Responses streaming events (``usage`` under ``response``).
+        """
+        if not isinstance(payload, dict):
+            return
+        usage = payload.get("usage")
+        if not isinstance(usage, dict):
+            response = payload.get("response")
+            usage = response.get("usage") if isinstance(response, dict) else None
+        if not isinstance(usage, dict):
+            return
+        input_tokens = usage.get("input_tokens", usage.get("prompt_tokens"))
+        output_tokens = usage.get("output_tokens", usage.get("completion_tokens"))
+        if isinstance(input_tokens, int):
+            self.input_tokens += input_tokens
+        if isinstance(output_tokens, int):
+            self.output_tokens += output_tokens
+
+    def record_sse_event(self, event: bytes) -> None:
+        for line in event.splitlines():
+            if not line.startswith(b"data:"):
+                continue
+            data = line[len(b"data:") :].strip()
+            if not data or data == b"[DONE]":
+                continue
+            try:
+                payload = json.loads(data)
+            except ValueError:
+                continue
+            self.record_token_payload(payload)
 
 
 def _now() -> float:
@@ -118,14 +186,18 @@ def _session_is_active(pool: list[PipelineUnit], session_id: str) -> bool:
     return False
 
 
-def mount_llm_proxy(app: FastAPI, pool: list[PipelineUnit], config: LLMProxyConfig | None) -> None:
+def mount_llm_proxy(app: FastAPI, pool: list[PipelineUnit], config: LLMProxyConfig | None) -> LLMProxyUsage:
     """Mount the proxy paths on *app* according to *config*.
 
     Both known paths always answer: the path matching an enabled remote
     backend proxies, every other combination answers 501 naming the reason,
     so a misconfigured deployment is diagnosed in one request.
+
+    Returns the usage counters the passthrough records into, for the usage
+    endpoint to surface (all zeros when the proxy is unavailable).
     """
     config = config or LLMProxyConfig()
+    usage = LLMProxyUsage()
 
     if not config.enabled:
         reason = "The LLM proxy is disabled. Start the server with --enable_llm_proxy to enable it."
@@ -140,19 +212,20 @@ def mount_llm_proxy(app: FastAPI, pool: list[PipelineUnit], config: LLMProxyConf
     if reason is not None:
         for path in _PATHS.values():
             _mount_unavailable(app, path, reason)
-        return
+        return usage
 
     assert config.llm_backend is not None
     serving_path = _PATHS[config.llm_backend]
     for path in _PATHS.values():
         if path == serving_path:
-            _mount_passthrough(app, path, pool, config)
+            _mount_passthrough(app, path, pool, config, usage)
         else:
             _mount_unavailable(
                 app,
                 path,
                 f"This server runs the '{config.llm_backend}' backend; use {serving_path} instead.",
             )
+    return usage
 
 
 def _mount_unavailable(app: FastAPI, path: str, reason: str) -> None:
@@ -161,13 +234,24 @@ def _mount_unavailable(app: FastAPI, path: str, reason: str) -> None:
         return _error_response(501, reason, "not_implemented")
 
 
-def _mount_passthrough(app: FastAPI, path: str, pool: list[PipelineUnit], config: LLMProxyConfig) -> None:
+def _mount_passthrough(
+    app: FastAPI,
+    path: str,
+    pool: list[PipelineUnit],
+    config: LLMProxyConfig,
+    usage: LLMProxyUsage,
+) -> None:
     base_url = (config.upstream_base_url or DEFAULT_UPSTREAM_BASE_URL).rstrip("/")
     upstream_url = base_url + path.removeprefix("/v1")
     rate_limiter = _SessionRateLimiter(config.rate_limit_rpm)
 
     @app.post(path)
     async def passthrough_endpoint(request: Request) -> Response:
+        response = await _proxy(request)
+        usage.record_status(response.status_code)
+        return response
+
+    async def _proxy(request: Request) -> Response:
         session_id = _bearer_session_id(request)
         if session_id is None or not _session_is_active(pool, session_id):
             return _error_response(
@@ -194,6 +278,15 @@ def _mount_passthrough(app: FastAPI, path: str, pool: list[PipelineUnit], config
             # Session holders are anonymous; forcing store off keeps them from
             # creating persistent state on the operator's provider account.
             body["store"] = False
+        elif body.get("stream"):
+            # Streamed chat completions only report usage when asked; inject
+            # the ask so the proxy can account tokens. The client receives
+            # every upstream frame verbatim, including the final usage chunk
+            # it may not have requested (valid protocol). Responses streams
+            # always carry usage on response.completed, so no mutation there.
+            stream_options = body.get("stream_options") or {}
+            stream_options["include_usage"] = True
+            body["stream_options"] = stream_options
 
         headers = {"Authorization": f"Bearer {config.upstream_api_key}"}
         # Generation can legitimately take minutes, so only the connect
@@ -206,6 +299,11 @@ def _mount_passthrough(app: FastAPI, path: str, pool: list[PipelineUnit], config
                     upstream = await client.post(upstream_url, json=body, headers=headers)
             except httpx.HTTPError as e:
                 return _upstream_unreachable(e)
+            if upstream.status_code < 400:
+                try:
+                    usage.record_token_payload(upstream.json())
+                except ValueError:
+                    pass
             return _verbatim_response(upstream, upstream.content)
 
         # Streaming: forward every upstream byte as it arrives. The client
@@ -234,8 +332,30 @@ def _mount_passthrough(app: FastAPI, path: str, pool: list[PipelineUnit], config
             return _verbatim_response(upstream, content)
 
         return StreamingResponse(
-            upstream.aiter_raw(),
+            _forward_and_account(upstream, usage),
             status_code=upstream.status_code,
             media_type=upstream.headers.get("content-type"),
             background=BackgroundTask(_cleanup),
         )
+
+
+# SSE events end at a blank line; the spec allows LF, CRLF, or CR line endings.
+_SSE_EVENT_END = re.compile(rb"\r\n\r\n|\n\n|\r\r")
+
+
+async def _forward_and_account(upstream: httpx.Response, usage: LLMProxyUsage) -> AsyncIterator[bytes]:
+    """Yield upstream bytes verbatim while parsing SSE events for token usage.
+
+    Accounting happens on a copy of the byte stream; nothing it does can
+    change what the client receives.
+    """
+    buffer = b""
+    async for chunk in upstream.aiter_raw():
+        yield chunk
+        buffer += chunk
+        while True:
+            end = _SSE_EVENT_END.search(buffer)
+            if end is None:
+                break
+            event, buffer = buffer[: end.start()], buffer[end.end() :]
+            usage.record_sse_event(event)

--- a/src/speech_to_speech/api/openai_realtime/llm_proxy.py
+++ b/src/speech_to_speech/api/openai_realtime/llm_proxy.py
@@ -1,0 +1,143 @@
+"""Session-gated LLM proxy: OpenAI-compatible passthrough for remote LLM backends.
+
+Mounts ``POST /v1/chat/completions`` (backend ``chat-completions``) or
+``POST /v1/responses`` (backend ``responses-api``) as a passthrough to the
+configured upstream provider. The ticket to use it is an open realtime
+session: the client presents its realtime session id as the bearer token,
+which is validated against the pipeline pool at request start and used for
+nothing else. Requests never touch pipeline units' queues or cancel scopes,
+so proxied generations run fully concurrent with the speech pipeline and are
+never interrupted by new speech.
+"""
+
+import logging
+
+import httpx
+from fastapi import FastAPI, Request, Response
+from pydantic import BaseModel
+
+from speech_to_speech.api.openai_realtime.pipeline_unit import PipelineUnit
+
+logger = logging.getLogger(__name__)
+
+DEFAULT_UPSTREAM_BASE_URL = "https://api.openai.com/v1"
+_PATHS = {
+    "chat-completions": "/v1/chat/completions",
+    "responses-api": "/v1/responses",
+}
+
+
+class LLMProxyConfig(BaseModel):
+    enabled: bool = False
+    llm_backend: str | None = None
+    upstream_base_url: str | None = None
+    upstream_api_key: str | None = None
+    model_name: str | None = None
+
+
+class _ErrorDetail(BaseModel):
+    message: str
+    type: str
+
+
+class _ErrorEnvelope(BaseModel):
+    error: _ErrorDetail
+
+
+def _error_response(status_code: int, message: str, error_type: str) -> Response:
+    envelope = _ErrorEnvelope(error=_ErrorDetail(message=message, type=error_type))
+    return Response(
+        content=envelope.model_dump_json(),
+        status_code=status_code,
+        media_type="application/json",
+    )
+
+
+def _bearer_session_id(request: Request) -> str | None:
+    auth = request.headers.get("authorization", "")
+    scheme, _, token = auth.partition(" ")
+    if scheme.lower() != "bearer" or not token.strip():
+        return None
+    return token.strip()
+
+
+def _session_is_active(pool: list[PipelineUnit], session_id: str) -> bool:
+    for unit in pool:
+        session = unit.session
+        if session is not None and session.session_id == session_id and session.released_at is None:
+            return True
+    return False
+
+
+def mount_llm_proxy(app: FastAPI, pool: list[PipelineUnit], config: LLMProxyConfig | None) -> None:
+    """Mount the proxy paths on *app* according to *config*.
+
+    Both known paths always answer: the path matching an enabled remote
+    backend proxies, every other combination answers 501 naming the reason,
+    so a misconfigured deployment is diagnosed in one request.
+    """
+    config = config or LLMProxyConfig()
+
+    if not config.enabled:
+        reason = "The LLM proxy is disabled. Start the server with --enable_llm_proxy to enable it."
+    elif config.llm_backend not in _PATHS:
+        reason = (
+            f"The LLM proxy requires a remote LLM backend; this server runs '{config.llm_backend}'. "
+            "It works with --llm_backend chat-completions or --llm_backend responses-api."
+        )
+    else:
+        reason = None
+
+    if reason is not None:
+        for path in _PATHS.values():
+            _mount_unavailable(app, path, reason)
+        return
+
+    assert config.llm_backend is not None
+    serving_path = _PATHS[config.llm_backend]
+    for path in _PATHS.values():
+        if path == serving_path:
+            _mount_passthrough(app, path, pool, config)
+        else:
+            _mount_unavailable(
+                app,
+                path,
+                f"This server runs the '{config.llm_backend}' backend; use {serving_path} instead.",
+            )
+
+
+def _mount_unavailable(app: FastAPI, path: str, reason: str) -> None:
+    @app.post(path)
+    async def unavailable_endpoint() -> Response:
+        return _error_response(501, reason, "not_implemented")
+
+
+def _mount_passthrough(app: FastAPI, path: str, pool: list[PipelineUnit], config: LLMProxyConfig) -> None:
+    base_url = (config.upstream_base_url or DEFAULT_UPSTREAM_BASE_URL).rstrip("/")
+    upstream_url = base_url + path.removeprefix("/v1")
+
+    @app.post(path)
+    async def passthrough_endpoint(request: Request) -> Response:
+        session_id = _bearer_session_id(request)
+        if session_id is None or not _session_is_active(pool, session_id):
+            return _error_response(
+                401,
+                "Invalid bearer token: pass the realtime session id of an open session "
+                "(from the session.created event) as the API key.",
+                "invalid_session",
+            )
+
+        try:
+            body = await request.json()
+        except Exception:
+            return _error_response(400, "Request body must be valid JSON.", "invalid_request_error")
+        body["model"] = config.model_name
+
+        headers = {"Authorization": f"Bearer {config.upstream_api_key}"}
+        async with httpx.AsyncClient() as client:
+            upstream = await client.post(upstream_url, json=body, headers=headers)
+        return Response(
+            content=upstream.content,
+            status_code=upstream.status_code,
+            media_type=upstream.headers.get("content-type"),
+        )

--- a/src/speech_to_speech/api/openai_realtime/llm_proxy.py
+++ b/src/speech_to_speech/api/openai_realtime/llm_proxy.py
@@ -1,20 +1,18 @@
-"""Session-gated LLM proxy: OpenAI-compatible passthrough for remote LLM backends.
+"""LLM proxy: OpenAI-compatible passthrough for remote LLM backends.
 
 Mounts ``POST /v1/chat/completions`` (backend ``chat-completions``) or
 ``POST /v1/responses`` (backend ``responses-api``) as a passthrough to the
-configured upstream provider. The ticket to use it is an open realtime
-session: the client presents its realtime session id as the bearer token,
-which is validated against the pipeline pool at request start and used for
-nothing else. Requests never touch pipeline units' queues or cancel scopes,
-so proxied generations run fully concurrent with the speech pipeline and are
-never interrupted by new speech.
+configured upstream provider. The server performs no authentication and no
+throttling of its own: it is designed to run on a trusted network or behind
+a gateway that owns access control (the s2s-endpoint compute replica gates
+these paths with the session's HF token). Requests never touch pipeline
+units' queues or cancel scopes, so proxied generations run fully concurrent
+with the speech pipeline and are never interrupted by new speech.
 """
 
 import json
 import logging
 import re
-import time
-from collections import defaultdict, deque
 from collections.abc import AsyncIterator
 from typing import Any
 
@@ -23,8 +21,6 @@ from fastapi import FastAPI, Request, Response
 from pydantic import BaseModel
 from starlette.background import BackgroundTask
 from starlette.responses import StreamingResponse
-
-from speech_to_speech.api.openai_realtime.pipeline_unit import PipelineUnit
 
 logger = logging.getLogger(__name__)
 
@@ -42,7 +38,6 @@ class LLMProxyConfig(BaseModel):
     upstream_api_key: str | None = None
     model_name: str | None = None
     connect_timeout_s: float = 10.0
-    rate_limit_rpm: int = 20
 
 
 class LLMProxyUsage(BaseModel):
@@ -109,36 +104,6 @@ class LLMProxyUsage(BaseModel):
             self.record_token_payload(payload)
 
 
-def _now() -> float:
-    # Module-level so tests can monkeypatch the clock instead of sleeping.
-    return time.monotonic()
-
-
-_RATE_LIMIT_WINDOW_S = 60.0
-
-
-class _SessionRateLimiter:
-    """In-memory sliding window, keyed by session id, replica-local."""
-
-    def __init__(self, limit_rpm: int):
-        self.limit_rpm = limit_rpm
-        self._hits: dict[str, deque[float]] = defaultdict(deque)
-
-    def allow(self, session_id: str) -> bool:
-        now = _now()
-        hits = self._hits[session_id]
-        while hits and now - hits[0] >= _RATE_LIMIT_WINDOW_S:
-            hits.popleft()
-        if len(hits) >= self.limit_rpm:
-            return False
-        hits.append(now)
-        # Sessions are short-lived relative to the process; drop fully expired
-        # entries so dead session ids don't accumulate forever.
-        if len(self._hits) > 1024:
-            self._hits = defaultdict(deque, {k: v for k, v in self._hits.items() if v})
-        return True
-
-
 class _ErrorDetail(BaseModel):
     message: str
     type: str
@@ -170,23 +135,7 @@ def _upstream_unreachable(error: httpx.HTTPError) -> Response:
     return _error_response(502, f"Upstream request failed: {type(error).__name__}", "upstream_unreachable")
 
 
-def _bearer_session_id(request: Request) -> str | None:
-    auth = request.headers.get("authorization", "")
-    scheme, _, token = auth.partition(" ")
-    if scheme.lower() != "bearer" or not token.strip():
-        return None
-    return token.strip()
-
-
-def _session_is_active(pool: list[PipelineUnit], session_id: str) -> bool:
-    for unit in pool:
-        session = unit.session
-        if session is not None and session.session_id == session_id and session.released_at is None:
-            return True
-    return False
-
-
-def mount_llm_proxy(app: FastAPI, pool: list[PipelineUnit], config: LLMProxyConfig | None) -> LLMProxyUsage:
+def mount_llm_proxy(app: FastAPI, config: LLMProxyConfig | None) -> LLMProxyUsage:
     """Mount the proxy paths on *app* according to *config*.
 
     Both known paths always answer: the path matching an enabled remote
@@ -218,7 +167,7 @@ def mount_llm_proxy(app: FastAPI, pool: list[PipelineUnit], config: LLMProxyConf
     serving_path = _PATHS[config.llm_backend]
     for path in _PATHS.values():
         if path == serving_path:
-            _mount_passthrough(app, path, pool, config, usage)
+            _mount_passthrough(app, path, config, usage)
         else:
             _mount_unavailable(
                 app,
@@ -237,13 +186,11 @@ def _mount_unavailable(app: FastAPI, path: str, reason: str) -> None:
 def _mount_passthrough(
     app: FastAPI,
     path: str,
-    pool: list[PipelineUnit],
     config: LLMProxyConfig,
     usage: LLMProxyUsage,
 ) -> None:
     base_url = (config.upstream_base_url or DEFAULT_UPSTREAM_BASE_URL).rstrip("/")
     upstream_url = base_url + path.removeprefix("/v1")
-    rate_limiter = _SessionRateLimiter(config.rate_limit_rpm)
 
     @app.post(path)
     async def passthrough_endpoint(request: Request) -> Response:
@@ -252,23 +199,6 @@ def _mount_passthrough(
         return response
 
     async def _proxy(request: Request) -> Response:
-        session_id = _bearer_session_id(request)
-        if session_id is None or not _session_is_active(pool, session_id):
-            return _error_response(
-                401,
-                "Invalid bearer token: pass the realtime session id of an open session "
-                "(from the session.created event) as the API key.",
-                "invalid_session",
-            )
-
-        if not rate_limiter.allow(session_id):
-            return _error_response(
-                429,
-                f"Rate limit exceeded: this session may make {config.rate_limit_rpm} requests "
-                "per minute. Back off and retry.",
-                "rate_limit_exceeded",
-            )
-
         try:
             body = await request.json()
         except Exception:

--- a/src/speech_to_speech/api/openai_realtime/llm_proxy.py
+++ b/src/speech_to_speech/api/openai_realtime/llm_proxy.py
@@ -203,6 +203,10 @@ def _mount_passthrough(
             body = await request.json()
         except Exception:
             return _error_response(400, "Request body must be valid JSON.", "invalid_request_error")
+        if not isinstance(body, dict):
+            # Valid JSON is not necessarily an object; anything else cannot
+            # carry the mutations below and would be rejected upstream anyway.
+            return _error_response(400, "Request body must be a JSON object.", "invalid_request_error")
         body["model"] = config.model_name
         if path == _PATHS["responses-api"]:
             # Session holders are anonymous; forcing store off keeps them from
@@ -214,9 +218,11 @@ def _mount_passthrough(
             # every upstream frame verbatim, including the final usage chunk
             # it may not have requested (valid protocol). Responses streams
             # always carry usage on response.completed, so no mutation there.
-            stream_options = body.get("stream_options") or {}
-            stream_options["include_usage"] = True
-            body["stream_options"] = stream_options
+            # A non-dict stream_options is left alone for the upstream to
+            # reject with its own error.
+            stream_options = body.get("stream_options")
+            if stream_options is None or isinstance(stream_options, dict):
+                body["stream_options"] = {**(stream_options or {}), "include_usage": True}
 
         headers = {"Authorization": f"Bearer {config.upstream_api_key}"}
         # Generation can legitimately take minutes, so only the connect
@@ -261,8 +267,22 @@ def _mount_passthrough(
             await _cleanup()
             return _verbatim_response(upstream, content)
 
+        async def _stream_and_cleanup() -> AsyncIterator[bytes]:
+            # The generator owns the cleanup: Starlette only runs background
+            # tasks after a successful send, so an upstream failure or a
+            # client disconnect mid-stream would otherwise leak the httpx
+            # client and its connection. The finally runs on normal
+            # exhaustion, on upstream errors, and on cancellation alike; the
+            # BackgroundTask below is a harmless second aclose for the
+            # successful path.
+            try:
+                async for chunk in _forward_and_account(upstream, usage):
+                    yield chunk
+            finally:
+                await _cleanup()
+
         return StreamingResponse(
-            _forward_and_account(upstream, usage),
+            _stream_and_cleanup(),
             status_code=upstream.status_code,
             media_type=upstream.headers.get("content-type"),
             background=BackgroundTask(_cleanup),

--- a/src/speech_to_speech/api/openai_realtime/llm_proxy.py
+++ b/src/speech_to_speech/api/openai_realtime/llm_proxy.py
@@ -274,13 +274,17 @@ _SSE_EVENT_END = re.compile(rb"\r\n\r\n|\n\n|\r\r")
 
 
 async def _forward_and_account(upstream: httpx.Response, usage: LLMProxyUsage) -> AsyncIterator[bytes]:
-    """Yield upstream bytes verbatim while parsing SSE events for token usage.
+    """Yield upstream bytes while parsing SSE events for token usage.
 
-    Accounting happens on a copy of the byte stream; nothing it does can
-    change what the client receives.
+    ``aiter_bytes`` (not ``aiter_raw``): the upstream may compress the
+    stream, and the forwarded response carries no Content-Encoding header,
+    so the bytes must be decoded here — for the client and for the SSE
+    accounting alike. An uncompressed stream passes through byte-identical.
+    Accounting happens on a copy of the stream; nothing it does can change
+    what the client receives.
     """
     buffer = b""
-    async for chunk in upstream.aiter_raw():
+    async for chunk in upstream.aiter_bytes():
         yield chunk
         buffer += chunk
         while True:

--- a/src/speech_to_speech/api/openai_realtime/server.py
+++ b/src/speech_to_speech/api/openai_realtime/server.py
@@ -4,6 +4,7 @@ from threading import Event
 
 import uvicorn
 
+from speech_to_speech.api.openai_realtime.llm_proxy import LLMProxyConfig
 from speech_to_speech.api.openai_realtime.pipeline_unit import PipelineUnit
 from speech_to_speech.api.openai_realtime.websocket_router import create_app
 
@@ -25,6 +26,7 @@ class RealtimeServer:
         pool: list[PipelineUnit],
         host: str = "0.0.0.0",
         port: int = 8765,
+        llm_proxy_config: LLMProxyConfig | None = None,
     ) -> None:
         if not pool:
             raise ValueError("RealtimeServer requires at least one PipelineUnit in the pool")
@@ -32,10 +34,11 @@ class RealtimeServer:
         self.pool = pool
         self.host = host
         self.port = port
+        self.llm_proxy_config = llm_proxy_config
 
     def run(self) -> None:
         """Start the FastAPI/uvicorn server (called from a ThreadManager thread)."""
-        app = create_app(pool=self.pool, stop_event=self.stop_event)
+        app = create_app(pool=self.pool, stop_event=self.stop_event, llm_proxy_config=self.llm_proxy_config)
 
         logger.info(
             f"OpenAI Realtime API starting on ws://{self.host}:{self.port}/v1/realtime (pool size {len(self.pool)})"

--- a/src/speech_to_speech/api/openai_realtime/websocket_router.py
+++ b/src/speech_to_speech/api/openai_realtime/websocket_router.py
@@ -19,6 +19,7 @@ from openai.types.realtime import (
     SessionUpdateEvent,
 )
 
+from speech_to_speech.api.openai_realtime.llm_proxy import LLMProxyConfig, mount_llm_proxy
 from speech_to_speech.api.openai_realtime.pipeline_unit import PipelineUnit, SessionState
 from speech_to_speech.api.openai_realtime.service import (
     PIPELINE_SAMPLE_RATE,
@@ -403,7 +404,11 @@ async def _dispatch_client_event(
         unit.response_playing.clear()
 
 
-def create_app(pool: list[PipelineUnit], stop_event: ThreadingEvent) -> FastAPI:
+def create_app(
+    pool: list[PipelineUnit],
+    stop_event: ThreadingEvent,
+    llm_proxy_config: LLMProxyConfig | None = None,
+) -> FastAPI:
     @asynccontextmanager
     async def lifespan(app: FastAPI) -> AsyncIterator[None]:
         # One send loop per pipeline unit; each polls its own queues and forwards
@@ -426,6 +431,8 @@ def create_app(pool: list[PipelineUnit], stop_event: ThreadingEvent) -> FastAPI:
                     pass
 
     app = FastAPI(lifespan=lifespan)
+
+    mount_llm_proxy(app, pool, llm_proxy_config)
 
     def _claim_unit(transport: SessionTransport | None) -> PipelineUnit | None:
         """Atomically (between asyncio yield points) reserve the first idle unit.

--- a/src/speech_to_speech/api/openai_realtime/websocket_router.py
+++ b/src/speech_to_speech/api/openai_realtime/websocket_router.py
@@ -432,7 +432,7 @@ def create_app(
 
     app = FastAPI(lifespan=lifespan)
 
-    mount_llm_proxy(app, pool, llm_proxy_config)
+    llm_proxy_usage = mount_llm_proxy(app, pool, llm_proxy_config)
 
     def _claim_unit(transport: SessionTransport | None) -> PipelineUnit | None:
         """Atomically (between asyncio yield points) reserve the first idle unit.
@@ -525,6 +525,9 @@ def create_app(
         total: dict[str, Any] = {}
         for unit in pool:
             _merge(total, unit.service.get_usage())
+        # Additive section: proxy traffic is app-level, not per-unit, so it
+        # lands after the per-unit merge and never collides with unit keys.
+        total["llm_proxy"] = llm_proxy_usage.model_dump()
         return total
 
     @app.get("/v1/pool")

--- a/src/speech_to_speech/api/openai_realtime/websocket_router.py
+++ b/src/speech_to_speech/api/openai_realtime/websocket_router.py
@@ -432,7 +432,7 @@ def create_app(
 
     app = FastAPI(lifespan=lifespan)
 
-    llm_proxy_usage = mount_llm_proxy(app, pool, llm_proxy_config)
+    llm_proxy_usage = mount_llm_proxy(app, llm_proxy_config)
 
     def _claim_unit(transport: SessionTransport | None) -> PipelineUnit | None:
         """Atomically (between asyncio yield points) reserve the first idle unit.

--- a/src/speech_to_speech/arguments_classes/module_arguments.py
+++ b/src/speech_to_speech/arguments_classes/module_arguments.py
@@ -70,6 +70,13 @@ class ModuleArguments:
             "--mode realtime."
         },
     )
+    llm_proxy_requests_per_minute: int = field(
+        default=20,
+        metadata={
+            "help": "Per-session rate limit for LLM proxy requests, as a sliding window in requests per minute. "
+            "Exceeding it answers 429. Default is 20."
+        },
+    )
     llm_proxy_connect_timeout_s: float = field(
         default=10.0,
         metadata={

--- a/src/speech_to_speech/arguments_classes/module_arguments.py
+++ b/src/speech_to_speech/arguments_classes/module_arguments.py
@@ -61,6 +61,15 @@ class ModuleArguments:
             "help": "Minimum silence duration (ms) before ending speech when live transcription is enabled (default: 500ms)"
         },
     )
+    enable_llm_proxy: bool = field(
+        default=False,
+        metadata={
+            "help": "Expose the configured remote LLM (--llm_backend chat-completions or responses-api) as an "
+            "OpenAI-compatible HTTP endpoint on the realtime server, gated by an open realtime session: clients "
+            "authenticate with their realtime session id as the bearer token. Off by default. Only valid for "
+            "--mode realtime."
+        },
+    )
     num_pipelines: int = field(
         default=1,
         metadata={

--- a/src/speech_to_speech/arguments_classes/module_arguments.py
+++ b/src/speech_to_speech/arguments_classes/module_arguments.py
@@ -70,6 +70,13 @@ class ModuleArguments:
             "--mode realtime."
         },
     )
+    llm_proxy_connect_timeout_s: float = field(
+        default=10.0,
+        metadata={
+            "help": "Connect timeout in seconds for LLM proxy requests to the upstream provider. Reads have no "
+            "timeout (generation may take minutes). Default is 10.0."
+        },
+    )
     num_pipelines: int = field(
         default=1,
         metadata={

--- a/src/speech_to_speech/arguments_classes/module_arguments.py
+++ b/src/speech_to_speech/arguments_classes/module_arguments.py
@@ -65,16 +65,9 @@ class ModuleArguments:
         default=False,
         metadata={
             "help": "Expose the configured remote LLM (--llm_backend chat-completions or responses-api) as an "
-            "OpenAI-compatible HTTP endpoint on the realtime server, gated by an open realtime session: clients "
-            "authenticate with their realtime session id as the bearer token. Off by default. Only valid for "
-            "--mode realtime."
-        },
-    )
-    llm_proxy_requests_per_minute: int = field(
-        default=20,
-        metadata={
-            "help": "Per-session rate limit for LLM proxy requests, as a sliding window in requests per minute. "
-            "Exceeding it answers 429. Default is 20."
+            "OpenAI-compatible HTTP endpoint on the realtime server. The server performs no authentication of "
+            "its own: enable it only on a trusted network or behind a gateway that owns access control. Off by "
+            "default. Only valid for --mode realtime."
         },
     )
     llm_proxy_connect_timeout_s: float = field(

--- a/src/speech_to_speech/s2s_pipeline.py
+++ b/src/speech_to_speech/s2s_pipeline.py
@@ -672,6 +672,7 @@ def build_pipeline(
             upstream_base_url=responses_api_language_model_handler_kwargs.responses_api_base_url,
             upstream_api_key=responses_api_language_model_handler_kwargs.responses_api_api_key,
             model_name=responses_api_language_model_handler_kwargs.model_name,
+            connect_timeout_s=module_kwargs.llm_proxy_connect_timeout_s,
         )
 
         realtime_server = RealtimeServer(

--- a/src/speech_to_speech/s2s_pipeline.py
+++ b/src/speech_to_speech/s2s_pipeline.py
@@ -673,6 +673,7 @@ def build_pipeline(
             upstream_api_key=responses_api_language_model_handler_kwargs.responses_api_api_key,
             model_name=responses_api_language_model_handler_kwargs.model_name,
             connect_timeout_s=module_kwargs.llm_proxy_connect_timeout_s,
+            rate_limit_rpm=module_kwargs.llm_proxy_requests_per_minute,
         )
 
         realtime_server = RealtimeServer(

--- a/src/speech_to_speech/s2s_pipeline.py
+++ b/src/speech_to_speech/s2s_pipeline.py
@@ -637,6 +637,7 @@ def build_pipeline(
         )
         comms_handlers = [websocket_streamer]
     elif module_kwargs.mode == "realtime":
+        from speech_to_speech.api.openai_realtime.llm_proxy import LLMProxyConfig
         from speech_to_speech.api.openai_realtime.server import RealtimeServer
 
         pool_size = max(1, module_kwargs.num_pipelines)
@@ -662,11 +663,23 @@ def build_pipeline(
             for i in range(pool_size)
         ]
 
+        # Both remote backends read their connection settings from the
+        # responses-api argument class (see get_llm_handler), so the proxy
+        # reuses the same upstream URL, key, and model the pipeline LM uses.
+        llm_proxy_config = LLMProxyConfig(
+            enabled=module_kwargs.enable_llm_proxy,
+            llm_backend=module_kwargs.llm_backend,
+            upstream_base_url=responses_api_language_model_handler_kwargs.responses_api_base_url,
+            upstream_api_key=responses_api_language_model_handler_kwargs.responses_api_api_key,
+            model_name=responses_api_language_model_handler_kwargs.model_name,
+        )
+
         realtime_server = RealtimeServer(
             stop_event=stop_event,
             pool=pool,
             host=websocket_streamer_kwargs.ws_host,
             port=websocket_streamer_kwargs.ws_port,
+            llm_proxy_config=llm_proxy_config,
         )
 
         all_handlers: list[Any] = [realtime_server]

--- a/src/speech_to_speech/s2s_pipeline.py
+++ b/src/speech_to_speech/s2s_pipeline.py
@@ -126,6 +126,34 @@ def rename_args(args: Any, prefix: str) -> None:
     args.__dict__["gen_kwargs"] = gen_kwargs
 
 
+def build_llm_proxy_config(
+    module_kwargs: ModuleArguments,
+    responses_api_language_model_handler_kwargs: ResponsesApiLanguageModelHandlerArguments,
+) -> Any:
+    """Proxy upstream settings, read from the same fields the pipeline LM uses.
+
+    Both remote backends read their connection settings from the responses-api
+    argument class (see get_llm_handler), so the proxy reuses the upstream URL,
+    key, and model the pipeline LM runs with. Must be called after
+    prepare_all_args(): rename_args() has popped the raw ``responses_api_*``
+    fields into their handler names (``base_url``, ``api_key``), and reading
+    the raw names after that silently returns the dataclass class defaults
+    (None) — which pointed the proxy at the OpenAI default upstream with no
+    key, whatever the flags said. Indexing vars() keeps that failure loud.
+    """
+    from speech_to_speech.api.openai_realtime.llm_proxy import LLMProxyConfig
+
+    lm_vars = vars(responses_api_language_model_handler_kwargs)
+    return LLMProxyConfig(
+        enabled=module_kwargs.enable_llm_proxy,
+        llm_backend=module_kwargs.llm_backend,
+        upstream_base_url=lm_vars["base_url"],
+        upstream_api_key=lm_vars["api_key"],
+        model_name=lm_vars["model_name"],
+        connect_timeout_s=module_kwargs.llm_proxy_connect_timeout_s,
+    )
+
+
 def parse_arguments() -> ParsedArguments:
     # Pre-parse to determine which LM backend is selected, so only one of the
     # mutually exclusive LM argument classes is registered with HfArgumentParser
@@ -637,7 +665,6 @@ def build_pipeline(
         )
         comms_handlers = [websocket_streamer]
     elif module_kwargs.mode == "realtime":
-        from speech_to_speech.api.openai_realtime.llm_proxy import LLMProxyConfig
         from speech_to_speech.api.openai_realtime.server import RealtimeServer
 
         pool_size = max(1, module_kwargs.num_pipelines)
@@ -663,17 +690,7 @@ def build_pipeline(
             for i in range(pool_size)
         ]
 
-        # Both remote backends read their connection settings from the
-        # responses-api argument class (see get_llm_handler), so the proxy
-        # reuses the same upstream URL, key, and model the pipeline LM uses.
-        llm_proxy_config = LLMProxyConfig(
-            enabled=module_kwargs.enable_llm_proxy,
-            llm_backend=module_kwargs.llm_backend,
-            upstream_base_url=responses_api_language_model_handler_kwargs.responses_api_base_url,
-            upstream_api_key=responses_api_language_model_handler_kwargs.responses_api_api_key,
-            model_name=responses_api_language_model_handler_kwargs.model_name,
-            connect_timeout_s=module_kwargs.llm_proxy_connect_timeout_s,
-        )
+        llm_proxy_config = build_llm_proxy_config(module_kwargs, responses_api_language_model_handler_kwargs)
 
         realtime_server = RealtimeServer(
             stop_event=stop_event,

--- a/src/speech_to_speech/s2s_pipeline.py
+++ b/src/speech_to_speech/s2s_pipeline.py
@@ -673,7 +673,6 @@ def build_pipeline(
             upstream_api_key=responses_api_language_model_handler_kwargs.responses_api_api_key,
             model_name=responses_api_language_model_handler_kwargs.model_name,
             connect_timeout_s=module_kwargs.llm_proxy_connect_timeout_s,
-            rate_limit_rpm=module_kwargs.llm_proxy_requests_per_minute,
         )
 
         realtime_server = RealtimeServer(

--- a/tests/openai_realtime/test_llm_proxy.py
+++ b/tests/openai_realtime/test_llm_proxy.py
@@ -9,13 +9,18 @@ hooks in production code.
 
 import json
 import threading
+import time
 from http.server import BaseHTTPRequestHandler, ThreadingHTTPServer
 from queue import Queue
 from threading import Event as ThreadingEvent
 from typing import Any
 
+import httpx
 import pytest
+import uvicorn
+from pydantic import BaseModel
 from starlette.testclient import TestClient
+from websockets.sync.client import connect as ws_connect
 
 from speech_to_speech.api.openai_realtime.llm_proxy import LLMProxyConfig
 from speech_to_speech.api.openai_realtime.pipeline_unit import PipelineUnit
@@ -28,11 +33,19 @@ from speech_to_speech.pipeline.cancel_scope import CancelScope
 # ---------------------------------------------------------------------------
 
 
+class SSEScript(BaseModel):
+    """Streamed answer for the fake upstream: raw frames with a delay before each."""
+
+    frames: list[tuple[float, bytes]]
+
+
 class FakeUpstream:
     """A real OpenAI-shaped HTTP server on an ephemeral port.
 
     Records every request (path, headers, parsed JSON body) and answers with
-    whatever ``responder`` returns: ``(status_code, json_payload)``.
+    whatever ``responder`` returns: ``(status_code, json_payload)`` for a
+    buffered JSON answer, or an ``SSEScript`` to stream raw frames with
+    delays between them.
     """
 
     def __init__(self):
@@ -54,7 +67,17 @@ class FakeUpstream:
                     "body": json.loads(raw) if raw else None,
                 }
                 upstream.requests.append(request)
-                status, payload = upstream.responder(request)
+                answer = upstream.responder(request)
+                if isinstance(answer, SSEScript):
+                    self.send_response(200)
+                    self.send_header("Content-Type", "text/event-stream")
+                    self.end_headers()
+                    for delay, frame in answer.frames:
+                        time.sleep(delay)
+                        self.wfile.write(frame)
+                        self.wfile.flush()
+                    return
+                status, payload = answer
                 body = json.dumps(payload).encode()
                 self.send_response(status)
                 self.send_header("Content-Type", "application/json")
@@ -83,6 +106,35 @@ def upstream():
     server = FakeUpstream()
     yield server
     server.close()
+
+
+class LiveApp:
+    """Run the app under a real uvicorn server on an ephemeral port.
+
+    Needed only where TestClient cannot observe the behavior under test:
+    it buffers the whole ASGI response, hiding streaming timing and
+    mid-stream lifecycle.
+    """
+
+    def __init__(self, app):
+        config = uvicorn.Config(app, host="127.0.0.1", port=0, log_level="warning")
+        self._server = uvicorn.Server(config)
+        self._server.install_signal_handlers = lambda: None  # type: ignore[method-assign]
+        self._thread = threading.Thread(target=self._server.run, daemon=True)
+
+    def __enter__(self) -> "LiveApp":
+        self._thread.start()
+        deadline = time.monotonic() + 5
+        while not self._server.started:
+            if time.monotonic() > deadline:
+                raise RuntimeError("uvicorn did not start in time")
+            time.sleep(0.01)
+        self.port = self._server.servers[0].sockets[0].getsockname()[1]
+        return self
+
+    def __exit__(self, *exc_info: Any) -> None:
+        self._server.should_exit = True
+        self._thread.join(timeout=5)
 
 
 # ---------------------------------------------------------------------------
@@ -236,6 +288,116 @@ class TestUnavailableContract:
         r = self._post_with_session(app, "/v1/responses")
         assert r.status_code == 501
         assert "/v1/chat/completions" in r.json()["error"]["message"]
+
+
+SSE_FRAMES = [
+    b'data: {"id":"chatcmpl-1","choices":[{"delta":{"content":"Hel"}}]}\n\n',
+    b'data: {"id":"chatcmpl-1","choices":[{"delta":{"content":"lo"}}]}\n\n',
+    b"data: [DONE]\n\n",
+]
+
+STREAM_BODY = {**CHAT_BODY, "stream": True}
+
+
+class TestStreamingPassthrough:
+    def test_streamed_bytes_arrive_verbatim_in_order(self, upstream):
+        upstream.responder = lambda request: SSEScript(frames=[(0.0, f) for f in SSE_FRAMES])
+        app = _make_app(_proxy_config(upstream))
+        with TestClient(app) as client:
+            with client.websocket_connect("/v1/realtime") as ws:
+                session_id = ws.receive_json()["session"]["id"]
+                with client.stream(
+                    "POST",
+                    "/v1/chat/completions",
+                    json=STREAM_BODY,
+                    headers={"Authorization": f"Bearer {session_id}"},
+                ) as r:
+                    assert r.status_code == 200
+                    received = b"".join(r.iter_raw())
+        assert received == b"".join(SSE_FRAMES)
+
+    def test_frames_forward_as_they_arrive_not_buffered(self, upstream):
+        # Starlette's TestClient buffers the whole ASGI response, so timing
+        # is only observable over a real server.
+        delay = 0.4
+        upstream.responder = lambda request: SSEScript(
+            frames=[(0.0, SSE_FRAMES[0]), (delay, SSE_FRAMES[1]), (0.0, SSE_FRAMES[2])]
+        )
+        with LiveApp(_make_app(_proxy_config(upstream))) as live:
+            with ws_connect(f"ws://127.0.0.1:{live.port}/v1/realtime") as ws:
+                session_id = json.loads(ws.recv())["session"]["id"]
+                arrivals: list[float] = []
+                with httpx.stream(
+                    "POST",
+                    f"http://127.0.0.1:{live.port}/v1/chat/completions",
+                    json=STREAM_BODY,
+                    headers={"Authorization": f"Bearer {session_id}"},
+                ) as r:
+                    for _ in r.iter_raw():
+                        arrivals.append(time.monotonic())
+        # If the proxy buffered the whole upstream response, every chunk
+        # would land at once and the spread would be ~0.
+        assert arrivals[-1] - arrivals[0] >= delay * 0.5
+
+    def test_in_flight_stream_survives_session_close(self, upstream):
+        upstream.responder = lambda request: SSEScript(
+            frames=[(0.0, SSE_FRAMES[0]), (0.5, SSE_FRAMES[1]), (0.0, SSE_FRAMES[2])]
+        )
+        with LiveApp(_make_app(_proxy_config(upstream))) as live:
+            with httpx.Client() as client:
+                ws = ws_connect(f"ws://127.0.0.1:{live.port}/v1/realtime")
+                session_id = json.loads(ws.recv())["session"]["id"]
+                with client.stream(
+                    "POST",
+                    f"http://127.0.0.1:{live.port}/v1/chat/completions",
+                    json=STREAM_BODY,
+                    headers={"Authorization": f"Bearer {session_id}"},
+                ) as r:
+                    iterator = r.iter_raw()
+                    first = next(iterator)
+                    assert first  # request authorized and streaming
+                    # Close the session mid-stream; delivery must continue.
+                    ws.close()
+                    rest = b"".join(iterator)
+        assert (first + rest) == b"".join(SSE_FRAMES)
+
+    def test_unreachable_upstream_fails_cleanly_within_connect_timeout(self):
+        config = LLMProxyConfig(
+            enabled=True,
+            llm_backend="chat-completions",
+            upstream_base_url="http://10.255.255.1:9/v1",  # blackhole address
+            upstream_api_key="sk-server-secret",
+            model_name="server-model",
+            connect_timeout_s=0.2,
+        )
+        app = _make_app(config)
+        with TestClient(app) as client:
+            with client.websocket_connect("/v1/realtime") as ws:
+                session_id = ws.receive_json()["session"]["id"]
+                start = time.monotonic()
+                r = client.post(
+                    "/v1/chat/completions",
+                    json=STREAM_BODY,
+                    headers={"Authorization": f"Bearer {session_id}"},
+                )
+                elapsed = time.monotonic() - start
+        assert r.status_code == 502
+        assert "error" in r.json()
+        assert elapsed < 3
+
+    def test_upstream_error_before_stream_passes_through(self, upstream):
+        upstream.responder = lambda request: (429, {"error": {"message": "quota", "type": "rate_limit"}})
+        app = _make_app(_proxy_config(upstream))
+        with TestClient(app) as client:
+            with client.websocket_connect("/v1/realtime") as ws:
+                session_id = ws.receive_json()["session"]["id"]
+                r = client.post(
+                    "/v1/chat/completions",
+                    json=STREAM_BODY,
+                    headers={"Authorization": f"Bearer {session_id}"},
+                )
+        assert r.status_code == 429
+        assert r.json() == {"error": {"message": "quota", "type": "rate_limit"}}
 
 
 class TestUpstreamErrorPassthrough:

--- a/tests/openai_realtime/test_llm_proxy.py
+++ b/tests/openai_realtime/test_llm_proxy.py
@@ -400,6 +400,116 @@ class TestStreamingPassthrough:
         assert r.json() == {"error": {"message": "quota", "type": "rate_limit"}}
 
 
+RESPONSES_BODY = {
+    "model": "client-model",
+    "input": [{"role": "user", "content": "hello"}],
+    "store": True,
+}
+
+RESPONSES_SSE_FRAMES = [
+    b'event: response.created\ndata: {"type":"response.created","response":{"id":"resp_1"}}\n\n',
+    b'event: response.output_text.delta\ndata: {"type":"response.output_text.delta","delta":"Hi"}\n\n',
+    b'event: response.completed\ndata: {"type":"response.completed","response":{"id":"resp_1"}}\n\n',
+]
+
+
+class TestResponsesPassthrough:
+    def _config(self, upstream, **overrides):
+        return _proxy_config(upstream, llm_backend="responses-api", **overrides)
+
+    def test_non_streaming_passes_through_verbatim(self, upstream):
+        upstream.responder = lambda request: (200, {"id": "resp_1", "object": "response", "output": []})
+        app = _make_app(self._config(upstream))
+        with TestClient(app) as client:
+            with client.websocket_connect("/v1/realtime") as ws:
+                session_id = ws.receive_json()["session"]["id"]
+                r = client.post(
+                    "/v1/responses",
+                    json=RESPONSES_BODY,
+                    headers={"Authorization": f"Bearer {session_id}"},
+                )
+        assert r.status_code == 200
+        assert r.json() == {"id": "resp_1", "object": "response", "output": []}
+
+    def test_upstream_receives_store_false_and_forced_model(self, upstream):
+        app = _make_app(self._config(upstream))
+        with TestClient(app) as client:
+            with client.websocket_connect("/v1/realtime") as ws:
+                session_id = ws.receive_json()["session"]["id"]
+                client.post(
+                    "/v1/responses",
+                    json=RESPONSES_BODY,
+                    headers={"Authorization": f"Bearer {session_id}"},
+                )
+        (request,) = upstream.requests
+        assert request["path"] == "/v1/responses"
+        assert request["body"]["store"] is False
+        assert request["body"]["model"] == "server-model"
+        assert request["body"]["input"] == RESPONSES_BODY["input"]
+
+    def test_streaming_responses_grammar_passes_through_verbatim(self, upstream):
+        upstream.responder = lambda request: SSEScript(frames=[(0.0, f) for f in RESPONSES_SSE_FRAMES])
+        app = _make_app(self._config(upstream))
+        with TestClient(app) as client:
+            with client.websocket_connect("/v1/realtime") as ws:
+                session_id = ws.receive_json()["session"]["id"]
+                with client.stream(
+                    "POST",
+                    "/v1/responses",
+                    json={**RESPONSES_BODY, "stream": True},
+                    headers={"Authorization": f"Bearer {session_id}"},
+                ) as r:
+                    assert r.status_code == 200
+                    received = b"".join(r.iter_raw())
+        assert received == b"".join(RESPONSES_SSE_FRAMES)
+        (request,) = upstream.requests
+        assert request["body"]["store"] is False
+
+    def test_chat_completions_path_is_501_under_responses_backend(self, upstream):
+        app = _make_app(self._config(upstream))
+        with TestClient(app) as client:
+            with client.websocket_connect("/v1/realtime") as ws:
+                session_id = ws.receive_json()["session"]["id"]
+                r = client.post(
+                    "/v1/chat/completions",
+                    json=CHAT_BODY,
+                    headers={"Authorization": f"Bearer {session_id}"},
+                )
+        assert r.status_code == 501
+        assert "/v1/responses" in r.json()["error"]["message"]
+
+    def test_missing_bearer_is_401_on_responses_path(self, upstream):
+        app = _make_app(self._config(upstream))
+        with TestClient(app) as client:
+            r = client.post("/v1/responses", json=RESPONSES_BODY)
+        assert r.status_code == 401
+        assert upstream.requests == []
+
+    def test_unknown_session_is_401_on_responses_path(self, upstream):
+        app = _make_app(self._config(upstream))
+        with TestClient(app) as client:
+            with client.websocket_connect("/v1/realtime") as ws:
+                ws.receive_json()
+                r = client.post(
+                    "/v1/responses",
+                    json=RESPONSES_BODY,
+                    headers={"Authorization": "Bearer sess_deadbeef"},
+                )
+        assert r.status_code == 401
+        assert upstream.requests == []
+
+    @pytest.mark.parametrize("backend", ["transformers", "mlx-lm"])
+    def test_flag_off_and_local_backend_are_501_on_responses_path(self, upstream, backend):
+        for config in (
+            self._config(upstream, enabled=False),
+            _proxy_config(upstream, llm_backend=backend),
+        ):
+            app = _make_app(config)
+            with TestClient(app) as client:
+                r = client.post("/v1/responses", json=RESPONSES_BODY)
+            assert r.status_code == 501
+
+
 class TestUpstreamErrorPassthrough:
     @pytest.mark.parametrize("status", [400, 429, 500, 503])
     def test_upstream_errors_pass_through_verbatim(self, upstream, status):

--- a/tests/openai_realtime/test_llm_proxy.py
+++ b/tests/openai_realtime/test_llm_proxy.py
@@ -160,8 +160,9 @@ def _make_unit(index: int = 0) -> PipelineUnit:
     )
 
 
-def _make_app(config: LLMProxyConfig | None):
-    return create_app(pool=[_make_unit()], stop_event=ThreadingEvent(), llm_proxy_config=config)
+def _make_app(config: LLMProxyConfig | None, pool_size: int = 1):
+    pool = [_make_unit(i) for i in range(pool_size)]
+    return create_app(pool=pool, stop_event=ThreadingEvent(), llm_proxy_config=config)
 
 
 def _proxy_config(upstream: FakeUpstream, **overrides: Any) -> LLMProxyConfig:
@@ -508,6 +509,73 @@ class TestResponsesPassthrough:
             with TestClient(app) as client:
                 r = client.post("/v1/responses", json=RESPONSES_BODY)
             assert r.status_code == 501
+
+
+class TestRateLimit:
+    def _post(self, client, session_id):
+        return client.post(
+            "/v1/chat/completions",
+            json=CHAT_BODY,
+            headers={"Authorization": f"Bearer {session_id}"},
+        )
+
+    def test_default_ceiling_is_20_per_minute_and_other_sessions_unaffected(self, upstream):
+        app = _make_app(_proxy_config(upstream), pool_size=2)
+        with TestClient(app) as client:
+            with client.websocket_connect("/v1/realtime") as ws1:
+                session_1 = ws1.receive_json()["session"]["id"]
+                with client.websocket_connect("/v1/realtime") as ws2:
+                    session_2 = ws2.receive_json()["session"]["id"]
+                    for _ in range(20):
+                        assert self._post(client, session_1).status_code == 200
+                    r = self._post(client, session_1)
+                    assert r.status_code == 429
+                    assert "error" in r.json()
+                    # The other session still has its own budget.
+                    assert self._post(client, session_2).status_code == 200
+        # The 21st request never reached the upstream.
+        assert len(upstream.requests) == 21
+
+    def test_ceiling_is_configurable(self, upstream):
+        app = _make_app(_proxy_config(upstream, rate_limit_rpm=2))
+        with TestClient(app) as client:
+            with client.websocket_connect("/v1/realtime") as ws:
+                session_id = ws.receive_json()["session"]["id"]
+                assert self._post(client, session_id).status_code == 200
+                assert self._post(client, session_id).status_code == 200
+                assert self._post(client, session_id).status_code == 429
+
+    def test_window_slides_and_recovers(self, upstream, monkeypatch):
+        import speech_to_speech.api.openai_realtime.llm_proxy as llm_proxy_module
+
+        clock = {"now": 1000.0}
+        monkeypatch.setattr(llm_proxy_module, "_now", lambda: clock["now"])
+        app = _make_app(_proxy_config(upstream, rate_limit_rpm=2))
+        with TestClient(app) as client:
+            with client.websocket_connect("/v1/realtime") as ws:
+                session_id = ws.receive_json()["session"]["id"]
+                assert self._post(client, session_id).status_code == 200
+                clock["now"] += 30.0
+                assert self._post(client, session_id).status_code == 200
+                assert self._post(client, session_id).status_code == 429
+                # 61s after the first hit, one slot has slid out of the window.
+                clock["now"] += 31.0
+                assert self._post(client, session_id).status_code == 200
+                assert self._post(client, session_id).status_code == 429
+
+    def test_unknown_bearer_is_401_and_consumes_no_budget(self, upstream):
+        app = _make_app(_proxy_config(upstream, rate_limit_rpm=1))
+        with TestClient(app) as client:
+            with client.websocket_connect("/v1/realtime") as ws:
+                session_id = ws.receive_json()["session"]["id"]
+                for _ in range(3):
+                    r = client.post(
+                        "/v1/chat/completions",
+                        json=CHAT_BODY,
+                        headers={"Authorization": "Bearer sess_unknown"},
+                    )
+                    assert r.status_code == 401
+                assert self._post(client, session_id).status_code == 200
 
 
 class TestUpstreamErrorPassthrough:

--- a/tests/openai_realtime/test_llm_proxy.py
+++ b/tests/openai_realtime/test_llm_proxy.py
@@ -578,6 +578,142 @@ class TestRateLimit:
                 assert self._post(client, session_id).status_code == 200
 
 
+class TestUsageSection:
+    def _post(self, client, session_id, body=None, path="/v1/chat/completions"):
+        return client.post(
+            path,
+            json=body or CHAT_BODY,
+            headers={"Authorization": f"Bearer {session_id}"},
+        )
+
+    def test_counters_after_mixed_traffic(self, upstream):
+        answers = iter(
+            [
+                (200, {"choices": [], "usage": {"prompt_tokens": 7, "completion_tokens": 3}}),
+                (200, {"choices": [], "usage": {"prompt_tokens": 7, "completion_tokens": 3}}),
+                (500, {"error": {"message": "boom", "type": "server_error"}}),
+            ]
+        )
+        upstream.responder = lambda request: next(answers)
+        app = _make_app(_proxy_config(upstream, rate_limit_rpm=3))
+        with TestClient(app) as client:
+            with client.websocket_connect("/v1/realtime") as ws:
+                session_id = ws.receive_json()["session"]["id"]
+                assert self._post(client, session_id).status_code == 200
+                assert self._post(client, session_id).status_code == 200
+                assert self._post(client, session_id).status_code == 500
+                assert self._post(client, session_id).status_code == 429
+                assert self._post(client, "sess_unknown").status_code == 401
+                usage = client.get("/v1/usage").json()["llm_proxy"]
+        assert usage["requests"] == 5
+        assert usage["responses_2xx"] == 2
+        assert usage["responses_5xx"] == 1
+        assert usage["responses_429"] == 1
+        assert usage["responses_4xx"] == 1
+        assert usage["input_tokens"] == 14
+        assert usage["output_tokens"] == 6
+
+    def test_streamed_chat_completions_get_include_usage_injected_and_tokens_counted(self, upstream):
+        frames = SSE_FRAMES[:2] + [
+            b'data: {"id":"chatcmpl-1","choices":[],"usage":{"prompt_tokens":11,"completion_tokens":5}}\n\n',
+            b"data: [DONE]\n\n",
+        ]
+        upstream.responder = lambda request: SSEScript(frames=[(0.0, f) for f in frames])
+        app = _make_app(_proxy_config(upstream))
+        with TestClient(app) as client:
+            with client.websocket_connect("/v1/realtime") as ws:
+                session_id = ws.receive_json()["session"]["id"]
+                with client.stream(
+                    "POST",
+                    "/v1/chat/completions",
+                    json=STREAM_BODY,
+                    headers={"Authorization": f"Bearer {session_id}"},
+                ) as r:
+                    received = b"".join(r.iter_raw())
+                usage = client.get("/v1/usage").json()["llm_proxy"]
+        # The client did not ask for usage, the server injected it upstream,
+        # and the byte stream still arrives verbatim including the usage frame.
+        (request,) = upstream.requests
+        assert request["body"]["stream_options"]["include_usage"] is True
+        assert received == b"".join(frames)
+        assert usage["input_tokens"] == 11
+        assert usage["output_tokens"] == 5
+
+    def test_streamed_responses_tokens_come_from_completed_event_without_mutation(self, upstream):
+        frames = RESPONSES_SSE_FRAMES[:2] + [
+            b'event: response.completed\ndata: {"type":"response.completed","response":{"id":"resp_1",'
+            b'"usage":{"input_tokens":9,"output_tokens":4}}}\n\n',
+        ]
+        upstream.responder = lambda request: SSEScript(frames=[(0.0, f) for f in frames])
+        app = _make_app(_proxy_config(upstream, llm_backend="responses-api"))
+        with TestClient(app) as client:
+            with client.websocket_connect("/v1/realtime") as ws:
+                session_id = ws.receive_json()["session"]["id"]
+                with client.stream(
+                    "POST",
+                    "/v1/responses",
+                    json={**RESPONSES_BODY, "stream": True},
+                    headers={"Authorization": f"Bearer {session_id}"},
+                ) as r:
+                    received = b"".join(r.iter_raw())
+                usage = client.get("/v1/usage").json()["llm_proxy"]
+        (request,) = upstream.requests
+        assert "stream_options" not in request["body"]  # no request mutation on Responses
+        assert received == b"".join(frames)
+        assert usage["input_tokens"] == 9
+        assert usage["output_tokens"] == 4
+
+    def test_tokens_counted_from_crlf_delimited_sse(self, upstream):
+        # The SSE spec allows CRLF event delimiters; accounting must not
+        # depend on LF-only upstreams (the bytes pass through verbatim
+        # either way).
+        frames = [
+            b'data: {"id":"chatcmpl-1","choices":[{"delta":{"content":"Hi"}}]}\r\n\r\n',
+            b'data: {"id":"chatcmpl-1","choices":[],"usage":{"prompt_tokens":6,"completion_tokens":2}}\r\n\r\n',
+            b"data: [DONE]\r\n\r\n",
+        ]
+        upstream.responder = lambda request: SSEScript(frames=[(0.0, f) for f in frames])
+        app = _make_app(_proxy_config(upstream))
+        with TestClient(app) as client:
+            with client.websocket_connect("/v1/realtime") as ws:
+                session_id = ws.receive_json()["session"]["id"]
+                with client.stream(
+                    "POST",
+                    "/v1/chat/completions",
+                    json=STREAM_BODY,
+                    headers={"Authorization": f"Bearer {session_id}"},
+                ) as r:
+                    received = b"".join(r.iter_raw())
+                usage = client.get("/v1/usage").json()["llm_proxy"]
+        assert received == b"".join(frames)
+        assert usage["input_tokens"] == 6
+        assert usage["output_tokens"] == 2
+
+    def test_non_streaming_responses_tokens_come_from_body(self, upstream):
+        upstream.responder = lambda request: (
+            200,
+            {"id": "resp_1", "output": [], "usage": {"input_tokens": 21, "output_tokens": 8}},
+        )
+        app = _make_app(_proxy_config(upstream, llm_backend="responses-api"))
+        with TestClient(app) as client:
+            with client.websocket_connect("/v1/realtime") as ws:
+                session_id = ws.receive_json()["session"]["id"]
+                assert self._post(client, session_id, RESPONSES_BODY, "/v1/responses").status_code == 200
+                usage = client.get("/v1/usage").json()["llm_proxy"]
+        assert usage["input_tokens"] == 21
+        assert usage["output_tokens"] == 8
+
+    def test_existing_usage_shape_keeps_its_keys(self, upstream):
+        app = _make_app(_proxy_config(upstream))
+        with TestClient(app) as client:
+            with client.websocket_connect("/v1/realtime") as ws:
+                ws.receive_json()
+                data = client.get("/v1/usage").json()
+        # Pre-existing aggregate keys survive next to the additive section.
+        assert "connections" in data
+        assert "llm_proxy" in data
+
+
 class TestUpstreamErrorPassthrough:
     @pytest.mark.parametrize("status", [400, 429, 500, 503])
     def test_upstream_errors_pass_through_verbatim(self, upstream, status):

--- a/tests/openai_realtime/test_llm_proxy.py
+++ b/tests/openai_realtime/test_llm_proxy.py
@@ -1,0 +1,255 @@
+"""Integration tests for the session-gated LLM proxy.
+
+Drives the full FastAPI app produced by ``create_app`` through its public
+HTTP surface (Starlette TestClient), exactly like the websocket lifecycle
+tests. The upstream provider is a real local HTTP server on an ephemeral
+port that the proxy reaches through its configured base URL — no injection
+hooks in production code.
+"""
+
+import json
+import threading
+from http.server import BaseHTTPRequestHandler, ThreadingHTTPServer
+from queue import Queue
+from threading import Event as ThreadingEvent
+from typing import Any
+
+import pytest
+from starlette.testclient import TestClient
+
+from speech_to_speech.api.openai_realtime.llm_proxy import LLMProxyConfig
+from speech_to_speech.api.openai_realtime.pipeline_unit import PipelineUnit
+from speech_to_speech.api.openai_realtime.service import RealtimeService
+from speech_to_speech.api.openai_realtime.websocket_router import create_app
+from speech_to_speech.pipeline.cancel_scope import CancelScope
+
+# ---------------------------------------------------------------------------
+# Fake upstream provider
+# ---------------------------------------------------------------------------
+
+
+class FakeUpstream:
+    """A real OpenAI-shaped HTTP server on an ephemeral port.
+
+    Records every request (path, headers, parsed JSON body) and answers with
+    whatever ``responder`` returns: ``(status_code, json_payload)``.
+    """
+
+    def __init__(self):
+        self.requests: list[dict[str, Any]] = []
+        self.responder = lambda request: (
+            200,
+            {"id": "chatcmpl-1", "object": "chat.completion", "choices": []},
+        )
+
+        upstream = self
+
+        class Handler(BaseHTTPRequestHandler):
+            def do_POST(self) -> None:
+                length = int(self.headers.get("Content-Length", 0))
+                raw = self.rfile.read(length)
+                request = {
+                    "path": self.path,
+                    "headers": dict(self.headers),
+                    "body": json.loads(raw) if raw else None,
+                }
+                upstream.requests.append(request)
+                status, payload = upstream.responder(request)
+                body = json.dumps(payload).encode()
+                self.send_response(status)
+                self.send_header("Content-Type", "application/json")
+                self.send_header("Content-Length", str(len(body)))
+                self.end_headers()
+                self.wfile.write(body)
+
+            def log_message(self, format: str, *args: Any) -> None:
+                pass
+
+        self._server = ThreadingHTTPServer(("127.0.0.1", 0), Handler)
+        self._thread = threading.Thread(target=self._server.serve_forever, daemon=True)
+        self._thread.start()
+
+    @property
+    def base_url(self) -> str:
+        return f"http://127.0.0.1:{self._server.server_address[1]}/v1"
+
+    def close(self) -> None:
+        self._server.shutdown()
+        self._server.server_close()
+
+
+@pytest.fixture
+def upstream():
+    server = FakeUpstream()
+    yield server
+    server.close()
+
+
+# ---------------------------------------------------------------------------
+# App fixtures
+# ---------------------------------------------------------------------------
+
+
+def _make_unit(index: int = 0) -> PipelineUnit:
+    text_prompt_queue: Queue = Queue()
+    should_listen = ThreadingEvent()
+    should_listen.set()
+    return PipelineUnit(
+        index=index,
+        service=RealtimeService(text_prompt_queue=text_prompt_queue, should_listen=should_listen),
+        cancel_scope=CancelScope(),
+        should_listen=should_listen,
+        response_playing=ThreadingEvent(),
+        input_queue=Queue(),
+        output_queue=Queue(),
+        text_output_queue=Queue(),
+        text_prompt_queue=text_prompt_queue,
+        handlers=[],
+    )
+
+
+def _make_app(config: LLMProxyConfig | None):
+    return create_app(pool=[_make_unit()], stop_event=ThreadingEvent(), llm_proxy_config=config)
+
+
+def _proxy_config(upstream: FakeUpstream, **overrides: Any) -> LLMProxyConfig:
+    defaults: dict[str, Any] = dict(
+        enabled=True,
+        llm_backend="chat-completions",
+        upstream_base_url=upstream.base_url,
+        upstream_api_key="sk-server-secret",
+        model_name="server-model",
+    )
+    defaults.update(overrides)
+    return LLMProxyConfig(**defaults)
+
+
+CHAT_BODY = {
+    "model": "client-model",
+    "messages": [{"role": "user", "content": "hello"}],
+}
+
+
+# ---------------------------------------------------------------------------
+# Chat completions passthrough (non-streaming)
+# ---------------------------------------------------------------------------
+
+
+class TestChatCompletionsPassthrough:
+    def test_valid_session_gets_upstream_response_verbatim(self, upstream):
+        app = _make_app(_proxy_config(upstream))
+        with TestClient(app) as client:
+            with client.websocket_connect("/v1/realtime") as ws:
+                session_id = ws.receive_json()["session"]["id"]
+                r = client.post(
+                    "/v1/chat/completions",
+                    json=CHAT_BODY,
+                    headers={"Authorization": f"Bearer {session_id}"},
+                )
+        assert r.status_code == 200
+        assert r.json() == {"id": "chatcmpl-1", "object": "chat.completion", "choices": []}
+
+    def test_upstream_receives_forced_model_and_server_key(self, upstream):
+        app = _make_app(_proxy_config(upstream))
+        with TestClient(app) as client:
+            with client.websocket_connect("/v1/realtime") as ws:
+                session_id = ws.receive_json()["session"]["id"]
+                client.post(
+                    "/v1/chat/completions",
+                    json=CHAT_BODY,
+                    headers={"Authorization": f"Bearer {session_id}"},
+                )
+        (request,) = upstream.requests
+        assert request["path"] == "/v1/chat/completions"
+        assert request["body"]["model"] == "server-model"
+        assert request["body"]["messages"] == CHAT_BODY["messages"]
+        assert request["headers"]["Authorization"] == "Bearer sk-server-secret"
+        assert session_id not in json.dumps(request["headers"])
+
+
+class TestAuthentication:
+    def test_missing_bearer_is_401(self, upstream):
+        app = _make_app(_proxy_config(upstream))
+        with TestClient(app) as client:
+            r = client.post("/v1/chat/completions", json=CHAT_BODY)
+        assert r.status_code == 401
+        assert "error" in r.json()
+        assert upstream.requests == []
+
+    def test_unknown_session_id_is_401(self, upstream):
+        app = _make_app(_proxy_config(upstream))
+        with TestClient(app) as client:
+            with client.websocket_connect("/v1/realtime") as ws:
+                ws.receive_json()
+                r = client.post(
+                    "/v1/chat/completions",
+                    json=CHAT_BODY,
+                    headers={"Authorization": "Bearer sess_deadbeef"},
+                )
+        assert r.status_code == 401
+        assert upstream.requests == []
+
+    def test_closed_session_is_401(self, upstream):
+        app = _make_app(_proxy_config(upstream))
+        with TestClient(app) as client:
+            with client.websocket_connect("/v1/realtime") as ws:
+                session_id = ws.receive_json()["session"]["id"]
+            r = client.post(
+                "/v1/chat/completions",
+                json=CHAT_BODY,
+                headers={"Authorization": f"Bearer {session_id}"},
+            )
+        assert r.status_code == 401
+        assert upstream.requests == []
+
+
+class TestUnavailableContract:
+    def _post_with_session(self, app, path: str):
+        with TestClient(app) as client:
+            with client.websocket_connect("/v1/realtime") as ws:
+                session_id = ws.receive_json()["session"]["id"]
+                return client.post(path, json=CHAT_BODY, headers={"Authorization": f"Bearer {session_id}"})
+
+    def test_flag_off_is_501(self, upstream):
+        app = _make_app(_proxy_config(upstream, enabled=False))
+        r = self._post_with_session(app, "/v1/chat/completions")
+        assert r.status_code == 501
+        assert "disabled" in r.json()["error"]["message"]
+
+    def test_no_config_defaults_to_disabled(self):
+        app = create_app(pool=[_make_unit()], stop_event=ThreadingEvent())
+        with TestClient(app) as client:
+            r = client.post("/v1/chat/completions", json=CHAT_BODY)
+        assert r.status_code == 501
+
+    @pytest.mark.parametrize("backend", ["transformers", "mlx-lm"])
+    def test_local_backend_is_501_naming_remote_backends(self, upstream, backend):
+        app = _make_app(_proxy_config(upstream, llm_backend=backend))
+        r = self._post_with_session(app, "/v1/chat/completions")
+        assert r.status_code == 501
+        message = r.json()["error"]["message"]
+        assert "chat-completions" in message
+        assert "responses-api" in message
+
+    def test_responses_path_is_501_under_chat_completions_backend(self, upstream):
+        app = _make_app(_proxy_config(upstream))
+        r = self._post_with_session(app, "/v1/responses")
+        assert r.status_code == 501
+        assert "/v1/chat/completions" in r.json()["error"]["message"]
+
+
+class TestUpstreamErrorPassthrough:
+    @pytest.mark.parametrize("status", [400, 429, 500, 503])
+    def test_upstream_errors_pass_through_verbatim(self, upstream, status):
+        upstream.responder = lambda request: (status, {"error": {"message": "upstream says no", "type": "boom"}})
+        app = _make_app(_proxy_config(upstream))
+        with TestClient(app) as client:
+            with client.websocket_connect("/v1/realtime") as ws:
+                session_id = ws.receive_json()["session"]["id"]
+                r = client.post(
+                    "/v1/chat/completions",
+                    json=CHAT_BODY,
+                    headers={"Authorization": f"Bearer {session_id}"},
+                )
+        assert r.status_code == status
+        assert r.json() == {"error": {"message": "upstream says no", "type": "boom"}}

--- a/tests/openai_realtime/test_llm_proxy.py
+++ b/tests/openai_realtime/test_llm_proxy.py
@@ -491,6 +491,37 @@ class TestUsageSection:
         assert "llm_proxy" in data
 
 
+class TestProxyConfigFollowsBackendSettings:
+    def test_config_reads_the_renamed_connection_fields(self):
+        # Regression: main() runs prepare_all_args() before the proxy config
+        # is built, and rename_args() pops responses_api_base_url/api_key
+        # into base_url/api_key. Reading the raw names afterwards silently
+        # returned the dataclass class defaults (None), so the proxy hit the
+        # OpenAI default upstream with no key regardless of the flags while
+        # the pipeline LM used the configured provider.
+        from speech_to_speech.arguments_classes.module_arguments import ModuleArguments
+        from speech_to_speech.arguments_classes.responses_api_language_model_arguments import (
+            ResponsesApiLanguageModelHandlerArguments,
+        )
+        from speech_to_speech.s2s_pipeline import build_llm_proxy_config, rename_args
+
+        module_kwargs = ModuleArguments(enable_llm_proxy=True, llm_backend="chat-completions")
+        lm_kwargs = ResponsesApiLanguageModelHandlerArguments(
+            model_name="google/gemma-test",
+            responses_api_base_url="https://router.huggingface.co/v1",
+            responses_api_api_key="hf_secret",
+        )
+        rename_args(lm_kwargs, "responses_api")  # what prepare_all_args() does before the config is built
+
+        config = build_llm_proxy_config(module_kwargs, lm_kwargs)
+
+        assert config.enabled is True
+        assert config.llm_backend == "chat-completions"
+        assert config.upstream_base_url == "https://router.huggingface.co/v1"
+        assert config.upstream_api_key == "hf_secret"
+        assert config.model_name == "google/gemma-test"
+
+
 class TestUpstreamErrorPassthrough:
     @pytest.mark.parametrize("status", [400, 429, 500, 503])
     def test_upstream_errors_pass_through_verbatim(self, upstream, status):

--- a/tests/openai_realtime/test_llm_proxy.py
+++ b/tests/openai_realtime/test_llm_proxy.py
@@ -212,6 +212,33 @@ class TestChatCompletionsPassthrough:
         assert request["body"]["messages"] == CHAT_BODY["messages"]
         assert request["headers"]["Authorization"] == "Bearer sk-server-secret"
 
+    @pytest.mark.parametrize("raw_body", [b"[1, 2]", b'"a string"', b"42", b"null", b"true"])
+    def test_valid_json_that_is_not_an_object_is_400(self, upstream, raw_body):
+        # request.json() accepts any JSON value; only objects can carry the
+        # forced fields, and the contract allows 400, never 500.
+        app = _make_app(_proxy_config(upstream))
+        with TestClient(app) as client:
+            r = client.post(
+                "/v1/chat/completions",
+                content=raw_body,
+                headers={"Content-Type": "application/json"},
+            )
+        assert r.status_code == 400
+        assert r.json()["error"]["type"] == "invalid_request_error"
+        assert upstream.requests == []
+
+    def test_non_dict_stream_options_passes_through_for_upstream_to_reject(self, upstream):
+        upstream.responder = lambda request: (400, {"error": {"message": "bad stream_options", "type": "invalid_request_error"}})
+        app = _make_app(_proxy_config(upstream))
+        with TestClient(app) as client:
+            r = client.post(
+                "/v1/chat/completions",
+                json={**STREAM_BODY, "stream_options": [1, 2]},
+            )
+        assert r.status_code == 400  # upstream's answer, not a crash
+        (request,) = upstream.requests
+        assert request["body"]["stream_options"] == [1, 2]  # untouched
+
     def test_client_bearer_is_ignored_and_never_forwarded(self, upstream):
         # The server does no authentication: whatever api_key the SDK sends
         # is accepted and replaced by the server-held upstream key.

--- a/tests/openai_realtime/test_llm_proxy.py
+++ b/tests/openai_realtime/test_llm_proxy.py
@@ -1,4 +1,4 @@
-"""Integration tests for the session-gated LLM proxy.
+"""Integration tests for the LLM proxy.
 
 Drives the full FastAPI app produced by ``create_app`` through its public
 HTTP surface (Starlette TestClient), exactly like the websocket lifecycle
@@ -20,7 +20,6 @@ import pytest
 import uvicorn
 from pydantic import BaseModel
 from starlette.testclient import TestClient
-from websockets.sync.client import connect as ws_connect
 
 from speech_to_speech.api.openai_realtime.llm_proxy import LLMProxyConfig
 from speech_to_speech.api.openai_realtime.pipeline_unit import PipelineUnit
@@ -160,9 +159,8 @@ def _make_unit(index: int = 0) -> PipelineUnit:
     )
 
 
-def _make_app(config: LLMProxyConfig | None, pool_size: int = 1):
-    pool = [_make_unit(i) for i in range(pool_size)]
-    return create_app(pool=pool, stop_event=ThreadingEvent(), llm_proxy_config=config)
+def _make_app(config: LLMProxyConfig | None):
+    return create_app(pool=[_make_unit()], stop_event=ThreadingEvent(), llm_proxy_config=config)
 
 
 def _proxy_config(upstream: FakeUpstream, **overrides: Any) -> LLMProxyConfig:
@@ -189,83 +187,47 @@ CHAT_BODY = {
 
 
 class TestChatCompletionsPassthrough:
-    def test_valid_session_gets_upstream_response_verbatim(self, upstream):
+    def test_upstream_response_arrives_verbatim(self, upstream):
         app = _make_app(_proxy_config(upstream))
         with TestClient(app) as client:
-            with client.websocket_connect("/v1/realtime") as ws:
-                session_id = ws.receive_json()["session"]["id"]
-                r = client.post(
-                    "/v1/chat/completions",
-                    json=CHAT_BODY,
-                    headers={"Authorization": f"Bearer {session_id}"},
-                )
+            r = client.post("/v1/chat/completions", json=CHAT_BODY)
         assert r.status_code == 200
         assert r.json() == {"id": "chatcmpl-1", "object": "chat.completion", "choices": []}
 
     def test_upstream_receives_forced_model_and_server_key(self, upstream):
         app = _make_app(_proxy_config(upstream))
         with TestClient(app) as client:
-            with client.websocket_connect("/v1/realtime") as ws:
-                session_id = ws.receive_json()["session"]["id"]
-                client.post(
-                    "/v1/chat/completions",
-                    json=CHAT_BODY,
-                    headers={"Authorization": f"Bearer {session_id}"},
-                )
+            client.post("/v1/chat/completions", json=CHAT_BODY)
         (request,) = upstream.requests
         assert request["path"] == "/v1/chat/completions"
         assert request["body"]["model"] == "server-model"
         assert request["body"]["messages"] == CHAT_BODY["messages"]
         assert request["headers"]["Authorization"] == "Bearer sk-server-secret"
-        assert session_id not in json.dumps(request["headers"])
 
-
-class TestAuthentication:
-    def test_missing_bearer_is_401(self, upstream):
+    def test_client_bearer_is_ignored_and_never_forwarded(self, upstream):
+        # The server does no authentication: whatever api_key the SDK sends
+        # is accepted and replaced by the server-held upstream key.
         app = _make_app(_proxy_config(upstream))
         with TestClient(app) as client:
-            r = client.post("/v1/chat/completions", json=CHAT_BODY)
-        assert r.status_code == 401
-        assert "error" in r.json()
-        assert upstream.requests == []
-
-    def test_unknown_session_id_is_401(self, upstream):
-        app = _make_app(_proxy_config(upstream))
-        with TestClient(app) as client:
-            with client.websocket_connect("/v1/realtime") as ws:
-                ws.receive_json()
-                r = client.post(
-                    "/v1/chat/completions",
-                    json=CHAT_BODY,
-                    headers={"Authorization": "Bearer sess_deadbeef"},
-                )
-        assert r.status_code == 401
-        assert upstream.requests == []
-
-    def test_closed_session_is_401(self, upstream):
-        app = _make_app(_proxy_config(upstream))
-        with TestClient(app) as client:
-            with client.websocket_connect("/v1/realtime") as ws:
-                session_id = ws.receive_json()["session"]["id"]
             r = client.post(
                 "/v1/chat/completions",
                 json=CHAT_BODY,
-                headers={"Authorization": f"Bearer {session_id}"},
+                headers={"Authorization": "Bearer client-credential"},
             )
-        assert r.status_code == 401
-        assert upstream.requests == []
+        assert r.status_code == 200
+        (request,) = upstream.requests
+        assert request["headers"]["Authorization"] == "Bearer sk-server-secret"
+        assert "client-credential" not in json.dumps(request["headers"])
 
 
 class TestUnavailableContract:
-    def _post_with_session(self, app, path: str):
+    def _post(self, app, path: str):
         with TestClient(app) as client:
-            with client.websocket_connect("/v1/realtime") as ws:
-                session_id = ws.receive_json()["session"]["id"]
-                return client.post(path, json=CHAT_BODY, headers={"Authorization": f"Bearer {session_id}"})
+            return client.post(path, json=CHAT_BODY)
 
     def test_flag_off_is_501(self, upstream):
         app = _make_app(_proxy_config(upstream, enabled=False))
-        r = self._post_with_session(app, "/v1/chat/completions")
+        r = self._post(app, "/v1/chat/completions")
         assert r.status_code == 501
         assert "disabled" in r.json()["error"]["message"]
 
@@ -278,7 +240,7 @@ class TestUnavailableContract:
     @pytest.mark.parametrize("backend", ["transformers", "mlx-lm"])
     def test_local_backend_is_501_naming_remote_backends(self, upstream, backend):
         app = _make_app(_proxy_config(upstream, llm_backend=backend))
-        r = self._post_with_session(app, "/v1/chat/completions")
+        r = self._post(app, "/v1/chat/completions")
         assert r.status_code == 501
         message = r.json()["error"]["message"]
         assert "chat-completions" in message
@@ -286,7 +248,7 @@ class TestUnavailableContract:
 
     def test_responses_path_is_501_under_chat_completions_backend(self, upstream):
         app = _make_app(_proxy_config(upstream))
-        r = self._post_with_session(app, "/v1/responses")
+        r = self._post(app, "/v1/responses")
         assert r.status_code == 501
         assert "/v1/chat/completions" in r.json()["error"]["message"]
 
@@ -305,16 +267,9 @@ class TestStreamingPassthrough:
         upstream.responder = lambda request: SSEScript(frames=[(0.0, f) for f in SSE_FRAMES])
         app = _make_app(_proxy_config(upstream))
         with TestClient(app) as client:
-            with client.websocket_connect("/v1/realtime") as ws:
-                session_id = ws.receive_json()["session"]["id"]
-                with client.stream(
-                    "POST",
-                    "/v1/chat/completions",
-                    json=STREAM_BODY,
-                    headers={"Authorization": f"Bearer {session_id}"},
-                ) as r:
-                    assert r.status_code == 200
-                    received = b"".join(r.iter_raw())
+            with client.stream("POST", "/v1/chat/completions", json=STREAM_BODY) as r:
+                assert r.status_code == 200
+                received = b"".join(r.iter_raw())
         assert received == b"".join(SSE_FRAMES)
 
     def test_frames_forward_as_they_arrive_not_buffered(self, upstream):
@@ -325,42 +280,17 @@ class TestStreamingPassthrough:
             frames=[(0.0, SSE_FRAMES[0]), (delay, SSE_FRAMES[1]), (0.0, SSE_FRAMES[2])]
         )
         with LiveApp(_make_app(_proxy_config(upstream))) as live:
-            with ws_connect(f"ws://127.0.0.1:{live.port}/v1/realtime") as ws:
-                session_id = json.loads(ws.recv())["session"]["id"]
-                arrivals: list[float] = []
-                with httpx.stream(
-                    "POST",
-                    f"http://127.0.0.1:{live.port}/v1/chat/completions",
-                    json=STREAM_BODY,
-                    headers={"Authorization": f"Bearer {session_id}"},
-                ) as r:
-                    for _ in r.iter_raw():
-                        arrivals.append(time.monotonic())
+            arrivals: list[float] = []
+            with httpx.stream(
+                "POST",
+                f"http://127.0.0.1:{live.port}/v1/chat/completions",
+                json=STREAM_BODY,
+            ) as r:
+                for _ in r.iter_raw():
+                    arrivals.append(time.monotonic())
         # If the proxy buffered the whole upstream response, every chunk
         # would land at once and the spread would be ~0.
         assert arrivals[-1] - arrivals[0] >= delay * 0.5
-
-    def test_in_flight_stream_survives_session_close(self, upstream):
-        upstream.responder = lambda request: SSEScript(
-            frames=[(0.0, SSE_FRAMES[0]), (0.5, SSE_FRAMES[1]), (0.0, SSE_FRAMES[2])]
-        )
-        with LiveApp(_make_app(_proxy_config(upstream))) as live:
-            with httpx.Client() as client:
-                ws = ws_connect(f"ws://127.0.0.1:{live.port}/v1/realtime")
-                session_id = json.loads(ws.recv())["session"]["id"]
-                with client.stream(
-                    "POST",
-                    f"http://127.0.0.1:{live.port}/v1/chat/completions",
-                    json=STREAM_BODY,
-                    headers={"Authorization": f"Bearer {session_id}"},
-                ) as r:
-                    iterator = r.iter_raw()
-                    first = next(iterator)
-                    assert first  # request authorized and streaming
-                    # Close the session mid-stream; delivery must continue.
-                    ws.close()
-                    rest = b"".join(iterator)
-        assert (first + rest) == b"".join(SSE_FRAMES)
 
     def test_unreachable_upstream_fails_cleanly_within_connect_timeout(self):
         config = LLMProxyConfig(
@@ -373,15 +303,9 @@ class TestStreamingPassthrough:
         )
         app = _make_app(config)
         with TestClient(app) as client:
-            with client.websocket_connect("/v1/realtime") as ws:
-                session_id = ws.receive_json()["session"]["id"]
-                start = time.monotonic()
-                r = client.post(
-                    "/v1/chat/completions",
-                    json=STREAM_BODY,
-                    headers={"Authorization": f"Bearer {session_id}"},
-                )
-                elapsed = time.monotonic() - start
+            start = time.monotonic()
+            r = client.post("/v1/chat/completions", json=STREAM_BODY)
+            elapsed = time.monotonic() - start
         assert r.status_code == 502
         assert "error" in r.json()
         assert elapsed < 3
@@ -390,13 +314,7 @@ class TestStreamingPassthrough:
         upstream.responder = lambda request: (429, {"error": {"message": "quota", "type": "rate_limit"}})
         app = _make_app(_proxy_config(upstream))
         with TestClient(app) as client:
-            with client.websocket_connect("/v1/realtime") as ws:
-                session_id = ws.receive_json()["session"]["id"]
-                r = client.post(
-                    "/v1/chat/completions",
-                    json=STREAM_BODY,
-                    headers={"Authorization": f"Bearer {session_id}"},
-                )
+            r = client.post("/v1/chat/completions", json=STREAM_BODY)
         assert r.status_code == 429
         assert r.json() == {"error": {"message": "quota", "type": "rate_limit"}}
 
@@ -422,26 +340,14 @@ class TestResponsesPassthrough:
         upstream.responder = lambda request: (200, {"id": "resp_1", "object": "response", "output": []})
         app = _make_app(self._config(upstream))
         with TestClient(app) as client:
-            with client.websocket_connect("/v1/realtime") as ws:
-                session_id = ws.receive_json()["session"]["id"]
-                r = client.post(
-                    "/v1/responses",
-                    json=RESPONSES_BODY,
-                    headers={"Authorization": f"Bearer {session_id}"},
-                )
+            r = client.post("/v1/responses", json=RESPONSES_BODY)
         assert r.status_code == 200
         assert r.json() == {"id": "resp_1", "object": "response", "output": []}
 
     def test_upstream_receives_store_false_and_forced_model(self, upstream):
         app = _make_app(self._config(upstream))
         with TestClient(app) as client:
-            with client.websocket_connect("/v1/realtime") as ws:
-                session_id = ws.receive_json()["session"]["id"]
-                client.post(
-                    "/v1/responses",
-                    json=RESPONSES_BODY,
-                    headers={"Authorization": f"Bearer {session_id}"},
-                )
+            client.post("/v1/responses", json=RESPONSES_BODY)
         (request,) = upstream.requests
         assert request["path"] == "/v1/responses"
         assert request["body"]["store"] is False
@@ -452,16 +358,9 @@ class TestResponsesPassthrough:
         upstream.responder = lambda request: SSEScript(frames=[(0.0, f) for f in RESPONSES_SSE_FRAMES])
         app = _make_app(self._config(upstream))
         with TestClient(app) as client:
-            with client.websocket_connect("/v1/realtime") as ws:
-                session_id = ws.receive_json()["session"]["id"]
-                with client.stream(
-                    "POST",
-                    "/v1/responses",
-                    json={**RESPONSES_BODY, "stream": True},
-                    headers={"Authorization": f"Bearer {session_id}"},
-                ) as r:
-                    assert r.status_code == 200
-                    received = b"".join(r.iter_raw())
+            with client.stream("POST", "/v1/responses", json={**RESPONSES_BODY, "stream": True}) as r:
+                assert r.status_code == 200
+                received = b"".join(r.iter_raw())
         assert received == b"".join(RESPONSES_SSE_FRAMES)
         (request,) = upstream.requests
         assert request["body"]["store"] is False
@@ -469,35 +368,9 @@ class TestResponsesPassthrough:
     def test_chat_completions_path_is_501_under_responses_backend(self, upstream):
         app = _make_app(self._config(upstream))
         with TestClient(app) as client:
-            with client.websocket_connect("/v1/realtime") as ws:
-                session_id = ws.receive_json()["session"]["id"]
-                r = client.post(
-                    "/v1/chat/completions",
-                    json=CHAT_BODY,
-                    headers={"Authorization": f"Bearer {session_id}"},
-                )
+            r = client.post("/v1/chat/completions", json=CHAT_BODY)
         assert r.status_code == 501
         assert "/v1/responses" in r.json()["error"]["message"]
-
-    def test_missing_bearer_is_401_on_responses_path(self, upstream):
-        app = _make_app(self._config(upstream))
-        with TestClient(app) as client:
-            r = client.post("/v1/responses", json=RESPONSES_BODY)
-        assert r.status_code == 401
-        assert upstream.requests == []
-
-    def test_unknown_session_is_401_on_responses_path(self, upstream):
-        app = _make_app(self._config(upstream))
-        with TestClient(app) as client:
-            with client.websocket_connect("/v1/realtime") as ws:
-                ws.receive_json()
-                r = client.post(
-                    "/v1/responses",
-                    json=RESPONSES_BODY,
-                    headers={"Authorization": "Bearer sess_deadbeef"},
-                )
-        assert r.status_code == 401
-        assert upstream.requests == []
 
     @pytest.mark.parametrize("backend", ["transformers", "mlx-lm"])
     def test_flag_off_and_local_backend_are_501_on_responses_path(self, upstream, backend):
@@ -511,80 +384,9 @@ class TestResponsesPassthrough:
             assert r.status_code == 501
 
 
-class TestRateLimit:
-    def _post(self, client, session_id):
-        return client.post(
-            "/v1/chat/completions",
-            json=CHAT_BODY,
-            headers={"Authorization": f"Bearer {session_id}"},
-        )
-
-    def test_default_ceiling_is_20_per_minute_and_other_sessions_unaffected(self, upstream):
-        app = _make_app(_proxy_config(upstream), pool_size=2)
-        with TestClient(app) as client:
-            with client.websocket_connect("/v1/realtime") as ws1:
-                session_1 = ws1.receive_json()["session"]["id"]
-                with client.websocket_connect("/v1/realtime") as ws2:
-                    session_2 = ws2.receive_json()["session"]["id"]
-                    for _ in range(20):
-                        assert self._post(client, session_1).status_code == 200
-                    r = self._post(client, session_1)
-                    assert r.status_code == 429
-                    assert "error" in r.json()
-                    # The other session still has its own budget.
-                    assert self._post(client, session_2).status_code == 200
-        # The 21st request never reached the upstream.
-        assert len(upstream.requests) == 21
-
-    def test_ceiling_is_configurable(self, upstream):
-        app = _make_app(_proxy_config(upstream, rate_limit_rpm=2))
-        with TestClient(app) as client:
-            with client.websocket_connect("/v1/realtime") as ws:
-                session_id = ws.receive_json()["session"]["id"]
-                assert self._post(client, session_id).status_code == 200
-                assert self._post(client, session_id).status_code == 200
-                assert self._post(client, session_id).status_code == 429
-
-    def test_window_slides_and_recovers(self, upstream, monkeypatch):
-        import speech_to_speech.api.openai_realtime.llm_proxy as llm_proxy_module
-
-        clock = {"now": 1000.0}
-        monkeypatch.setattr(llm_proxy_module, "_now", lambda: clock["now"])
-        app = _make_app(_proxy_config(upstream, rate_limit_rpm=2))
-        with TestClient(app) as client:
-            with client.websocket_connect("/v1/realtime") as ws:
-                session_id = ws.receive_json()["session"]["id"]
-                assert self._post(client, session_id).status_code == 200
-                clock["now"] += 30.0
-                assert self._post(client, session_id).status_code == 200
-                assert self._post(client, session_id).status_code == 429
-                # 61s after the first hit, one slot has slid out of the window.
-                clock["now"] += 31.0
-                assert self._post(client, session_id).status_code == 200
-                assert self._post(client, session_id).status_code == 429
-
-    def test_unknown_bearer_is_401_and_consumes_no_budget(self, upstream):
-        app = _make_app(_proxy_config(upstream, rate_limit_rpm=1))
-        with TestClient(app) as client:
-            with client.websocket_connect("/v1/realtime") as ws:
-                session_id = ws.receive_json()["session"]["id"]
-                for _ in range(3):
-                    r = client.post(
-                        "/v1/chat/completions",
-                        json=CHAT_BODY,
-                        headers={"Authorization": "Bearer sess_unknown"},
-                    )
-                    assert r.status_code == 401
-                assert self._post(client, session_id).status_code == 200
-
-
 class TestUsageSection:
-    def _post(self, client, session_id, body=None, path="/v1/chat/completions"):
-        return client.post(
-            path,
-            json=body or CHAT_BODY,
-            headers={"Authorization": f"Bearer {session_id}"},
-        )
+    def _post(self, client, body=None, path="/v1/chat/completions"):
+        return client.post(path, json=body or CHAT_BODY)
 
     def test_counters_after_mixed_traffic(self, upstream):
         answers = iter(
@@ -592,19 +394,19 @@ class TestUsageSection:
                 (200, {"choices": [], "usage": {"prompt_tokens": 7, "completion_tokens": 3}}),
                 (200, {"choices": [], "usage": {"prompt_tokens": 7, "completion_tokens": 3}}),
                 (500, {"error": {"message": "boom", "type": "server_error"}}),
+                (429, {"error": {"message": "quota", "type": "rate_limit"}}),
+                (400, {"error": {"message": "bad", "type": "invalid_request_error"}}),
             ]
         )
         upstream.responder = lambda request: next(answers)
-        app = _make_app(_proxy_config(upstream, rate_limit_rpm=3))
+        app = _make_app(_proxy_config(upstream))
         with TestClient(app) as client:
-            with client.websocket_connect("/v1/realtime") as ws:
-                session_id = ws.receive_json()["session"]["id"]
-                assert self._post(client, session_id).status_code == 200
-                assert self._post(client, session_id).status_code == 200
-                assert self._post(client, session_id).status_code == 500
-                assert self._post(client, session_id).status_code == 429
-                assert self._post(client, "sess_unknown").status_code == 401
-                usage = client.get("/v1/usage").json()["llm_proxy"]
+            assert self._post(client).status_code == 200
+            assert self._post(client).status_code == 200
+            assert self._post(client).status_code == 500
+            assert self._post(client).status_code == 429
+            assert self._post(client).status_code == 400
+            usage = client.get("/v1/usage").json()["llm_proxy"]
         assert usage["requests"] == 5
         assert usage["responses_2xx"] == 2
         assert usage["responses_5xx"] == 1
@@ -621,16 +423,9 @@ class TestUsageSection:
         upstream.responder = lambda request: SSEScript(frames=[(0.0, f) for f in frames])
         app = _make_app(_proxy_config(upstream))
         with TestClient(app) as client:
-            with client.websocket_connect("/v1/realtime") as ws:
-                session_id = ws.receive_json()["session"]["id"]
-                with client.stream(
-                    "POST",
-                    "/v1/chat/completions",
-                    json=STREAM_BODY,
-                    headers={"Authorization": f"Bearer {session_id}"},
-                ) as r:
-                    received = b"".join(r.iter_raw())
-                usage = client.get("/v1/usage").json()["llm_proxy"]
+            with client.stream("POST", "/v1/chat/completions", json=STREAM_BODY) as r:
+                received = b"".join(r.iter_raw())
+            usage = client.get("/v1/usage").json()["llm_proxy"]
         # The client did not ask for usage, the server injected it upstream,
         # and the byte stream still arrives verbatim including the usage frame.
         (request,) = upstream.requests
@@ -647,16 +442,9 @@ class TestUsageSection:
         upstream.responder = lambda request: SSEScript(frames=[(0.0, f) for f in frames])
         app = _make_app(_proxy_config(upstream, llm_backend="responses-api"))
         with TestClient(app) as client:
-            with client.websocket_connect("/v1/realtime") as ws:
-                session_id = ws.receive_json()["session"]["id"]
-                with client.stream(
-                    "POST",
-                    "/v1/responses",
-                    json={**RESPONSES_BODY, "stream": True},
-                    headers={"Authorization": f"Bearer {session_id}"},
-                ) as r:
-                    received = b"".join(r.iter_raw())
-                usage = client.get("/v1/usage").json()["llm_proxy"]
+            with client.stream("POST", "/v1/responses", json={**RESPONSES_BODY, "stream": True}) as r:
+                received = b"".join(r.iter_raw())
+            usage = client.get("/v1/usage").json()["llm_proxy"]
         (request,) = upstream.requests
         assert "stream_options" not in request["body"]  # no request mutation on Responses
         assert received == b"".join(frames)
@@ -675,16 +463,9 @@ class TestUsageSection:
         upstream.responder = lambda request: SSEScript(frames=[(0.0, f) for f in frames])
         app = _make_app(_proxy_config(upstream))
         with TestClient(app) as client:
-            with client.websocket_connect("/v1/realtime") as ws:
-                session_id = ws.receive_json()["session"]["id"]
-                with client.stream(
-                    "POST",
-                    "/v1/chat/completions",
-                    json=STREAM_BODY,
-                    headers={"Authorization": f"Bearer {session_id}"},
-                ) as r:
-                    received = b"".join(r.iter_raw())
-                usage = client.get("/v1/usage").json()["llm_proxy"]
+            with client.stream("POST", "/v1/chat/completions", json=STREAM_BODY) as r:
+                received = b"".join(r.iter_raw())
+            usage = client.get("/v1/usage").json()["llm_proxy"]
         assert received == b"".join(frames)
         assert usage["input_tokens"] == 6
         assert usage["output_tokens"] == 2
@@ -696,19 +477,15 @@ class TestUsageSection:
         )
         app = _make_app(_proxy_config(upstream, llm_backend="responses-api"))
         with TestClient(app) as client:
-            with client.websocket_connect("/v1/realtime") as ws:
-                session_id = ws.receive_json()["session"]["id"]
-                assert self._post(client, session_id, RESPONSES_BODY, "/v1/responses").status_code == 200
-                usage = client.get("/v1/usage").json()["llm_proxy"]
+            assert self._post(client, RESPONSES_BODY, "/v1/responses").status_code == 200
+            usage = client.get("/v1/usage").json()["llm_proxy"]
         assert usage["input_tokens"] == 21
         assert usage["output_tokens"] == 8
 
     def test_existing_usage_shape_keeps_its_keys(self, upstream):
         app = _make_app(_proxy_config(upstream))
         with TestClient(app) as client:
-            with client.websocket_connect("/v1/realtime") as ws:
-                ws.receive_json()
-                data = client.get("/v1/usage").json()
+            data = client.get("/v1/usage").json()
         # Pre-existing aggregate keys survive next to the additive section.
         assert "connections" in data
         assert "llm_proxy" in data
@@ -720,12 +497,6 @@ class TestUpstreamErrorPassthrough:
         upstream.responder = lambda request: (status, {"error": {"message": "upstream says no", "type": "boom"}})
         app = _make_app(_proxy_config(upstream))
         with TestClient(app) as client:
-            with client.websocket_connect("/v1/realtime") as ws:
-                session_id = ws.receive_json()["session"]["id"]
-                r = client.post(
-                    "/v1/chat/completions",
-                    json=CHAT_BODY,
-                    headers={"Authorization": f"Bearer {session_id}"},
-                )
+            r = client.post("/v1/chat/completions", json=CHAT_BODY)
         assert r.status_code == status
         assert r.json() == {"error": {"message": "upstream says no", "type": "boom"}}

--- a/tests/openai_realtime/test_llm_proxy.py
+++ b/tests/openai_realtime/test_llm_proxy.py
@@ -228,7 +228,10 @@ class TestChatCompletionsPassthrough:
         assert upstream.requests == []
 
     def test_non_dict_stream_options_passes_through_for_upstream_to_reject(self, upstream):
-        upstream.responder = lambda request: (400, {"error": {"message": "bad stream_options", "type": "invalid_request_error"}})
+        upstream.responder = lambda request: (
+            400,
+            {"error": {"message": "bad stream_options", "type": "invalid_request_error"}},
+        )
         app = _make_app(_proxy_config(upstream))
         with TestClient(app) as client:
             r = client.post(

--- a/tests/openai_realtime/test_llm_proxy.py
+++ b/tests/openai_realtime/test_llm_proxy.py
@@ -7,6 +7,7 @@ port that the proxy reaches through its configured base URL — no injection
 hooks in production code.
 """
 
+import gzip
 import json
 import threading
 import time
@@ -33,9 +34,14 @@ from speech_to_speech.pipeline.cancel_scope import CancelScope
 
 
 class SSEScript(BaseModel):
-    """Streamed answer for the fake upstream: raw frames with a delay before each."""
+    """Streamed answer for the fake upstream: raw frames with a delay before each.
+
+    ``content_encoding`` labels pre-encoded frames (e.g. gzip): the handler
+    advertises it so the proxy's HTTP client decodes what it reads.
+    """
 
     frames: list[tuple[float, bytes]]
+    content_encoding: str | None = None
 
 
 class FakeUpstream:
@@ -70,6 +76,8 @@ class FakeUpstream:
                 if isinstance(answer, SSEScript):
                     self.send_response(200)
                     self.send_header("Content-Type", "text/event-stream")
+                    if answer.content_encoding:
+                        self.send_header("Content-Encoding", answer.content_encoding)
                     self.end_headers()
                     for delay, frame in answer.frames:
                         time.sleep(delay)
@@ -309,6 +317,28 @@ class TestStreamingPassthrough:
         assert r.status_code == 502
         assert "error" in r.json()
         assert elapsed < 3
+
+    def test_gzip_compressed_upstream_stream_is_decoded_for_the_client(self, upstream):
+        # The upstream may honor the proxy's Accept-Encoding and compress the
+        # stream. The forwarded response carries no Content-Encoding header,
+        # so the proxy must forward decoded bytes — and account tokens on the
+        # decoded stream too.
+        frames = SSE_FRAMES[:2] + [
+            b'data: {"id":"chatcmpl-1","choices":[],"usage":{"prompt_tokens":11,"completion_tokens":5}}\n\n',
+            b"data: [DONE]\n\n",
+        ]
+        compressed = gzip.compress(b"".join(frames))
+        upstream.responder = lambda request: SSEScript(frames=[(0.0, compressed)], content_encoding="gzip")
+        app = _make_app(_proxy_config(upstream))
+        with TestClient(app) as client:
+            with client.stream("POST", "/v1/chat/completions", json=STREAM_BODY) as r:
+                assert r.status_code == 200
+                assert "content-encoding" not in r.headers
+                received = b"".join(r.iter_raw())
+            usage = client.get("/v1/usage").json()["llm_proxy"]
+        assert received == b"".join(frames)
+        assert usage["input_tokens"] == 11
+        assert usage["output_tokens"] == 5
 
     def test_upstream_error_before_stream_passes_through(self, upstream):
         upstream.responder = lambda request: (429, {"error": {"message": "quota", "type": "rate_limit"}})

--- a/tests/openai_realtime/test_websocket_router.py
+++ b/tests/openai_realtime/test_websocket_router.py
@@ -139,7 +139,7 @@ class TestConnection:
                 msg = ws.receive_json()
                 assert msg["type"] == "session.created"
                 assert msg["event_id"].startswith("event_")
-                assert "session" in msg
+                assert msg["session"]["id"].startswith("session_")
 
     def test_second_connection_rejected(self, setup):
         app, *_ = setup


### PR DESCRIPTION
## What this adds

A client can use the LLM this deployment is already configured with as a plain OpenAI compatible endpoint, fully concurrent with the voice conversation and never interrupted by new speech. With `--enable_llm_proxy` on a remote backend the server mounts the matching path as a passthrough proxy to the configured upstream:

* `POST /v1/chat/completions` under `--llm_backend chat-completions`
* `POST /v1/responses` under `--llm_backend responses-api`

**The auth story changed in the last commit, read this twice: this server no longer authenticates these paths at all.** Access control belongs to the gateway deployed in front of it. Behind s2s-endpoint (andimarafioti/s2s-endpoint#67) the compute replica opens the paths only to the HF token a connected session was created with, so the API key clients pass to the SDK is the session's HF token. It is not the realtime session id anymore, and it was never the id returned by the session creation call.

## Design in brief

* **No auth and no throttling in the engine, by design.** The first version gated on the realtime session id and rate limited per session. Review feedback moved both concerns to s2s-endpoint, where user identity actually lives: the compute replica opens the routes per user (HF token) and throttles per user. Standalone deployments that turn the flag on run an open proxy and should do so only on a trusted network or behind their own gateway; the README says so plainly.
* **Passthrough with normalization, no protocol translation.** The forwarded body is the client body with three server side mutations: `model` is overwritten with the configured model, `store` is forced to false on Responses requests, and `stream_options.include_usage` is injected on streamed chat completions for token accounting. Everything else, including unknown fields, passes through untouched, and the client receives every upstream frame verbatim.
* **Remote backends only.** Local generation (`transformers`, `mlx-lm`) is serialized behind locks, so the proxy answers 501 naming the two backends that work. Off by default; the flag off, a local backend, and the wrong protocol path all answer 501 with the reason. The proxy paths answer 200, 400, 501, or 502 and nothing else.
* **The proxy never touches pipeline units, queues, or cancel scopes**, which is what guarantees the speech response path cannot regress. A request in flight completes even if its session closes mid generation.
* **Observability.** The usage endpoint gains an additive `llm_proxy` section: request totals, status classes with 429 in its own bucket, and input and output token totals parsed from bodies, streamed usage frames, and Responses completion events.
* **Security posture, stated plainly.** The upstream API key never reaches clients. With the flag on and nothing in front, the proxy is open and unthrottled; the supported gated deployment is behind the s2s-endpoint compute replica.

## Commits

One commit per ticket, each green on its own, plus the rework:

1. Flag, session gate, non streaming chat completions passthrough, 401/501 contract, README
2. Streaming SSE forwarded verbatim as it arrives, connect timeout, in flight survives session close
3. Responses path with `store` forced false
4. Per session rate limit
5. `llm_proxy` usage section
6. Remove auth from the LLM proxy: access control moves to the deployment gateway (this is the rework commit; it removes the session gate and the rate limiter from 1 and 4, `session.created` keeps carrying `session.id` as plain protocol correctness)
7. Read the LLM proxy upstream settings from the renamed argument fields (bug found in manual testing, also review P1: `rename_args` strips the `responses_api_` prefix before the proxy config is built, so the config silently read the dataclass defaults and hit the OpenAI default upstream with no key; the proxy now reads the same renamed fields the pipeline LM reads, with a regression test through the rename)
8. Decode compressed upstream bytes before forwarding LLM proxy streams (review P2: the forwarded response carries no `Content-Encoding`, so a gzip upstream stream reached clients as unreadable compressed bytes and broke token accounting; the stream is now decoded once at the proxy, with a gzip regression test)
9. Drop the bearer token mention from the session id comment

🤖 Generated with [Claude Code](https://claude.com/claude-code)
