### PR TITLE
Add voice cloning for the Qwen3 TTS backend

### DIFF
--- a/demo/index.html
+++ b/demo/index.html
@@ -271,6 +271,11 @@
                   <option value="Vivian">Vivian</option>
                 </select>
               </label>
+              <!-- Voice cloning: revealed only after the capability probe
+                   (GET /api/voices) answers 200 on a connected call. -->
+              <button id="create-voice-btn" type="button" class="btn create-voice-btn" hidden>
+                Create voice
+              </button>
             </div>
 
             <!-- WS-only: the gate runs in the WebSocket capture worklet; the
@@ -322,6 +327,66 @@
           <button id="settings-save" type="submit" class="btn primary" value="save">Save</button>
         </footer>
       </form>
+    </dialog>
+
+    <!-- Create a cloned voice from a short reference clip. Opened from the
+         "Create voice" button in Settings; only reachable while a call is live
+         on a backend that answered the voice-cloning capability probe. -->
+    <dialog id="voice-modal" class="modal">
+      <div class="modal-content">
+        <header class="modal-header">
+          <h2>Create voice</h2>
+          <button id="voice-modal-close" class="icon-btn" aria-label="Close">
+            <svg width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><line x1="18" y1="6" x2="6" y2="18"/><line x1="6" y1="6" x2="18" y2="18"/></svg>
+          </button>
+        </header>
+
+        <div class="voice-mode" role="tablist" aria-label="Voice source">
+          <button id="voice-mode-record" type="button" role="tab" aria-selected="true" class="voice-mode-btn active">Record</button>
+          <button id="voice-mode-upload" type="button" role="tab" aria-selected="false" class="voice-mode-btn">Upload</button>
+        </div>
+
+        <section id="voice-record-panel" class="voice-panel">
+          <div class="field">
+            <span>Read this aloud</span>
+            <p id="voice-script" class="voice-script">
+              Hi! I'm recording a short sample so the assistant can speak with my
+              voice. The quick brown fox jumps over the lazy dog, while soft music
+              plays in the background. Let me count: one, two, three, four, five.
+              That should be plenty — thank you for listening.
+            </p>
+            <small>The recording and this script become the voice's reference pair, so read it as written.</small>
+          </div>
+          <div class="voice-record-row">
+            <button id="voice-record-btn" type="button" class="btn voice-record-btn">Record</button>
+            <span id="voice-record-time" class="voice-record-time" hidden>0:00</span>
+            <audio id="voice-preview" class="voice-preview" controls hidden></audio>
+          </div>
+        </section>
+
+        <section id="voice-upload-panel" class="voice-panel" hidden>
+          <label class="field">
+            <span>Audio file</span>
+            <input id="voice-file" type="file" accept="audio/*" />
+            <small>3–60 seconds of clean speech. Any format your browser can decode (MP3, M4A, OGG, WAV…).</small>
+          </label>
+          <label class="field">
+            <span>Transcript</span>
+            <textarea id="voice-transcript" rows="3" placeholder="Exactly what is said in the clip…"></textarea>
+          </label>
+        </section>
+
+        <label class="field">
+          <span>Voice name</span>
+          <input id="voice-name" type="text" autocomplete="off" spellcheck="false" maxlength="80" placeholder="My voice" />
+        </label>
+
+        <p id="voice-error" class="voice-error" hidden></p>
+
+        <footer class="modal-footer">
+          <button id="voice-save" type="button" class="btn primary" disabled>Save voice</button>
+        </footer>
+      </div>
     </dialog>
 
     <dialog id="tools-modal" class="modal">

--- a/demo/index.html
+++ b/demo/index.html
@@ -57,6 +57,9 @@
           <button id="about-btn-m" class="icon-btn about-btn-mobile" title="About this space" aria-label="About this space">
             <svg width="18" height="18" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><circle cx="12" cy="12" r="10"/><line x1="12" y1="16" x2="12" y2="12"/><line x1="12" y1="8" x2="12.01" y2="8"/></svg>
           </button>
+          <button id="create-voice-top-btn" class="icon-btn" title="Create voice" aria-label="Create voice">
+            <svg width="18" height="18" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><rect x="7" y="3" width="6" height="11" rx="3"/><path d="M4 11a6 6 0 0 0 12 0"/><line x1="10" y1="19" x2="10" y2="22"/><line x1="19" y1="3" x2="19" y2="9"/><line x1="16" y1="6" x2="22" y2="6"/></svg>
+          </button>
           <button id="tools-btn" class="icon-btn" title="Tools" aria-label="Tools">
             <svg width="18" height="18" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M14.7 6.3a1 1 0 0 0 0 1.4l1.6 1.6a1 1 0 0 0 1.4 0l3.77-3.77a6 6 0 0 1-7.94 7.94l-6.91 6.91a2.12 2.12 0 0 1-3-3l6.91-6.91a6 6 0 0 1 7.94-7.94l-3.76 3.76z"/></svg>
           </button>
@@ -329,9 +332,10 @@
       </form>
     </dialog>
 
-    <!-- Create a cloned voice from a short reference clip. Opened from the
-         "Create voice" button in Settings; only reachable while a call is live
-         on a backend that answered the voice-cloning capability probe. -->
+    <!-- Create a cloned voice from a short reference clip. Always reachable
+         from the top-bar button; also from the Settings button that the
+         capability probe reveals during a call. Without a live cloning-capable
+         call, saves are kept in the tab and uploaded on the next connect. -->
     <dialog id="voice-modal" class="modal">
       <div class="modal-content">
         <header class="modal-header">
@@ -340,6 +344,11 @@
             <svg width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><line x1="18" y1="6" x2="6" y2="18"/><line x1="6" y1="6" x2="18" y2="18"/></svg>
           </button>
         </header>
+
+        <p id="voice-offline-note" class="voice-offline-note" hidden>
+          No live call yet — the voice will be kept in this tab, selectable right
+          away, and uploaded automatically when your next call connects.
+        </p>
 
         <div class="voice-mode" role="tablist" aria-label="Voice source">
           <button id="voice-mode-record" type="button" role="tab" aria-selected="true" class="voice-mode-btn active">Record</button>

--- a/demo/main.js
+++ b/demo/main.js
@@ -292,8 +292,12 @@ const settingsForm = /** @type {HTMLFormElement} */ (settingsModal.querySelector
 
 /** @type {HTMLButtonElement} */
 const createVoiceBtn = $("#create-voice-btn");
+/** @type {HTMLButtonElement} */
+const createVoiceTopBtn = $("#create-voice-top-btn");
 /** @type {HTMLDialogElement} */
 const voiceModal = $("#voice-modal");
+/** @type {HTMLElement} */
+const voiceOfflineNote = $("#voice-offline-note");
 /** @type {HTMLButtonElement} */
 const voiceModalClose = $("#voice-modal-close");
 /** @type {HTMLButtonElement} */
@@ -1122,18 +1126,37 @@ settingsForm.addEventListener("submit", (event) => {
 });
 
 // ── Voice cloning ───────────────────────────────────────────────────────────
-// Revealed only when the live call's backend answers the capability probe
-// (GET /api/voices → 200; a non-Qwen backend answers 409 and the feature stays
-// invisible). The popup records a fixed script — the script IS the reference
-// transcript, never typed — or accepts an uploaded clip plus its transcript.
-// Whatever the source, the browser decodes it and re-encodes PCM16 mono WAV so
-// the server never needs a transcoder. On save the voice is stored in the
-// deployment's global library, auto-selected, and applied to the running
-// session via a plain session.update.
+// The popup records a fixed script — the script IS the reference transcript,
+// never typed — or accepts an uploaded clip plus its transcript. Whatever the
+// source, the browser decodes it and re-encodes PCM16 mono WAV so the server
+// never needs a transcoder.
+//
+// Two ways in: the top-bar button is always available; the Settings button is
+// revealed only when the live call's backend answers the capability probe
+// (GET /api/voices → 200; a non-Qwen backend answers 409). With a live
+// cloning-capable call, saving stores the voice in the deployment's global
+// library, auto-selects it, and applies it via a plain session.update.
+// Without one, the voice waits in this tab's pending store (memory only — a
+// reload drops it), is selectable immediately, and is uploaded automatically
+// right after the next successful capability probe.
 
 const PRESET_VOICES = new Set(Array.from(inputVoice.options).map((o) => o.value));
 const VOICE_RECORD_MIN_SEC = 3;
 const VOICE_RECORD_MAX_SEC = 60;
+// Ids of voices created outside a call, waiting for one to upload through.
+// Deliberately colliding with nothing the server hands out (16 hex chars).
+const PENDING_VOICE_PREFIX = "pending:";
+
+/** Voices saved without a live cloning-capable call, keyed by their temporary
+ *  id. Tab memory only: the encoded WAV can't reasonably go to localStorage.
+ *  @type {Map<string, { wav: Blob, name: string, refText: string }>} */
+const pendingVoices = new Map();
+let pendingVoiceSeq = 0;
+
+/** @param {string} voiceId */
+function isPendingVoiceId(voiceId) {
+  return voiceId.startsWith(PENDING_VOICE_PREFIX);
+}
 
 let voiceCloningAvailable = false;
 // One probe per conversation: the client status returns to "connected" after
@@ -1173,8 +1196,45 @@ async function probeVoiceCloning() {
     voiceCloningAvailable = true;
     createVoiceBtn.hidden = false;
     syncClonedVoiceOptions(Array.isArray(json.voices) ? json.voices : []);
+    await flushPendingVoices();
   } catch (err) {
     if (DEBUG) console.debug("[ui] voices probe failed:", err);
+  } finally {
+    syncVoiceOfflineNote();
+  }
+}
+
+/** Upload every voice created outside a call, now that one is up. Each 201
+ *  swaps the temporary option for the server's content-hash id; a failed
+ *  upload keeps its pending entry for the next conversation's flush. */
+async function flushPendingVoices() {
+  for (const [tempId, pending] of Array.from(pendingVoices)) {
+    const url = voicesApiUrl();
+    if (!url || !voiceCloningAvailable) return;
+    const form = new FormData();
+    form.append("audio", pending.wav, "voice.wav");
+    form.append("ref_text", pending.refText);
+    form.append("name", pending.name);
+    try {
+      const res = await fetch(url, { method: "POST", body: form });
+      const json = await res.json().catch(() => ({}));
+      if (!res.ok || !json.voice_id) {
+        if (DEBUG) console.debug("[ui] pending voice upload failed:", res.status, json);
+        continue;
+      }
+      pendingVoices.delete(tempId);
+      const group = clonedVoicesGroup();
+      Array.from(group.children)
+        .find((o) => /** @type {HTMLOptionElement} */ (o).value === tempId)
+        ?.remove();
+      if (settings.voice === tempId) {
+        applyClonedVoice(json.voice_id, json.name || pending.name);
+      } else {
+        upsertClonedOption(group, json.voice_id, json.name || pending.name);
+      }
+    } catch (err) {
+      if (DEBUG) console.debug("[ui] pending voice upload failed:", err);
+    }
   }
 }
 
@@ -1215,10 +1275,31 @@ function syncClonedVoiceOptions(voices) {
   for (const v of voices) {
     if (v && v.voice_id) upsertClonedOption(group, v.voice_id, v.name || "Cloned voice");
   }
-  if (!PRESET_VOICES.has(settings.voice) && !voices.some((v) => v && v.voice_id === settings.voice)) {
+  for (const [tempId, pending] of pendingVoices) {
+    upsertClonedOption(group, tempId, pendingVoiceLabel(pending.name));
+  }
+  if (
+    !PRESET_VOICES.has(settings.voice) &&
+    !isPendingVoiceId(settings.voice) &&
+    !voices.some((v) => v && v.voice_id === settings.voice)
+  ) {
     upsertClonedOption(group, settings.voice, "Cloned voice");
   }
   if (!group.childElementCount) group.remove();
+  inputVoice.value = settings.voice;
+}
+
+/** @param {string} name */
+function pendingVoiceLabel(name) {
+  return `${name} (pending)`;
+}
+
+// A pending voice never reached the server; its audio lived only in the
+// previous page's memory, so the persisted selection points at nothing.
+// Fall back to the first preset rather than sending a dead id.
+if (isPendingVoiceId(settings.voice)) {
+  settings.voice = /** @type {HTMLOptionElement} */ (inputVoice.options[0]).value;
+  saveSettings(settings);
   inputVoice.value = settings.voice;
 }
 
@@ -1404,17 +1485,28 @@ function applyClonedVoice(voiceId, name) {
   settings.voice = voiceId;
   saveSettings(settings);
   inputVoice.value = voiceId;
-  if (client && LIVE_STATES.has(currentState)) {
+  // A pending id means nothing to the backend; the flush after the next
+  // successful probe swaps it for the real id and re-applies.
+  if (client && LIVE_STATES.has(currentState) && !isPendingVoiceId(voiceId)) {
     client.updateSession({ voice: voiceId });
   }
 }
 
+/** Stash a voice created without a live cloning-capable call. It is selected
+ *  like a server voice and uploaded by the flush on the next connect. */
+function stashPendingVoice(/** @type {Blob} */ wav, /** @type {string} */ name, /** @type {string} */ refText) {
+  const tempId = `${PENDING_VOICE_PREFIX}${++pendingVoiceSeq}`;
+  pendingVoices.set(tempId, { wav, name, refText });
+  applyClonedVoice(tempId, pendingVoiceLabel(name));
+}
+
+/** The in-modal hint that a save will wait in the tab instead of uploading. */
+function syncVoiceOfflineNote() {
+  voiceOfflineNote.hidden = !!(voicesApiUrl() && voiceCloningAvailable);
+}
+
 async function saveVoice() {
   const url = voicesApiUrl();
-  if (!url || !voiceCloningAvailable) {
-    setVoiceError("The call ended — reconnect to create a voice.");
-    return;
-  }
   const name = voiceNameInput.value.trim();
   const source = voiceMode === "record" ? voiceRecordingBlob : (voiceFileInput.files?.[0] ?? null);
   const refText = voiceMode === "record" ? voiceScriptText() : voiceTranscriptInput.value.trim();
@@ -1430,6 +1522,11 @@ async function saveVoice() {
       wav = await encodeVoiceBlobToWav(source);
     } catch {
       setVoiceError("Couldn't decode that audio — try a different file or re-record.");
+      return;
+    }
+    if (!url || !voiceCloningAvailable) {
+      stashPendingVoice(wav, name, refText);
+      voiceModal.close();
       return;
     }
     const form = new FormData();
@@ -1452,11 +1549,17 @@ async function saveVoice() {
   }
 }
 
+function openVoiceModal() {
+  resetVoiceModal();
+  syncVoiceOfflineNote();
+  voiceModal.showModal();
+}
+
 createVoiceBtn.addEventListener("click", () => {
   if (!voiceCloningAvailable) return;
-  resetVoiceModal();
-  voiceModal.showModal();
+  openVoiceModal();
 });
+createVoiceTopBtn.addEventListener("click", openVoiceModal);
 voiceModalClose.addEventListener("click", () => voiceModal.close());
 voiceModal.addEventListener("close", () => stopVoiceRecording());
 voiceModeRecordBtn.addEventListener("click", () => setVoiceMode("record"));
@@ -1911,12 +2014,13 @@ async function teardown() {
   stopJoinCountdown();
   endTrackedSession();
   endQueueTicket();
-  // Voice cloning is session-scoped: the routes need a live session, so the
-  // affordance hides until the next call's probe. Cloned options stay in the
-  // select — the saved selection must survive reconnects.
+  // The voices routes need a live session, so the Settings affordance hides
+  // until the next call's probe. The popup itself survives (creation without
+  // a call stashes locally); only its hint changes. Cloned options stay in
+  // the select — the saved selection must survive reconnects.
   voiceCloningAvailable = false;
   createVoiceBtn.hidden = true;
-  if (voiceModal.open) voiceModal.close();
+  syncVoiceOfflineNote();
   chat.reset({ dismiss: true });
   if (client) {
     try {

--- a/demo/main.js
+++ b/demo/main.js
@@ -290,6 +290,39 @@ const restartBtn = $("#restart-conversation");
 const restartHint = $("#restart-hint");
 const settingsForm = /** @type {HTMLFormElement} */ (settingsModal.querySelector("form"));
 
+/** @type {HTMLButtonElement} */
+const createVoiceBtn = $("#create-voice-btn");
+/** @type {HTMLDialogElement} */
+const voiceModal = $("#voice-modal");
+/** @type {HTMLButtonElement} */
+const voiceModalClose = $("#voice-modal-close");
+/** @type {HTMLButtonElement} */
+const voiceModeRecordBtn = $("#voice-mode-record");
+/** @type {HTMLButtonElement} */
+const voiceModeUploadBtn = $("#voice-mode-upload");
+/** @type {HTMLElement} */
+const voiceRecordPanel = $("#voice-record-panel");
+/** @type {HTMLElement} */
+const voiceUploadPanel = $("#voice-upload-panel");
+/** @type {HTMLElement} */
+const voiceScriptEl = $("#voice-script");
+/** @type {HTMLButtonElement} */
+const voiceRecordBtn = $("#voice-record-btn");
+/** @type {HTMLElement} */
+const voiceRecordTime = $("#voice-record-time");
+/** @type {HTMLAudioElement} */
+const voicePreview = $("#voice-preview");
+/** @type {HTMLInputElement} */
+const voiceFileInput = $("#voice-file");
+/** @type {HTMLTextAreaElement} */
+const voiceTranscriptInput = $("#voice-transcript");
+/** @type {HTMLInputElement} */
+const voiceNameInput = $("#voice-name");
+/** @type {HTMLElement} */
+const voiceErrorEl = $("#voice-error");
+/** @type {HTMLButtonElement} */
+const voiceSaveBtn = $("#voice-save");
+
 /** @type {AppState} */
 let currentState = "idle";
 let settings = loadSettings();
@@ -1088,6 +1121,358 @@ settingsForm.addEventListener("submit", (event) => {
   }
 });
 
+// ── Voice cloning ───────────────────────────────────────────────────────────
+// Revealed only when the live call's backend answers the capability probe
+// (GET /api/voices → 200; a non-Qwen backend answers 409 and the feature stays
+// invisible). The popup records a fixed script — the script IS the reference
+// transcript, never typed — or accepts an uploaded clip plus its transcript.
+// Whatever the source, the browser decodes it and re-encodes PCM16 mono WAV so
+// the server never needs a transcoder. On save the voice is stored in the
+// deployment's global library, auto-selected, and applied to the running
+// session via a plain session.update.
+
+const PRESET_VOICES = new Set(Array.from(inputVoice.options).map((o) => o.value));
+const VOICE_RECORD_MIN_SEC = 3;
+const VOICE_RECORD_MAX_SEC = 60;
+
+let voiceCloningAvailable = false;
+// One probe per conversation: the client status returns to "connected" after
+// every assistant turn, and re-probing on each would spam the proxy.
+let voiceProbeDone = false;
+/** @type {"record" | "upload"} */
+let voiceMode = "record";
+/** @type {MediaRecorder | null} */
+let voiceRecorder = null;
+/** @type {Blob | null} */
+let voiceRecordingBlob = null;
+let voiceRecordingSec = 0;
+let voiceRecordTimer = 0;
+let voiceRecordStartedAt = 0;
+
+/** Same-origin proxy URL for the live session's voices routes (null when no
+ *  call is up). Carries the realtime session id and, in LB mode, the grant id
+ *  the proxy uses to find the compute host it recorded. */
+function voicesApiUrl() {
+  if (!client || !client.realtimeSessionId) return null;
+  const params = new URLSearchParams({ session: client.realtimeSessionId });
+  if (client.grantSessionId) params.set("grant", client.grantSessionId);
+  return `api/voices?${params}`;
+}
+
+/** Capability probe, once per conversation: 200 reveals the UI and populates
+ *  the cloned-voices optgroup; anything else keeps the feature invisible. */
+async function probeVoiceCloning() {
+  voiceCloningAvailable = false;
+  createVoiceBtn.hidden = true;
+  const url = voicesApiUrl();
+  if (!url) return;
+  try {
+    const res = await fetch(url);
+    if (!res.ok) return;
+    const json = await res.json().catch(() => ({}));
+    voiceCloningAvailable = true;
+    createVoiceBtn.hidden = false;
+    syncClonedVoiceOptions(Array.isArray(json.voices) ? json.voices : []);
+  } catch (err) {
+    if (DEBUG) console.debug("[ui] voices probe failed:", err);
+  }
+}
+
+/** The "Cloned voices" optgroup in the voice select (created on demand). */
+function clonedVoicesGroup() {
+  let group = /** @type {HTMLOptGroupElement | null} */ (inputVoice.querySelector("optgroup[data-cloned]"));
+  if (!group) {
+    group = document.createElement("optgroup");
+    group.label = "Cloned voices";
+    group.dataset.cloned = "1";
+    inputVoice.appendChild(group);
+  }
+  return group;
+}
+
+/** @param {HTMLOptGroupElement} group @param {string} voiceId @param {string} name */
+function upsertClonedOption(group, voiceId, name) {
+  let opt = /** @type {HTMLOptionElement | null} */ (
+    Array.from(group.children).find((o) => /** @type {HTMLOptionElement} */ (o).value === voiceId) ?? null
+  );
+  if (!opt) {
+    opt = document.createElement("option");
+    opt.value = voiceId;
+    group.appendChild(opt);
+  }
+  opt.textContent = name;
+  return opt;
+}
+
+/** Rebuild the optgroup from a server listing, preserving the saved selection.
+ *  A persisted cloned id missing from the listing (deleted on the server)
+ *  keeps a placeholder so saving Settings can't silently fall back to a
+ *  preset; selecting it degrades to the backend's unsupported-voice warning.
+ *  @param {{ voice_id: string, name: string }[]} voices */
+function syncClonedVoiceOptions(voices) {
+  const group = clonedVoicesGroup();
+  group.textContent = "";
+  for (const v of voices) {
+    if (v && v.voice_id) upsertClonedOption(group, v.voice_id, v.name || "Cloned voice");
+  }
+  if (!PRESET_VOICES.has(settings.voice) && !voices.some((v) => v && v.voice_id === settings.voice)) {
+    upsertClonedOption(group, settings.voice, "Cloned voice");
+  }
+  if (!group.childElementCount) group.remove();
+  inputVoice.value = settings.voice;
+}
+
+// A cloned voice persisted from a previous visit must stay selectable before
+// any probe runs, or opening + saving Settings would overwrite it with the
+// select's first preset.
+if (!PRESET_VOICES.has(settings.voice)) {
+  upsertClonedOption(clonedVoicesGroup(), settings.voice, "Cloned voice");
+  inputVoice.value = settings.voice;
+}
+
+/** @param {string} message Empty string hides the error line. */
+function setVoiceError(message) {
+  voiceErrorEl.textContent = message;
+  voiceErrorEl.hidden = !message;
+}
+
+/** The fixed script shown in Record mode — it doubles as the transcript. */
+function voiceScriptText() {
+  return (voiceScriptEl.textContent || "").replace(/\s+/g, " ").trim();
+}
+
+function updateVoiceSaveEnabled() {
+  const named = !!voiceNameInput.value.trim();
+  const recording = !!(voiceRecorder && voiceRecorder.state === "recording");
+  const sourced =
+    voiceMode === "record"
+      ? !!voiceRecordingBlob && voiceRecordingSec >= VOICE_RECORD_MIN_SEC
+      : !!voiceFileInput.files?.[0] && !!voiceTranscriptInput.value.trim();
+  voiceSaveBtn.disabled = recording || !named || !sourced;
+}
+
+/** @param {"record" | "upload"} mode */
+function setVoiceMode(mode) {
+  voiceMode = mode;
+  const record = mode === "record";
+  if (!record) stopVoiceRecording();
+  voiceModeRecordBtn.classList.toggle("active", record);
+  voiceModeRecordBtn.setAttribute("aria-selected", String(record));
+  voiceModeUploadBtn.classList.toggle("active", !record);
+  voiceModeUploadBtn.setAttribute("aria-selected", String(!record));
+  voiceRecordPanel.hidden = !record;
+  voiceUploadPanel.hidden = record;
+  setVoiceError("");
+  updateVoiceSaveEnabled();
+}
+
+function resetVoiceModal() {
+  stopVoiceRecording();
+  discardVoiceRecording();
+  voiceFileInput.value = "";
+  voiceTranscriptInput.value = "";
+  voiceNameInput.value = "";
+  voiceSaveBtn.textContent = "Save voice";
+  setVoiceMode("record");
+}
+
+function discardVoiceRecording() {
+  voiceRecordingBlob = null;
+  voiceRecordingSec = 0;
+  if (voicePreview.src) URL.revokeObjectURL(voicePreview.src);
+  voicePreview.removeAttribute("src");
+  voicePreview.hidden = true;
+  voiceRecordTime.hidden = true;
+  voiceRecordBtn.textContent = "Record";
+  voiceRecordBtn.classList.remove("recording");
+}
+
+/** @param {number} sec */
+function paintVoiceRecordTime(sec) {
+  const m = Math.floor(sec / 60);
+  const s = Math.floor(sec % 60);
+  voiceRecordTime.textContent = `${m}:${String(s).padStart(2, "0")}`;
+  voiceRecordTime.hidden = false;
+}
+
+async function startVoiceRecording() {
+  discardVoiceRecording();
+  setVoiceError("");
+  /** @type {MediaStream} */
+  let stream;
+  try {
+    stream = await navigator.mediaDevices.getUserMedia({ audio: true });
+  } catch {
+    setVoiceError("Microphone access is needed to record a voice sample.");
+    return;
+  }
+  const chunks = /** @type {Blob[]} */ ([]);
+  // Default container (WebM/Opus, or MP4 on Safari) — the Web Audio decode on
+  // save flattens the difference, so no mimeType negotiation is needed.
+  const recorder = new MediaRecorder(stream);
+  voiceRecorder = recorder;
+  voiceRecordStartedAt = performance.now();
+  recorder.addEventListener("dataavailable", (e) => {
+    if (e.data.size) chunks.push(e.data);
+  });
+  recorder.addEventListener("stop", () => {
+    for (const track of stream.getTracks()) track.stop();
+    if (voiceRecordTimer) clearInterval(voiceRecordTimer);
+    voiceRecordTimer = 0;
+    voiceRecorder = null;
+    voiceRecordingSec = (performance.now() - voiceRecordStartedAt) / 1000;
+    voiceRecordingBlob = new Blob(chunks, { type: recorder.mimeType || "audio/webm" });
+    voicePreview.src = URL.createObjectURL(voiceRecordingBlob);
+    voicePreview.hidden = false;
+    voiceRecordBtn.textContent = "Re-record";
+    voiceRecordBtn.classList.remove("recording");
+    paintVoiceRecordTime(voiceRecordingSec);
+    if (voiceRecordingSec < VOICE_RECORD_MIN_SEC) {
+      setVoiceError(`That was under ${VOICE_RECORD_MIN_SEC} seconds — please record the whole script.`);
+    }
+    updateVoiceSaveEnabled();
+  });
+  recorder.start();
+  voiceRecordBtn.textContent = "Stop";
+  voiceRecordBtn.classList.add("recording");
+  paintVoiceRecordTime(0);
+  voiceRecordTimer = window.setInterval(() => {
+    const sec = (performance.now() - voiceRecordStartedAt) / 1000;
+    paintVoiceRecordTime(sec);
+    // Server-side clamp is 60 s; stop for the user instead of failing later.
+    if (sec >= VOICE_RECORD_MAX_SEC) stopVoiceRecording();
+  }, 250);
+  updateVoiceSaveEnabled();
+}
+
+function stopVoiceRecording() {
+  if (voiceRecorder && voiceRecorder.state === "recording") voiceRecorder.stop();
+}
+
+/** Decode any browser-supported audio (MediaRecorder blob or picked file) and
+ *  re-encode PCM16 mono WAV, the one format the server accepts.
+ *  @param {Blob} blob */
+async function encodeVoiceBlobToWav(blob) {
+  const Ctx = window.AudioContext || /** @type {any} */ (window).webkitAudioContext;
+  const ctx = new Ctx();
+  try {
+    const decoded = await ctx.decodeAudioData(await blob.arrayBuffer());
+    const mono = new Float32Array(decoded.length);
+    for (let c = 0; c < decoded.numberOfChannels; c++) {
+      const channel = decoded.getChannelData(c);
+      for (let i = 0; i < channel.length; i++) mono[i] += channel[i] / decoded.numberOfChannels;
+    }
+    return wavFromFloat32(mono, decoded.sampleRate);
+  } finally {
+    void ctx.close().catch(() => {});
+  }
+}
+
+/** @param {Float32Array} samples @param {number} sampleRate */
+function wavFromFloat32(samples, sampleRate) {
+  const buf = new ArrayBuffer(44 + samples.length * 2);
+  const view = new DataView(buf);
+  const writeStr = (/** @type {number} */ off, /** @type {string} */ s) => {
+    for (let i = 0; i < s.length; i++) view.setUint8(off + i, s.charCodeAt(i));
+  };
+  writeStr(0, "RIFF");
+  view.setUint32(4, 36 + samples.length * 2, true);
+  writeStr(8, "WAVE");
+  writeStr(12, "fmt ");
+  view.setUint32(16, 16, true); // PCM chunk size
+  view.setUint16(20, 1, true); // PCM format
+  view.setUint16(22, 1, true); // mono
+  view.setUint32(24, sampleRate, true);
+  view.setUint32(28, sampleRate * 2, true); // byte rate
+  view.setUint16(32, 2, true); // block align
+  view.setUint16(34, 16, true); // bits per sample
+  writeStr(36, "data");
+  view.setUint32(40, samples.length * 2, true);
+  let off = 44;
+  for (let i = 0; i < samples.length; i++, off += 2) {
+    const s = Math.max(-1, Math.min(1, samples[i]));
+    view.setInt16(off, s < 0 ? s * 0x8000 : s * 0x7fff, true);
+  }
+  return new Blob([buf], { type: "audio/wav" });
+}
+
+/** Add/refresh the option, persist the selection, and apply it to the live
+ *  session so the very next assistant reply speaks in the new voice.
+ *  @param {string} voiceId @param {string} name */
+function applyClonedVoice(voiceId, name) {
+  upsertClonedOption(clonedVoicesGroup(), voiceId, name);
+  settings.voice = voiceId;
+  saveSettings(settings);
+  inputVoice.value = voiceId;
+  if (client && LIVE_STATES.has(currentState)) {
+    client.updateSession({ voice: voiceId });
+  }
+}
+
+async function saveVoice() {
+  const url = voicesApiUrl();
+  if (!url || !voiceCloningAvailable) {
+    setVoiceError("The call ended — reconnect to create a voice.");
+    return;
+  }
+  const name = voiceNameInput.value.trim();
+  const source = voiceMode === "record" ? voiceRecordingBlob : (voiceFileInput.files?.[0] ?? null);
+  const refText = voiceMode === "record" ? voiceScriptText() : voiceTranscriptInput.value.trim();
+  if (!source || !name || !refText) return;
+
+  setVoiceError("");
+  voiceSaveBtn.disabled = true;
+  voiceSaveBtn.textContent = "Saving…";
+  try {
+    /** @type {Blob} */
+    let wav;
+    try {
+      wav = await encodeVoiceBlobToWav(source);
+    } catch {
+      setVoiceError("Couldn't decode that audio — try a different file or re-record.");
+      return;
+    }
+    const form = new FormData();
+    form.append("audio", wav, "voice.wav");
+    form.append("ref_text", refText);
+    form.append("name", name);
+    const res = await fetch(url, { method: "POST", body: form });
+    const json = await res.json().catch(() => ({}));
+    if (!res.ok) {
+      setVoiceError(json?.error?.message || `Upload failed (${res.status}).`);
+      return;
+    }
+    applyClonedVoice(json.voice_id, json.name || name);
+    voiceModal.close();
+  } catch (err) {
+    setVoiceError(err instanceof Error ? err.message : String(err));
+  } finally {
+    voiceSaveBtn.textContent = "Save voice";
+    updateVoiceSaveEnabled();
+  }
+}
+
+createVoiceBtn.addEventListener("click", () => {
+  if (!voiceCloningAvailable) return;
+  resetVoiceModal();
+  voiceModal.showModal();
+});
+voiceModalClose.addEventListener("click", () => voiceModal.close());
+voiceModal.addEventListener("close", () => stopVoiceRecording());
+voiceModeRecordBtn.addEventListener("click", () => setVoiceMode("record"));
+voiceModeUploadBtn.addEventListener("click", () => setVoiceMode("upload"));
+voiceRecordBtn.addEventListener("click", () => {
+  if (voiceRecorder && voiceRecorder.state === "recording") stopVoiceRecording();
+  else void startVoiceRecording();
+});
+voiceFileInput.addEventListener("change", () => {
+  setVoiceError("");
+  updateVoiceSaveEnabled();
+});
+voiceTranscriptInput.addEventListener("input", updateVoiceSaveEnabled);
+voiceNameInput.addEventListener("input", updateVoiceSaveEnabled);
+voiceSaveBtn.addEventListener("click", () => void saveVoice());
+
 // The noise gate applies live (worklet param), so tune it without a restart:
 // update the label/marker, persist, and push straight to the running client.
 inputNoiseGate.addEventListener("input", () => {
@@ -1276,6 +1661,7 @@ async function doStart(audioContext = null) {
 
   chat.clear();
   chat.reset();
+  voiceProbeDone = false;
   setState("connecting");
   setCaption("Asking for mic…", "muted");
 
@@ -1494,6 +1880,13 @@ function onClientStatus(status) {
       break;
     case "connected":
       setState("listening");
+      // First "connected" of the conversation: session.created has been
+      // handled (the client sets its realtimeSessionId before flipping the
+      // status), so the voices capability probe can run now.
+      if (!voiceProbeDone) {
+        voiceProbeDone = true;
+        void probeVoiceCloning();
+      }
       break;
     case "user-speaking":
       setState("user-speaking");
@@ -1518,6 +1911,12 @@ async function teardown() {
   stopJoinCountdown();
   endTrackedSession();
   endQueueTicket();
+  // Voice cloning is session-scoped: the routes need a live session, so the
+  // affordance hides until the next call's probe. Cloned options stay in the
+  // select — the saved selection must survive reconnects.
+  voiceCloningAvailable = false;
+  createVoiceBtn.hidden = true;
+  if (voiceModal.open) voiceModal.close();
   chat.reset({ dismiss: true });
   if (client) {
     try {

--- a/demo/rtc/s2s-rtc-client.js
+++ b/demo/rtc/s2s-rtc-client.js
@@ -119,6 +119,12 @@ export class S2sRtcRealtimeClient extends EventTarget {
     this._lastAudibleAt = 0;
     /** @type {RtcStatus} */
     this._status = "idle";
+    /** @type {string} Realtime session id from `session.created`; addresses the
+     * session-scoped voices routes (empty until the event arrives). */
+    this.realtimeSessionId = "";
+    /** @type {string} Always empty over WebRTC (env-pinned direct mode only);
+     * mirrors the WS client so callers can read it transport-agnostically. */
+    this.grantSessionId = "";
     this._aiSpeaking = false;
     /** @type {string} The response currently holding the backend slot (from
      * response.created), so RMS-detected audio can be attributed to it. */
@@ -420,6 +426,8 @@ export class S2sRtcRealtimeClient extends EventTarget {
 
     switch (type) {
       case "session.created":
+        // The session id addresses session-scoped HTTP routes (voice cloning).
+        this.realtimeSessionId = event.session?.id || "";
         // Server-side defaults are already what we want; push only the
         // user-tunable bits (voice, instructions, tools) — same as WS.
         this._sendSessionUpdate();

--- a/demo/server.py
+++ b/demo/server.py
@@ -27,6 +27,8 @@ Endpoints:
   GET  /api/me               -> login + tier + remaining budget (LB mode only)
   POST /api/search           -> { results, answer }  Google via Serper.dev
   POST /api/calls            -> proxies the WebRTC SDP offer to <s2s>/v1/realtime/calls
+  GET  /api/voices           -> proxies the s2s cloned-voice listing (capability probe)
+  POST /api/voices           -> proxies a cloned-voice upload (rate-capped per identity)
   POST /api/session          -> proxies <LB>/session: a grant, or a queue ticket
   GET  /api/queue/{id}       -> proxies <LB>/queue/{id}: position, or a grant on claim
   DELETE /api/queue/{id}     -> leave the queue (explicit "Leave queue" button)
@@ -45,6 +47,8 @@ import asyncio
 import json
 import logging
 import os
+from collections import OrderedDict
+from datetime import datetime, timezone
 from urllib.parse import urlsplit, urlunsplit
 
 import auth
@@ -121,10 +125,39 @@ def _webrtc_calls_url(s2s_url: str) -> str:
     return urlunsplit((scheme, parts.netloc, path.rstrip("/") + "/calls", parts.query, ""))
 
 
+def _http_base_url(url: str) -> str:
+    """Reduce any realtime/connect URL to its plain http(s) origin.
+
+    ``wss://host:port/v1/realtime?token=...`` -> ``https://host:port``"""
+    s = url.strip()
+    if not s.startswith(("ws://", "wss://", "http://", "https://")):
+        s = "http://" + s
+    parts = urlsplit(s)
+    scheme = {"ws": "http", "wss": "https"}.get(parts.scheme, parts.scheme)
+    return urlunsplit((scheme, parts.netloc, "", "", ""))
+
+
 SERPER_URL = "https://google.serper.dev/search"
 # Cap results so the tool output stays small enough to feed back to the model.
 MAX_RESULTS = 5
 HERE = os.path.dirname(os.path.abspath(__file__))
+
+# ── Cloned-voice proxy ───────────────────────────────────────────────────────
+# The s2s server rejects reference audio over 10 MB; cap the whole multipart
+# body a little above that so oversized uploads die here instead of transiting.
+VOICE_UPLOAD_MAX_BYTES = 12 * 1024 * 1024
+# Modest per-identity daily cap on voice creations (in-memory: voice cloning is
+# cheap to retry and the cap only guards against scripting, so restarts may
+# forgive — unlike talk time there is no budget to protect across reboots).
+VOICE_CREATE_DAILY_CAP = int(os.environ.get("VOICE_CREATE_DAILY_CAP", "10"))
+_voice_creations: dict = {}
+_voice_creations_day = ""
+# LB mode: session grant id -> compute-host origin, recorded when the grant is
+# relayed. Voices requests forward ONLY to a recorded host (or the pinned URL in
+# direct mode) — never to a client-supplied target. Bounded LRU so abandoned
+# grants can't grow it forever.
+_grant_hosts: "OrderedDict[str, str]" = OrderedDict()
+GRANT_HOSTS_MAX = 1024
 
 app = FastAPI(title="s2s-demo")
 
@@ -303,6 +336,111 @@ async def calls(request: Request):
     )
 
 
+def _voice_error(status_code: int, message: str, code: str) -> JSONResponse:
+    """Same error shape as the s2s voices routes, so the client handles one format."""
+    return JSONResponse({"error": {"message": message, "code": code}}, status_code=status_code)
+
+
+def _voices_backend_url(session_id: str, grant_id: str) -> "str | JSONResponse":
+    """Resolve the only backend a voices request may go to.
+
+    Direct mode: the env-pinned s2s URL. LB mode: the compute host recorded
+    when this grant was relayed (the `grant` param is the LB session id the
+    client already holds). A client-supplied target is never honoured —
+    same SSRF stance as /api/calls."""
+    if SPEECH_TO_SPEECH_URL:
+        base = _http_base_url(SPEECH_TO_SPEECH_URL)
+    elif LOAD_BALANCER_URL:
+        base = _grant_hosts.get(grant_id) if grant_id else None
+        if not base:
+            return _voice_error(404, "Unknown session grant.", "unknown_grant")
+    else:
+        raise HTTPException(status_code=404, detail="Not found.")
+    return f"{base}/v1/realtime/sessions/{session_id}/voices"
+
+
+def _relay_voices_response(resp: httpx.Response) -> Response:
+    return Response(
+        content=resp.content,
+        status_code=resp.status_code,
+        media_type=resp.headers.get("content-type", "application/json"),
+    )
+
+
+def _voice_creation_allowance(keys) -> int:
+    """Creations already burned today by any of the caller's identity keys."""
+    global _voice_creations_day
+    today = datetime.now(timezone.utc).strftime("%Y-%m-%d")
+    if _voice_creations_day != today:
+        _voice_creations_day = today
+        _voice_creations.clear()
+    return max((_voice_creations.get(k, 0) for k in keys), default=0)
+
+
+@app.get("/api/voices")
+async def voices_list(session: str = "", grant: str = ""):
+    """Proxy the cloned-voice listing; doubles as the capability probe (200 vs
+    409) the front-end uses to decide whether to show the voice-cloning UI."""
+    if not session:
+        return _voice_error(400, "Missing session id.", "missing_session")
+    url = _voices_backend_url(session, grant)
+    if isinstance(url, JSONResponse):
+        return url
+    try:
+        async with httpx.AsyncClient(timeout=15.0) as http:
+            resp = await http.get(url)
+    except httpx.RequestError as exc:
+        logger.warning("s2s voices endpoint unreachable: %r", exc)
+        raise HTTPException(status_code=502, detail="Speech service unreachable.")
+    return _relay_voices_response(resp)
+
+
+@app.post("/api/voices")
+async def voices_create(request: Request, session: str = "", grant: str = ""):
+    """Proxy a cloned-voice upload, enforcing the size cap and a per-identity
+    daily creation cap before anything reaches the compute fleet."""
+    if not session:
+        return _voice_error(400, "Missing session id.", "missing_session")
+    url = _voices_backend_url(session, grant)
+    if isinstance(url, JSONResponse):
+        return url
+
+    tier, keys, _set_cookie = auth.resolve_identity(request)
+    metered = LIMITER_ENABLED and limiter.budget_for(tier) is not None
+    if metered and _voice_creation_allowance(keys) >= VOICE_CREATE_DAILY_CAP:
+        return _voice_error(
+            429,
+            f"Daily voice-creation limit reached ({VOICE_CREATE_DAILY_CAP}).",
+            "voice_creation_limit",
+        )
+
+    body = await request.body()
+    if len(body) > VOICE_UPLOAD_MAX_BYTES:
+        return _voice_error(
+            413,
+            f"Upload is too large (max {VOICE_UPLOAD_MAX_BYTES // (1024 * 1024)} MB).",
+            "upload_too_large",
+        )
+
+    try:
+        # Generous timeout: with a hub-backed voice store the s2s server pushes
+        # the voice to the Hub before answering 201.
+        async with httpx.AsyncClient(timeout=60.0) as http:
+            resp = await http.post(
+                url,
+                content=body,
+                headers={"Content-Type": request.headers.get("content-type", "")},
+            )
+    except httpx.RequestError as exc:
+        logger.warning("s2s voices endpoint unreachable: %r", exc)
+        raise HTTPException(status_code=502, detail="Speech service unreachable.")
+
+    if metered and resp.status_code == 201:
+        for k in keys:
+            _voice_creations[k] = _voice_creations.get(k, 0) + 1
+    return _relay_voices_response(resp)
+
+
 @app.post("/api/session")
 async def session(request: Request):
     """Proxy the session handshake to the load balancer, keeping its URL secret,
@@ -455,6 +593,14 @@ async def queue_end(request: Request):
 async def _finalize_grant(data, keys, tier, tracked, set_cookie):
     """Shared grant tail (fast path or queue claim): reserve the first chunk, attach
     the metering fields the client needs, and set the anon cookie."""
+    # Remember which compute host this grant points at so /api/voices can
+    # forward there without ever trusting a client-supplied target.
+    connect = data.get("connect_url") or data.get("websocket_url")
+    if data.get("session_id") and connect:
+        _grant_hosts[data["session_id"]] = _http_base_url(connect)
+        while len(_grant_hosts) > GRANT_HOSTS_MAX:
+            _grant_hosts.popitem(last=False)
+
     remaining = None
     if tracked and data.get("session_id"):
         await asyncio.to_thread(limiter.begin, data["session_id"], keys, tier)

--- a/demo/server.py
+++ b/demo/server.py
@@ -150,7 +150,7 @@ VOICE_UPLOAD_MAX_BYTES = 12 * 1024 * 1024
 # cheap to retry and the cap only guards against scripting, so restarts may
 # forgive — unlike talk time there is no budget to protect across reboots).
 VOICE_CREATE_DAILY_CAP = int(os.environ.get("VOICE_CREATE_DAILY_CAP", "10"))
-_voice_creations: dict = {}
+_voice_creations: "dict[str, int]" = {}
 _voice_creations_day = ""
 # LB mode: session grant id -> compute-host origin, recorded when the grant is
 # relayed. Voices requests forward ONLY to a recorded host (or the pinned URL in
@@ -336,24 +336,36 @@ async def calls(request: Request):
     )
 
 
-def _voice_error(status_code: int, message: str, code: str) -> JSONResponse:
-    """Same error shape as the s2s voices routes, so the client handles one format."""
-    return JSONResponse({"error": {"message": message, "code": code}}, status_code=status_code)
+class VoiceProxyError(Exception):
+    """A proxy-side refusal, rendered in the s2s voices routes' error shape
+    (the app-level handler below) so the client handles one format."""
+
+    def __init__(self, status_code: int, message: str, code: str) -> None:
+        super().__init__(message)
+        self.status_code = status_code
+        self.code = code
 
 
-def _voices_backend_url(session_id: str, grant_id: str) -> "str | JSONResponse":
+@app.exception_handler(VoiceProxyError)
+async def _voice_proxy_error(_request: Request, exc: VoiceProxyError) -> JSONResponse:
+    return JSONResponse({"error": {"message": str(exc), "code": exc.code}}, status_code=exc.status_code)
+
+
+def _voices_backend_url(session_id: str, grant_id: str) -> str:
     """Resolve the only backend a voices request may go to.
 
     Direct mode: the env-pinned s2s URL. LB mode: the compute host recorded
     when this grant was relayed (the `grant` param is the LB session id the
     client already holds). A client-supplied target is never honoured —
     same SSRF stance as /api/calls."""
+    if not session_id:
+        raise VoiceProxyError(400, "Missing session id.", "missing_session")
     if SPEECH_TO_SPEECH_URL:
         base = _http_base_url(SPEECH_TO_SPEECH_URL)
     elif LOAD_BALANCER_URL:
         base = _grant_hosts.get(grant_id) if grant_id else None
         if not base:
-            return _voice_error(404, "Unknown session grant.", "unknown_grant")
+            raise VoiceProxyError(404, "Unknown session grant.", "unknown_grant")
     else:
         raise HTTPException(status_code=404, detail="Not found.")
     return f"{base}/v1/realtime/sessions/{session_id}/voices"
@@ -381,11 +393,7 @@ def _voice_creation_allowance(keys) -> int:
 async def voices_list(session: str = "", grant: str = ""):
     """Proxy the cloned-voice listing; doubles as the capability probe (200 vs
     409) the front-end uses to decide whether to show the voice-cloning UI."""
-    if not session:
-        return _voice_error(400, "Missing session id.", "missing_session")
     url = _voices_backend_url(session, grant)
-    if isinstance(url, JSONResponse):
-        return url
     try:
         async with httpx.AsyncClient(timeout=15.0) as http:
             resp = await http.get(url)
@@ -399,16 +407,12 @@ async def voices_list(session: str = "", grant: str = ""):
 async def voices_create(request: Request, session: str = "", grant: str = ""):
     """Proxy a cloned-voice upload, enforcing the size cap and a per-identity
     daily creation cap before anything reaches the compute fleet."""
-    if not session:
-        return _voice_error(400, "Missing session id.", "missing_session")
     url = _voices_backend_url(session, grant)
-    if isinstance(url, JSONResponse):
-        return url
 
     tier, keys, _set_cookie = auth.resolve_identity(request)
     metered = LIMITER_ENABLED and limiter.budget_for(tier) is not None
     if metered and _voice_creation_allowance(keys) >= VOICE_CREATE_DAILY_CAP:
-        return _voice_error(
+        raise VoiceProxyError(
             429,
             f"Daily voice-creation limit reached ({VOICE_CREATE_DAILY_CAP}).",
             "voice_creation_limit",
@@ -416,7 +420,7 @@ async def voices_create(request: Request, session: str = "", grant: str = ""):
 
     body = await request.body()
     if len(body) > VOICE_UPLOAD_MAX_BYTES:
-        return _voice_error(
+        raise VoiceProxyError(
             413,
             f"Upload is too large (max {VOICE_UPLOAD_MAX_BYTES // (1024 * 1024)} MB).",
             "upload_too_large",

--- a/demo/style.css
+++ b/demo/style.css
@@ -1735,6 +1735,15 @@ body.cam-on .footer {
   display: none;
 }
 
+.voice-offline-note {
+  margin: 0;
+  font-size: 13px;
+  color: var(--text-dim);
+}
+.voice-offline-note[hidden] {
+  display: none;
+}
+
 /* ─── Chat button + badge ────────────────────────────────────────────── */
 
 #chat-btn {

--- a/demo/style.css
+++ b/demo/style.css
@@ -1648,6 +1648,93 @@ body.cam-on .footer {
   gap: 12px;
 }
 
+/* ─── Create-voice button + modal ────────────────────────────────────── */
+
+/* Sits beside the voice select; hidden until the capability probe passes. */
+.create-voice-btn {
+  align-self: end;
+}
+.create-voice-btn[hidden] {
+  display: none;
+}
+
+/* Record / Upload segmented toggle. */
+.voice-mode {
+  display: flex;
+  width: fit-content;
+  border: 1px solid var(--border);
+  border-radius: var(--radius-sm);
+  overflow: hidden;
+}
+.voice-mode-btn {
+  padding: 8px 18px;
+  background: transparent;
+  border: none;
+  color: var(--text-dim);
+  font: inherit;
+  font-size: 13px;
+  font-weight: 600;
+  cursor: pointer;
+  transition: background 0.15s, color 0.15s;
+}
+.voice-mode-btn.active {
+  background: var(--bg-elev-2);
+  color: var(--text);
+}
+
+.voice-panel {
+  display: flex;
+  flex-direction: column;
+  gap: 14px;
+}
+.voice-panel[hidden] {
+  display: none;
+}
+
+/* The fixed script the user reads aloud — it IS the reference transcript. */
+.voice-script {
+  margin: 0;
+  padding: 12px 14px;
+  background: var(--bg);
+  border: 1px solid var(--border);
+  border-radius: var(--radius-sm);
+  color: var(--text);
+  font-size: 14px;
+  line-height: 1.55;
+}
+
+.voice-record-row {
+  display: flex;
+  align-items: center;
+  gap: 12px;
+}
+.voice-record-btn.recording {
+  border-color: var(--error);
+  color: var(--error);
+}
+.voice-record-time {
+  font-family: var(--font-mono);
+  font-size: 13px;
+  color: var(--text-dim);
+}
+.voice-preview {
+  flex: 1;
+  min-width: 0;
+  height: 36px;
+}
+.voice-preview[hidden] {
+  display: none;
+}
+
+.voice-error {
+  margin: 0;
+  font-size: 13px;
+  color: var(--error);
+}
+.voice-error[hidden] {
+  display: none;
+}
+
 /* ─── Chat button + badge ────────────────────────────────────────────── */
 
 #chat-btn {

--- a/demo/ws/s2s-ws-client.js
+++ b/demo/ws/s2s-ws-client.js
@@ -167,6 +167,12 @@ export class S2sWsRealtimeClient extends EventTarget {
     this._visualiser = null;
     /** @type {WsStatus} */
     this._status = "idle";
+    /** @type {string} Realtime session id from `session.created`; addresses the
+     * session-scoped voices routes (empty until the event arrives). */
+    this.realtimeSessionId = "";
+    /** @type {string} LB grant session id (LB mode only; empty in direct mode).
+     * The /api/voices proxy uses it to find the compute host it recorded. */
+    this.grantSessionId = "";
     this._aiSpeaking = false;
     /** @type {Set<string>} response_ids that have actually played audio, so the
      * UI can tell a barge-in cut (keep it) from a never-heard speculative
@@ -256,6 +262,7 @@ export class S2sWsRealtimeClient extends EventTarget {
         await this._awaitJoin(grant);
         if (this._closed) throw _codedError("connect aborted", "aborted");
       }
+      this.grantSessionId = grant.sessionId || "";
       this.dispatchEvent(new CustomEvent("session", { detail: { info: grant } }));
       connectUrl = grant.connectUrl;
       this._setStatus("connecting");
@@ -620,6 +627,8 @@ export class S2sWsRealtimeClient extends EventTarget {
 
     switch (type) {
       case "session.created":
+        // The session id addresses session-scoped HTTP routes (voice cloning).
+        this.realtimeSessionId = event.session?.id || "";
         // Server-side defaults for the s2s pipeline are already what we
         // want (server_vad, whisper-1 transcription, PCM16 16k in / 24k
         // out). We only push the user-tunable bits: voice + instructions.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -59,6 +59,7 @@ dependencies = [
     "espeakng-loader>=0.2.4; platform_system == 'Darwin'",
     "spacy>=3.8.4; platform_system == 'Darwin'",
     "phonemizer-fork>=3.3.2; platform_system == 'Darwin'",
+    "python-multipart>=0.0.18",
 ]
 
 [project.optional-dependencies]

--- a/src/speech_to_speech/TTS/qwen3_tts_handler.py
+++ b/src/speech_to_speech/TTS/qwen3_tts_handler.py
@@ -17,7 +17,7 @@ from pathlib import Path
 from sys import platform
 from threading import Event
 from time import perf_counter
-from typing import Any, Iterator, Optional
+from typing import TYPE_CHECKING, Any, Iterator, Optional
 
 import numpy as np
 import torch
@@ -32,6 +32,9 @@ from speech_to_speech.pipeline.handler_types import TTSIn, TTSOut
 from speech_to_speech.pipeline.messages import AUDIO_RESPONSE_DONE, PIPELINE_END, EndOfResponse, TTSInput
 from speech_to_speech.pipeline.speculative_turns import SpeculativeTurnTracker
 from speech_to_speech.utils.mlx_lock import MLXLockContext
+
+if TYPE_CHECKING:
+    from speech_to_speech.voice_store import VoiceStore
 
 logger = logging.getLogger(__name__)
 console = Console()
@@ -113,9 +116,11 @@ class Qwen3TTSHandler(BaseHandler[TTSIn, TTSOut]):
         gen_kwargs: dict[str, Any] | None = None,
         cancel_scope: CancelScope | None = None,
         speculative_turns: SpeculativeTurnTracker | None = None,
+        voice_store: "VoiceStore | None" = None,
     ) -> None:
         self.cancel_scope = cancel_scope
         self.speculative_turns = speculative_turns
+        self.voice_store = voice_store
         self.should_listen = should_listen
         self.requested_device = device
         self.ref_audio = ref_audio
@@ -179,6 +184,7 @@ class Qwen3TTSHandler(BaseHandler[TTSIn, TTSOut]):
 
         self._initial_speaker = self.speaker
         self._initial_ref_audio = self.ref_audio
+        self._initial_ref_text = self.ref_text
 
         self.warmup()
 
@@ -423,6 +429,17 @@ class Qwen3TTSHandler(BaseHandler[TTSIn, TTSOut]):
         if not session_voice:
             return
 
+        # A voice id from the cloned-voice registry resolves to a stored
+        # (reference audio, transcript) pair. Checked before preset-speaker
+        # matching: ids are hex strings that cannot collide with speaker names.
+        voice_store = getattr(self, "voice_store", None)
+        if voice_store is not None:
+            resolved = voice_store.resolve(session_voice)
+            if resolved is not None:
+                self.ref_audio = resolved.ref_audio
+                self.ref_text = resolved.ref_text
+                return
+
         if model_type == "custom_voice":
             supported_speakers = self._supported_speakers()
             if supported_speakers is not None:
@@ -443,12 +460,12 @@ class Qwen3TTSHandler(BaseHandler[TTSIn, TTSOut]):
             self.ref_audio = None
             return
 
-        if self._resolve_audio_path(session_voice) is not None:
-            self.ref_audio = session_voice
-            return
-
+        # Deliberately no filesystem-path fallback here: letting an API session
+        # point ref_audio at arbitrary server paths is a file-probe primitive.
+        # The CLI --qwen3_tts_ref_audio launch argument is the only path-based
+        # input; API sessions select voices by registry id or preset speaker.
         logger.warning(
-            "Ignoring Qwen3-TTS session voice override because it is not an audio file path: %r",
+            "Ignoring Qwen3-TTS session voice override because it is not a known voice id: %r",
             session_voice,
         )
 
@@ -876,6 +893,7 @@ class Qwen3TTSHandler(BaseHandler[TTSIn, TTSOut]):
     def on_session_end(self) -> None:
         self.speaker = self._initial_speaker
         self.ref_audio = self._initial_ref_audio
+        self.ref_text = self._initial_ref_text
         logger.debug("Qwen3-TTS session state reset")
 
     def cleanup(self) -> None:

--- a/src/speech_to_speech/api/openai_realtime/handlers/session.py
+++ b/src/speech_to_speech/api/openai_realtime/handlers/session.py
@@ -54,7 +54,10 @@ class SessionHandler(RealtimeBaseHandler):
     def build_session_created(self, conn_id: str) -> SessionCreatedEvent:
         """Build a SessionCreatedEvent populated with the current config."""
         cfg = self._state(conn_id).runtime_config
-        session = cfg.session
+        # The GA wire format carries the session id on session.created (the SDK
+        # request model tolerates it via extra="allow"); WebSocket clients have
+        # no other way to learn the id that addresses session-scoped routes.
+        session = cfg.session.model_copy(update={"id": conn_id})
         return SessionCreatedEvent(
             type="session.created",
             event_id=self._next_event_id(),

--- a/src/speech_to_speech/api/openai_realtime/server.py
+++ b/src/speech_to_speech/api/openai_realtime/server.py
@@ -6,6 +6,7 @@ import uvicorn
 
 from speech_to_speech.api.openai_realtime.pipeline_unit import PipelineUnit
 from speech_to_speech.api.openai_realtime.websocket_router import create_app
+from speech_to_speech.voice_store import VoiceStore
 
 logger = logging.getLogger(__name__)
 
@@ -25,6 +26,7 @@ class RealtimeServer:
         pool: list[PipelineUnit],
         host: str = "0.0.0.0",
         port: int = 8765,
+        voice_store: VoiceStore | None = None,
     ) -> None:
         if not pool:
             raise ValueError("RealtimeServer requires at least one PipelineUnit in the pool")
@@ -32,10 +34,11 @@ class RealtimeServer:
         self.pool = pool
         self.host = host
         self.port = port
+        self.voice_store = voice_store
 
     def run(self) -> None:
         """Start the FastAPI/uvicorn server (called from a ThreadManager thread)."""
-        app = create_app(pool=self.pool, stop_event=self.stop_event)
+        app = create_app(pool=self.pool, stop_event=self.stop_event, voice_store=self.voice_store)
 
         logger.info(
             f"OpenAI Realtime API starting on ws://{self.host}:{self.port}/v1/realtime (pool size {len(self.pool)})"

--- a/src/speech_to_speech/api/openai_realtime/voices_router.py
+++ b/src/speech_to_speech/api/openai_realtime/voices_router.py
@@ -1,0 +1,105 @@
+"""Session-scoped HTTP routes for the cloned-voice library.
+
+Mounted by ``create_app`` next to the realtime WebSocket route. The GET
+route doubles as the capability probe: 200 means the backend supports voice
+cloning for this session, 409 means it does not (no voice store is wired —
+the pipeline's TTS is not Qwen3). No custom fields are added to any OpenAI
+Realtime event; capability is discovered by probing these routes.
+
+Voices are selected afterwards with a plain ``session.update`` carrying the
+voice id in the session audio output voice field.
+"""
+
+from __future__ import annotations
+
+import logging
+from typing import Optional
+
+from fastapi import APIRouter, File, Form, UploadFile
+from fastapi.responses import JSONResponse
+from pydantic import BaseModel
+from starlette.concurrency import run_in_threadpool
+
+from speech_to_speech.api.openai_realtime.pipeline_unit import PipelineUnit
+from speech_to_speech.voice_store import VoiceStore, VoiceValidationError
+
+logger = logging.getLogger(__name__)
+
+
+class VoiceInfo(BaseModel):
+    voice_id: str
+    name: str
+    created_at: str
+
+
+class VoiceListResponse(BaseModel):
+    voices: list[VoiceInfo]
+
+
+class VoiceRouteError(BaseModel):
+    message: str
+    code: str
+
+
+class VoiceRouteErrorResponse(BaseModel):
+    error: VoiceRouteError
+
+
+def _error_response(status_code: int, message: str, code: str) -> JSONResponse:
+    body = VoiceRouteErrorResponse(error=VoiceRouteError(message=message, code=code))
+    return JSONResponse(content=body.model_dump(), status_code=status_code)
+
+
+def build_voices_router(pool: list[PipelineUnit], voice_store: Optional[VoiceStore]) -> APIRouter:
+    router = APIRouter()
+
+    def _gate(session_id: str) -> Optional[JSONResponse]:
+        """Session addressing + capability gating shared by both routes."""
+        for unit in pool:
+            session = unit.session
+            if session is not None and session.session_id == session_id and session.released_at is None:
+                break
+        else:
+            return _error_response(404, "Unknown session", "unknown_session")
+        if voice_store is None:
+            return _error_response(
+                409,
+                "Voice cloning is not available on this server's TTS backend.",
+                "voice_cloning_unsupported",
+            )
+        return None
+
+    @router.get("/v1/realtime/sessions/{session_id}/voices")
+    async def list_voices(session_id: str) -> JSONResponse:
+        err = _gate(session_id)
+        if err is not None:
+            return err
+        assert voice_store is not None
+        records = await run_in_threadpool(voice_store.list_voices)
+        body = VoiceListResponse(
+            voices=[VoiceInfo(voice_id=r.voice_id, name=r.name, created_at=r.created_at) for r in records]
+        )
+        return JSONResponse(content=body.model_dump(), status_code=200)
+
+    @router.post("/v1/realtime/sessions/{session_id}/voices")
+    async def create_voice(
+        session_id: str,
+        audio: UploadFile = File(...),
+        ref_text: str = Form(...),
+        name: str = Form(...),
+    ) -> JSONResponse:
+        err = _gate(session_id)
+        if err is not None:
+            return err
+        assert voice_store is not None
+        audio_bytes = await audio.read()
+        try:
+            # Decode/resample/store off the event loop: this loop also carries
+            # every live conversation's audio.
+            record = await run_in_threadpool(voice_store.add_voice, audio_bytes, ref_text=ref_text, name=name)
+        except VoiceValidationError as e:
+            return _error_response(e.status_code, str(e), e.code)
+        body = VoiceInfo(voice_id=record.voice_id, name=record.name, created_at=record.created_at)
+        return JSONResponse(content=body.model_dump(), status_code=201)
+
+    return router

--- a/src/speech_to_speech/api/openai_realtime/voices_router.py
+++ b/src/speech_to_speech/api/openai_realtime/voices_router.py
@@ -21,7 +21,7 @@ from pydantic import BaseModel
 from starlette.concurrency import run_in_threadpool
 
 from speech_to_speech.api.openai_realtime.pipeline_unit import PipelineUnit
-from speech_to_speech.voice_store import VoiceStore, VoiceValidationError
+from speech_to_speech.voice_store import VoiceStore, VoiceSyncError, VoiceValidationError
 
 logger = logging.getLogger(__name__)
 
@@ -99,6 +99,9 @@ def build_voices_router(pool: list[PipelineUnit], voice_store: Optional[VoiceSto
             record = await run_in_threadpool(voice_store.add_voice, audio_bytes, ref_text=ref_text, name=name)
         except VoiceValidationError as e:
             return _error_response(e.status_code, str(e), e.code)
+        except VoiceSyncError as e:
+            # The store rolled the local copy back; nothing was created.
+            return _error_response(502, str(e), "voice_store_sync_failed")
         body = VoiceInfo(voice_id=record.voice_id, name=record.name, created_at=record.created_at)
         return JSONResponse(content=body.model_dump(), status_code=201)
 

--- a/src/speech_to_speech/api/openai_realtime/websocket_router.py
+++ b/src/speech_to_speech/api/openai_realtime/websocket_router.py
@@ -29,6 +29,7 @@ from speech_to_speech.api.openai_realtime.transports import (
     WebSocketTransport,
     send_ws_event,
 )
+from speech_to_speech.api.openai_realtime.voices_router import build_voices_router
 from speech_to_speech.pipeline.control import SESSION_END, PipelineControlMessage, is_control_message
 from speech_to_speech.pipeline.events import (
     AssistantTextEvent,
@@ -41,6 +42,7 @@ from speech_to_speech.pipeline.events import (
 )
 from speech_to_speech.pipeline.log_context import pipeline_log_ctx
 from speech_to_speech.pipeline.messages import AUDIO_RESPONSE_DONE, PIPELINE_END, AudioOutput
+from speech_to_speech.voice_store import VoiceStore
 
 # aiortc (the 'webrtc' extra) is optional. Import it here, at module load,
 # rather than lazily in the calls endpoint: the av/cryptography C extensions
@@ -403,7 +405,11 @@ async def _dispatch_client_event(
         unit.response_playing.clear()
 
 
-def create_app(pool: list[PipelineUnit], stop_event: ThreadingEvent) -> FastAPI:
+def create_app(
+    pool: list[PipelineUnit],
+    stop_event: ThreadingEvent,
+    voice_store: VoiceStore | None = None,
+) -> FastAPI:
     @asynccontextmanager
     async def lifespan(app: FastAPI) -> AsyncIterator[None]:
         # One send loop per pipeline unit; each polls its own queues and forwards
@@ -426,6 +432,7 @@ def create_app(pool: list[PipelineUnit], stop_event: ThreadingEvent) -> FastAPI:
                     pass
 
     app = FastAPI(lifespan=lifespan)
+    app.include_router(build_voices_router(pool, voice_store))
 
     def _claim_unit(transport: SessionTransport | None) -> PipelineUnit | None:
         """Atomically (between asyncio yield points) reserve the first idle unit.

--- a/src/speech_to_speech/arguments_classes/voice_store_arguments.py
+++ b/src/speech_to_speech/arguments_classes/voice_store_arguments.py
@@ -1,0 +1,24 @@
+from dataclasses import dataclass, field
+from typing import Optional
+
+
+@dataclass
+class VoiceStoreArguments:
+    """Configuration for the cloned-voice library (realtime mode, Qwen3-TTS).
+
+    Kept separate from the Qwen3 TTS arguments because the store is
+    TTS-agnostic; only the route gating is Qwen-specific today.
+    """
+
+    voice_store_dir: Optional[str] = field(
+        default=None,
+        metadata={
+            "help": "Local directory holding the cloned-voice library (one folder per voice). Defaults to ~/.cache/speech-to-speech/voices."
+        },
+    )
+    voice_store_hub_repo: Optional[str] = field(
+        default=None,
+        metadata={
+            "help": "Optional Hugging Face Hub dataset repo id (e.g. 'org/voices') used as the durable, fleet-consistent source of truth for the voice library. Authentication uses the standard HF_TOKEN environment variable. When unset, voices only persist in the local directory (single-instance deployments)."
+        },
+    )

--- a/src/speech_to_speech/s2s_pipeline.py
+++ b/src/speech_to_speech/s2s_pipeline.py
@@ -655,10 +655,11 @@ def build_pipeline(
         # answer 409, which is the capability-probe contract.
         voice_store = None
         if module_kwargs.tts == "qwen3":
-            from speech_to_speech.voice_store import DEFAULT_STORE_DIR, VoiceStore
+            from speech_to_speech.voice_store import DEFAULT_STORE_DIR, HubVoiceRepo, VoiceStore
 
             store_args = voice_store_kwargs or VoiceStoreArguments()
-            voice_store = VoiceStore(store_args.voice_store_dir or DEFAULT_STORE_DIR)
+            hub = HubVoiceRepo(store_args.voice_store_hub_repo) if store_args.voice_store_hub_repo else None
+            voice_store = VoiceStore(store_args.voice_store_dir or DEFAULT_STORE_DIR, hub=hub)
 
         pool_size = max(1, module_kwargs.num_pipelines)
         pool = [

--- a/src/speech_to_speech/s2s_pipeline.py
+++ b/src/speech_to_speech/s2s_pipeline.py
@@ -467,6 +467,7 @@ def _build_realtime_pipeline_unit(
     pocket_tts_handler_kwargs: PocketTTSHandlerArguments,
     kokoro_tts_handler_kwargs: KokoroTTSHandlerArguments,
     qwen3_tts_handler_kwargs: Qwen3TTSHandlerArguments,
+    voice_store: Any = None,
 ) -> "PipelineUnit":
     """Build one isolated realtime pipeline (own queues, events, service, handlers).
 
@@ -517,6 +518,11 @@ def _build_realtime_pipeline_unit(
     ):
         vars(kw)["cancel_scope"] = cancel_scope
         vars(kw)["speculative_turns"] = speculative_turns
+
+    # Injected after the deepcopy above: the voice store is shared across the
+    # pool (one library, many pipelines), so it must not be per-unit copied.
+    if voice_store is not None:
+        vars(qwen3_tts_kw)["voice_store"] = voice_store
 
     if module_kwargs.llm_backend in ("responses-api", "chat-completions"):
         chat_size = vars(responses_api_kw).get("chat_size", 10)
@@ -673,6 +679,7 @@ def build_pipeline(
                 pocket_tts_handler_kwargs=pocket_tts_handler_kwargs,
                 kokoro_tts_handler_kwargs=kokoro_tts_handler_kwargs,
                 qwen3_tts_handler_kwargs=qwen3_tts_handler_kwargs,
+                voice_store=voice_store,
             )
             for i in range(pool_size)
         ]

--- a/src/speech_to_speech/s2s_pipeline.py
+++ b/src/speech_to_speech/s2s_pipeline.py
@@ -47,6 +47,7 @@ from speech_to_speech.arguments_classes.responses_api_language_model_arguments i
 from speech_to_speech.arguments_classes.socket_receiver_arguments import SocketReceiverArguments
 from speech_to_speech.arguments_classes.socket_sender_arguments import SocketSenderArguments
 from speech_to_speech.arguments_classes.vad_arguments import VADHandlerArguments
+from speech_to_speech.arguments_classes.voice_store_arguments import VoiceStoreArguments
 from speech_to_speech.arguments_classes.websocket_streamer_arguments import WebSocketStreamerArguments
 from speech_to_speech.arguments_classes.whisper_stt_arguments import WhisperSTTHandlerArguments
 from speech_to_speech.baseHandler import BaseHandler
@@ -107,6 +108,7 @@ class ParsedArguments:
     pocket_tts_handler_kwargs: PocketTTSHandlerArguments
     kokoro_tts_handler_kwargs: KokoroTTSHandlerArguments
     qwen3_tts_handler_kwargs: Qwen3TTSHandlerArguments
+    voice_store_kwargs: VoiceStoreArguments
 
 
 def rename_args(args: Any, prefix: str) -> None:
@@ -165,6 +167,7 @@ def parse_arguments() -> ParsedArguments:
             PocketTTSHandlerArguments,
             KokoroTTSHandlerArguments,
             Qwen3TTSHandlerArguments,
+            VoiceStoreArguments,
         )
     )
 
@@ -200,6 +203,7 @@ def parse_arguments() -> ParsedArguments:
         pocket_tts_handler_kwargs=by_type[PocketTTSHandlerArguments],
         kokoro_tts_handler_kwargs=by_type[KokoroTTSHandlerArguments],
         qwen3_tts_handler_kwargs=by_type[Qwen3TTSHandlerArguments],
+        voice_store_kwargs=by_type[VoiceStoreArguments],
     )
 
 
@@ -597,6 +601,7 @@ def build_pipeline(
     kokoro_tts_handler_kwargs: KokoroTTSHandlerArguments,
     qwen3_tts_handler_kwargs: Qwen3TTSHandlerArguments,
     queues_and_events: dict[str, Any],
+    voice_store_kwargs: VoiceStoreArguments | None = None,
 ) -> ThreadManager:
     stop_event = queues_and_events["stop_event"]
     should_listen = queues_and_events["should_listen"]
@@ -639,6 +644,16 @@ def build_pipeline(
     elif module_kwargs.mode == "realtime":
         from speech_to_speech.api.openai_realtime.server import RealtimeServer
 
+        # The cloned-voice library only makes sense when the TTS can condition
+        # on a (ref_audio, ref_text) pair; without a store the voices routes
+        # answer 409, which is the capability-probe contract.
+        voice_store = None
+        if module_kwargs.tts == "qwen3":
+            from speech_to_speech.voice_store import DEFAULT_STORE_DIR, VoiceStore
+
+            store_args = voice_store_kwargs or VoiceStoreArguments()
+            voice_store = VoiceStore(store_args.voice_store_dir or DEFAULT_STORE_DIR)
+
         pool_size = max(1, module_kwargs.num_pipelines)
         pool = [
             _build_realtime_pipeline_unit(
@@ -667,6 +682,7 @@ def build_pipeline(
             pool=pool,
             host=websocket_streamer_kwargs.ws_host,
             port=websocket_streamer_kwargs.ws_port,
+            voice_store=voice_store,
         )
 
         all_handlers: list[Any] = [realtime_server]
@@ -1048,6 +1064,7 @@ def main() -> None:
         args.kokoro_tts_handler_kwargs,
         args.qwen3_tts_handler_kwargs,
         queues_and_events,
+        voice_store_kwargs=args.voice_store_kwargs,
     )
 
     # Set up graceful shutdown handler

--- a/src/speech_to_speech/s2s_pipeline.py
+++ b/src/speech_to_speech/s2s_pipeline.py
@@ -11,7 +11,7 @@ from queue import Queue
 from sys import platform
 from threading import Event
 from types import FrameType
-from typing import Any, Optional
+from typing import TYPE_CHECKING, Any, Optional
 
 import nltk
 import torch
@@ -68,6 +68,9 @@ from speech_to_speech.pipeline.speculative_turns import SpeculativeTurnTracker
 from speech_to_speech.STT.transcription_notifier import TranscriptionNotifier
 from speech_to_speech.utils.thread_manager import ThreadManager
 from speech_to_speech.VAD.vad_handler import VADHandler
+
+if TYPE_CHECKING:
+    from speech_to_speech.voice_store import VoiceStore
 
 # Ensure that the necessary NLTK resources are available
 try:
@@ -467,7 +470,7 @@ def _build_realtime_pipeline_unit(
     pocket_tts_handler_kwargs: PocketTTSHandlerArguments,
     kokoro_tts_handler_kwargs: KokoroTTSHandlerArguments,
     qwen3_tts_handler_kwargs: Qwen3TTSHandlerArguments,
-    voice_store: Any = None,
+    voice_store: "VoiceStore | None" = None,
 ) -> "PipelineUnit":
     """Build one isolated realtime pipeline (own queues, events, service, handlers).
 

--- a/src/speech_to_speech/voice_store.py
+++ b/src/speech_to_speech/voice_store.py
@@ -53,6 +53,14 @@ class VoiceRecord(BaseModel):
     created_at: str
 
 
+class ResolvedVoice(BaseModel):
+    """What a TTS handler needs to speak in a cloned voice."""
+
+    voice_id: str
+    ref_audio: str
+    ref_text: str
+
+
 class VoiceValidationError(Exception):
     """A client-side problem with an uploaded voice (bad audio, bad metadata)."""
 
@@ -189,6 +197,17 @@ class VoiceStore:
 
     def list_voices(self) -> list[VoiceRecord]:
         return sorted(self._records.values(), key=lambda r: (r.created_at, r.voice_id))
+
+    def resolve(self, voice_id: str) -> Optional[ResolvedVoice]:
+        """Resolve a voice id to its (reference audio path, transcript) pair."""
+        record = self._records.get(voice_id)
+        if record is None:
+            return None
+        return ResolvedVoice(
+            voice_id=record.voice_id,
+            ref_audio=str(self.root / record.voice_id / REF_AUDIO_FILENAME),
+            ref_text=record.ref_text,
+        )
 
     # ------------------------------------------------------------------
     # Internals

--- a/src/speech_to_speech/voice_store.py
+++ b/src/speech_to_speech/voice_store.py
@@ -16,6 +16,24 @@ metadata in place.
 The store is owned by the server layer and injected into both the realtime
 router (HTTP routes) and the TTS voice-resolution path; it is deliberately
 TTS-agnostic.
+
+When an HF Hub dataset repo is configured, the hub is the source of truth
+and the local folder is a mirror the server reads from:
+
+- Startup pulls every hub voice into the local folder (hub wins).
+- Uploads write locally, then push to the repo synchronously *before* the
+  request succeeds; a persistently failing push rolls the local copy back so
+  no instance ever holds a voice the rest of the fleet cannot see. Voice
+  folders are disjoint paths, so concurrent pushes from different instances
+  can only hit optimistic-lock races, absorbed by a small retry loop.
+- Reads stay fresh via a revision check: one cheap repo-info call per
+  listing; when the revision moved, only new voice folders are downloaded
+  and voices whose folders vanished from the repo are evicted from the
+  registry (operator deletion propagates with no DELETE API). Evicted
+  reference files are left on disk so a live session that already resolved
+  the voice finishes on it.
+- A lookup miss triggers one re-sync before the voice is rejected, so a
+  voice created through another instance resolves immediately.
 """
 
 from __future__ import annotations
@@ -25,8 +43,10 @@ import io
 import json
 import logging
 import shutil
+import time
 from datetime import datetime, timezone
 from pathlib import Path
+from threading import RLock
 from typing import Optional
 
 import numpy as np
@@ -44,6 +64,8 @@ MAX_REF_TEXT_CHARS = 2000
 VOICE_ID_HEX_CHARS = 16
 REF_AUDIO_FILENAME = "ref.wav"
 METADATA_FILENAME = "voice.json"
+HUB_PUSH_ATTEMPTS = 3
+HUB_PUSH_RETRY_SLEEP_S = 0.2
 
 
 class VoiceRecord(BaseModel):
@@ -68,6 +90,57 @@ class VoiceValidationError(Exception):
         super().__init__(message)
         self.code = code
         self.status_code = status_code
+
+
+class VoiceSyncError(Exception):
+    """The hub repo could not be updated; the upload was rolled back."""
+
+
+class HubVoiceRepo:
+    """Thin huggingface_hub adapter — one hub call per method.
+
+    Everything above this surface (pull, push-with-retry-and-rollback,
+    revision short-circuit, mirror deletion, miss re-sync) lives in
+    VoiceStore and is tested against a fake of this interface.
+    """
+
+    def __init__(self, repo_id: str) -> None:
+        from huggingface_hub import HfApi
+
+        self.repo_id = repo_id
+        self._api = HfApi()
+        self._api.create_repo(repo_id, repo_type="dataset", private=True, exist_ok=True)
+
+    def revision(self) -> str:
+        sha = self._api.repo_info(self.repo_id, repo_type="dataset").sha
+        if sha is None:
+            raise VoiceSyncError(f"Hub repo {self.repo_id} reported no revision")
+        return sha
+
+    def list_voice_ids(self, revision: Optional[str] = None) -> set[str]:
+        files = self._api.list_repo_files(self.repo_id, repo_type="dataset", revision=revision)
+        return {f.split("/", 1)[0] for f in files if f.endswith(f"/{METADATA_FILENAME}")}
+
+    def download_voice(self, voice_id: str, root: Path, revision: Optional[str] = None) -> None:
+        from huggingface_hub import hf_hub_download
+
+        for filename in (METADATA_FILENAME, REF_AUDIO_FILENAME):
+            hf_hub_download(
+                self.repo_id,
+                f"{voice_id}/{filename}",
+                repo_type="dataset",
+                revision=revision,
+                local_dir=root,
+            )
+
+    def upload_voice(self, root: Path, voice_id: str) -> None:
+        self._api.upload_folder(
+            repo_id=self.repo_id,
+            repo_type="dataset",
+            folder_path=root / voice_id,
+            path_in_repo=voice_id,
+            commit_message=f"Add voice {voice_id}",
+        )
 
 
 def _validate_metadata(name: str, ref_text: str) -> tuple[str, str]:
@@ -142,13 +215,25 @@ def _decode_and_normalize(audio_bytes: bytes) -> tuple[np.ndarray, float]:
 
 
 class VoiceStore:
-    """Folder-per-voice library rooted at a local directory."""
+    """Folder-per-voice library rooted at a local directory.
 
-    def __init__(self, root: Path | str) -> None:
+    With ``hub`` set (any object implementing the HubVoiceRepo surface), the
+    repo is the fleet-wide source of truth — see the module docstring for the
+    sync semantics.
+    """
+
+    def __init__(self, root: Path | str, hub: Optional[HubVoiceRepo] = None) -> None:
         self.root = Path(root).expanduser()
         self.root.mkdir(parents=True, exist_ok=True)
+        self._hub = hub
+        self._lock = RLock()
+        self._synced_revision: Optional[str] = None
         self._records: dict[str, VoiceRecord] = {}
         self._scan()
+        if self._hub is not None:
+            # Startup pull must succeed: serving with a silently unsynced
+            # library would defeat the fleet-consistency contract.
+            self._mirror_sync()
 
     # ------------------------------------------------------------------
     # Public API
@@ -162,52 +247,151 @@ class VoiceStore:
         """
         name, ref_text = _validate_metadata(name, ref_text)
         waveform, _duration = _decode_and_normalize(audio_bytes)
-
         voice_id = hashlib.sha256(audio_bytes).hexdigest()[:VOICE_ID_HEX_CHARS]
-        existing = self._records.get(voice_id)
-        record = VoiceRecord(
-            voice_id=voice_id,
-            name=name,
-            ref_text=ref_text,
-            created_at=existing.created_at if existing else datetime.now(timezone.utc).isoformat(),
-        )
 
-        voice_dir = self.root / voice_id
-        try:
-            voice_dir.mkdir(parents=True, exist_ok=True)
-            if existing is None:
-                import soundfile as sf
+        with self._lock:
+            existing = self._records.get(voice_id)
+            record = VoiceRecord(
+                voice_id=voice_id,
+                name=name,
+                ref_text=ref_text,
+                created_at=existing.created_at if existing else datetime.now(timezone.utc).isoformat(),
+            )
 
-                sf.write(
-                    str(voice_dir / REF_AUDIO_FILENAME),
-                    waveform,
-                    STORE_SAMPLE_RATE,
-                    format="WAV",
-                    subtype="PCM_16",
-                )
-            (voice_dir / METADATA_FILENAME).write_text(json.dumps(record.model_dump(), indent=2))
-        except Exception:
-            shutil.rmtree(voice_dir, ignore_errors=True)
-            self._records.pop(voice_id, None)
-            raise
+            voice_dir = self.root / voice_id
+            try:
+                voice_dir.mkdir(parents=True, exist_ok=True)
+                if existing is None:
+                    import soundfile as sf
 
-        self._records[voice_id] = record
-        logger.info("Voice %s (%r) %s in store %s", voice_id, name, "updated" if existing else "created", self.root)
-        return record
+                    sf.write(
+                        str(voice_dir / REF_AUDIO_FILENAME),
+                        waveform,
+                        STORE_SAMPLE_RATE,
+                        format="WAV",
+                        subtype="PCM_16",
+                    )
+                (voice_dir / METADATA_FILENAME).write_text(json.dumps(record.model_dump(), indent=2))
+                if self._hub is not None:
+                    self._push_with_retry(voice_id)
+            except Exception as e:
+                self._rollback(voice_id, existing)
+                if isinstance(e, VoiceSyncError):
+                    raise
+                raise
+
+            self._records[voice_id] = record
+            logger.info(
+                "Voice %s (%r) %s in store %s", voice_id, name, "updated" if existing else "created", self.root
+            )
+            return record
 
     def list_voices(self) -> list[VoiceRecord]:
-        return sorted(self._records.values(), key=lambda r: (r.created_at, r.voice_id))
+        with self._lock:
+            if self._hub is not None:
+                self._refresh_from_hub()
+            return sorted(self._records.values(), key=lambda r: (r.created_at, r.voice_id))
 
     def resolve(self, voice_id: str) -> Optional[ResolvedVoice]:
-        """Resolve a voice id to its (reference audio path, transcript) pair."""
-        record = self._records.get(voice_id)
-        if record is None:
-            return None
-        return ResolvedVoice(
-            voice_id=record.voice_id,
-            ref_audio=str(self.root / record.voice_id / REF_AUDIO_FILENAME),
-            ref_text=record.ref_text,
-        )
+        """Resolve a voice id to its (reference audio path, transcript) pair.
+
+        A miss triggers one hub re-sync before giving up, so a voice created
+        through another instance moments ago still resolves.
+        """
+        with self._lock:
+            record = self._records.get(voice_id)
+            if record is None and self._hub is not None:
+                self._refresh_from_hub()
+                record = self._records.get(voice_id)
+            if record is None:
+                return None
+            return ResolvedVoice(
+                voice_id=record.voice_id,
+                ref_audio=str(self.root / record.voice_id / REF_AUDIO_FILENAME),
+                ref_text=record.ref_text,
+            )
+
+    # ------------------------------------------------------------------
+    # Hub synchronization
+    # ------------------------------------------------------------------
+
+    def _push_with_retry(self, voice_id: str) -> None:
+        """Push one voice folder to the hub, absorbing optimistic-lock races.
+
+        Voice folders are disjoint paths, so concurrent commits from other
+        instances can only conflict on the repo head — safe to retry. A push
+        that keeps failing raises VoiceSyncError; the caller rolls the local
+        copy back so the fleet never diverges.
+        """
+        assert self._hub is not None
+        last_error: Exception | None = None
+        for attempt in range(1, HUB_PUSH_ATTEMPTS + 1):
+            try:
+                self._hub.upload_voice(self.root, voice_id)
+                return
+            except Exception as e:  # noqa: BLE001 — any hub failure is retryable here
+                last_error = e
+                logger.warning(
+                    "Voice %s hub push attempt %d/%d failed: %s", voice_id, attempt, HUB_PUSH_ATTEMPTS, e
+                )
+                if attempt < HUB_PUSH_ATTEMPTS:
+                    time.sleep(HUB_PUSH_RETRY_SLEEP_S)
+        raise VoiceSyncError(
+            f"Could not persist voice {voice_id} to the hub repo after {HUB_PUSH_ATTEMPTS} attempts: {last_error}"
+        ) from last_error
+
+    def _rollback(self, voice_id: str, previous: Optional[VoiceRecord]) -> None:
+        """Undo a failed add: restore the prior metadata or remove the folder."""
+        voice_dir = self.root / voice_id
+        if previous is not None:
+            try:
+                (voice_dir / METADATA_FILENAME).write_text(json.dumps(previous.model_dump(), indent=2))
+            except OSError:
+                logger.exception("Failed to restore metadata for voice %s during rollback", voice_id)
+            self._records[voice_id] = previous
+        else:
+            shutil.rmtree(voice_dir, ignore_errors=True)
+            self._records.pop(voice_id, None)
+
+    def _refresh_from_hub(self) -> None:
+        """Best-effort revision check; a brief hub outage serves the local mirror."""
+        try:
+            self._mirror_sync()
+        except Exception as e:  # noqa: BLE001 — reads must not fail on hub hiccups
+            logger.warning("Voice store hub sync failed; serving local mirror: %s", e)
+
+    def _mirror_sync(self) -> None:
+        """Bring the local mirror in line with the hub repo (hub wins).
+
+        One repo-info call; if the revision moved, download voice folders we
+        do not have and evict registry entries whose folders vanished from the
+        repo. Evicted reference files stay on disk so live sessions keep
+        working; the local dir is a mirror, not the source of truth.
+        """
+        assert self._hub is not None
+        revision = self._hub.revision()
+        if revision == self._synced_revision:
+            return
+
+        hub_ids = self._hub.list_voice_ids(revision)
+        complete = True
+        for voice_id in hub_ids:
+            if self._voice_files_present(voice_id):
+                continue
+            try:
+                self._hub.download_voice(voice_id, self.root, revision)
+            except Exception as e:  # noqa: BLE001 — sync the rest, retry on next revision check
+                complete = False
+                logger.warning("Failed to download voice %s from hub: %s", voice_id, e)
+
+        self._scan()
+        self._records = {vid: rec for vid, rec in self._records.items() if vid in hub_ids}
+        if complete:
+            self._synced_revision = revision
+
+    def _voice_files_present(self, voice_id: str) -> bool:
+        voice_dir = self.root / voice_id
+        return (voice_dir / METADATA_FILENAME).exists() and (voice_dir / REF_AUDIO_FILENAME).exists()
 
     # ------------------------------------------------------------------
     # Internals

--- a/src/speech_to_speech/voice_store.py
+++ b/src/speech_to_speech/voice_store.py
@@ -281,9 +281,7 @@ class VoiceStore:
                 raise
 
             self._records[voice_id] = record
-            logger.info(
-                "Voice %s (%r) %s in store %s", voice_id, name, "updated" if existing else "created", self.root
-            )
+            logger.info("Voice %s (%r) %s in store %s", voice_id, name, "updated" if existing else "created", self.root)
             return record
 
     def list_voices(self) -> list[VoiceRecord]:
@@ -331,9 +329,7 @@ class VoiceStore:
                 return
             except Exception as e:  # noqa: BLE001 — any hub failure is retryable here
                 last_error = e
-                logger.warning(
-                    "Voice %s hub push attempt %d/%d failed: %s", voice_id, attempt, HUB_PUSH_ATTEMPTS, e
-                )
+                logger.warning("Voice %s hub push attempt %d/%d failed: %s", voice_id, attempt, HUB_PUSH_ATTEMPTS, e)
                 if attempt < HUB_PUSH_ATTEMPTS:
                     time.sleep(HUB_PUSH_RETRY_SLEEP_S)
         raise VoiceSyncError(

--- a/src/speech_to_speech/voice_store.py
+++ b/src/speech_to_speech/voice_store.py
@@ -109,7 +109,13 @@ class HubVoiceRepo:
 
         self.repo_id = repo_id
         self._api = HfApi()
-        self._api.create_repo(repo_id, repo_type="dataset", private=True, exist_ok=True)
+        # Operator convenience: create the repo (private) on first launch.
+        # Best-effort — a read-only token (or a repo someone else owns) can't
+        # create, and that must not block startup against an existing repo.
+        try:
+            self._api.create_repo(repo_id, repo_type="dataset", private=True, exist_ok=True)
+        except Exception as e:  # noqa: BLE001
+            logger.debug("Could not ensure hub repo %s exists (continuing): %s", repo_id, e)
 
     def revision(self) -> str:
         sha = self._api.repo_info(self.repo_id, repo_type="dataset").sha
@@ -274,10 +280,8 @@ class VoiceStore:
                 (voice_dir / METADATA_FILENAME).write_text(json.dumps(record.model_dump(), indent=2))
                 if self._hub is not None:
                     self._push_with_retry(voice_id)
-            except Exception as e:
+            except Exception:
                 self._rollback(voice_id, existing)
-                if isinstance(e, VoiceSyncError):
-                    raise
                 raise
 
             self._records[voice_id] = record
@@ -288,18 +292,27 @@ class VoiceStore:
         with self._lock:
             if self._hub is not None:
                 self._refresh_from_hub()
+            else:
+                # Local mode: the folder itself is the source of truth, so an
+                # operator adding or deleting a voice folder shows up on the
+                # next listing without a restart.
+                self._scan()
             return sorted(self._records.values(), key=lambda r: (r.created_at, r.voice_id))
 
     def resolve(self, voice_id: str) -> Optional[ResolvedVoice]:
         """Resolve a voice id to its (reference audio path, transcript) pair.
 
-        A miss triggers one hub re-sync before giving up, so a voice created
-        through another instance moments ago still resolves.
+        A miss triggers one re-sync before giving up, so a voice created
+        through another instance moments ago (hub mode) or dropped into the
+        local folder still resolves.
         """
         with self._lock:
             record = self._records.get(voice_id)
-            if record is None and self._hub is not None:
-                self._refresh_from_hub()
+            if record is None:
+                if self._hub is not None:
+                    self._refresh_from_hub()
+                else:
+                    self._scan()
                 record = self._records.get(voice_id)
             if record is None:
                 return None
@@ -322,7 +335,7 @@ class VoiceStore:
         copy back so the fleet never diverges.
         """
         assert self._hub is not None
-        last_error: Exception | None = None
+        last_error: Optional[Exception] = None
         for attempt in range(1, HUB_PUSH_ATTEMPTS + 1):
             try:
                 self._hub.upload_voice(self.root, voice_id)

--- a/src/speech_to_speech/voice_store.py
+++ b/src/speech_to_speech/voice_store.py
@@ -1,0 +1,223 @@
+"""Global library of cloned voices for voice-cloning TTS backends.
+
+A voice is a (reference audio, reference transcript) pair — Qwen3-TTS
+conditions on the pair at every generation call, so there is no bake step
+and the voice id is purely a registry key. The store persists one folder
+per voice under a local root directory:
+
+    <root>/<voice_id>/ref.wav     normalized 24 kHz PCM16 mono reference
+    <root>/<voice_id>/voice.json  id, display name, transcript, created-at
+
+The voice id is a truncated content hash of the uploaded audio bytes, so
+identical uploads converge on one entry (retries and duplicates are free)
+and re-uploading the same audio with corrected metadata overwrites the
+metadata in place.
+
+The store is owned by the server layer and injected into both the realtime
+router (HTTP routes) and the TTS voice-resolution path; it is deliberately
+TTS-agnostic.
+"""
+
+from __future__ import annotations
+
+import hashlib
+import io
+import json
+import logging
+import shutil
+from datetime import datetime, timezone
+from pathlib import Path
+from typing import Optional
+
+import numpy as np
+from pydantic import BaseModel
+
+logger = logging.getLogger(__name__)
+
+DEFAULT_STORE_DIR = Path.home() / ".cache" / "speech-to-speech" / "voices"
+MAX_UPLOAD_BYTES = 10 * 1024 * 1024
+MIN_CLIP_SECONDS = 3.0
+MAX_CLIP_SECONDS = 60.0
+STORE_SAMPLE_RATE = 24000
+MAX_NAME_CHARS = 80
+MAX_REF_TEXT_CHARS = 2000
+VOICE_ID_HEX_CHARS = 16
+REF_AUDIO_FILENAME = "ref.wav"
+METADATA_FILENAME = "voice.json"
+
+
+class VoiceRecord(BaseModel):
+    voice_id: str
+    name: str
+    ref_text: str
+    created_at: str
+
+
+class VoiceValidationError(Exception):
+    """A client-side problem with an uploaded voice (bad audio, bad metadata)."""
+
+    def __init__(self, message: str, *, code: str, status_code: int = 400) -> None:
+        super().__init__(message)
+        self.code = code
+        self.status_code = status_code
+
+
+def _validate_metadata(name: str, ref_text: str) -> tuple[str, str]:
+    name = (name or "").strip()
+    if not name or len(name) > MAX_NAME_CHARS:
+        raise VoiceValidationError(
+            f"Voice name is required and must be at most {MAX_NAME_CHARS} characters.",
+            code="invalid_name",
+        )
+    ref_text = (ref_text or "").strip()
+    if not ref_text or len(ref_text) > MAX_REF_TEXT_CHARS:
+        raise VoiceValidationError(
+            f"Reference transcript is required and must be at most {MAX_REF_TEXT_CHARS} characters.",
+            code="invalid_transcript",
+        )
+    return name, ref_text
+
+
+def _decode_and_normalize(audio_bytes: bytes) -> tuple[np.ndarray, float]:
+    """Decode a WAV upload and return (mono 24 kHz float32 waveform, duration seconds)."""
+    import soundfile as sf
+
+    if len(audio_bytes) > MAX_UPLOAD_BYTES:
+        raise VoiceValidationError(
+            f"Reference audio must be at most {MAX_UPLOAD_BYTES // (1024 * 1024)} MB.",
+            code="audio_too_large",
+            status_code=413,
+        )
+
+    try:
+        with sf.SoundFile(io.BytesIO(audio_bytes)) as f:
+            container = f.format
+            sample_rate = f.samplerate
+            waveform = f.read(always_2d=False, dtype="float32")
+    except Exception as e:
+        raise VoiceValidationError(
+            f"Reference audio is not readable WAV audio: {e}",
+            code="audio_unreadable",
+            status_code=415,
+        ) from e
+
+    if container != "WAV":
+        raise VoiceValidationError(
+            f"Reference audio must be a WAV file (got {container}).",
+            code="audio_unreadable",
+            status_code=415,
+        )
+
+    waveform = np.asarray(waveform, dtype=np.float32)
+    if waveform.ndim > 1:
+        waveform = waveform.mean(axis=1)
+
+    duration = waveform.shape[0] / float(sample_rate) if sample_rate else 0.0
+    if duration < MIN_CLIP_SECONDS:
+        raise VoiceValidationError(
+            f"Reference audio is too short: {duration:.1f}s (minimum {MIN_CLIP_SECONDS:.0f}s).",
+            code="audio_too_short",
+        )
+    if duration > MAX_CLIP_SECONDS:
+        raise VoiceValidationError(
+            f"Reference audio is too long: {duration:.1f}s (maximum {MAX_CLIP_SECONDS:.0f}s).",
+            code="audio_too_long",
+        )
+
+    if sample_rate != STORE_SAMPLE_RATE:
+        from scipy.signal import resample_poly
+
+        gcd = np.gcd(int(sample_rate), STORE_SAMPLE_RATE)
+        waveform = resample_poly(waveform, up=STORE_SAMPLE_RATE // gcd, down=int(sample_rate) // gcd)
+
+    return waveform, duration
+
+
+class VoiceStore:
+    """Folder-per-voice library rooted at a local directory."""
+
+    def __init__(self, root: Path | str) -> None:
+        self.root = Path(root).expanduser()
+        self.root.mkdir(parents=True, exist_ok=True)
+        self._records: dict[str, VoiceRecord] = {}
+        self._scan()
+
+    # ------------------------------------------------------------------
+    # Public API
+    # ------------------------------------------------------------------
+
+    def add_voice(self, audio_bytes: bytes, *, ref_text: str, name: str) -> VoiceRecord:
+        """Validate, normalize, and persist a voice; returns its registry record.
+
+        Raises VoiceValidationError on any client-side problem. Identical audio
+        converges on one voice id; re-uploads overwrite name and transcript.
+        """
+        name, ref_text = _validate_metadata(name, ref_text)
+        waveform, _duration = _decode_and_normalize(audio_bytes)
+
+        voice_id = hashlib.sha256(audio_bytes).hexdigest()[:VOICE_ID_HEX_CHARS]
+        existing = self._records.get(voice_id)
+        record = VoiceRecord(
+            voice_id=voice_id,
+            name=name,
+            ref_text=ref_text,
+            created_at=existing.created_at if existing else datetime.now(timezone.utc).isoformat(),
+        )
+
+        voice_dir = self.root / voice_id
+        try:
+            voice_dir.mkdir(parents=True, exist_ok=True)
+            if existing is None:
+                import soundfile as sf
+
+                sf.write(
+                    str(voice_dir / REF_AUDIO_FILENAME),
+                    waveform,
+                    STORE_SAMPLE_RATE,
+                    format="WAV",
+                    subtype="PCM_16",
+                )
+            (voice_dir / METADATA_FILENAME).write_text(json.dumps(record.model_dump(), indent=2))
+        except Exception:
+            shutil.rmtree(voice_dir, ignore_errors=True)
+            self._records.pop(voice_id, None)
+            raise
+
+        self._records[voice_id] = record
+        logger.info("Voice %s (%r) %s in store %s", voice_id, name, "updated" if existing else "created", self.root)
+        return record
+
+    def list_voices(self) -> list[VoiceRecord]:
+        return sorted(self._records.values(), key=lambda r: (r.created_at, r.voice_id))
+
+    # ------------------------------------------------------------------
+    # Internals
+    # ------------------------------------------------------------------
+
+    def _scan(self) -> None:
+        """Rebuild the in-memory registry from the folders on disk."""
+        records: dict[str, VoiceRecord] = {}
+        for meta_path in self.root.glob(f"*/{METADATA_FILENAME}"):
+            voice_id = meta_path.parent.name
+            record = self._read_record(meta_path, voice_id)
+            if record is not None:
+                records[voice_id] = record
+        self._records = records
+
+    def _read_record(self, meta_path: Path, voice_id: str) -> Optional[VoiceRecord]:
+        try:
+            record = VoiceRecord.model_validate_json(meta_path.read_text())
+        except Exception as e:
+            logger.warning("Skipping unreadable voice metadata %s: %s", meta_path, e)
+            return None
+        if record.voice_id != voice_id:
+            logger.warning(
+                "Skipping voice folder %s: metadata id %s does not match folder name",
+                meta_path.parent,
+                record.voice_id,
+            )
+            return None
+        if not (meta_path.parent / REF_AUDIO_FILENAME).exists():
+            logger.warning("Skipping voice folder %s: missing %s", meta_path.parent, REF_AUDIO_FILENAME)
+            return None
+        return record

--- a/tests/openai_realtime/test_voice_routes.py
+++ b/tests/openai_realtime/test_voice_routes.py
@@ -144,6 +144,33 @@ class TestVoicesRoutes:
                 assert r.status_code == 400
                 assert r.json()["error"]["code"] == "invalid_name"
 
+    def test_hub_push_failure_maps_to_502(self, tmp_path):
+        """A voice the fleet cannot see must fail the upload (rolled back store-side)."""
+
+        class _DownHub:
+            def revision(self):
+                return "rev-0"
+
+            def list_voice_ids(self, revision=None):
+                return set()
+
+            def download_voice(self, voice_id, root, revision=None):
+                raise AssertionError("nothing to download")
+
+            def upload_voice(self, root, voice_id):
+                raise RuntimeError("hub unreachable")
+
+        store = VoiceStore(tmp_path / "voices", hub=_DownHub())
+        app = create_app(pool=[_make_unit()], stop_event=ThreadingEvent(), voice_store=store)
+        with TestClient(app) as client:
+            with client.websocket_connect("/v1/realtime") as ws:
+                session_id = ws.receive_json()["session"]["id"]
+                r = client.post(f"/v1/realtime/sessions/{session_id}/voices", **_upload())
+                assert r.status_code == 502
+                assert r.json()["error"]["code"] == "voice_store_sync_failed"
+                listed = client.get(f"/v1/realtime/sessions/{session_id}/voices").json()
+                assert listed["voices"] == []
+
     def test_post_to_released_session_answers_404(self, tmp_path):
         app, _ = self._client_and_session(tmp_path)
         with TestClient(app) as client:

--- a/tests/openai_realtime/test_voice_routes.py
+++ b/tests/openai_realtime/test_voice_routes.py
@@ -1,0 +1,155 @@
+"""Integration tests for the session-scoped voices routes.
+
+Drives the full FastAPI app via ``create_app`` with a fake pipeline unit
+(mirroring test_websocket_router.py). The voices routes are the capability
+probe for voice cloning: they answer 200 when a voice store is wired
+(Qwen3-TTS backend), 409 otherwise, and 404 for unknown sessions.
+"""
+
+import io
+from queue import Queue
+from threading import Event as ThreadingEvent
+
+import numpy as np
+import soundfile as sf
+from starlette.testclient import TestClient
+
+from speech_to_speech.api.openai_realtime.pipeline_unit import PipelineUnit
+from speech_to_speech.api.openai_realtime.service import RealtimeService
+from speech_to_speech.api.openai_realtime.websocket_router import create_app
+from speech_to_speech.pipeline.cancel_scope import CancelScope
+from speech_to_speech.voice_store import VoiceStore
+
+
+def _make_unit(index: int = 0) -> PipelineUnit:
+    text_prompt_queue: Queue = Queue()
+    should_listen = ThreadingEvent()
+    should_listen.set()
+    return PipelineUnit(
+        index=index,
+        service=RealtimeService(text_prompt_queue=text_prompt_queue, should_listen=should_listen),
+        cancel_scope=CancelScope(),
+        should_listen=should_listen,
+        response_playing=ThreadingEvent(),
+        input_queue=Queue(),
+        output_queue=Queue(),
+        text_output_queue=Queue(),
+        text_prompt_queue=text_prompt_queue,
+        handlers=[],
+    )
+
+
+def _wav_bytes(seconds: float = 4.0, sr: int = 16000) -> bytes:
+    t = np.linspace(0, seconds, int(seconds * sr), endpoint=False)
+    buf = io.BytesIO()
+    sf.write(buf, (0.3 * np.sin(2 * np.pi * 440 * t)).astype(np.float32), sr, format="WAV", subtype="PCM_16")
+    return buf.getvalue()
+
+
+def _upload(name: str = "My Voice", ref_text: str = "hello reference", audio: bytes | None = None) -> dict:
+    return {
+        "files": {"audio": ("clip.wav", audio if audio is not None else _wav_bytes(), "audio/wav")},
+        "data": {"ref_text": ref_text, "name": name},
+    }
+
+
+class TestCapabilityGating:
+    def test_get_answers_409_without_voice_store(self):
+        app = create_app(pool=[_make_unit()], stop_event=ThreadingEvent())
+        with TestClient(app) as client:
+            with client.websocket_connect("/v1/realtime") as ws:
+                session_id = ws.receive_json()["session"]["id"]
+                r = client.get(f"/v1/realtime/sessions/{session_id}/voices")
+                assert r.status_code == 409
+                assert r.json()["error"]["code"] == "voice_cloning_unsupported"
+
+    def test_post_answers_409_without_voice_store(self):
+        app = create_app(pool=[_make_unit()], stop_event=ThreadingEvent())
+        with TestClient(app) as client:
+            with client.websocket_connect("/v1/realtime") as ws:
+                session_id = ws.receive_json()["session"]["id"]
+                kw = _upload()
+                r = client.post(f"/v1/realtime/sessions/{session_id}/voices", **kw)
+                assert r.status_code == 409
+
+    def test_unknown_session_answers_404(self, tmp_path):
+        store = VoiceStore(tmp_path / "voices")
+        app = create_app(pool=[_make_unit()], stop_event=ThreadingEvent(), voice_store=store)
+        with TestClient(app) as client:
+            r = client.get("/v1/realtime/sessions/sess_nope/voices")
+            assert r.status_code == 404
+            assert r.json()["error"]["code"] == "unknown_session"
+
+
+class TestVoicesRoutes:
+    def _client_and_session(self, tmp_path):
+        store = VoiceStore(tmp_path / "voices")
+        app = create_app(pool=[_make_unit()], stop_event=ThreadingEvent(), voice_store=store)
+        return app, store
+
+    def test_get_returns_empty_list_on_fresh_store(self, tmp_path):
+        app, _ = self._client_and_session(tmp_path)
+        with TestClient(app) as client:
+            with client.websocket_connect("/v1/realtime") as ws:
+                session_id = ws.receive_json()["session"]["id"]
+                r = client.get(f"/v1/realtime/sessions/{session_id}/voices")
+                assert r.status_code == 200
+                assert r.json() == {"voices": []}
+
+    def test_post_creates_voice_and_get_lists_it(self, tmp_path):
+        app, _ = self._client_and_session(tmp_path)
+        with TestClient(app) as client:
+            with client.websocket_connect("/v1/realtime") as ws:
+                session_id = ws.receive_json()["session"]["id"]
+                r = client.post(f"/v1/realtime/sessions/{session_id}/voices", **_upload())
+                assert r.status_code == 201
+                created = r.json()
+                assert created["name"] == "My Voice"
+                assert created["voice_id"]
+
+                listed = client.get(f"/v1/realtime/sessions/{session_id}/voices").json()
+                assert [v["voice_id"] for v in listed["voices"]] == [created["voice_id"]]
+                assert listed["voices"][0]["name"] == "My Voice"
+                assert "ref_text" not in listed["voices"][0]
+
+    def test_duplicate_upload_returns_same_voice_id(self, tmp_path):
+        app, _ = self._client_and_session(tmp_path)
+        audio = _wav_bytes()
+        with TestClient(app) as client:
+            with client.websocket_connect("/v1/realtime") as ws:
+                session_id = ws.receive_json()["session"]["id"]
+                first = client.post(f"/v1/realtime/sessions/{session_id}/voices", **_upload(audio=audio))
+                second = client.post(f"/v1/realtime/sessions/{session_id}/voices", **_upload(audio=audio))
+                assert first.status_code == second.status_code == 201
+                assert first.json()["voice_id"] == second.json()["voice_id"]
+                listed = client.get(f"/v1/realtime/sessions/{session_id}/voices").json()
+                assert len(listed["voices"]) == 1
+
+    def test_validation_errors_map_to_status_codes(self, tmp_path):
+        app, _ = self._client_and_session(tmp_path)
+        with TestClient(app) as client:
+            with client.websocket_connect("/v1/realtime") as ws:
+                session_id = ws.receive_json()["session"]["id"]
+                url = f"/v1/realtime/sessions/{session_id}/voices"
+
+                r = client.post(url, **_upload(audio=b"not audio"))
+                assert r.status_code == 415
+                assert r.json()["error"]["code"] == "audio_unreadable"
+
+                r = client.post(url, **_upload(audio=_wav_bytes(seconds=1.0)))
+                assert r.status_code == 400
+                assert r.json()["error"]["code"] == "audio_too_short"
+
+                r = client.post(url, **_upload(name="   "))
+                assert r.status_code == 400
+                assert r.json()["error"]["code"] == "invalid_name"
+
+    def test_post_to_released_session_answers_404(self, tmp_path):
+        app, _ = self._client_and_session(tmp_path)
+        with TestClient(app) as client:
+            with client.websocket_connect("/v1/realtime") as ws:
+                session_id = ws.receive_json()["session"]["id"]
+            # Session disconnected (drain may be pending); voices routes must
+            # treat it as gone.
+            r = client.get(f"/v1/realtime/sessions/{session_id}/voices")
+            assert r.status_code == 404

--- a/tests/openai_realtime/test_voice_routes.py
+++ b/tests/openai_realtime/test_voice_routes.py
@@ -6,19 +6,17 @@ probe for voice cloning: they answer 200 when a voice store is wired
 (Qwen3-TTS backend), 409 otherwise, and 404 for unknown sessions.
 """
 
-import io
 from queue import Queue
 from threading import Event as ThreadingEvent
 
-import numpy as np
-import soundfile as sf
 from starlette.testclient import TestClient
 
 from speech_to_speech.api.openai_realtime.pipeline_unit import PipelineUnit
 from speech_to_speech.api.openai_realtime.service import RealtimeService
 from speech_to_speech.api.openai_realtime.websocket_router import create_app
 from speech_to_speech.pipeline.cancel_scope import CancelScope
-from speech_to_speech.voice_store import VoiceStore
+from speech_to_speech.voice_store import MAX_UPLOAD_BYTES, VoiceStore
+from tests.wav_utils import wav_bytes as _wav_bytes
 
 
 def _make_unit(index: int = 0) -> PipelineUnit:
@@ -37,13 +35,6 @@ def _make_unit(index: int = 0) -> PipelineUnit:
         text_prompt_queue=text_prompt_queue,
         handlers=[],
     )
-
-
-def _wav_bytes(seconds: float = 4.0, sr: int = 16000) -> bytes:
-    t = np.linspace(0, seconds, int(seconds * sr), endpoint=False)
-    buf = io.BytesIO()
-    sf.write(buf, (0.3 * np.sin(2 * np.pi * 440 * t)).astype(np.float32), sr, format="WAV", subtype="PCM_16")
-    return buf.getvalue()
 
 
 def _upload(name: str = "My Voice", ref_text: str = "hello reference", audio: bytes | None = None) -> dict:
@@ -124,6 +115,32 @@ class TestVoicesRoutes:
                 assert first.json()["voice_id"] == second.json()["voice_id"]
                 listed = client.get(f"/v1/realtime/sessions/{session_id}/voices").json()
                 assert len(listed["voices"]) == 1
+
+    def test_oversized_upload_rejected_with_413(self, tmp_path):
+        app, _ = self._client_and_session(tmp_path)
+        with TestClient(app) as client:
+            with client.websocket_connect("/v1/realtime") as ws:
+                session_id = ws.receive_json()["session"]["id"]
+                r = client.post(
+                    f"/v1/realtime/sessions/{session_id}/voices",
+                    **_upload(audio=b"\x00" * (MAX_UPLOAD_BYTES + 1)),
+                )
+                assert r.status_code == 413
+                assert r.json()["error"]["code"] == "audio_too_large"
+
+    def test_reupload_with_corrected_transcript_overwrites_it(self, tmp_path):
+        app, store = self._client_and_session(tmp_path)
+        audio = _wav_bytes()
+        with TestClient(app) as client:
+            with client.websocket_connect("/v1/realtime") as ws:
+                session_id = ws.receive_json()["session"]["id"]
+                url = f"/v1/realtime/sessions/{session_id}/voices"
+                first = client.post(url, **_upload(audio=audio, ref_text="typo transcript"))
+                second = client.post(url, **_upload(audio=audio, ref_text="fixed transcript"))
+                assert first.json()["voice_id"] == second.json()["voice_id"]
+                resolved = store.resolve(first.json()["voice_id"])
+                assert resolved is not None
+                assert resolved.ref_text == "fixed transcript"
 
     def test_validation_errors_map_to_status_codes(self, tmp_path):
         app, _ = self._client_and_session(tmp_path)

--- a/tests/openai_realtime/test_websocket_router.py
+++ b/tests/openai_realtime/test_websocket_router.py
@@ -141,6 +141,16 @@ class TestConnection:
                 assert msg["event_id"].startswith("event_")
                 assert "session" in msg
 
+    def test_session_created_carries_session_id(self, setup):
+        """The GA wire format exposes the session id on session.created; clients
+        need it to address the session-scoped voices routes (the WebSocket
+        transport has no Location header to learn it from)."""
+        app, service, *_ = setup
+        with TestClient(app) as client:
+            with client.websocket_connect("/v1/realtime") as ws:
+                msg = ws.receive_json()
+                assert msg["session"]["id"] == service.connection_ids[0]
+
     def test_second_connection_rejected(self, setup):
         app, *_ = setup
         with TestClient(app) as client:

--- a/tests/test_cli_defaults.py
+++ b/tests/test_cli_defaults.py
@@ -18,6 +18,7 @@ from speech_to_speech.arguments_classes.responses_api_language_model_arguments i
 from speech_to_speech.arguments_classes.socket_receiver_arguments import SocketReceiverArguments
 from speech_to_speech.arguments_classes.socket_sender_arguments import SocketSenderArguments
 from speech_to_speech.arguments_classes.vad_arguments import VADHandlerArguments
+from speech_to_speech.arguments_classes.voice_store_arguments import VoiceStoreArguments
 from speech_to_speech.arguments_classes.websocket_streamer_arguments import WebSocketStreamerArguments
 from speech_to_speech.arguments_classes.whisper_stt_arguments import WhisperSTTHandlerArguments
 from speech_to_speech.s2s_pipeline import ParsedArguments, parse_arguments
@@ -74,6 +75,7 @@ EXPECTED_FIELD_TYPES = {
     "pocket_tts_handler_kwargs": PocketTTSHandlerArguments,
     "kokoro_tts_handler_kwargs": KokoroTTSHandlerArguments,
     "qwen3_tts_handler_kwargs": Qwen3TTSHandlerArguments,
+    "voice_store_kwargs": VoiceStoreArguments,
 }
 
 
@@ -103,6 +105,30 @@ def test_parse_arguments_default_backend_returns_openai_api():
     assert isinstance(args.language_model_handler_kwargs, LanguageModelHandlerArguments)
     assert args.responses_api_language_model_handler_kwargs.model_name == "gpt-5.4-mini"
     assert args.module_kwargs.llm_backend == "responses-api"
+
+
+def test_voice_store_defaults_are_local_only():
+    store_args = VoiceStoreArguments()
+    assert store_args.voice_store_dir is None
+    assert store_args.voice_store_hub_repo is None
+
+
+def test_parse_arguments_accepts_voice_store_overrides():
+    original_argv = sys.argv[:]
+    try:
+        sys.argv = [
+            "speech-to-speech",
+            "--voice_store_dir",
+            "/tmp/voices",
+            "--voice_store_hub_repo",
+            "org/voices-repo",
+        ]
+        args = parse_arguments()
+    finally:
+        sys.argv = original_argv
+
+    assert args.voice_store_kwargs.voice_store_dir == "/tmp/voices"
+    assert args.voice_store_kwargs.voice_store_hub_repo == "org/voices-repo"
 
 
 def test_parse_arguments_accepts_qwen3_tts_backend_override():

--- a/tests/test_qwen3_tts_handler_backend.py
+++ b/tests/test_qwen3_tts_handler_backend.py
@@ -406,6 +406,105 @@ def test_apply_session_voice_override_accepts_supported_custom_voice_speaker():
     assert handler.speaker == "vivian"
 
 
+def _make_voice_store(tmp_path):
+    import io
+
+    import soundfile as sf
+
+    from speech_to_speech.voice_store import VoiceStore
+
+    t = np.linspace(0, 4.0, 4 * 16000, endpoint=False)
+    buf = io.BytesIO()
+    sf.write(buf, (0.3 * np.sin(2 * np.pi * 440 * t)).astype(np.float32), 16000, format="WAV", subtype="PCM_16")
+    store = VoiceStore(tmp_path / "voices")
+    record = store.add_voice(buf.getvalue(), ref_text="stored transcript", name="mine")
+    return store, record
+
+
+def _fake_voice_cfg(voice: str):
+    return SimpleNamespace(session=SimpleNamespace(audio=SimpleNamespace(output=SimpleNamespace(voice=voice))))
+
+
+def test_apply_session_voice_override_resolves_store_voice_id(tmp_path):
+    store, record = _make_voice_store(tmp_path)
+    handler = object.__new__(Qwen3TTSHandler)
+    handler.voice_store = store
+    handler.ref_audio = None
+    handler.ref_text = "launch transcript"
+    handler.speaker = None
+
+    handler._apply_session_voice_override("base", runtime_config=_fake_voice_cfg(record.voice_id))
+
+    assert handler.ref_audio == str(tmp_path / "voices" / record.voice_id / "ref.wav")
+    assert handler.ref_text == "stored transcript"
+
+
+def test_apply_session_voice_override_store_id_wins_over_speaker_matching(tmp_path):
+    store, record = _make_voice_store(tmp_path)
+    handler = object.__new__(Qwen3TTSHandler)
+    handler.voice_store = store
+    handler.ref_audio = None
+    handler.ref_text = "launch transcript"
+    handler.speaker = "Aiden"
+    handler.model = SimpleNamespace(model=SimpleNamespace(get_supported_speakers=lambda: ["aiden", "vivian"]))
+
+    handler._apply_session_voice_override("custom_voice", runtime_config=_fake_voice_cfg(record.voice_id))
+
+    assert handler.ref_audio == str(tmp_path / "voices" / record.voice_id / "ref.wav")
+    assert handler.ref_text == "stored transcript"
+
+
+def test_apply_session_voice_override_falls_through_to_speaker_when_store_misses(tmp_path):
+    store, _record = _make_voice_store(tmp_path)
+    handler = object.__new__(Qwen3TTSHandler)
+    handler.voice_store = store
+    handler.ref_audio = "TTS/ref_audio.wav"
+    handler.ref_text = "launch transcript"
+    handler.speaker = "Aiden"
+    handler.model = SimpleNamespace(model=SimpleNamespace(get_supported_speakers=lambda: ["aiden", "vivian"]))
+
+    handler._apply_session_voice_override("custom_voice", runtime_config=_fake_voice_cfg("Vivian"))
+
+    assert handler.ref_audio is None
+    assert handler.ref_text == "launch transcript"
+    assert handler.speaker == "vivian"
+
+
+def test_apply_session_voice_override_no_longer_resolves_filesystem_paths(tmp_path, caplog):
+    """Path-probe hardening: an API session voice naming a real server file must
+    not become ref_audio (the CLI launch argument is the only path-based input)."""
+    real_file = tmp_path / "probe.wav"
+    real_file.write_bytes(b"RIFF")
+    handler = object.__new__(Qwen3TTSHandler)
+    handler.voice_store = None
+    handler.ref_audio = None
+    handler.ref_text = "launch transcript"
+    handler.speaker = None
+
+    with caplog.at_level("WARNING"):
+        handler._apply_session_voice_override("base", runtime_config=_fake_voice_cfg(str(real_file)))
+
+    assert handler.ref_audio is None
+    assert handler.ref_text == "launch transcript"
+    assert "Ignoring Qwen3-TTS session voice override" in caplog.text
+
+
+def test_on_session_end_resets_voice_state_to_launch_values():
+    handler = object.__new__(Qwen3TTSHandler)
+    handler.speaker = "session speaker"
+    handler.ref_audio = "/store/abc/ref.wav"
+    handler.ref_text = "session transcript"
+    handler._initial_speaker = "Aiden"
+    handler._initial_ref_audio = None
+    handler._initial_ref_text = "launch transcript"
+
+    handler.on_session_end()
+
+    assert handler.speaker == "Aiden"
+    assert handler.ref_audio is None
+    assert handler.ref_text == "launch transcript"
+
+
 def test_process_only_reenables_listening_after_end_of_response(monkeypatch):
     handler = object.__new__(Qwen3TTSHandler)
     handler.should_listen = Event()

--- a/tests/test_qwen3_tts_handler_backend.py
+++ b/tests/test_qwen3_tts_handler_backend.py
@@ -407,17 +407,11 @@ def test_apply_session_voice_override_accepts_supported_custom_voice_speaker():
 
 
 def _make_voice_store(tmp_path):
-    import io
-
-    import soundfile as sf
-
     from speech_to_speech.voice_store import VoiceStore
+    from tests.wav_utils import wav_bytes
 
-    t = np.linspace(0, 4.0, 4 * 16000, endpoint=False)
-    buf = io.BytesIO()
-    sf.write(buf, (0.3 * np.sin(2 * np.pi * 440 * t)).astype(np.float32), 16000, format="WAV", subtype="PCM_16")
     store = VoiceStore(tmp_path / "voices")
-    record = store.add_voice(buf.getvalue(), ref_text="stored transcript", name="mine")
+    record = store.add_voice(wav_bytes(), ref_text="stored transcript", name="mine")
     return store, record
 
 

--- a/tests/test_voice_store.py
+++ b/tests/test_voice_store.py
@@ -121,6 +121,22 @@ class TestNormalization:
         assert info.duration == pytest.approx(5.0, abs=0.05)
 
 
+class TestResolve:
+    def test_resolve_returns_reference_audio_path_and_transcript(self, tmp_path):
+        root = tmp_path / "voices"
+        store = VoiceStore(root)
+        record = store.add_voice(_wav_bytes(), ref_text="the reference transcript", name="v")
+
+        resolved = store.resolve(record.voice_id)
+
+        assert resolved is not None
+        assert resolved.ref_text == "the reference transcript"
+        assert resolved.ref_audio == str(root / record.voice_id / "ref.wav")
+
+    def test_resolve_unknown_id_returns_none(self, tmp_path):
+        assert VoiceStore(tmp_path / "voices").resolve("deadbeefdeadbeef") is None
+
+
 class TestValidation:
     def test_rejects_unreadable_audio(self, tmp_path):
         store = VoiceStore(tmp_path / "voices")

--- a/tests/test_voice_store.py
+++ b/tests/test_voice_store.py
@@ -1,0 +1,171 @@
+"""Unit tests for the voice store module (speech_to_speech.voice_store).
+
+The store is the one new seam introduced by the voice-cloning feature: a
+global library of cloned voices persisted as one folder per voice (normalized
+reference WAV + metadata JSON). Tests run against temp directories.
+"""
+
+import hashlib
+import io
+import json
+
+import numpy as np
+import pytest
+import soundfile as sf
+
+from speech_to_speech.voice_store import (
+    MAX_UPLOAD_BYTES,
+    STORE_SAMPLE_RATE,
+    VoiceStore,
+    VoiceValidationError,
+)
+
+
+def _wav_bytes(seconds: float = 4.0, sr: int = 16000, channels: int = 1, freq: float = 440.0) -> bytes:
+    t = np.linspace(0, seconds, int(seconds * sr), endpoint=False)
+    data = (0.3 * np.sin(2 * np.pi * freq * t)).astype(np.float32)
+    if channels > 1:
+        data = np.stack([data] * channels, axis=1)
+    buf = io.BytesIO()
+    sf.write(buf, data, sr, format="WAV", subtype="PCM_16")
+    return buf.getvalue()
+
+
+class TestCreateAndList:
+    def test_add_voice_returns_content_hash_id_and_lists_it(self, tmp_path):
+        store = VoiceStore(tmp_path / "voices")
+        audio = _wav_bytes()
+
+        record = store.add_voice(audio, ref_text="hello reference", name="My Voice")
+
+        expected_id = hashlib.sha256(audio).hexdigest()[:16]
+        assert record.voice_id == expected_id
+        assert record.name == "My Voice"
+        assert record.ref_text == "hello reference"
+        assert record.created_at
+
+        listed = store.list_voices()
+        assert [v.voice_id for v in listed] == [expected_id]
+        assert listed[0].name == "My Voice"
+
+    def test_store_layout_is_one_folder_per_voice(self, tmp_path):
+        root = tmp_path / "voices"
+        store = VoiceStore(root)
+        record = store.add_voice(_wav_bytes(), ref_text="ref", name="v")
+
+        voice_dir = root / record.voice_id
+        assert (voice_dir / "ref.wav").exists()
+        meta = json.loads((voice_dir / "voice.json").read_text())
+        assert meta["voice_id"] == record.voice_id
+        assert meta["name"] == "v"
+        assert meta["ref_text"] == "ref"
+
+    def test_fresh_store_instance_sees_persisted_voices(self, tmp_path):
+        root = tmp_path / "voices"
+        VoiceStore(root).add_voice(_wav_bytes(), ref_text="ref", name="v")
+
+        reopened = VoiceStore(root)
+        assert [v.name for v in reopened.list_voices()] == ["v"]
+
+    def test_empty_store_lists_nothing(self, tmp_path):
+        assert VoiceStore(tmp_path / "voices").list_voices() == []
+
+
+class TestDedup:
+    def test_identical_audio_converges_on_one_voice(self, tmp_path):
+        store = VoiceStore(tmp_path / "voices")
+        audio = _wav_bytes()
+
+        first = store.add_voice(audio, ref_text="ref", name="a")
+        second = store.add_voice(audio, ref_text="ref", name="a")
+
+        assert first.voice_id == second.voice_id
+        assert len(store.list_voices()) == 1
+
+    def test_reupload_overwrites_transcript_and_name(self, tmp_path):
+        store = VoiceStore(tmp_path / "voices")
+        audio = _wav_bytes()
+
+        store.add_voice(audio, ref_text="typo transcript", name="old")
+        updated = store.add_voice(audio, ref_text="fixed transcript", name="new")
+
+        listed = store.list_voices()
+        assert len(listed) == 1
+        assert listed[0].ref_text == "fixed transcript"
+        assert listed[0].name == "new"
+        assert updated.ref_text == "fixed transcript"
+
+    def test_different_audio_gets_different_id(self, tmp_path):
+        store = VoiceStore(tmp_path / "voices")
+        a = store.add_voice(_wav_bytes(freq=440.0), ref_text="r", name="a")
+        b = store.add_voice(_wav_bytes(freq=220.0), ref_text="r", name="b")
+        assert a.voice_id != b.voice_id
+        assert len(store.list_voices()) == 2
+
+
+class TestNormalization:
+    def test_stereo_48k_input_is_stored_as_mono_24k_pcm16(self, tmp_path):
+        root = tmp_path / "voices"
+        store = VoiceStore(root)
+        record = store.add_voice(
+            _wav_bytes(seconds=5.0, sr=48000, channels=2),
+            ref_text="ref",
+            name="v",
+        )
+
+        info = sf.info(str(root / record.voice_id / "ref.wav"))
+        assert info.samplerate == STORE_SAMPLE_RATE
+        assert info.channels == 1
+        assert info.subtype == "PCM_16"
+        assert info.format == "WAV"
+        assert info.duration == pytest.approx(5.0, abs=0.05)
+
+
+class TestValidation:
+    def test_rejects_unreadable_audio(self, tmp_path):
+        store = VoiceStore(tmp_path / "voices")
+        with pytest.raises(VoiceValidationError) as exc:
+            store.add_voice(b"definitely not audio", ref_text="ref", name="v")
+        assert exc.value.status_code == 415
+
+    def test_rejects_non_wav_container(self, tmp_path):
+        buf = io.BytesIO()
+        t = np.linspace(0, 4.0, 4 * 16000, endpoint=False)
+        sf.write(buf, (0.3 * np.sin(2 * np.pi * 440 * t)).astype(np.float32), 16000, format="FLAC")
+        store = VoiceStore(tmp_path / "voices")
+        with pytest.raises(VoiceValidationError) as exc:
+            store.add_voice(buf.getvalue(), ref_text="ref", name="v")
+        assert exc.value.status_code == 415
+
+    def test_rejects_oversized_upload(self, tmp_path):
+        store = VoiceStore(tmp_path / "voices")
+        with pytest.raises(VoiceValidationError) as exc:
+            store.add_voice(b"\x00" * (MAX_UPLOAD_BYTES + 1), ref_text="ref", name="v")
+        assert exc.value.status_code == 413
+
+    def test_rejects_clip_outside_duration_clamp(self, tmp_path):
+        store = VoiceStore(tmp_path / "voices")
+        with pytest.raises(VoiceValidationError, match="short"):
+            store.add_voice(_wav_bytes(seconds=1.0), ref_text="ref", name="v")
+        with pytest.raises(VoiceValidationError, match="long"):
+            store.add_voice(_wav_bytes(seconds=61.0, sr=8000), ref_text="ref", name="v")
+
+    def test_rejects_missing_or_oversized_name_and_transcript(self, tmp_path):
+        store = VoiceStore(tmp_path / "voices")
+        audio = _wav_bytes()
+        with pytest.raises(VoiceValidationError, match="name"):
+            store.add_voice(audio, ref_text="ref", name="   ")
+        with pytest.raises(VoiceValidationError, match="name"):
+            store.add_voice(audio, ref_text="ref", name="x" * 200)
+        with pytest.raises(VoiceValidationError, match="transcript"):
+            store.add_voice(audio, ref_text="", name="v")
+        with pytest.raises(VoiceValidationError, match="transcript"):
+            store.add_voice(audio, ref_text="x" * 5000, name="v")
+
+    def test_rejected_upload_leaves_no_store_entry(self, tmp_path):
+        root = tmp_path / "voices"
+        store = VoiceStore(root)
+        with pytest.raises(VoiceValidationError):
+            store.add_voice(_wav_bytes(seconds=1.0), ref_text="ref", name="v")
+        assert store.list_voices() == []
+        assert [p for p in root.iterdir()] == []

--- a/tests/test_voice_store.py
+++ b/tests/test_voice_store.py
@@ -8,6 +8,7 @@ reference WAV + metadata JSON). Tests run against temp directories.
 import hashlib
 import io
 import json
+import shutil
 
 import numpy as np
 import pytest
@@ -20,16 +21,7 @@ from speech_to_speech.voice_store import (
     VoiceSyncError,
     VoiceValidationError,
 )
-
-
-def _wav_bytes(seconds: float = 4.0, sr: int = 16000, channels: int = 1, freq: float = 440.0) -> bytes:
-    t = np.linspace(0, seconds, int(seconds * sr), endpoint=False)
-    data = (0.3 * np.sin(2 * np.pi * freq * t)).astype(np.float32)
-    if channels > 1:
-        data = np.stack([data] * channels, axis=1)
-    buf = io.BytesIO()
-    sf.write(buf, data, sr, format="WAV", subtype="PCM_16")
-    return buf.getvalue()
+from tests.wav_utils import wav_bytes as _wav_bytes
 
 
 class TestCreateAndList:
@@ -120,6 +112,30 @@ class TestNormalization:
         assert info.subtype == "PCM_16"
         assert info.format == "WAV"
         assert info.duration == pytest.approx(5.0, abs=0.05)
+
+
+class TestLocalDeletion:
+    def test_local_folder_deletion_propagates_on_next_listing(self, tmp_path):
+        """Story 22's local case: an operator removing a voice folder from the
+        local store is noticed on the next read, without a restart."""
+        root = tmp_path / "voices"
+        store = VoiceStore(root)
+        record = store.add_voice(_wav_bytes(), ref_text="ref", name="v")
+        assert len(store.list_voices()) == 1
+
+        shutil.rmtree(root / record.voice_id)
+
+        assert store.list_voices() == []
+        assert store.resolve(record.voice_id) is None
+
+    def test_manually_added_folder_appears_on_next_listing(self, tmp_path):
+        root = tmp_path / "voices"
+        writer = VoiceStore(root)
+        reader = VoiceStore(root)
+        record = writer.add_voice(_wav_bytes(), ref_text="ref", name="v")
+
+        assert [v.voice_id for v in reader.list_voices()] == [record.voice_id]
+        assert reader.resolve(record.voice_id) is not None
 
 
 class TestResolve:

--- a/tests/test_voice_store.py
+++ b/tests/test_voice_store.py
@@ -17,6 +17,7 @@ from speech_to_speech.voice_store import (
     MAX_UPLOAD_BYTES,
     STORE_SAMPLE_RATE,
     VoiceStore,
+    VoiceSyncError,
     VoiceValidationError,
 )
 
@@ -185,3 +186,159 @@ class TestValidation:
             store.add_voice(_wav_bytes(seconds=1.0), ref_text="ref", name="v")
         assert store.list_voices() == []
         assert [p for p in root.iterdir()] == []
+
+
+class FakeHubRepo:
+    """In-memory stand-in for the huggingface_hub adapter surface."""
+
+    def __init__(self):
+        self.voices: dict[str, dict[str, bytes]] = {}
+        self._rev = 0
+        self.revision_calls = 0
+        self.download_calls: list[str] = []
+        self.uploads: list[str] = []
+        self.upload_failures = 0
+
+    def bump(self):
+        self._rev += 1
+
+    def revision(self) -> str:
+        self.revision_calls += 1
+        return f"rev-{self._rev}"
+
+    def list_voice_ids(self, revision=None) -> set:
+        return set(self.voices)
+
+    def download_voice(self, voice_id, root, revision=None) -> None:
+        self.download_calls.append(voice_id)
+        voice_dir = root / voice_id
+        voice_dir.mkdir(parents=True, exist_ok=True)
+        for filename, data in self.voices[voice_id].items():
+            (voice_dir / filename).write_bytes(data)
+
+    def upload_voice(self, root, voice_id) -> None:
+        if self.upload_failures > 0:
+            self.upload_failures -= 1
+            raise RuntimeError("simulated optimistic-lock conflict")
+        folder = root / voice_id
+        self.voices[voice_id] = {p.name: p.read_bytes() for p in folder.iterdir()}
+        self.uploads.append(voice_id)
+        self.bump()
+
+
+class TestHubPersistence:
+    def test_startup_pull_materializes_hub_voices(self, tmp_path):
+        hub = FakeHubRepo()
+        writer = VoiceStore(tmp_path / "a", hub=hub)
+        record = writer.add_voice(_wav_bytes(), ref_text="ref", name="fleet voice")
+
+        fresh = VoiceStore(tmp_path / "b", hub=hub)
+
+        assert [v.voice_id for v in fresh.list_voices()] == [record.voice_id]
+        resolved = fresh.resolve(record.voice_id)
+        assert resolved is not None
+        assert (tmp_path / "b" / record.voice_id / "ref.wav").exists()
+
+    def test_upload_pushes_to_hub_before_returning(self, tmp_path):
+        hub = FakeHubRepo()
+        store = VoiceStore(tmp_path / "voices", hub=hub)
+
+        record = store.add_voice(_wav_bytes(), ref_text="ref", name="v")
+
+        assert hub.uploads == [record.voice_id]
+        assert set(hub.voices[record.voice_id]) == {"ref.wav", "voice.json"}
+
+    def test_persistent_push_failure_rolls_back_local_copy(self, tmp_path):
+        hub = FakeHubRepo()
+        root = tmp_path / "voices"
+        store = VoiceStore(root, hub=hub)
+        hub.upload_failures = 99
+
+        with pytest.raises(VoiceSyncError):
+            store.add_voice(_wav_bytes(), ref_text="ref", name="v")
+
+        assert store.list_voices() == []
+        assert [p for p in root.iterdir()] == []
+
+    def test_transient_push_conflict_is_retried(self, tmp_path):
+        hub = FakeHubRepo()
+        store = VoiceStore(tmp_path / "voices", hub=hub)
+        hub.upload_failures = 2
+
+        record = store.add_voice(_wav_bytes(), ref_text="ref", name="v")
+
+        assert hub.uploads == [record.voice_id]
+        assert len(store.list_voices()) == 1
+
+    def test_metadata_update_push_failure_restores_previous_transcript(self, tmp_path):
+        hub = FakeHubRepo()
+        store = VoiceStore(tmp_path / "voices", hub=hub)
+        audio = _wav_bytes()
+        store.add_voice(audio, ref_text="original", name="v")
+        hub.upload_failures = 99
+
+        with pytest.raises(VoiceSyncError):
+            store.add_voice(audio, ref_text="corrected", name="v")
+
+        assert [v.ref_text for v in store.list_voices()] == ["original"]
+
+    def test_unchanged_revision_short_circuits_to_one_repo_info_call(self, tmp_path):
+        hub = FakeHubRepo()
+        writer = VoiceStore(tmp_path / "a", hub=hub)
+        writer.add_voice(_wav_bytes(), ref_text="ref", name="v")
+        reader = VoiceStore(tmp_path / "b", hub=hub)
+
+        downloads_after_startup = list(hub.download_calls)
+        hub.revision_calls = 0
+        reader.list_voices()
+        reader.list_voices()
+
+        assert hub.revision_calls == 2
+        assert hub.download_calls == downloads_after_startup
+
+    def test_moved_revision_pulls_only_new_voice_folders(self, tmp_path):
+        hub = FakeHubRepo()
+        writer = VoiceStore(tmp_path / "a", hub=hub)
+        first = writer.add_voice(_wav_bytes(freq=440.0), ref_text="ref", name="one")
+        reader = VoiceStore(tmp_path / "b", hub=hub)
+        reader.list_voices()
+
+        second = writer.add_voice(_wav_bytes(freq=220.0), ref_text="ref", name="two")
+        hub.download_calls.clear()
+        listed = reader.list_voices()
+
+        assert {v.voice_id for v in listed} == {first.voice_id, second.voice_id}
+        assert hub.download_calls == [second.voice_id]
+
+    def test_hub_deletion_propagates_on_next_revision_check(self, tmp_path):
+        hub = FakeHubRepo()
+        writer = VoiceStore(tmp_path / "a", hub=hub)
+        record = writer.add_voice(_wav_bytes(), ref_text="ref", name="v")
+        reader = VoiceStore(tmp_path / "b", hub=hub)
+        assert len(reader.list_voices()) == 1
+
+        del hub.voices[record.voice_id]
+        hub.bump()
+
+        assert reader.list_voices() == []
+        assert reader.resolve(record.voice_id) is None
+        # The reference file is not unlinked out from under a live session; it
+        # is only evicted from the registry.
+        assert (tmp_path / "b" / record.voice_id / "ref.wav").exists()
+
+    def test_selection_miss_triggers_resync(self, tmp_path):
+        hub = FakeHubRepo()
+        reader = VoiceStore(tmp_path / "b", hub=hub)
+        reader.list_voices()
+
+        writer = VoiceStore(tmp_path / "a", hub=hub)
+        record = writer.add_voice(_wav_bytes(), ref_text="fleet transcript", name="v")
+
+        resolved = reader.resolve(record.voice_id)
+        assert resolved is not None
+        assert resolved.ref_text == "fleet transcript"
+
+    def test_local_mode_never_touches_hub(self, tmp_path):
+        store = VoiceStore(tmp_path / "voices")
+        store.add_voice(_wav_bytes(), ref_text="ref", name="v")
+        assert len(store.list_voices()) == 1

--- a/tests/wav_utils.py
+++ b/tests/wav_utils.py
@@ -1,0 +1,16 @@
+"""Shared helper for tests that need small in-memory WAV clips."""
+
+import io
+
+import numpy as np
+import soundfile as sf
+
+
+def wav_bytes(seconds: float = 4.0, sr: int = 16000, channels: int = 1, freq: float = 440.0) -> bytes:
+    t = np.linspace(0, seconds, int(seconds * sr), endpoint=False)
+    data = (0.3 * np.sin(2 * np.pi * freq * t)).astype(np.float32)
+    if channels > 1:
+        data = np.stack([data] * channels, axis=1)
+    buf = io.BytesIO()
+    sf.write(buf, data, sr, format="WAV", subtype="PCM_16")
+    return buf.getvalue()


### PR DESCRIPTION
## What this adds

Voice cloning for the realtime pipeline when it runs with `--tts qwen3`. A caller can upload a short reference clip with its transcript and get back a voice id that any session can then select through the standard `session.update` event. The demo gets a popup to record or upload a clip and speak with the cloned voice right away.

## How it works

* A new voice store (`src/speech_to_speech/voice_store.py`) keeps one folder per voice: the reference audio normalized to mono PCM16 at 24 kHz plus a small metadata file. The voice id is derived from a hash of the uploaded audio, so sending the same clip twice returns the same voice instead of a duplicate.
* New routes `GET` and `POST` on `/v1/realtime/sessions/{session_id}/voices`. The `GET` doubles as a capability probe: 200 means voice cloning is available, 409 means the running backend does not support it, 404 means the session is unknown. No custom fields were added to the OpenAI Realtime events.
* The Qwen3 TTS handler resolves a session voice override against the store first and applies both the reference audio and the reference text. Preset voices keep working unchanged, and session end restores the initial voice.
* Optional fleet persistence through a private HF Hub dataset repo (`--voice_store_hub_repo`). Creation pushes to the Hub before the route returns 201, with retry and rollback on failure; other machines pick up new voices through a cheap revision check on read. Without the flag everything stays local under `--voice_store_dir`.
* The demo server proxies `/api/voices` only to hosts it already trusts: the pinned `SPEECH_TO_SPEECH_URL` or the compute host recorded from the load balancer grant. Client supplied targets are never contacted. A small daily creation cap per identity guards against scripting.
* The demo UI gains two ways into the create voice popup: a button in the top bar that is always available, and one beside the voice picker revealed when the capability probe succeeds. The popup offers recording against a fixed script or uploading a file with a transcript, encodes the audio to WAV in the browser, and selects the new voice on save. A voice created outside a call waits in the tab as pending, is selectable right away, and uploads automatically once the next call with cloning support connects.

## Worth flagging

* `session.created` now carries the standard `session.id` field. WebSocket clients had no other way to learn the id they need to address the new session scoped routes. This matches the OpenAI GA wire format and the SDK models accept it.
* `python-multipart` joins the core dependencies for the multipart upload route.

## Testing

* New suites cover the voice store (including a fake Hub repo exercising push retry, rollback, mirror sync, and deletion propagation), the routes (gating, validation, dedup, Hub failure mapping), and the handler override logic.
* Full gate green: 644 tests passed, ruff check and format clean, mypy clean.

Draft until the popup gets a manual browser pass (record and upload, WebSocket and WebRTC). The HTTP layer under it was already verified end to end against a live server through the demo proxy.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
