### PR TITLE
fix: RuntimeError: Cannot execute emptyCache() without MPS backend.

### DIFF
--- a/src/speech_to_speech/STT/paraformer_handler.py
+++ b/src/speech_to_speech/STT/paraformer_handler.py
@@ -59,7 +59,8 @@ class ParaformerSTTHandler(BaseSTTHandler):
         logger.debug("infering paraformer...")
 
         pred_text = self.model.generate(vad_audio.audio)[0]["text"].strip().replace(" ", "")
-        torch.mps.empty_cache()
+        if self.device == "mps":
+            torch.mps.empty_cache()
 
         logger.debug("finished paraformer inference")
         console.print(f"[yellow]USER: {pred_text}")

--- a/tests/test_paraformer_transcription_events.py
+++ b/tests/test_paraformer_transcription_events.py
@@ -10,9 +10,10 @@ class _FakeParaformerModel:
         return [{"text": " 今 天 天 气 不 错 "}]
 
 
-def _handler():
+def _handler(device="mps"):
     handler = object.__new__(ParaformerSTTHandler)
     handler.model = _FakeParaformerModel()
+    handler.device = device
     return handler
 
 
@@ -60,3 +61,26 @@ def test_final_paraformer_transcription_is_final(monkeypatch):
     assert result[0].turn_id == "turn_1"
     assert result[0].turn_revision == 2
     assert result[0].speech_stopped_at_s == 123.0
+
+
+def test_process_does_not_touch_mps_cache_on_non_mps_device(monkeypatch):
+    monkeypatch.setattr(paraformer_handler.console, "print", lambda *args, **kwargs: None)
+
+    def _raise():
+        raise RuntimeError("Cannot execute emptyCache() without MPS backend.")
+
+    monkeypatch.setattr(paraformer_handler.torch.mps, "empty_cache", _raise)
+
+    result = list(
+        _handler(device="cuda").process(
+            VADAudio(
+                audio=np.zeros(16000, dtype=np.float32),
+                mode="final",
+                turn_id="turn_1",
+                turn_revision=2,
+                created_at_s=123.0,
+            )
+        )
+    )
+
+    assert len(result) == 1


### PR DESCRIPTION
## Summary

FIx #145 

File `torch.mps.empty_cache()` in `src/speech_to_speech/STT/paraformer_handler.py:62` was called unconditionally after every STT inference, but MPS is only available on Apple Silicon Macs — on CUDA/CPU systems this raised `RuntimeError: Cannot execute emptyCache() without MPS backend.`

**Change:** guarded the call with `if self.device == "mps":`, matching the exact pattern already used for the same purpose in `src/speech_to_speech/LLM/language_model.py:719`.

**Tests:** updated `tests/test_paraformer_transcription_events.py` to set `handler.device` in the test fixture (previously unset, since `torch.mps.empty_cache` was fully monkeypatched to a no-op) and added `test_process_does_not_touch_mps_cache_on_non_mps_device`, which patches `empty_cache` to raise the exact `RuntimeError` from the bug report and asserts `process()` with `device="cuda"` doesn't trigger it. I verified this test fails against the pre-fix code (reproducing the reported traceback) and passes with the fix. Full suite: 598 passed.