### PR TITLE
Add Telnyx managed STT and TTS backends

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -37,7 +37,9 @@ jobs:
       - uses: astral-sh/setup-uv@v8.3.2
         with:
           version: "latest"
-      - run: uv sync --group dev
+      - run: uv sync --group dev --extra telnyx
+      - name: ffmpeg (MP3 decode for the Telnyx TTS backend)
+        run: sudo apt-get update && sudo apt-get install -y ffmpeg
       - name: NLTK data (punkt_tab for sent_tokenize)
         run: uv run python -c "import nltk; nltk.download('punkt_tab')"
       - name: Pytest

--- a/README.md
+++ b/README.md
@@ -132,6 +132,7 @@ pip install "speech-to-speech[facebook-mms]"    # MMS TTS
 pip install "speech-to-speech[faster-whisper]"  # Faster Whisper STT
 pip install "speech-to-speech[whisper-mlx]"     # Lightning Whisper MLX STT on macOS
 pip install "speech-to-speech[paraformer]"      # Paraformer STT through FunASR
+pip install "speech-to-speech[telnyx]"          # Telnyx managed STT + TTS (requires ffmpeg for MP3 decode)
 pip install "speech-to-speech[mlx-lm]"          # mlx-vlm support for vision models on macOS
 ```
 
@@ -160,6 +161,7 @@ This installs the package in editable mode and makes the `speech-to-speech` CLI 
 | STT | [Lightning Whisper MLX](https://github.com/mustafaaljadery/lightning-whisper-mlx) | Apple Silicon | `whisper-mlx` |
 | STT | [MLX Audio Whisper](https://github.com/huggingface/mlx-audio) | Apple Silicon | built-in on macOS |
 | STT | [Paraformer](https://github.com/modelscope/FunASR) | CUDA / CPU | `paraformer` |
+| STT | [Telnyx](https://developers.telnyx.com/docs/tts-stt/stt-websocket-streaming) (managed, multi-engine) | hosted | `telnyx` |
 | LLM | OpenAI-compatible API (`responses-api`, `chat-completions`) | hosted providers or self-hosted servers | built-in |
 | LLM | [Transformers](https://huggingface.co/models?pipeline_tag=text-generation&sort=trending) | CUDA / CPU | built-in |
 | LLM | [mlx-lm](https://github.com/ml-explore/mlx-lm) | Apple Silicon | built-in on macOS |
@@ -168,6 +170,7 @@ This installs the package in editable mode and makes the `speech-to-speech` CLI 
 | TTS | [Pocket TTS](https://github.com/kyutai-labs/pocket-tts) | CPU / CUDA | `pocket` |
 | TTS | [ChatTTS](https://github.com/2noise/ChatTTS) | CUDA / CPU | `chattts` |
 | TTS | [MMS TTS](https://huggingface.co/docs/transformers/model_doc/mms) | CUDA / CPU | `facebook-mms` |
+| TTS | [Telnyx](https://developers.telnyx.com/docs/voice/programmable-voice/tts-standalone) (managed, multi-provider voices) | hosted | `telnyx` |
 
 Select implementations with `--stt`, `--llm_backend`, and `--tts`. Run `speech-to-speech -h` for exact values and backend-specific flags.
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -90,8 +90,7 @@ pocket = [
     "pocket-tts>=0.1.0",
 ]
 telnyx = [
-    "websocket-client",
-    "pydub",
+    "websocket-client>=1.7.0",
 ]
 webrtc = [
     "aiortc>=1.9.0",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -89,6 +89,10 @@ paraformer = [
 pocket = [
     "pocket-tts>=0.1.0",
 ]
+telnyx = [
+    "websocket-client",
+    "pydub",
+]
 webrtc = [
     "aiortc>=1.9.0",
 ]

--- a/src/speech_to_speech/STT/README.md
+++ b/src/speech_to_speech/STT/README.md
@@ -10,6 +10,7 @@ This document summarizes the Speech-to-Text (STT) implementations in the `STT/` 
 - `faster-whisper` → `STT/faster_whisper_handler.py`
 - `parakeet-tdt` → `STT/parakeet_tdt_handler.py`
 - `paraformer` → `STT/paraformer_handler.py`
+- `telnyx` → `STT/telnyx_stt_handler.py`
 
 ## Language Support by Handler
 
@@ -74,6 +75,53 @@ This document summarizes the Speech-to-Text (STT) implementations in the `STT/` 
 - Practical support:
   - Depends on selected FunASR model checkpoint
   - Default setup is Chinese-oriented (`zh`)
+
+### 7) Telnyx (`--stt telnyx`)
+
+- Handler: `TelnyxSTTHandler`
+- Managed WebSocket STT backed by Telnyx's unified speech API
+- One WebSocket per VAD segment, audio sent as WAV (zero codec dep)
+- Auth: `--telnyx_stt_api_key` or `$TELNYX_API_KEY` env var
+- Engine flag: `--telnyx_stt_engine` (default `Telnyx`)
+- Language flag: `--telnyx_stt_language` (default `en`)
+- Model flag: `--telnyx_stt_model` (engine-specific, e.g. `nova-3` for Deepgram)
+- Input format flag: `--telnyx_stt_input_format` (`wav` or `mp3`, default `wav`)
+- Partial results flag: `--telnyx_stt_partial_results` (default `True`)
+- Supports live transcription via `--enable_live_transcription`
+
+Supported engines (one endpoint, swap with `--telnyx_stt_engine`):
+
+| Engine | Notes |
+|---|---|
+| `Telnyx` | Telnyx's managed Whisper-based engine (default) |
+| `Deepgram` | Nova-2, Nova-3, Flux; set `--telnyx_stt_model` |
+| `Google` | Google Cloud Speech |
+| `Azure` | Azure Speech Services |
+| `xAI` | xAI Grok speech |
+| `AssemblyAI` | AssemblyAI Universal |
+| `Speechmatics` | Speechmatics |
+| `Soniox` | Soniox |
+| `Parakeet` | NVIDIA Parakeet via Telnyx |
+
+Install:
+
+```bash
+pip install "speech-to-speech[telnyx]"
+export TELNYX_API_KEY=...
+```
+
+Usage:
+
+```bash
+# Default Telnyx engine
+python s2s_pipeline.py --stt telnyx --telnyx_stt_engine Telnyx
+
+# Deepgram Nova-3 through Telnyx's unified API
+python s2s_pipeline.py --stt telnyx --telnyx_stt_engine Deepgram --telnyx_stt_model nova-3
+
+# With live transcription
+python s2s_pipeline.py --stt telnyx --enable_live_transcription --live_transcription_update_interval 0.25
+```
 
 ## Language Abbreviations (ISO-style codes seen in STT handlers)
 

--- a/src/speech_to_speech/STT/README.md
+++ b/src/speech_to_speech/STT/README.md
@@ -80,12 +80,11 @@ This document summarizes the Speech-to-Text (STT) implementations in the `STT/` 
 
 - Handler: `TelnyxSTTHandler`
 - Managed WebSocket STT backed by Telnyx's unified speech API
-- One WebSocket per VAD segment, audio sent as WAV (zero codec dep)
+- One WebSocket per VAD segment, audio sent as WAV in 2 KB binary frames (zero codec dep)
 - Auth: `--telnyx_stt_api_key` or `$TELNYX_API_KEY` env var
 - Engine flag: `--telnyx_stt_engine` (default `Telnyx`)
 - Language flag: `--telnyx_stt_language` (default `en`)
 - Model flag: `--telnyx_stt_model` (engine-specific, e.g. `nova-3` for Deepgram)
-- Input format flag: `--telnyx_stt_input_format` (`wav` or `mp3`, default `wav`)
 - Partial results flag: `--telnyx_stt_partial_results` (default `True`)
 - Supports live transcription via `--enable_live_transcription`
 
@@ -94,14 +93,13 @@ Supported engines (one endpoint, swap with `--telnyx_stt_engine`):
 | Engine | Notes |
 |---|---|
 | `Telnyx` | Telnyx's managed Whisper-based engine (default) |
-| `Deepgram` | Nova-2, Nova-3, Flux; set `--telnyx_stt_model` |
+| `Deepgram` | Set the variant with `--telnyx_stt_model`, e.g. `nova-3` |
 | `Google` | Google Cloud Speech |
 | `Azure` | Azure Speech Services |
-| `xAI` | xAI Grok speech |
-| `AssemblyAI` | AssemblyAI Universal |
-| `Speechmatics` | Speechmatics |
-| `Soniox` | Soniox |
-| `Parakeet` | NVIDIA Parakeet via Telnyx |
+
+The STT WebSocket endpoint requires STT to be enabled on the Telnyx account.
+A key without that entitlement gets a `403` on the WebSocket handshake even
+though the same key works against other Telnyx APIs.
 
 Install:
 

--- a/src/speech_to_speech/STT/README.md
+++ b/src/speech_to_speech/STT/README.md
@@ -85,7 +85,7 @@ This document summarizes the Speech-to-Text (STT) implementations in the `STT/` 
 - Engine flag: `--telnyx_stt_engine` (default `Telnyx`)
 - Language flag: `--telnyx_stt_language` (default `en`)
 - Model flag: `--telnyx_stt_model` (engine-specific, e.g. `nova-3` for Deepgram)
-- Partial results flag: `--telnyx_stt_partial_results` (default `True`)
+- Partial results flag: `--telnyx_stt_partial_results` (default `True`, Deepgram only)
 - Supports live transcription via `--enable_live_transcription`
 
 Supported engines (one endpoint, swap with `--telnyx_stt_engine`):
@@ -93,13 +93,13 @@ Supported engines (one endpoint, swap with `--telnyx_stt_engine`):
 | Engine | Notes |
 |---|---|
 | `Telnyx` | Telnyx's managed Whisper-based engine (default) |
-| `Deepgram` | Set the variant with `--telnyx_stt_model`, e.g. `nova-3` |
+| `Deepgram` | Set the variant with `--telnyx_stt_model`, e.g. `nova-3`. The only engine that returns interim results |
 | `Google` | Google Cloud Speech |
 | `Azure` | Azure Speech Services |
 
-The STT WebSocket endpoint requires STT to be enabled on the Telnyx account.
-A key without that entitlement gets a `403` on the WebSocket handshake even
-though the same key works against other Telnyx APIs.
+Telnyx's edge rejects WebSocket handshakes that carry an `Origin` header with
+a `403`, so both clients connect with `suppress_origin=True`. Without it every
+connection fails before reaching the API.
 
 Install:
 

--- a/src/speech_to_speech/STT/telnyx_stt_handler.py
+++ b/src/speech_to_speech/STT/telnyx_stt_handler.py
@@ -1,0 +1,157 @@
+"""Telnyx managed Speech-to-Text handler.
+
+Streams each VAD segment to Telnyx's managed STT WebSocket API. One
+WebSocket per utterance, matching the existing handler lifecycle.
+
+Supports the full Telnyx engine catalog through one endpoint:
+Telnyx (Whisper-based), Deepgram Nova-2/3/Flux, Google, Azure, xAI,
+AssemblyAI, Speechmatics, Soniox, Parakeet.
+"""
+
+from __future__ import annotations
+
+import logging
+import os
+from time import perf_counter
+from typing import Any, Iterator
+
+import numpy as np
+from rich.console import Console
+
+from speech_to_speech.pipeline.handler_types import STTIn, STTOut
+from speech_to_speech.pipeline.messages import PartialTranscription, Transcription
+from speech_to_speech.STT.base_stt_handler import BaseSTTHandler
+from speech_to_speech.utils.telnyx_ws import TelnyxSTTClient
+
+logger = logging.getLogger(__name__)
+console = Console()
+
+
+class TelnyxSTTHandler(BaseSTTHandler):
+    """Handles Speech-to-Text via Telnyx's managed WebSocket API."""
+
+    def setup(
+        self,
+        should_listen: Any = None,
+        api_key: str = "",
+        engine: str = "Telnyx",
+        language: str = "en",
+        model: str = "",
+        input_format: str = "wav",
+        partial_results: bool = True,
+        gen_kwargs: dict[str, Any] | None = None,
+        cancel_scope: Any = None,
+        speculative_turns: Any = None,
+        enable_live_transcription: bool = False,
+        live_transcription_update_interval: float = 0.25,
+    ) -> None:
+        resolved_key = api_key or os.environ.get("TELNYX_API_KEY", "")
+        if not resolved_key:
+            raise ValueError(
+                "Telnyx STT requires an API key. Set --telnyx_stt_api_key or the TELNYX_API_KEY env var."
+            )
+
+        self.api_key = resolved_key
+        self.engine = engine
+        self.language = language
+        self.model = model
+        self.input_format = input_format
+        self.partial_results = partial_results
+        self.gen_kwargs = gen_kwargs or {}
+        self.cancel_scope = cancel_scope
+        self.speculative_turns = speculative_turns
+        self.enable_live_transcription = enable_live_transcription
+        self.live_transcription_update_interval = live_transcription_update_interval
+        self.sample_rate = 16000
+
+        self._last_partial_emit_s: float = 0.0
+        self._last_partial_text: str = ""
+
+        logger.info(
+            "Telnyx STT ready: engine=%s language=%s input_format=%s partial_results=%s",
+            self.engine,
+            self.language,
+            self.input_format,
+            self.partial_results,
+        )
+
+    def process(self, vad_audio: STTIn) -> Iterator[STTOut]:
+        """Send the VAD segment to Telnyx STT and yield the final transcript."""
+        audio = np.asarray(vad_audio.audio, dtype=np.int16)
+        if audio.ndim > 1:
+            audio = audio.mean(axis=1).astype(np.int16)
+
+        client = TelnyxSTTClient(
+            api_key=self.api_key,
+            engine=self.engine,
+            language=self.language,
+            input_format=self.input_format,
+            partial_results=self.partial_results,
+            model=self.model,
+        )
+
+        final_text = ""
+        partials_emitted = 0
+        try:
+            client.connect()
+            client.send_audio(audio, sample_rate=self.sample_rate)
+
+            while True:
+                event = client.recv_transcript()
+                if event is None:
+                    break
+
+                event_type = event.get("type")
+                if event_type == "error":
+                    logger.error("Telnyx STT error: %s", event.get("error"))
+                    break
+
+                if event_type != "transcript":
+                    continue
+
+                text = event.get("transcript", "") or ""
+                is_final = bool(event.get("is_final", False))
+
+                if is_final:
+                    final_text = text
+                    break
+
+                if self.enable_live_transcription and text:
+                    partial = self._maybe_emit_partial(text, vad_audio)
+                    if partial is not None:
+                        partials_emitted += 1
+                        yield partial
+        except Exception as e:
+            logger.error("Telnyx STT request failed: %s", e, exc_info=True)
+        finally:
+            client.close()
+
+        if final_text.strip():
+            console.print(f"[yellow]USER: {final_text.strip()}")
+
+        yield Transcription(
+            text=final_text,
+            language_code=self.language,
+            turn_id=vad_audio.turn_id,
+            turn_revision=vad_audio.turn_revision,
+            speech_stopped_at_s=vad_audio.created_at_s,
+        )
+
+    def _maybe_emit_partial(self, text: str, vad_audio: STTIn) -> PartialTranscription | None:
+        """Build a rate-limited partial transcription for live display.
+
+        Returns ``None`` when the update should be suppressed (duplicate text
+        or within the throttle window).
+        """
+        now = perf_counter()
+        if text == self._last_partial_text:
+            return None
+        if now - self._last_partial_emit_s < self.live_transcription_update_interval:
+            return None
+        self._last_partial_text = text
+        self._last_partial_emit_s = now
+        return PartialTranscription(
+            text=text,
+            turn_id=vad_audio.turn_id,
+            turn_revision=vad_audio.turn_revision,
+        )

--- a/src/speech_to_speech/STT/telnyx_stt_handler.py
+++ b/src/speech_to_speech/STT/telnyx_stt_handler.py
@@ -3,9 +3,8 @@
 Streams each VAD segment to Telnyx's managed STT WebSocket API. One
 WebSocket per utterance, matching the existing handler lifecycle.
 
-Supports the full Telnyx engine catalog through one endpoint:
-Telnyx (Whisper-based), Deepgram Nova-2/3/Flux, Google, Azure, xAI,
-AssemblyAI, Speechmatics, Soniox, Parakeet.
+Engines are selected with ``--telnyx_stt_engine``: Telnyx (Whisper-based),
+Deepgram, Google, Azure.
 """
 
 from __future__ import annotations
@@ -32,34 +31,25 @@ class TelnyxSTTHandler(BaseSTTHandler):
 
     def setup(
         self,
-        should_listen: Any = None,
         api_key: str = "",
         engine: str = "Telnyx",
         language: str = "en",
         model: str = "",
-        input_format: str = "wav",
         partial_results: bool = True,
         gen_kwargs: dict[str, Any] | None = None,
-        cancel_scope: Any = None,
-        speculative_turns: Any = None,
         enable_live_transcription: bool = False,
         live_transcription_update_interval: float = 0.25,
     ) -> None:
         resolved_key = api_key or os.environ.get("TELNYX_API_KEY", "")
         if not resolved_key:
-            raise ValueError(
-                "Telnyx STT requires an API key. Set --telnyx_stt_api_key or the TELNYX_API_KEY env var."
-            )
+            raise ValueError("Telnyx STT requires an API key. Set --telnyx_stt_api_key or the TELNYX_API_KEY env var.")
 
         self.api_key = resolved_key
         self.engine = engine
         self.language = language
         self.model = model
-        self.input_format = input_format
         self.partial_results = partial_results
         self.gen_kwargs = gen_kwargs or {}
-        self.cancel_scope = cancel_scope
-        self.speculative_turns = speculative_turns
         self.enable_live_transcription = enable_live_transcription
         self.live_transcription_update_interval = live_transcription_update_interval
         self.sample_rate = 16000
@@ -68,10 +58,9 @@ class TelnyxSTTHandler(BaseSTTHandler):
         self._last_partial_text: str = ""
 
         logger.info(
-            "Telnyx STT ready: engine=%s language=%s input_format=%s partial_results=%s",
+            "Telnyx STT ready: engine=%s language=%s partial_results=%s",
             self.engine,
             self.language,
-            self.input_format,
             self.partial_results,
         )
 
@@ -85,13 +74,11 @@ class TelnyxSTTHandler(BaseSTTHandler):
             api_key=self.api_key,
             engine=self.engine,
             language=self.language,
-            input_format=self.input_format,
             partial_results=self.partial_results,
             model=self.model,
         )
 
         final_text = ""
-        partials_emitted = 0
         try:
             client.connect()
             client.send_audio(audio, sample_rate=self.sample_rate)
@@ -100,26 +87,17 @@ class TelnyxSTTHandler(BaseSTTHandler):
                 event = client.recv_transcript()
                 if event is None:
                     break
-
-                event_type = event.get("type")
-                if event_type == "error":
-                    logger.error("Telnyx STT error: %s", event.get("error"))
-                    break
-
-                if event_type != "transcript":
+                if "transcript" not in event:
                     continue
 
-                text = event.get("transcript", "") or ""
-                is_final = bool(event.get("is_final", False))
-
-                if is_final:
+                text = event.get("transcript") or ""
+                if bool(event.get("is_final", False)):
                     final_text = text
                     break
 
                 if self.enable_live_transcription and text:
                     partial = self._maybe_emit_partial(text, vad_audio)
                     if partial is not None:
-                        partials_emitted += 1
                         yield partial
         except Exception as e:
             logger.error("Telnyx STT request failed: %s", e, exc_info=True)

--- a/src/speech_to_speech/TTS/README.md
+++ b/src/speech_to_speech/TTS/README.md
@@ -150,7 +150,8 @@ python s2s_pipeline.py \
 
 - Handler: `TelnyxTTSHandler`
 - Managed WebSocket TTS backed by Telnyx's unified speech API
-- One WebSocket per LLM response, audio returned as base64 MP3
+- One WebSocket per synthesis request (the LLM output processor emits sentence batches, so this is one connection per sentence batch, not per response)
+- Telnyx returns one continuous MP3 bitstream split across many small frames; individual frames are not independently decodable, so the handler pipes the stream through a long-lived `ffmpeg` process and emits PCM as it arrives
 - Auth: `--telnyx_tts_api_key` or `$TELNYX_API_KEY` env var
 - Voice flag: `--telnyx_tts_voice` (default `Telnyx.NaturalHD.astra`)
 - Sample rate flag: `--telnyx_tts_sample_rate` (default `16000`)
@@ -169,7 +170,7 @@ Supported voice providers (one endpoint, swap with `--telnyx_tts_voice`):
 | Inworld | `Inworld.*` |
 | Rime | `Rime.*` |
 
-System dependency: `ffmpeg` (required by `pydub` for MP3 decode). Install with `brew install ffmpeg` (macOS) or `apt install ffmpeg` (Debian/Ubuntu).
+System dependency: `ffmpeg`, used to decode the MP3 stream. Install with `brew install ffmpeg` (macOS) or `apt install ffmpeg` (Debian/Ubuntu).
 
 Install:
 

--- a/src/speech_to_speech/TTS/README.md
+++ b/src/speech_to_speech/TTS/README.md
@@ -9,6 +9,7 @@ Runtime-supported values in `s2s_pipeline.py`:
 - `pocket` → `pocket_tts_handler.py`
 - `kokoro` → `kokoro_handler.py`
 - `qwen3` → `qwen3_tts_handler.py`
+- `telnyx` → `telnyx_tts_handler.py`
 
 Deprecated TTS implementations, including MeloTTS, live in [`../../../archive/TTS`](../../../archive/TTS) and are no longer wired into `s2s_pipeline.py`.
 
@@ -134,6 +135,61 @@ To benchmark the Apple Silicon MLX variants side by side:
 ```
 
 This will run separate benchmark entries for `qwen3[bf16]`, `qwen3[4bit]`, `qwen3[6bit]`, and `qwen3[8bit]`.
+
+### 6) Telnyx (`--tts telnyx`)
+
+Primary args prefix: `--telnyx_tts_*`
+
+```bash
+python s2s_pipeline.py \
+  --tts telnyx \
+  --telnyx_tts_voice Telnyx.NaturalHD.astra \
+  --telnyx_tts_sample_rate 16000 \
+  --telnyx_tts_blocksize 512
+```
+
+- Handler: `TelnyxTTSHandler`
+- Managed WebSocket TTS backed by Telnyx's unified speech API
+- One WebSocket per LLM response, audio returned as base64 MP3
+- Auth: `--telnyx_tts_api_key` or `$TELNYX_API_KEY` env var
+- Voice flag: `--telnyx_tts_voice` (default `Telnyx.NaturalHD.astra`)
+- Sample rate flag: `--telnyx_tts_sample_rate` (default `16000`)
+- Blocksize flag: `--telnyx_tts_blocksize` (default `512`)
+
+Supported voice providers (one endpoint, swap with `--telnyx_tts_voice`):
+
+| Provider | Example voice IDs |
+|---|---|
+| Telnyx NaturalHD | `Telnyx.NaturalHD.astra`, `Telnyx.NaturalHD.orion`, ... |
+| AWS Polly | `AWS.Polly.*` |
+| Azure | `Azure.*` |
+| ElevenLabs | `ElevenLabs.*` |
+| MiniMax | `MiniMax.*` |
+| ResembleAI | `ResembleAI.*` |
+| Inworld | `Inworld.*` |
+| Rime | `Rime.*` |
+
+System dependency: `ffmpeg` (required by `pydub` for MP3 decode). Install with `brew install ffmpeg` (macOS) or `apt install ffmpeg` (Debian/Ubuntu).
+
+Install:
+
+```bash
+pip install "speech-to-speech[telnyx]"
+export TELNYX_API_KEY=...
+```
+
+Usage:
+
+```bash
+# Default Telnyx NaturalHD voice
+python s2s_pipeline.py --tts telnyx
+
+# ElevenLabs voice through Telnyx's unified API
+python s2s_pipeline.py --tts telnyx --telnyx_tts_voice "ElevenLabs.<voice_id>"
+
+# Mixed: managed Telnyx STT + managed Telnyx TTS
+python s2s_pipeline.py --stt telnyx --tts telnyx
+```
 
 ## Setup
 

--- a/src/speech_to_speech/TTS/telnyx_tts_handler.py
+++ b/src/speech_to_speech/TTS/telnyx_tts_handler.py
@@ -1,0 +1,123 @@
+"""Telnyx managed Text-to-Speech handler.
+
+Streams each LLM response to Telnyx's managed TTS WebSocket API. One
+WebSocket per response, matching the existing handler lifecycle.
+
+Supports the full Telnyx voice catalog through one endpoint:
+Telnyx NaturalHD, AWS Polly, Azure, ElevenLabs, MiniMax, ResembleAI,
+Inworld, Rime.
+"""
+
+from __future__ import annotations
+
+import logging
+import os
+from threading import Event
+from typing import Any, Iterator
+
+import numpy as np
+from rich.console import Console
+
+from speech_to_speech.baseHandler import BaseHandler
+from speech_to_speech.pipeline.cancel_scope import CancelScope
+from speech_to_speech.pipeline.handler_types import TTSIn, TTSOut
+from speech_to_speech.pipeline.messages import AUDIO_RESPONSE_DONE, EndOfResponse
+from speech_to_speech.pipeline.speculative_turns import SpeculativeTurnTracker
+from speech_to_speech.utils.telnyx_ws import TelnyxTTSClient, mp3_base64_to_pcm_int16
+
+logger = logging.getLogger(__name__)
+console = Console()
+
+
+class TelnyxTTSHandler(BaseHandler[TTSIn, TTSOut]):
+    """Handles Text-to-Speech via Telnyx's managed WebSocket API."""
+
+    def setup(
+        self,
+        should_listen: Event,
+        api_key: str = "",
+        voice: str = "Telnyx.NaturalHD.astra",
+        sample_rate: int = 16000,
+        blocksize: int = 512,
+        gen_kwargs: dict[str, Any] | None = None,
+        cancel_scope: CancelScope | None = None,
+        speculative_turns: SpeculativeTurnTracker | None = None,
+    ) -> None:
+        resolved_key = api_key or os.environ.get("TELNYX_API_KEY", "")
+        if not resolved_key:
+            raise ValueError(
+                "Telnyx TTS requires an API key. Set --telnyx_tts_api_key or the TELNYX_API_KEY env var."
+            )
+
+        self.should_listen = should_listen
+        self.api_key = resolved_key
+        self.voice = voice
+        self.sample_rate = sample_rate
+        self.blocksize = blocksize
+        self.gen_kwargs = gen_kwargs or {}
+        self.cancel_scope = cancel_scope
+        self.speculative_turns = speculative_turns
+
+        logger.info("Telnyx TTS ready: voice=%s sample_rate=%d blocksize=%d", self.voice, self.sample_rate, self.blocksize)
+
+    def process(self, tts_input: TTSIn) -> Iterator[TTSOut]:
+        speculative_turns = getattr(self, "speculative_turns", None)
+        if isinstance(tts_input, EndOfResponse):
+            if speculative_turns and not speculative_turns.is_latest_after_reopen_grace(
+                tts_input.turn_id,
+                tts_input.turn_revision,
+            ):
+                return
+            yield AUDIO_RESPONSE_DONE
+            return
+
+        if speculative_turns and not speculative_turns.is_latest_after_reopen_grace(
+            tts_input.turn_id,
+            tts_input.turn_revision,
+        ):
+            logger.debug("Dropping stale TTS input for turn=%s rev=%s", tts_input.turn_id, tts_input.turn_revision)
+            return
+        if speculative_turns:
+            speculative_turns.commit(tts_input.turn_id, tts_input.turn_revision)
+
+        gen = self.cancel_scope.generation if self.cancel_scope else None
+        text = tts_input.text
+        console.print(f"[green]ASSISTANT: {text}")
+
+        client = TelnyxTTSClient(api_key=self.api_key, voice=self.voice)
+        try:
+            client.connect()
+            client.send_init()
+            client.send_text(text)
+            client.send_stop()
+
+            audio_buffer = np.array([], dtype=np.int16)
+            for frame in self._iter_audio_frames(client):
+                if gen is not None and self.cancel_scope is not None and self.cancel_scope.is_stale(gen):
+                    logger.info("TTS generation cancelled (interruption)")
+                    return
+
+                mp3_bytes, _is_final = frame
+                pcm = mp3_base64_to_pcm_int16(mp3_bytes, target_sample_rate=self.sample_rate)
+                audio_buffer = np.concatenate([audio_buffer, pcm])
+
+                while len(audio_buffer) >= self.blocksize:
+                    chunk = audio_buffer[: self.blocksize]
+                    audio_buffer = audio_buffer[self.blocksize :]
+                    yield chunk
+
+            if len(audio_buffer) > 0:
+                chunk = np.pad(audio_buffer, (0, self.blocksize - len(audio_buffer)))
+                yield chunk
+        except Exception as e:
+            logger.error("Telnyx TTS request failed: %s", e, exc_info=True)
+        finally:
+            client.close()
+
+    def _iter_audio_frames(self, client: TelnyxTTSClient) -> Iterator[tuple[bytes, bool]]:
+        """Yield audio frames until the server closes the stream."""
+        while True:
+            frame = client.recv_audio()
+            if frame is None:
+                return
+            yield frame

--- a/src/speech_to_speech/TTS/telnyx_tts_handler.py
+++ b/src/speech_to_speech/TTS/telnyx_tts_handler.py
@@ -1,7 +1,9 @@
 """Telnyx managed Text-to-Speech handler.
 
-Streams each LLM response to Telnyx's managed TTS WebSocket API. One
-WebSocket per response, matching the existing handler lifecycle.
+Streams each sentence batch from the LLM to Telnyx's managed TTS WebSocket
+API. The protocol has no per-utterance boundary marker inside a session, so a
+session covers exactly one synthesis request and the handler opens one
+WebSocket per call to :meth:`process`.
 
 Supports the full Telnyx voice catalog through one endpoint:
 Telnyx NaturalHD, AWS Polly, Azure, ElevenLabs, MiniMax, ResembleAI,
@@ -23,7 +25,7 @@ from speech_to_speech.pipeline.cancel_scope import CancelScope
 from speech_to_speech.pipeline.handler_types import TTSIn, TTSOut
 from speech_to_speech.pipeline.messages import AUDIO_RESPONSE_DONE, EndOfResponse
 from speech_to_speech.pipeline.speculative_turns import SpeculativeTurnTracker
-from speech_to_speech.utils.telnyx_ws import TelnyxTTSClient, mp3_base64_to_pcm_int16
+from speech_to_speech.utils.telnyx_ws import Mp3StreamDecoder, TelnyxTTSClient
 
 logger = logging.getLogger(__name__)
 console = Console()
@@ -45,9 +47,7 @@ class TelnyxTTSHandler(BaseHandler[TTSIn, TTSOut]):
     ) -> None:
         resolved_key = api_key or os.environ.get("TELNYX_API_KEY", "")
         if not resolved_key:
-            raise ValueError(
-                "Telnyx TTS requires an API key. Set --telnyx_tts_api_key or the TELNYX_API_KEY env var."
-            )
+            raise ValueError("Telnyx TTS requires an API key. Set --telnyx_tts_api_key or the TELNYX_API_KEY env var.")
 
         self.should_listen = should_listen
         self.api_key = resolved_key
@@ -58,7 +58,12 @@ class TelnyxTTSHandler(BaseHandler[TTSIn, TTSOut]):
         self.cancel_scope = cancel_scope
         self.speculative_turns = speculative_turns
 
-        logger.info("Telnyx TTS ready: voice=%s sample_rate=%d blocksize=%d", self.voice, self.sample_rate, self.blocksize)
+        logger.info(
+            "Telnyx TTS ready: voice=%s sample_rate=%d blocksize=%d",
+            self.voice,
+            self.sample_rate,
+            self.blocksize,
+        )
 
     def process(self, tts_input: TTSIn) -> Iterator[TTSOut]:
         speculative_turns = getattr(self, "speculative_turns", None)
@@ -85,39 +90,40 @@ class TelnyxTTSHandler(BaseHandler[TTSIn, TTSOut]):
         console.print(f"[green]ASSISTANT: {text}")
 
         client = TelnyxTTSClient(api_key=self.api_key, voice=self.voice)
+        decoder = Mp3StreamDecoder(sample_rate=self.sample_rate)
+        audio_buffer = np.array([], dtype=np.int16)
         try:
             client.connect()
             client.send_init()
             client.send_text(text)
             client.send_stop()
 
-            audio_buffer = np.array([], dtype=np.int16)
-            for frame in self._iter_audio_frames(client):
+            while True:
                 if gen is not None and self.cancel_scope is not None and self.cancel_scope.is_stale(gen):
                     logger.info("TTS generation cancelled (interruption)")
                     return
 
-                mp3_bytes, _is_final = frame
-                pcm = mp3_base64_to_pcm_int16(mp3_bytes, target_sample_rate=self.sample_rate)
-                audio_buffer = np.concatenate([audio_buffer, pcm])
+                frame = client.recv_audio()
+                if frame is None:
+                    break
 
-                while len(audio_buffer) >= self.blocksize:
-                    chunk = audio_buffer[: self.blocksize]
-                    audio_buffer = audio_buffer[self.blocksize :]
-                    yield chunk
+                mp3_bytes, is_final = frame
+                if mp3_bytes:
+                    audio_buffer = np.concatenate([audio_buffer, decoder.feed(mp3_bytes)])
+                    while len(audio_buffer) >= self.blocksize:
+                        yield audio_buffer[: self.blocksize]
+                        audio_buffer = audio_buffer[self.blocksize :]
+                if is_final:
+                    break
 
+            audio_buffer = np.concatenate([audio_buffer, decoder.flush()])
+            while len(audio_buffer) >= self.blocksize:
+                yield audio_buffer[: self.blocksize]
+                audio_buffer = audio_buffer[self.blocksize :]
             if len(audio_buffer) > 0:
-                chunk = np.pad(audio_buffer, (0, self.blocksize - len(audio_buffer)))
-                yield chunk
+                yield np.pad(audio_buffer, (0, self.blocksize - len(audio_buffer)))
         except Exception as e:
             logger.error("Telnyx TTS request failed: %s", e, exc_info=True)
         finally:
+            decoder.close()
             client.close()
-
-    def _iter_audio_frames(self, client: TelnyxTTSClient) -> Iterator[tuple[bytes, bool]]:
-        """Yield audio frames until the server closes the stream."""
-        while True:
-            frame = client.recv_audio()
-            if frame is None:
-                return
-            yield frame

--- a/src/speech_to_speech/arguments_classes/module_arguments.py
+++ b/src/speech_to_speech/arguments_classes/module_arguments.py
@@ -21,11 +21,11 @@ class ModuleArguments:
         },
     )
     stt: Optional[
-        Literal["whisper", "whisper-mlx", "mlx-audio-whisper", "faster-whisper", "parakeet-tdt", "paraformer"]
+        Literal["whisper", "whisper-mlx", "mlx-audio-whisper", "faster-whisper", "parakeet-tdt", "paraformer", "telnyx"]
     ] = field(
         default="parakeet-tdt",
         metadata={
-            "help": "The STT to use. Either 'whisper', 'whisper-mlx', 'mlx-audio-whisper', 'faster-whisper', 'parakeet-tdt', or 'paraformer'. Default is 'parakeet-tdt'."
+            "help": "The STT to use. Either 'whisper', 'whisper-mlx', 'mlx-audio-whisper', 'faster-whisper', 'parakeet-tdt', 'paraformer', or 'telnyx'. Default is 'parakeet-tdt'."
         },
     )
     llm_backend: Optional[Literal["transformers", "mlx-lm", "responses-api", "chat-completions"]] = field(
@@ -35,10 +35,10 @@ class ModuleArguments:
             "'chat-completions' (OpenAI-compatible /v1/chat/completions). Default is 'responses-api'."
         },
     )
-    tts: Optional[Literal["chatTTS", "facebookMMS", "pocket", "kokoro", "qwen3"]] = field(
+    tts: Optional[Literal["chatTTS", "facebookMMS", "pocket", "kokoro", "qwen3", "telnyx"]] = field(
         default="qwen3",
         metadata={
-            "help": "The TTS to use. Either 'chatTTS', 'facebookMMS', 'pocket', 'kokoro', or 'qwen3'. Default is 'qwen3'."
+            "help": "The TTS to use. Either 'chatTTS', 'facebookMMS', 'pocket', 'kokoro', 'qwen3', or 'telnyx'. Default is 'qwen3'."
         },
     )
     log_level: str = field(

--- a/src/speech_to_speech/arguments_classes/telnyx_stt_arguments.py
+++ b/src/speech_to_speech/arguments_classes/telnyx_stt_arguments.py
@@ -21,7 +21,10 @@ class TelnyxSTTHandlerArguments:
     )
     telnyx_stt_partial_results: bool = field(
         default=True,
-        metadata={"help": "Request partial transcript results for live transcription."},
+        metadata={
+            "help": "Request interim transcript results for live transcription. Deepgram only; "
+            "the Telnyx engine returns a single final result either way."
+        },
     )
     telnyx_stt_gen_kwargs: dict = field(
         default_factory=dict,

--- a/src/speech_to_speech/arguments_classes/telnyx_stt_arguments.py
+++ b/src/speech_to_speech/arguments_classes/telnyx_stt_arguments.py
@@ -1,0 +1,35 @@
+from dataclasses import dataclass, field
+
+
+@dataclass
+class TelnyxSTTHandlerArguments:
+    telnyx_stt_api_key: str = field(
+        default="",
+        metadata={"help": "Telnyx API key. Defaults to $TELNYX_API_KEY env var."},
+    )
+    telnyx_stt_engine: str = field(
+        default="Telnyx",
+        metadata={
+            "help": "STT engine: Telnyx, Deepgram, Google, Azure, xAI, AssemblyAI, Speechmatics, Soniox, Parakeet."
+        },
+    )
+    telnyx_stt_language: str = field(
+        default="en",
+        metadata={"help": "Language code or 'auto'."},
+    )
+    telnyx_stt_model: str = field(
+        default="",
+        metadata={"help": "Engine-specific model name (e.g. 'nova-3' for Deepgram)."},
+    )
+    telnyx_stt_input_format: str = field(
+        default="wav",
+        metadata={"help": "Audio format to send: 'wav' or 'mp3'."},
+    )
+    telnyx_stt_partial_results: bool = field(
+        default=True,
+        metadata={"help": "Request partial transcript results for live transcription."},
+    )
+    telnyx_stt_gen_kwargs: dict = field(
+        default_factory=dict,
+        metadata={"help": "Reserved for pipeline compatibility."},
+    )

--- a/src/speech_to_speech/arguments_classes/telnyx_stt_arguments.py
+++ b/src/speech_to_speech/arguments_classes/telnyx_stt_arguments.py
@@ -9,9 +9,7 @@ class TelnyxSTTHandlerArguments:
     )
     telnyx_stt_engine: str = field(
         default="Telnyx",
-        metadata={
-            "help": "STT engine: Telnyx, Deepgram, Google, Azure, xAI, AssemblyAI, Speechmatics, Soniox, Parakeet."
-        },
+        metadata={"help": "STT engine: Telnyx, Deepgram, Google, or Azure."},
     )
     telnyx_stt_language: str = field(
         default="en",
@@ -20,10 +18,6 @@ class TelnyxSTTHandlerArguments:
     telnyx_stt_model: str = field(
         default="",
         metadata={"help": "Engine-specific model name (e.g. 'nova-3' for Deepgram)."},
-    )
-    telnyx_stt_input_format: str = field(
-        default="wav",
-        metadata={"help": "Audio format to send: 'wav' or 'mp3'."},
     )
     telnyx_stt_partial_results: bool = field(
         default=True,

--- a/src/speech_to_speech/arguments_classes/telnyx_tts_arguments.py
+++ b/src/speech_to_speech/arguments_classes/telnyx_tts_arguments.py
@@ -1,0 +1,27 @@
+from dataclasses import dataclass, field
+
+
+@dataclass
+class TelnyxTTSHandlerArguments:
+    telnyx_tts_api_key: str = field(
+        default="",
+        metadata={"help": "Telnyx API key. Defaults to $TELNYX_API_KEY env var."},
+    )
+    telnyx_tts_voice: str = field(
+        default="Telnyx.NaturalHD.astra",
+        metadata={
+            "help": "Voice identifier. Telnyx.NaturalHD.*, AWS.Polly.*, Azure.*, ElevenLabs.*, MiniMax.*, ResembleAI.*, Inworld.*, Rime.*"
+        },
+    )
+    telnyx_tts_sample_rate: int = field(
+        default=16000,
+        metadata={"help": "Output sample rate. Default 16000 to match pipeline audio output."},
+    )
+    telnyx_tts_blocksize: int = field(
+        default=512,
+        metadata={"help": "Size of audio blocks to yield. Default 512."},
+    )
+    telnyx_tts_gen_kwargs: dict = field(
+        default_factory=dict,
+        metadata={"help": "Reserved for pipeline compatibility."},
+    )

--- a/src/speech_to_speech/s2s_pipeline.py
+++ b/src/speech_to_speech/s2s_pipeline.py
@@ -46,6 +46,8 @@ from speech_to_speech.arguments_classes.responses_api_language_model_arguments i
 )
 from speech_to_speech.arguments_classes.socket_receiver_arguments import SocketReceiverArguments
 from speech_to_speech.arguments_classes.socket_sender_arguments import SocketSenderArguments
+from speech_to_speech.arguments_classes.telnyx_stt_arguments import TelnyxSTTHandlerArguments
+from speech_to_speech.arguments_classes.telnyx_tts_arguments import TelnyxTTSHandlerArguments
 from speech_to_speech.arguments_classes.vad_arguments import VADHandlerArguments
 from speech_to_speech.arguments_classes.websocket_streamer_arguments import WebSocketStreamerArguments
 from speech_to_speech.arguments_classes.whisper_stt_arguments import WhisperSTTHandlerArguments
@@ -100,6 +102,7 @@ class ParsedArguments:
     faster_whisper_stt_handler_kwargs: FasterWhisperSTTHandlerArguments
     mlx_audio_whisper_stt_handler_kwargs: MLXAudioWhisperSTTHandlerArguments
     parakeet_tdt_stt_handler_kwargs: ParakeetTDTSTTHandlerArguments
+    telnyx_stt_handler_kwargs: TelnyxSTTHandlerArguments
     language_model_handler_kwargs: LanguageModelHandlerArguments
     responses_api_language_model_handler_kwargs: ResponsesApiLanguageModelHandlerArguments
     chat_tts_handler_kwargs: ChatTTSHandlerArguments
@@ -107,6 +110,7 @@ class ParsedArguments:
     pocket_tts_handler_kwargs: PocketTTSHandlerArguments
     kokoro_tts_handler_kwargs: KokoroTTSHandlerArguments
     qwen3_tts_handler_kwargs: Qwen3TTSHandlerArguments
+    telnyx_tts_handler_kwargs: TelnyxTTSHandlerArguments
 
 
 def rename_args(args: Any, prefix: str) -> None:
@@ -159,12 +163,14 @@ def parse_arguments() -> ParsedArguments:
             FasterWhisperSTTHandlerArguments,
             MLXAudioWhisperSTTHandlerArguments,
             ParakeetTDTSTTHandlerArguments,
+            TelnyxSTTHandlerArguments,
             _lm_class,
             ChatTTSHandlerArguments,
             FacebookMMSTTSHandlerArguments,
             PocketTTSHandlerArguments,
             KokoroTTSHandlerArguments,
             Qwen3TTSHandlerArguments,
+            TelnyxTTSHandlerArguments,
         )
     )
 
@@ -188,6 +194,7 @@ def parse_arguments() -> ParsedArguments:
         faster_whisper_stt_handler_kwargs=by_type[FasterWhisperSTTHandlerArguments],
         mlx_audio_whisper_stt_handler_kwargs=by_type[MLXAudioWhisperSTTHandlerArguments],
         parakeet_tdt_stt_handler_kwargs=by_type[ParakeetTDTSTTHandlerArguments],
+        telnyx_stt_handler_kwargs=by_type[TelnyxSTTHandlerArguments],
         language_model_handler_kwargs=by_type.get(LanguageModelHandlerArguments, LanguageModelHandlerArguments()),
         # The OpenAI-compatible slot holds whichever class was registered:
         # ChatCompletions... (a subclass) for chat-completions, else ResponsesApi....
@@ -200,6 +207,7 @@ def parse_arguments() -> ParsedArguments:
         pocket_tts_handler_kwargs=by_type[PocketTTSHandlerArguments],
         kokoro_tts_handler_kwargs=by_type[KokoroTTSHandlerArguments],
         qwen3_tts_handler_kwargs=by_type[Qwen3TTSHandlerArguments],
+        telnyx_tts_handler_kwargs=by_type[TelnyxTTSHandlerArguments],
     )
 
 
@@ -293,6 +301,7 @@ def prepare_all_args(
     faster_whisper_stt_handler_kwargs: FasterWhisperSTTHandlerArguments,
     mlx_audio_whisper_stt_handler_kwargs: MLXAudioWhisperSTTHandlerArguments,
     parakeet_tdt_stt_handler_kwargs: ParakeetTDTSTTHandlerArguments,
+    telnyx_stt_handler_kwargs: TelnyxSTTHandlerArguments,
     language_model_handler_kwargs: LanguageModelHandlerArguments,
     responses_api_language_model_handler_kwargs: ResponsesApiLanguageModelHandlerArguments,
     chat_tts_handler_kwargs: ChatTTSHandlerArguments,
@@ -300,6 +309,7 @@ def prepare_all_args(
     pocket_tts_handler_kwargs: PocketTTSHandlerArguments,
     kokoro_tts_handler_kwargs: KokoroTTSHandlerArguments,
     qwen3_tts_handler_kwargs: Qwen3TTSHandlerArguments,
+    telnyx_tts_handler_kwargs: TelnyxTTSHandlerArguments,
 ) -> None:
     prepare_module_args(
         module_kwargs,
@@ -308,6 +318,7 @@ def prepare_all_args(
         paraformer_stt_handler_kwargs,
         mlx_audio_whisper_stt_handler_kwargs,
         parakeet_tdt_stt_handler_kwargs,
+        telnyx_stt_handler_kwargs,
         language_model_handler_kwargs,
         responses_api_language_model_handler_kwargs,
         chat_tts_handler_kwargs,
@@ -315,6 +326,7 @@ def prepare_all_args(
         pocket_tts_handler_kwargs,
         kokoro_tts_handler_kwargs,
         qwen3_tts_handler_kwargs,
+        telnyx_tts_handler_kwargs,
     )
 
     rename_args(whisper_stt_handler_kwargs, "stt")
@@ -322,6 +334,7 @@ def prepare_all_args(
     rename_args(paraformer_stt_handler_kwargs, "paraformer_stt")
     rename_args(mlx_audio_whisper_stt_handler_kwargs, "mlx_audio_whisper")
     rename_args(parakeet_tdt_stt_handler_kwargs, "parakeet_tdt")
+    rename_args(telnyx_stt_handler_kwargs, "telnyx_stt")
     rename_args(language_model_handler_kwargs, "llm")
     rename_args(responses_api_language_model_handler_kwargs, "responses_api")
     rename_args(chat_tts_handler_kwargs, "chat_tts")
@@ -329,6 +342,7 @@ def prepare_all_args(
     rename_args(pocket_tts_handler_kwargs, "pocket_tts")
     rename_args(kokoro_tts_handler_kwargs, "kokoro")
     rename_args(qwen3_tts_handler_kwargs, "qwen3_tts")
+    rename_args(telnyx_tts_handler_kwargs, "telnyx_tts")
 
 
 def initialize_queues_and_events() -> dict[str, Any]:
@@ -368,6 +382,7 @@ def _build_pipeline_handlers(
     paraformer_stt_handler_kwargs: ParaformerSTTHandlerArguments,
     mlx_audio_whisper_stt_handler_kwargs: MLXAudioWhisperSTTHandlerArguments,
     parakeet_tdt_stt_handler_kwargs: ParakeetTDTSTTHandlerArguments,
+    telnyx_stt_handler_kwargs: TelnyxSTTHandlerArguments,
     language_model_handler_kwargs: LanguageModelHandlerArguments,
     responses_api_language_model_handler_kwargs: ResponsesApiLanguageModelHandlerArguments,
     chat_tts_handler_kwargs: ChatTTSHandlerArguments,
@@ -375,6 +390,7 @@ def _build_pipeline_handlers(
     pocket_tts_handler_kwargs: PocketTTSHandlerArguments,
     kokoro_tts_handler_kwargs: KokoroTTSHandlerArguments,
     qwen3_tts_handler_kwargs: Qwen3TTSHandlerArguments,
+    telnyx_tts_handler_kwargs: TelnyxTTSHandlerArguments,
     speculative_turns: SpeculativeTurnTracker | None = None,
 ) -> list[Any]:
     """Build the shared handler chain: VAD → STT → TranscriptionNotifier → LM → LMOutputProcessor → TTS.
@@ -411,6 +427,7 @@ def _build_pipeline_handlers(
         paraformer_stt_handler_kwargs,
         mlx_audio_whisper_stt_handler_kwargs,
         parakeet_tdt_stt_handler_kwargs,
+        telnyx_stt_handler_kwargs,
     )
 
     lm = get_llm_handler(
@@ -440,6 +457,7 @@ def _build_pipeline_handlers(
         pocket_tts_handler_kwargs,
         kokoro_tts_handler_kwargs,
         qwen3_tts_handler_kwargs,
+        telnyx_tts_handler_kwargs,
     )
 
     return [vad, stt, transcription_notifier, lm, lm_processor, tts]
@@ -456,6 +474,7 @@ def _build_realtime_pipeline_unit(
     paraformer_stt_handler_kwargs: ParaformerSTTHandlerArguments,
     mlx_audio_whisper_stt_handler_kwargs: MLXAudioWhisperSTTHandlerArguments,
     parakeet_tdt_stt_handler_kwargs: ParakeetTDTSTTHandlerArguments,
+    telnyx_stt_handler_kwargs: TelnyxSTTHandlerArguments,
     language_model_handler_kwargs: LanguageModelHandlerArguments,
     responses_api_language_model_handler_kwargs: ResponsesApiLanguageModelHandlerArguments,
     chat_tts_handler_kwargs: ChatTTSHandlerArguments,
@@ -463,6 +482,7 @@ def _build_realtime_pipeline_unit(
     pocket_tts_handler_kwargs: PocketTTSHandlerArguments,
     kokoro_tts_handler_kwargs: KokoroTTSHandlerArguments,
     qwen3_tts_handler_kwargs: Qwen3TTSHandlerArguments,
+    telnyx_tts_handler_kwargs: TelnyxTTSHandlerArguments,
 ) -> "PipelineUnit":
     """Build one isolated realtime pipeline (own queues, events, service, handlers).
 
@@ -479,6 +499,7 @@ def _build_realtime_pipeline_unit(
     paraformer_kw = deepcopy(paraformer_stt_handler_kwargs)
     mlx_audio_whisper_kw = deepcopy(mlx_audio_whisper_stt_handler_kwargs)
     parakeet_kw = deepcopy(parakeet_tdt_stt_handler_kwargs)
+    telnyx_stt_kw = deepcopy(telnyx_stt_handler_kwargs)
     lm_kw = deepcopy(language_model_handler_kwargs)
     responses_api_kw = deepcopy(responses_api_language_model_handler_kwargs)
     chat_tts_kw = deepcopy(chat_tts_handler_kwargs)
@@ -486,6 +507,7 @@ def _build_realtime_pipeline_unit(
     pocket_tts_kw = deepcopy(pocket_tts_handler_kwargs)
     kokoro_tts_kw = deepcopy(kokoro_tts_handler_kwargs)
     qwen3_tts_kw = deepcopy(qwen3_tts_handler_kwargs)
+    telnyx_tts_kw = deepcopy(telnyx_tts_handler_kwargs)
 
     should_listen = Event()
     response_playing = Event()
@@ -510,6 +532,7 @@ def _build_realtime_pipeline_unit(
         pocket_tts_kw,
         chat_tts_kw,
         facebook_mms_kw,
+        telnyx_tts_kw,
     ):
         vars(kw)["cancel_scope"] = cancel_scope
         vars(kw)["speculative_turns"] = speculative_turns
@@ -552,6 +575,7 @@ def _build_realtime_pipeline_unit(
         paraformer_stt_handler_kwargs=paraformer_kw,
         mlx_audio_whisper_stt_handler_kwargs=mlx_audio_whisper_kw,
         parakeet_tdt_stt_handler_kwargs=parakeet_kw,
+        telnyx_stt_handler_kwargs=telnyx_stt_kw,
         language_model_handler_kwargs=lm_kw,
         responses_api_language_model_handler_kwargs=responses_api_kw,
         chat_tts_handler_kwargs=chat_tts_kw,
@@ -559,6 +583,7 @@ def _build_realtime_pipeline_unit(
         pocket_tts_handler_kwargs=pocket_tts_kw,
         kokoro_tts_handler_kwargs=kokoro_tts_kw,
         qwen3_tts_handler_kwargs=qwen3_tts_kw,
+        telnyx_tts_handler_kwargs=telnyx_tts_kw,
         speculative_turns=speculative_turns,
     )
     for h in handlers:
@@ -589,6 +614,7 @@ def build_pipeline(
     paraformer_stt_handler_kwargs: ParaformerSTTHandlerArguments,
     mlx_audio_whisper_stt_handler_kwargs: MLXAudioWhisperSTTHandlerArguments,
     parakeet_tdt_stt_handler_kwargs: ParakeetTDTSTTHandlerArguments,
+    telnyx_stt_handler_kwargs: TelnyxSTTHandlerArguments,
     language_model_handler_kwargs: LanguageModelHandlerArguments,
     responses_api_language_model_handler_kwargs: ResponsesApiLanguageModelHandlerArguments,
     chat_tts_handler_kwargs: ChatTTSHandlerArguments,
@@ -596,6 +622,7 @@ def build_pipeline(
     pocket_tts_handler_kwargs: PocketTTSHandlerArguments,
     kokoro_tts_handler_kwargs: KokoroTTSHandlerArguments,
     qwen3_tts_handler_kwargs: Qwen3TTSHandlerArguments,
+    telnyx_tts_handler_kwargs: TelnyxTTSHandlerArguments,
     queues_and_events: dict[str, Any],
 ) -> ThreadManager:
     stop_event = queues_and_events["stop_event"]
@@ -651,6 +678,7 @@ def build_pipeline(
                 paraformer_stt_handler_kwargs=paraformer_stt_handler_kwargs,
                 mlx_audio_whisper_stt_handler_kwargs=mlx_audio_whisper_stt_handler_kwargs,
                 parakeet_tdt_stt_handler_kwargs=parakeet_tdt_stt_handler_kwargs,
+                telnyx_stt_handler_kwargs=telnyx_stt_handler_kwargs,
                 language_model_handler_kwargs=language_model_handler_kwargs,
                 responses_api_language_model_handler_kwargs=responses_api_language_model_handler_kwargs,
                 chat_tts_handler_kwargs=chat_tts_handler_kwargs,
@@ -658,6 +686,7 @@ def build_pipeline(
                 pocket_tts_handler_kwargs=pocket_tts_handler_kwargs,
                 kokoro_tts_handler_kwargs=kokoro_tts_handler_kwargs,
                 qwen3_tts_handler_kwargs=qwen3_tts_handler_kwargs,
+                telnyx_tts_handler_kwargs=telnyx_tts_handler_kwargs,
             )
             for i in range(pool_size)
         ]
@@ -735,6 +764,7 @@ def build_pipeline(
         paraformer_stt_handler_kwargs=paraformer_stt_handler_kwargs,
         mlx_audio_whisper_stt_handler_kwargs=mlx_audio_whisper_stt_handler_kwargs,
         parakeet_tdt_stt_handler_kwargs=parakeet_tdt_stt_handler_kwargs,
+        telnyx_stt_handler_kwargs=telnyx_stt_handler_kwargs,
         language_model_handler_kwargs=language_model_handler_kwargs,
         responses_api_language_model_handler_kwargs=responses_api_language_model_handler_kwargs,
         chat_tts_handler_kwargs=chat_tts_handler_kwargs,
@@ -742,6 +772,7 @@ def build_pipeline(
         pocket_tts_handler_kwargs=pocket_tts_handler_kwargs,
         kokoro_tts_handler_kwargs=kokoro_tts_handler_kwargs,
         qwen3_tts_handler_kwargs=qwen3_tts_handler_kwargs,
+        telnyx_tts_handler_kwargs=telnyx_tts_handler_kwargs,
     )
 
     return ThreadManager([*comms_handlers, *pipeline_handlers])
@@ -758,6 +789,7 @@ def get_stt_handler(
     paraformer_stt_handler_kwargs: ParaformerSTTHandlerArguments,
     mlx_audio_whisper_stt_handler_kwargs: MLXAudioWhisperSTTHandlerArguments,
     parakeet_tdt_stt_handler_kwargs: ParakeetTDTSTTHandlerArguments,
+    telnyx_stt_handler_kwargs: TelnyxSTTHandlerArguments,
 ) -> BaseHandler[STTIn, STTOut]:
     from speech_to_speech.STT.base_stt_handler import BaseSTTHandler
 
@@ -841,9 +873,31 @@ def get_stt_handler(
                 setup_kwargs=setup_kwargs,
             )
         )
+    elif module_kwargs.stt == "telnyx":
+        try:
+            from speech_to_speech.STT.telnyx_stt_handler import TelnyxSTTHandler
+        except ImportError as e:
+            raise ImportError(
+                'Telnyx STT is optional. Install it with `pip install "speech-to-speech[telnyx]"`.'
+            ) from e
+
+        setup_kwargs = {
+            **vars(telnyx_stt_handler_kwargs),
+            "enable_live_transcription": module_kwargs.enable_live_transcription,
+            "live_transcription_update_interval": module_kwargs.live_transcription_update_interval,
+        }
+
+        return with_speculative_turns(
+            TelnyxSTTHandler(
+                stop_event,
+                queue_in=spoken_prompt_queue,
+                queue_out=text_prompt_queue,
+                setup_kwargs=setup_kwargs,
+            )
+        )
     else:
         raise ValueError(
-            "The STT should be either whisper, whisper-mlx, mlx-audio-whisper, faster-whisper, parakeet-tdt, or paraformer."
+            "The STT should be either whisper, whisper-mlx, mlx-audio-whisper, faster-whisper, parakeet-tdt, paraformer, or telnyx."
         )
 
 
@@ -915,6 +969,7 @@ def get_tts_handler(
     pocket_tts_handler_kwargs: PocketTTSHandlerArguments,
     kokoro_tts_handler_kwargs: KokoroTTSHandlerArguments,
     qwen3_tts_handler_kwargs: Qwen3TTSHandlerArguments,
+    telnyx_tts_handler_kwargs: TelnyxTTSHandlerArguments,
 ) -> BaseHandler[TTSIn, TTSOut]:
     if module_kwargs.tts == "chatTTS":
         try:
@@ -977,8 +1032,23 @@ def get_tts_handler(
             setup_args=(should_listen,),
             setup_kwargs=vars(qwen3_tts_handler_kwargs),
         )
+    elif module_kwargs.tts == "telnyx":
+        try:
+            from speech_to_speech.TTS.telnyx_tts_handler import TelnyxTTSHandler
+        except ImportError as e:
+            raise ImportError(
+                'Telnyx TTS is optional. Install it with `pip install "speech-to-speech[telnyx]"`.'
+            ) from e
+
+        return TelnyxTTSHandler(
+            stop_event,
+            queue_in=lm_response_queue,
+            queue_out=send_audio_chunks_queue,
+            setup_args=(should_listen,),
+            setup_kwargs=vars(telnyx_tts_handler_kwargs),
+        )
     else:
-        raise ValueError("The TTS should be either chatTTS, facebookMMS, pocket, kokoro, or qwen3")
+        raise ValueError("The TTS should be either chatTTS, facebookMMS, pocket, kokoro, qwen3, or telnyx")
 
 
 def main() -> None:
@@ -996,6 +1066,7 @@ def main() -> None:
         args.faster_whisper_stt_handler_kwargs,
         args.mlx_audio_whisper_stt_handler_kwargs,
         args.parakeet_tdt_stt_handler_kwargs,
+        args.telnyx_stt_handler_kwargs,
         args.language_model_handler_kwargs,
         args.responses_api_language_model_handler_kwargs,
         args.chat_tts_handler_kwargs,
@@ -1003,6 +1074,7 @@ def main() -> None:
         args.pocket_tts_handler_kwargs,
         args.kokoro_tts_handler_kwargs,
         args.qwen3_tts_handler_kwargs,
+        args.telnyx_tts_handler_kwargs,
     )
 
     # Validate after prepare_all_args(): --local_mac_optimal_settings mutates
@@ -1040,6 +1112,7 @@ def main() -> None:
         args.paraformer_stt_handler_kwargs,
         args.mlx_audio_whisper_stt_handler_kwargs,
         args.parakeet_tdt_stt_handler_kwargs,
+        args.telnyx_stt_handler_kwargs,
         args.language_model_handler_kwargs,
         args.responses_api_language_model_handler_kwargs,
         args.chat_tts_handler_kwargs,
@@ -1047,6 +1120,7 @@ def main() -> None:
         args.pocket_tts_handler_kwargs,
         args.kokoro_tts_handler_kwargs,
         args.qwen3_tts_handler_kwargs,
+        args.telnyx_tts_handler_kwargs,
         queues_and_events,
     )
 

--- a/src/speech_to_speech/utils/telnyx_ws.py
+++ b/src/speech_to_speech/utils/telnyx_ws.py
@@ -37,6 +37,12 @@ class TelnyxProtocolError(RuntimeError):
     """Raised when a Telnyx WebSocket endpoint reports an error frame."""
 
 
+# websocket-client attaches an ``Origin`` header to wss:// handshakes. Telnyx's
+# edge rejects those with a 403 before the request reaches the API, so the
+# handshake has to go out without one.
+SUPPRESS_ORIGIN = True
+
+
 # ── Audio format helpers ────────────────────────────────────────────────
 
 
@@ -221,7 +227,9 @@ class TelnyxSTTClient:
             "transcription_engine": self.engine,
             "input_format": "wav",
             "language": self.language,
-            "partial_results": "true" if self.partial_results else "false",
+            # The endpoint calls this `interim_results`; `partial_results` is
+            # accepted but ignored, and silently gives you finals only.
+            "interim_results": "true" if self.partial_results else "false",
         }
         if self.model:
             params["model"] = self.model
@@ -235,6 +243,7 @@ class TelnyxSTTClient:
             self.url(),
             header=[f"Authorization: Bearer {self.api_key}"],
             timeout=self.connect_timeout,
+            suppress_origin=SUPPRESS_ORIGIN,
         )
         self._ws.settimeout(self.recv_timeout)
 
@@ -329,6 +338,7 @@ class TelnyxTTSClient:
             self.url(),
             header=[f"Authorization: Bearer {self.api_key}"],
             timeout=self.connect_timeout,
+            suppress_origin=SUPPRESS_ORIGIN,
         )
         self._ws.settimeout(self.recv_timeout)
 

--- a/src/speech_to_speech/utils/telnyx_ws.py
+++ b/src/speech_to_speech/utils/telnyx_ws.py
@@ -1,0 +1,254 @@
+"""Shared helpers for the Telnyx managed STT and TTS backends.
+
+Two responsibilities:
+
+1. Audio format conversion between the pipeline's PCM int16 representation and
+   the formats Telnyx's WebSocket APIs accept (WAV for STT input, base64 MP3
+   for TTS output).
+2. Thin sync WebSocket clients for the two Telnyx endpoints. The pipeline
+   runs handlers in plain threads, so we use ``websocket-client`` (sync) rather
+   than the async ``websockets`` library used elsewhere in the codebase.
+"""
+
+from __future__ import annotations
+
+import base64
+import io
+import json
+import logging
+import wave
+from typing import Any
+
+import numpy as np
+
+logger = logging.getLogger(__name__)
+
+
+# ── Audio format helpers ────────────────────────────────────────────────
+
+
+def pcm_int16_to_wav_bytes(pcm: np.ndarray, sample_rate: int = 16000) -> bytes:
+    """Wrap a mono int16 PCM numpy array in a WAV container.
+
+    Uses the stdlib ``wave`` module so we don't pull in a codec dependency
+    just to ship audio to Telnyx STT.
+    """
+    if pcm.dtype != np.int16:
+        pcm = pcm.astype(np.int16)
+    pcm = np.ascontiguousarray(pcm)
+
+    buf = io.BytesIO()
+    with wave.open(buf, "wb") as wf:
+        wf.setnchannels(1)
+        wf.setsampwidth(2)  # int16
+        wf.setframerate(sample_rate)
+        wf.writeframes(pcm.tobytes())
+    return buf.getvalue()
+
+
+def mp3_base64_to_pcm_int16(b64: str, target_sample_rate: int = 16000) -> np.ndarray:
+    """Decode a base64-encoded MP3 frame to a mono int16 PCM numpy array.
+
+    Requires ``pydub`` and an ``ffmpeg`` system binary. Resamples to the
+    target sample rate if the source rate differs.
+    """
+    from pydub import AudioSegment  # local import: optional dep
+
+    raw = base64.b64decode(b64)
+    audio = AudioSegment.from_file(io.BytesIO(raw), format="mp3")
+
+    if audio.frame_rate != target_sample_rate:
+        audio = audio.set_frame_rate(target_sample_rate)
+    if audio.channels != 1:
+        audio = audio.set_channels(1)
+    if audio.sample_width != 2:
+        audio = audio.set_sample_width(2)
+
+    samples = np.array(audio.get_array_of_samples(), dtype=np.int16)
+    return np.ascontiguousarray(samples)
+
+
+# ── STT WebSocket client ────────────────────────────────────────────────
+
+
+STT_WS_URL = "wss://api.telnyx.com/v2/speech-to-text/transcription"
+
+
+class TelnyxSTTClient:
+    """Sync WebSocket client for Telnyx's managed STT endpoint.
+
+    One client per utterance. The pipeline opens a fresh connection for each
+    VAD segment, sends the audio as a single binary frame, and reads JSON
+    transcript events until the server signals end-of-stream.
+    """
+
+    def __init__(
+        self,
+        api_key: str,
+        engine: str = "Telnyx",
+        language: str = "en",
+        input_format: str = "wav",
+        partial_results: bool = True,
+        model: str = "",
+    ) -> None:
+        self.api_key = api_key
+        self.engine = engine
+        self.language = language
+        self.input_format = input_format
+        self.partial_results = partial_results
+        self.model = model
+        self._ws: Any = None
+
+    def connect(self) -> None:
+        import websocket  # local import: optional dep
+
+        params: list[str] = [
+            f"transcription_engine={self.engine}",
+            f"input_format={self.input_format}",
+            f"language={self.language}",
+            f"partial_results={'true' if self.partial_results else 'false'}",
+        ]
+        if self.model:
+            params.append(f"model={self.model}")
+        url = f"{STT_WS_URL}?{'&'.join(params)}"
+
+        self._ws = websocket.WebSocket()
+        self._ws.connect(
+            url,
+            header=[f"Authorization: Bearer {self.api_key}"],
+            timeout=30,
+        )
+
+    def send_audio(self, pcm: np.ndarray, sample_rate: int = 16000) -> None:
+        """Wrap PCM in the configured container and send as a binary frame."""
+        import websocket  # local import: optional dep
+
+        if self._ws is None:
+            raise RuntimeError("TelnyxSTTClient.connect() must be called before send_audio()")
+        if self.input_format == "wav":
+            payload = pcm_int16_to_wav_bytes(pcm, sample_rate=sample_rate)
+        elif self.input_format == "mp3":
+            # Lazy import: pydub is only needed for MP3 input, which is rare.
+            from pydub import AudioSegment
+
+            audio = AudioSegment(
+                data=pcm.astype(np.int16).tobytes(),
+                sample_width=2,
+                frame_rate=sample_rate,
+                channels=1,
+            )
+            buf = io.BytesIO()
+            audio.export(buf, format="mp3")
+            payload = buf.getvalue()
+        else:
+            raise ValueError(f"Unsupported input_format: {self.input_format!r}")
+        self._ws.send(payload, opcode=websocket.ABNF.OPCODE_BINARY)
+
+    def recv_transcript(self) -> dict[str, Any] | None:
+        """Receive one JSON event from the server.
+
+        Returns ``None`` when the server closes the stream.
+        """
+        if self._ws is None:
+            raise RuntimeError("TelnyxSTTClient.connect() must be called before recv_transcript()")
+        try:
+            raw = self._ws.recv()
+        except Exception:
+            return None
+        if not raw:
+            return None
+        try:
+            return json.loads(raw)
+        except json.JSONDecodeError:
+            logger.warning("Telnyx STT: ignoring non-JSON frame: %r", raw[:200])
+            return None
+
+    def close(self) -> None:
+        if self._ws is None:
+            return
+        try:
+            self._ws.close()
+        except Exception:
+            pass
+        self._ws = None
+
+
+# ── TTS WebSocket client ────────────────────────────────────────────────
+
+
+TTS_WS_URL = "wss://api.telnyx.com/v2/text-to-speech/speech"
+
+
+class TelnyxTTSClient:
+    """Sync WebSocket client for Telnyx's managed TTS endpoint.
+
+    One client per LLM response. Sends an init frame, one or more content
+    frames, then a stop frame. Reads JSON audio frames back until the server
+    signals ``isFinal``.
+    """
+
+    def __init__(self, api_key: str, voice: str) -> None:
+        self.api_key = api_key
+        self.voice = voice
+        self._ws: Any = None
+
+    def connect(self) -> None:
+        import websocket  # local import: optional dep
+
+        url = f"{TTS_WS_URL}?voice={self.voice}"
+        self._ws = websocket.WebSocket()
+        self._ws.connect(
+            url,
+            header=[f"Authorization: Bearer {self.api_key}"],
+            timeout=30,
+        )
+
+    def _send_json(self, payload: dict[str, Any]) -> None:
+        if self._ws is None:
+            raise RuntimeError("TelnyxTTSClient.connect() must be called before sending frames")
+        self._ws.send(json.dumps(payload))
+
+    def send_init(self) -> None:
+        """Send the init frame that primes the TTS session."""
+        self._send_json({"text": " "})
+
+    def send_text(self, text: str) -> None:
+        """Send a content frame. Can be called multiple times for streaming."""
+        self._send_json({"text": text})
+
+    def send_stop(self) -> None:
+        """Send the stop frame that closes the synthesis stream."""
+        self._send_json({"text": ""})
+
+    def recv_audio(self) -> tuple[bytes, bool] | None:
+        """Receive one audio frame.
+
+        Returns ``(raw_mp3_bytes, is_final)`` or ``None`` when the server
+        closes the stream.
+        """
+        if self._ws is None:
+            raise RuntimeError("TelnyxTTSClient.connect() must be called before recv_audio()")
+        try:
+            raw = self._ws.recv()
+        except Exception:
+            return None
+        if not raw:
+            return None
+        try:
+            event = json.loads(raw)
+        except json.JSONDecodeError:
+            logger.warning("Telnyx TTS: ignoring non-JSON frame: %r", raw[:200])
+            return None
+        audio_b64 = event.get("audio")
+        if not audio_b64:
+            return None
+        return base64.b64decode(audio_b64), bool(event.get("isFinal", False))
+
+    def close(self) -> None:
+        if self._ws is None:
+            return
+        try:
+            self._ws.close()
+        except Exception:
+            pass
+        self._ws = None

--- a/src/speech_to_speech/utils/telnyx_ws.py
+++ b/src/speech_to_speech/utils/telnyx_ws.py
@@ -3,11 +3,16 @@
 Two responsibilities:
 
 1. Audio format conversion between the pipeline's PCM int16 representation and
-   the formats Telnyx's WebSocket APIs accept (WAV for STT input, base64 MP3
-   for TTS output).
-2. Thin sync WebSocket clients for the two Telnyx endpoints. The pipeline
-   runs handlers in plain threads, so we use ``websocket-client`` (sync) rather
-   than the async ``websockets`` library used elsewhere in the codebase.
+   the formats Telnyx's WebSocket APIs use (WAV for STT input, MP3 for TTS
+   output).
+2. Thin sync WebSocket clients for the two Telnyx endpoints. The pipeline runs
+   handlers in plain threads, so we use ``websocket-client`` (sync) rather than
+   the async ``websockets`` library used elsewhere in the codebase.
+
+Telnyx TTS returns the response as one continuous MP3 bitstream split across
+many small WebSocket frames. Individual frames are *not* independently
+decodable, so :class:`Mp3StreamDecoder` pipes the stream through a long-lived
+ffmpeg process and emits PCM as it becomes available.
 """
 
 from __future__ import annotations
@@ -16,12 +21,20 @@ import base64
 import io
 import json
 import logging
+import subprocess
 import wave
+from queue import Empty, Queue
+from threading import Thread
 from typing import Any
+from urllib.parse import urlencode
 
 import numpy as np
 
 logger = logging.getLogger(__name__)
+
+
+class TelnyxProtocolError(RuntimeError):
+    """Raised when a Telnyx WebSocket endpoint reports an error frame."""
 
 
 # ── Audio format helpers ────────────────────────────────────────────────
@@ -46,26 +59,125 @@ def pcm_int16_to_wav_bytes(pcm: np.ndarray, sample_rate: int = 16000) -> bytes:
     return buf.getvalue()
 
 
-def mp3_base64_to_pcm_int16(b64: str, target_sample_rate: int = 16000) -> np.ndarray:
-    """Decode a base64-encoded MP3 frame to a mono int16 PCM numpy array.
+_EMPTY_PCM = np.array([], dtype=np.int16)
 
-    Requires ``pydub`` and an ``ffmpeg`` system binary. Resamples to the
-    target sample rate if the source rate differs.
+
+class Mp3StreamDecoder:
+    """Incrementally decode a continuous MP3 byte stream to mono int16 PCM.
+
+    Feed MP3 bytes as they arrive; each call returns whatever PCM ffmpeg has
+    produced so far. Call :meth:`flush` once the stream is complete to drain
+    the decoder's tail, then :meth:`close`.
     """
-    from pydub import AudioSegment  # local import: optional dep
 
-    raw = base64.b64decode(b64)
-    audio = AudioSegment.from_file(io.BytesIO(raw), format="mp3")
+    def __init__(self, sample_rate: int = 16000) -> None:
+        self.sample_rate = sample_rate
+        # -probesize/-analyzeduration keep ffmpeg from buffering input while it
+        # probes the stream, which would add hundreds of ms to first audio.
+        self._proc = subprocess.Popen(
+            [
+                "ffmpeg",
+                "-hide_banner",
+                "-loglevel",
+                "error",
+                "-probesize",
+                "32",
+                "-analyzeduration",
+                "0",
+                "-f",
+                "mp3",
+                "-i",
+                "pipe:0",
+                "-f",
+                "s16le",
+                "-acodec",
+                "pcm_s16le",
+                "-ac",
+                "1",
+                "-ar",
+                str(sample_rate),
+                "-flush_packets",
+                "1",
+                "pipe:1",
+            ],
+            stdin=subprocess.PIPE,
+            stdout=subprocess.PIPE,
+            stderr=subprocess.DEVNULL,
+        )
+        self._pending: Queue[bytes | None] = Queue()
+        self._remainder = b""
+        self._drained = False
+        self._reader = Thread(target=self._drain_stdout, daemon=True)
+        self._reader.start()
 
-    if audio.frame_rate != target_sample_rate:
-        audio = audio.set_frame_rate(target_sample_rate)
-    if audio.channels != 1:
-        audio = audio.set_channels(1)
-    if audio.sample_width != 2:
-        audio = audio.set_sample_width(2)
+    def _drain_stdout(self) -> None:
+        stdout = self._proc.stdout
+        # Popen(stdout=PIPE) with default buffering hands back a BufferedReader,
+        # which is what gives us read1().
+        assert isinstance(stdout, io.BufferedReader)
+        try:
+            while True:
+                # read1() returns as soon as any data is available, unlike
+                # read(n) which blocks until n bytes or EOF.
+                buf = stdout.read1(8192)
+                if not buf:
+                    return
+                self._pending.put(buf)
+        except (OSError, ValueError):
+            return
+        finally:
+            self._pending.put(None)
 
-    samples = np.array(audio.get_array_of_samples(), dtype=np.int16)
-    return np.ascontiguousarray(samples)
+    def _collect(self, block: bool) -> np.ndarray:
+        parts = [self._remainder] if self._remainder else []
+        self._remainder = b""
+        while True:
+            try:
+                buf = self._pending.get(block=block, timeout=10.0)
+            except Empty:
+                break
+            if buf is None:
+                self._drained = True
+                break
+            parts.append(buf)
+            block = False  # the first read may wait; drain the rest immediately
+        raw = b"".join(parts)
+        # int16 samples are 2 bytes wide; carry an odd trailing byte forward.
+        if len(raw) % 2:
+            self._remainder = raw[-1:]
+            raw = raw[:-1]
+        if not raw:
+            return _EMPTY_PCM
+        return np.frombuffer(raw, dtype=np.int16)
+
+    def feed(self, mp3: bytes) -> np.ndarray:
+        """Push MP3 bytes in and return any PCM available right now."""
+        stdin = self._proc.stdin
+        assert stdin is not None
+        stdin.write(mp3)
+        stdin.flush()
+        return self._collect(block=False)
+
+    def flush(self) -> np.ndarray:
+        """Close the input side and return the decoder's remaining PCM."""
+        stdin = self._proc.stdin
+        if stdin is not None and not stdin.closed:
+            stdin.close()
+        parts = []
+        while not self._drained:
+            parts.append(self._collect(block=True))
+        return np.concatenate(parts) if parts else _EMPTY_PCM
+
+    def close(self) -> None:
+        for stream in (self._proc.stdin, self._proc.stdout):
+            if stream is not None and not stream.closed:
+                try:
+                    stream.close()
+                except OSError:
+                    pass
+        if self._proc.poll() is None:
+            self._proc.kill()
+        self._proc.wait()
 
 
 # ── STT WebSocket client ────────────────────────────────────────────────
@@ -73,13 +185,16 @@ def mp3_base64_to_pcm_int16(b64: str, target_sample_rate: int = 16000) -> np.nda
 
 STT_WS_URL = "wss://api.telnyx.com/v2/speech-to-text/transcription"
 
+# Telnyx recommends 2 KB audio frames.
+STT_CHUNK_BYTES = 2048
+
 
 class TelnyxSTTClient:
     """Sync WebSocket client for Telnyx's managed STT endpoint.
 
     One client per utterance. The pipeline opens a fresh connection for each
-    VAD segment, sends the audio as a single binary frame, and reads JSON
-    transcript events until the server signals end-of-stream.
+    VAD segment, sends the audio as WAV in 2 KB binary frames, and reads JSON
+    transcript events until the server returns the final result.
     """
 
     def __init__(
@@ -87,81 +202,83 @@ class TelnyxSTTClient:
         api_key: str,
         engine: str = "Telnyx",
         language: str = "en",
-        input_format: str = "wav",
         partial_results: bool = True,
         model: str = "",
+        connect_timeout: float = 10.0,
+        recv_timeout: float = 10.0,
     ) -> None:
         self.api_key = api_key
         self.engine = engine
         self.language = language
-        self.input_format = input_format
         self.partial_results = partial_results
         self.model = model
+        self.connect_timeout = connect_timeout
+        self.recv_timeout = recv_timeout
         self._ws: Any = None
+
+    def url(self) -> str:
+        params = {
+            "transcription_engine": self.engine,
+            "input_format": "wav",
+            "language": self.language,
+            "partial_results": "true" if self.partial_results else "false",
+        }
+        if self.model:
+            params["model"] = self.model
+        return f"{STT_WS_URL}?{urlencode(params)}"
 
     def connect(self) -> None:
         import websocket  # local import: optional dep
 
-        params: list[str] = [
-            f"transcription_engine={self.engine}",
-            f"input_format={self.input_format}",
-            f"language={self.language}",
-            f"partial_results={'true' if self.partial_results else 'false'}",
-        ]
-        if self.model:
-            params.append(f"model={self.model}")
-        url = f"{STT_WS_URL}?{'&'.join(params)}"
-
         self._ws = websocket.WebSocket()
         self._ws.connect(
-            url,
+            self.url(),
             header=[f"Authorization: Bearer {self.api_key}"],
-            timeout=30,
+            timeout=self.connect_timeout,
         )
+        self._ws.settimeout(self.recv_timeout)
 
     def send_audio(self, pcm: np.ndarray, sample_rate: int = 16000) -> None:
-        """Wrap PCM in the configured container and send as a binary frame."""
+        """Wrap PCM in a WAV container and send it as 2 KB binary frames."""
         import websocket  # local import: optional dep
 
         if self._ws is None:
             raise RuntimeError("TelnyxSTTClient.connect() must be called before send_audio()")
-        if self.input_format == "wav":
-            payload = pcm_int16_to_wav_bytes(pcm, sample_rate=sample_rate)
-        elif self.input_format == "mp3":
-            # Lazy import: pydub is only needed for MP3 input, which is rare.
-            from pydub import AudioSegment
-
-            audio = AudioSegment(
-                data=pcm.astype(np.int16).tobytes(),
-                sample_width=2,
-                frame_rate=sample_rate,
-                channels=1,
+        payload = pcm_int16_to_wav_bytes(pcm, sample_rate=sample_rate)
+        for offset in range(0, len(payload), STT_CHUNK_BYTES):
+            self._ws.send(
+                payload[offset : offset + STT_CHUNK_BYTES],
+                opcode=websocket.ABNF.OPCODE_BINARY,
             )
-            buf = io.BytesIO()
-            audio.export(buf, format="mp3")
-            payload = buf.getvalue()
-        else:
-            raise ValueError(f"Unsupported input_format: {self.input_format!r}")
-        self._ws.send(payload, opcode=websocket.ABNF.OPCODE_BINARY)
 
     def recv_transcript(self) -> dict[str, Any] | None:
         """Receive one JSON event from the server.
 
-        Returns ``None`` when the server closes the stream.
+        Returns ``None`` when the server closes the stream or the read times
+        out, and ``{}`` for a frame carrying nothing we can use. Raises
+        :class:`TelnyxProtocolError` on an error frame.
         """
+        import websocket  # local import: optional dep
+
         if self._ws is None:
             raise RuntimeError("TelnyxSTTClient.connect() must be called before recv_transcript()")
         try:
             raw = self._ws.recv()
-        except Exception:
+        except (
+            websocket.WebSocketConnectionClosedException,
+            websocket.WebSocketTimeoutException,
+        ):
             return None
         if not raw:
             return None
         try:
-            return json.loads(raw)
+            event = json.loads(raw)
         except json.JSONDecodeError:
             logger.warning("Telnyx STT: ignoring non-JSON frame: %r", raw[:200])
-            return None
+            return {}
+        if event.get("error"):
+            raise TelnyxProtocolError(str(event["error"]))
+        return event
 
     def close(self) -> None:
         if self._ws is None:
@@ -182,26 +299,38 @@ TTS_WS_URL = "wss://api.telnyx.com/v2/text-to-speech/speech"
 class TelnyxTTSClient:
     """Sync WebSocket client for Telnyx's managed TTS endpoint.
 
-    One client per LLM response. Sends an init frame, one or more content
-    frames, then a stop frame. Reads JSON audio frames back until the server
-    signals ``isFinal``.
+    One client per synthesis request. Sends an init frame, one or more content
+    frames, then a stop frame. Reads JSON frames back; each carries a slice of
+    a single continuous MP3 bitstream. The final frame has ``isFinal: true``
+    and an empty ``audio`` payload.
     """
 
-    def __init__(self, api_key: str, voice: str) -> None:
+    def __init__(
+        self,
+        api_key: str,
+        voice: str,
+        connect_timeout: float = 10.0,
+        recv_timeout: float = 10.0,
+    ) -> None:
         self.api_key = api_key
         self.voice = voice
+        self.connect_timeout = connect_timeout
+        self.recv_timeout = recv_timeout
         self._ws: Any = None
+
+    def url(self) -> str:
+        return f"{TTS_WS_URL}?{urlencode({'voice': self.voice})}"
 
     def connect(self) -> None:
         import websocket  # local import: optional dep
 
-        url = f"{TTS_WS_URL}?voice={self.voice}"
         self._ws = websocket.WebSocket()
         self._ws.connect(
-            url,
+            self.url(),
             header=[f"Authorization: Bearer {self.api_key}"],
-            timeout=30,
+            timeout=self.connect_timeout,
         )
+        self._ws.settimeout(self.recv_timeout)
 
     def _send_json(self, payload: dict[str, Any]) -> None:
         if self._ws is None:
@@ -223,14 +352,21 @@ class TelnyxTTSClient:
     def recv_audio(self) -> tuple[bytes, bool] | None:
         """Receive one audio frame.
 
-        Returns ``(raw_mp3_bytes, is_final)`` or ``None`` when the server
-        closes the stream.
+        Returns ``(mp3_bytes, is_final)`` or ``None`` when the server closes
+        the stream. ``mp3_bytes`` is a slice of a continuous MP3 bitstream and
+        is empty on the final frame. Raises :class:`TelnyxProtocolError` on an
+        error frame.
         """
+        import websocket  # local import: optional dep
+
         if self._ws is None:
             raise RuntimeError("TelnyxTTSClient.connect() must be called before recv_audio()")
         try:
             raw = self._ws.recv()
-        except Exception:
+        except (
+            websocket.WebSocketConnectionClosedException,
+            websocket.WebSocketTimeoutException,
+        ):
             return None
         if not raw:
             return None
@@ -238,10 +374,10 @@ class TelnyxTTSClient:
             event = json.loads(raw)
         except json.JSONDecodeError:
             logger.warning("Telnyx TTS: ignoring non-JSON frame: %r", raw[:200])
-            return None
-        audio_b64 = event.get("audio")
-        if not audio_b64:
-            return None
+            return b"", False
+        if event.get("error"):
+            raise TelnyxProtocolError(str(event["error"]))
+        audio_b64 = event.get("audio") or ""
         return base64.b64decode(audio_b64), bool(event.get("isFinal", False))
 
     def close(self) -> None:

--- a/tests/telnyx_helpers.py
+++ b/tests/telnyx_helpers.py
@@ -1,0 +1,90 @@
+"""Shared fixtures for the Telnyx backend tests.
+
+Builds real MP3 bitstreams with ffmpeg so the tests exercise the same decode
+path as production. No pydub, no network.
+"""
+
+from __future__ import annotations
+
+import shutil
+import subprocess
+
+import numpy as np
+import pytest
+
+
+def require_ffmpeg() -> None:
+    if shutil.which("ffmpeg") is None:
+        pytest.skip("ffmpeg not available")
+
+
+def sine_pcm(duration_s: float = 1.0, sample_rate: int = 16000, freq: int = 440) -> np.ndarray:
+    t = np.linspace(0, duration_s, int(sample_rate * duration_s), endpoint=False)
+    return (np.sin(2 * np.pi * freq * t) * 16000).astype(np.int16)
+
+
+def pcm_to_mp3(pcm: np.ndarray, sample_rate: int = 16000) -> bytes:
+    """Encode mono int16 PCM to an MP3 bitstream."""
+    require_ffmpeg()
+    proc = subprocess.run(
+        [
+            "ffmpeg",
+            "-hide_banner",
+            "-loglevel",
+            "error",
+            "-f",
+            "s16le",
+            "-ac",
+            "1",
+            "-ar",
+            str(sample_rate),
+            "-i",
+            "pipe:0",
+            "-f",
+            "mp3",
+            "pipe:1",
+        ],
+        input=pcm.tobytes(),
+        capture_output=True,
+        check=True,
+    )
+    return proc.stdout
+
+
+def mp3_to_pcm(mp3: bytes, sample_rate: int = 16000) -> np.ndarray:
+    """Decode a complete MP3 bitstream to mono int16 PCM in one shot."""
+    require_ffmpeg()
+    proc = subprocess.run(
+        [
+            "ffmpeg",
+            "-hide_banner",
+            "-loglevel",
+            "error",
+            "-f",
+            "mp3",
+            "-i",
+            "pipe:0",
+            "-f",
+            "s16le",
+            "-acodec",
+            "pcm_s16le",
+            "-ac",
+            "1",
+            "-ar",
+            str(sample_rate),
+            "pipe:1",
+        ],
+        input=mp3,
+        capture_output=True,
+        check=True,
+    )
+    return np.frombuffer(proc.stdout, dtype=np.int16)
+
+
+def slice_stream(data: bytes, size: int = 480) -> list[bytes]:
+    """Split a byte stream into fixed-size slices.
+
+    Telnyx sends the MP3 response this way: arbitrary slices of one continuous
+    bitstream, not a sequence of standalone MP3 files.
+    """
+    return [data[i : i + size] for i in range(0, len(data), size)]

--- a/tests/test_cli_defaults.py
+++ b/tests/test_cli_defaults.py
@@ -17,6 +17,8 @@ from speech_to_speech.arguments_classes.responses_api_language_model_arguments i
 )
 from speech_to_speech.arguments_classes.socket_receiver_arguments import SocketReceiverArguments
 from speech_to_speech.arguments_classes.socket_sender_arguments import SocketSenderArguments
+from speech_to_speech.arguments_classes.telnyx_stt_arguments import TelnyxSTTHandlerArguments
+from speech_to_speech.arguments_classes.telnyx_tts_arguments import TelnyxTTSHandlerArguments
 from speech_to_speech.arguments_classes.vad_arguments import VADHandlerArguments
 from speech_to_speech.arguments_classes.websocket_streamer_arguments import WebSocketStreamerArguments
 from speech_to_speech.arguments_classes.whisper_stt_arguments import WhisperSTTHandlerArguments
@@ -67,6 +69,7 @@ EXPECTED_FIELD_TYPES = {
     "faster_whisper_stt_handler_kwargs": FasterWhisperSTTHandlerArguments,
     "mlx_audio_whisper_stt_handler_kwargs": MLXAudioWhisperSTTHandlerArguments,
     "parakeet_tdt_stt_handler_kwargs": ParakeetTDTSTTHandlerArguments,
+    "telnyx_stt_handler_kwargs": TelnyxSTTHandlerArguments,
     "language_model_handler_kwargs": LanguageModelHandlerArguments,
     "responses_api_language_model_handler_kwargs": ResponsesApiLanguageModelHandlerArguments,
     "chat_tts_handler_kwargs": ChatTTSHandlerArguments,
@@ -74,6 +77,7 @@ EXPECTED_FIELD_TYPES = {
     "pocket_tts_handler_kwargs": PocketTTSHandlerArguments,
     "kokoro_tts_handler_kwargs": KokoroTTSHandlerArguments,
     "qwen3_tts_handler_kwargs": Qwen3TTSHandlerArguments,
+    "telnyx_tts_handler_kwargs": TelnyxTTSHandlerArguments,
 }
 
 

--- a/tests/test_telnyx_audio_codec.py
+++ b/tests/test_telnyx_audio_codec.py
@@ -1,0 +1,103 @@
+"""Tests for the Telnyx audio format helpers.
+
+These tests exercise the WAV container and MP3 decode paths without any
+network access. The MP3 test is skipped when pydub or ffmpeg are missing.
+"""
+
+from __future__ import annotations
+
+import base64
+import io
+
+import numpy as np
+import pytest
+
+from speech_to_speech.utils.telnyx_ws import mp3_base64_to_pcm_int16, pcm_int16_to_wav_bytes
+
+
+def test_pcm_to_wav_to_pcm_roundtrip():
+    """Random int16 PCM survives a WAV round-trip with matching samples."""
+    rng = np.random.default_rng(seed=42)
+    pcm = rng.integers(-32768, 32767, size=16000, dtype=np.int16)
+
+    wav_bytes = pcm_int16_to_wav_bytes(pcm, sample_rate=16000)
+    assert isinstance(wav_bytes, bytes)
+    assert len(wav_bytes) > 0
+    # WAV header is 44 bytes for mono PCM int16
+    assert wav_bytes[:4] == b"RIFF"
+    assert wav_bytes[8:12] == b"WAVE"
+
+    import wave
+
+    with wave.open(io.BytesIO(wav_bytes), "rb") as wf:
+        assert wf.getnchannels() == 1
+        assert wf.getsampwidth() == 2
+        assert wf.getframerate() == 16000
+        recovered = np.frombuffer(wf.readframes(wf.getnframes()), dtype=np.int16)
+
+    np.testing.assert_array_equal(recovered, pcm)
+
+
+def test_pcm_to_wav_respects_sample_rate():
+    """The WAV header carries the requested sample rate."""
+    pcm = np.zeros(8000, dtype=np.int16)
+    wav_bytes = pcm_int16_to_wav_bytes(pcm, sample_rate=8000)
+
+    import wave
+
+    with wave.open(io.BytesIO(wav_bytes), "rb") as wf:
+        assert wf.getframerate() == 8000
+        assert wf.getnframes() == 8000
+
+
+def test_pcm_to_wav_accepts_float_input():
+    """Float PCM is cast to int16 before wrapping."""
+    pcm = np.array([0.0, 0.5, -0.5, 1.0, -1.0], dtype=np.float32)
+    wav_bytes = pcm_int16_to_wav_bytes(pcm, sample_rate=16000)
+
+    import wave
+
+    with wave.open(io.BytesIO(wav_bytes), "rb") as wf:
+        recovered = np.frombuffer(wf.readframes(wf.getnframes()), dtype=np.int16)
+
+    assert recovered.dtype == np.int16
+    assert len(recovered) == 5
+
+
+def test_mp3_base64_to_pcm_int16():
+    """A sine wave encoded as MP3 round-trips through base64 + pydub decode."""
+    pytest.importorskip("pydub")
+
+    # ffmpeg is required by pydub for MP3 decode
+    import shutil
+
+    if shutil.which("ffmpeg") is None:
+        pytest.skip("ffmpeg not available")
+
+    from pydub import AudioSegment
+
+    sample_rate = 16000
+    duration_s = 0.5
+    t = np.linspace(0, duration_s, int(sample_rate * duration_s), endpoint=False)
+    # 440 Hz sine, scaled to int16 range
+    sine = (np.sin(2 * np.pi * 440 * t) * 16000).astype(np.int16)
+
+    audio = AudioSegment(
+        data=sine.tobytes(),
+        sample_width=2,
+        frame_rate=sample_rate,
+        channels=1,
+    )
+    buf = io.BytesIO()
+    audio.export(buf, format="mp3")
+    mp3_bytes = buf.getvalue()
+    b64 = base64.b64encode(mp3_bytes).decode("ascii")
+
+    recovered = mp3_base64_to_pcm_int16(b64, target_sample_rate=sample_rate)
+
+    assert recovered.dtype == np.int16
+    # MP3 is lossy, so we can't expect exact equality, but the length should
+    # be close to the original (within a few frames of codec delay).
+    assert abs(len(recovered) - len(sine)) < 4096
+    # And the recovered signal should have non-trivial energy.
+    assert np.max(np.abs(recovered)) > 1000

--- a/tests/test_telnyx_audio_codec.py
+++ b/tests/test_telnyx_audio_codec.py
@@ -1,18 +1,19 @@
 """Tests for the Telnyx audio format helpers.
 
-These tests exercise the WAV container and MP3 decode paths without any
-network access. The MP3 test is skipped when pydub or ffmpeg are missing.
+Exercises the WAV container and the streaming MP3 decoder without any network
+access. The MP3 tests are skipped when ffmpeg is missing.
 """
 
 from __future__ import annotations
 
-import base64
 import io
+import time
+import wave
 
 import numpy as np
-import pytest
 
-from speech_to_speech.utils.telnyx_ws import mp3_base64_to_pcm_int16, pcm_int16_to_wav_bytes
+from speech_to_speech.utils.telnyx_ws import Mp3StreamDecoder, pcm_int16_to_wav_bytes
+from tests.telnyx_helpers import mp3_to_pcm, pcm_to_mp3, require_ffmpeg, sine_pcm, slice_stream
 
 
 def test_pcm_to_wav_to_pcm_roundtrip():
@@ -21,13 +22,8 @@ def test_pcm_to_wav_to_pcm_roundtrip():
     pcm = rng.integers(-32768, 32767, size=16000, dtype=np.int16)
 
     wav_bytes = pcm_int16_to_wav_bytes(pcm, sample_rate=16000)
-    assert isinstance(wav_bytes, bytes)
-    assert len(wav_bytes) > 0
-    # WAV header is 44 bytes for mono PCM int16
     assert wav_bytes[:4] == b"RIFF"
     assert wav_bytes[8:12] == b"WAVE"
-
-    import wave
 
     with wave.open(io.BytesIO(wav_bytes), "rb") as wf:
         assert wf.getnchannels() == 1
@@ -40,10 +36,7 @@ def test_pcm_to_wav_to_pcm_roundtrip():
 
 def test_pcm_to_wav_respects_sample_rate():
     """The WAV header carries the requested sample rate."""
-    pcm = np.zeros(8000, dtype=np.int16)
-    wav_bytes = pcm_int16_to_wav_bytes(pcm, sample_rate=8000)
-
-    import wave
+    wav_bytes = pcm_int16_to_wav_bytes(np.zeros(8000, dtype=np.int16), sample_rate=8000)
 
     with wave.open(io.BytesIO(wav_bytes), "rb") as wf:
         assert wf.getframerate() == 8000
@@ -55,8 +48,6 @@ def test_pcm_to_wav_accepts_float_input():
     pcm = np.array([0.0, 0.5, -0.5, 1.0, -1.0], dtype=np.float32)
     wav_bytes = pcm_int16_to_wav_bytes(pcm, sample_rate=16000)
 
-    import wave
-
     with wave.open(io.BytesIO(wav_bytes), "rb") as wf:
         recovered = np.frombuffer(wf.readframes(wf.getnframes()), dtype=np.int16)
 
@@ -64,40 +55,82 @@ def test_pcm_to_wav_accepts_float_input():
     assert len(recovered) == 5
 
 
-def test_mp3_base64_to_pcm_int16():
-    """A sine wave encoded as MP3 round-trips through base64 + pydub decode."""
-    pytest.importorskip("pydub")
+def test_mp3_stream_decoder_matches_one_shot_decode():
+    """Feeding a bitstream in slices produces the same PCM as decoding it whole."""
+    require_ffmpeg()
+    mp3 = pcm_to_mp3(sine_pcm(duration_s=1.0))
+    expected = mp3_to_pcm(mp3)
 
-    # ffmpeg is required by pydub for MP3 decode
-    import shutil
+    decoder = Mp3StreamDecoder(sample_rate=16000)
+    try:
+        parts = [decoder.feed(chunk) for chunk in slice_stream(mp3, size=480)]
+        parts.append(decoder.flush())
+        streamed = np.concatenate(parts)
+    finally:
+        decoder.close()
 
-    if shutil.which("ffmpeg") is None:
-        pytest.skip("ffmpeg not available")
+    np.testing.assert_array_equal(streamed, expected)
 
-    from pydub import AudioSegment
 
-    sample_rate = 16000
-    duration_s = 0.5
-    t = np.linspace(0, duration_s, int(sample_rate * duration_s), endpoint=False)
-    # 440 Hz sine, scaled to int16 range
-    sine = (np.sin(2 * np.pi * 440 * t) * 16000).astype(np.int16)
+def test_mp3_stream_decoder_emits_before_flush():
+    """Audio comes out while the stream is still arriving, not only at the end.
 
-    audio = AudioSegment(
-        data=sine.tobytes(),
-        sample_width=2,
-        frame_rate=sample_rate,
-        channels=1,
-    )
-    buf = io.BytesIO()
-    audio.export(buf, format="mp3")
-    mp3_bytes = buf.getvalue()
-    b64 = base64.b64encode(mp3_bytes).decode("ascii")
+    ``feed`` never blocks, so it returns whatever ffmpeg has produced by the
+    time it is called. The small sleep stands in for the network gaps between
+    Telnyx frames; without any gap the reader thread may not have run yet.
+    """
+    require_ffmpeg()
+    mp3 = pcm_to_mp3(sine_pcm(duration_s=3.0))
 
-    recovered = mp3_base64_to_pcm_int16(b64, target_sample_rate=sample_rate)
+    decoder = Mp3StreamDecoder(sample_rate=16000)
+    try:
+        emitted_early = 0
+        for chunk in slice_stream(mp3, size=480):
+            emitted_early += len(decoder.feed(chunk))
+            time.sleep(0.001)
+        tail = len(decoder.flush())
+    finally:
+        decoder.close()
 
-    assert recovered.dtype == np.int16
-    # MP3 is lossy, so we can't expect exact equality, but the length should
-    # be close to the original (within a few frames of codec delay).
-    assert abs(len(recovered) - len(sine)) < 4096
-    # And the recovered signal should have non-trivial energy.
-    assert np.max(np.abs(recovered)) > 1000
+    # The bulk of a 3s clip must arrive during streaming, not in the tail.
+    assert emitted_early > tail
+
+
+def test_mp3_stream_decoder_output_is_audible():
+    """The decoded signal carries the energy of the source tone."""
+    require_ffmpeg()
+    mp3 = pcm_to_mp3(sine_pcm(duration_s=0.5))
+
+    decoder = Mp3StreamDecoder(sample_rate=16000)
+    try:
+        parts = [decoder.feed(chunk) for chunk in slice_stream(mp3, size=480)]
+        parts.append(decoder.flush())
+        pcm = np.concatenate(parts)
+    finally:
+        decoder.close()
+
+    assert pcm.dtype == np.int16
+    assert abs(len(pcm) - 8000) < 4096  # codec delay
+    assert np.max(np.abs(pcm)) > 1000
+
+
+def test_mp3_stream_decoder_handles_unaligned_slices():
+    """Slices that cut across MP3 frame boundaries still reconstruct exactly.
+
+    Telnyx slices the bitstream at arbitrary offsets, so the decoder has to
+    carry partial frames across `feed` calls.
+    """
+    require_ffmpeg()
+    mp3 = pcm_to_mp3(sine_pcm(duration_s=1.0))
+    expected = mp3_to_pcm(mp3)
+
+    decoder = Mp3StreamDecoder(sample_rate=16000)
+    try:
+        # 7 bytes at a time guarantees every slice is frame-misaligned.
+        parts = [decoder.feed(chunk) for chunk in slice_stream(mp3, size=7)]
+        parts.append(decoder.flush())
+        streamed = np.concatenate(parts)
+    finally:
+        decoder.close()
+
+    np.testing.assert_array_equal(streamed, expected)

--- a/tests/test_telnyx_live.py
+++ b/tests/test_telnyx_live.py
@@ -1,83 +1,117 @@
 """Live API tests for the Telnyx STT and TTS backends.
 
-These tests hit the real Telnyx WebSocket APIs and are skipped unless
-``TELNYX_API_KEY`` is set in the environment. Keep them minimal — they
-exist to catch credential, URL, and protocol regressions, not to validate
-audio quality.
+These hit the real Telnyx WebSocket APIs and are skipped unless
+``TELNYX_API_KEY`` is set. They assert on decoded audio and transcript text,
+not just on connectivity, so a protocol change fails the test rather than
+passing silently.
+
+The STT WebSocket endpoint needs STT enabled on the account; a key without
+that entitlement gets a 403 on the handshake and the STT test skips.
 """
 
 from __future__ import annotations
 
-import base64
-import io
 import os
+import random
 
 import numpy as np
 import pytest
-
-from speech_to_speech.utils.telnyx_ws import (
-    TelnyxSTTClient,
-    TelnyxTTSClient,
-    pcm_int16_to_wav_bytes,
-)
-
 
 pytestmark = pytest.mark.skipif(
     not os.environ.get("TELNYX_API_KEY"),
     reason="requires TELNYX_API_KEY env var",
 )
 
+pytest.importorskip("websocket")
 
-def test_live_stt_connection():
-    """STT WebSocket connects and accepts a short audio frame."""
-    client = TelnyxSTTClient(
-        api_key=os.environ["TELNYX_API_KEY"],
-        engine="Telnyx",
-        language="en",
-        input_format="wav",
-        partial_results=False,
-    )
-    client.connect()
+from speech_to_speech.utils.telnyx_ws import Mp3StreamDecoder, TelnyxSTTClient, TelnyxTTSClient  # noqa: E402
+from tests.telnyx_helpers import require_ffmpeg  # noqa: E402
+
+SENTENCE = "The quick brown fox jumps over the lazy dog."
+
+
+def _synthesize(text: str, sample_rate: int = 16000) -> np.ndarray:
+    client = TelnyxTTSClient(api_key=os.environ["TELNYX_API_KEY"], voice="Telnyx.NaturalHD.astra")
+    decoder = Mp3StreamDecoder(sample_rate=sample_rate)
+    parts = []
     try:
-        # 0.5s of silence at 16kHz
-        pcm = np.zeros(8000, dtype=np.int16)
-        client.send_audio(pcm, sample_rate=16000)
-
-        # Drain a few events; we don't assert on content (silence may yield
-        # nothing or an empty transcript).
-        for _ in range(5):
-            event = client.recv_transcript()
-            if event is None:
-                break
-    finally:
-        client.close()
-
-
-def test_live_tts_connection():
-    """TTS WebSocket connects and returns at least one audio frame."""
-    client = TelnyxTTSClient(
-        api_key=os.environ["TELNYX_API_KEY"],
-        voice="Telnyx.NaturalHD.astra",
-    )
-    client.connect()
-    try:
+        client.connect()
         client.send_init()
-        client.send_text("Hello.")
+        client.send_text(text)
         client.send_stop()
-
-        # Drain frames until the server closes the stream
-        frames_received = 0
-        for _ in range(20):
+        while True:
             frame = client.recv_audio()
             if frame is None:
                 break
             mp3_bytes, is_final = frame
-            assert isinstance(mp3_bytes, bytes)
-            assert len(mp3_bytes) > 0
-            frames_received += 1
+            if mp3_bytes:
+                parts.append(decoder.feed(mp3_bytes))
             if is_final:
                 break
+        parts.append(decoder.flush())
+    finally:
+        decoder.close()
+        client.close()
+    return np.concatenate(parts) if parts else np.array([], dtype=np.int16)
 
-        assert frames_received >= 1
+
+def test_live_tts_returns_audible_speech():
+    """TTS returns decodable audio of a plausible length and amplitude."""
+    require_ffmpeg()
+    # A unique prefix avoids Telnyx's synthesis cache, exercising the streaming path.
+    pcm = _synthesize(f"Test {random.randint(100000, 999999)}. {SENTENCE}")
+
+    assert pcm.dtype == np.int16
+    duration_s = len(pcm) / 16000
+    assert 1.0 < duration_s < 20.0, f"implausible duration: {duration_s:.2f}s"
+    assert np.max(np.abs(pcm)) > 1000, "decoded audio is silent"
+
+
+def test_live_tts_respects_sample_rate():
+    """Requesting 8 kHz yields roughly half the samples of 16 kHz."""
+    require_ffmpeg()
+    text = f"Test {random.randint(100000, 999999)}. {SENTENCE}"
+    at_16k = len(_synthesize(text, sample_rate=16000))
+    at_8k = len(_synthesize(text, sample_rate=8000))
+
+    assert at_16k > 0 and at_8k > 0
+    assert 1.6 < at_16k / at_8k < 2.4
+
+
+def test_live_stt_transcribes_synthesized_speech():
+    """STT returns a final transcript matching the synthesized sentence."""
+    require_ffmpeg()
+    import websocket
+
+    pcm = _synthesize(SENTENCE)
+    assert len(pcm) > 0, "TTS produced no audio to transcribe"
+
+    client = TelnyxSTTClient(
+        api_key=os.environ["TELNYX_API_KEY"],
+        engine="Telnyx",
+        language="en",
+        partial_results=False,
+    )
+    try:
+        client.connect()
+    except websocket.WebSocketBadStatusException as e:
+        if e.status_code in (401, 403):
+            pytest.skip(f"account lacks STT WebSocket access (HTTP {e.status_code})")
+        raise
+
+    final_text = ""
+    try:
+        client.send_audio(pcm, sample_rate=16000)
+        while True:
+            event = client.recv_transcript()
+            if event is None:
+                break
+            if event.get("is_final"):
+                final_text = event.get("transcript") or ""
+                break
     finally:
         client.close()
+
+    assert final_text.strip(), "no final transcript returned"
+    words = set(final_text.lower().replace(".", "").split())
+    assert {"quick", "brown", "fox"} <= words, f"unexpected transcript: {final_text!r}"

--- a/tests/test_telnyx_live.py
+++ b/tests/test_telnyx_live.py
@@ -1,0 +1,83 @@
+"""Live API tests for the Telnyx STT and TTS backends.
+
+These tests hit the real Telnyx WebSocket APIs and are skipped unless
+``TELNYX_API_KEY`` is set in the environment. Keep them minimal — they
+exist to catch credential, URL, and protocol regressions, not to validate
+audio quality.
+"""
+
+from __future__ import annotations
+
+import base64
+import io
+import os
+
+import numpy as np
+import pytest
+
+from speech_to_speech.utils.telnyx_ws import (
+    TelnyxSTTClient,
+    TelnyxTTSClient,
+    pcm_int16_to_wav_bytes,
+)
+
+
+pytestmark = pytest.mark.skipif(
+    not os.environ.get("TELNYX_API_KEY"),
+    reason="requires TELNYX_API_KEY env var",
+)
+
+
+def test_live_stt_connection():
+    """STT WebSocket connects and accepts a short audio frame."""
+    client = TelnyxSTTClient(
+        api_key=os.environ["TELNYX_API_KEY"],
+        engine="Telnyx",
+        language="en",
+        input_format="wav",
+        partial_results=False,
+    )
+    client.connect()
+    try:
+        # 0.5s of silence at 16kHz
+        pcm = np.zeros(8000, dtype=np.int16)
+        client.send_audio(pcm, sample_rate=16000)
+
+        # Drain a few events; we don't assert on content (silence may yield
+        # nothing or an empty transcript).
+        for _ in range(5):
+            event = client.recv_transcript()
+            if event is None:
+                break
+    finally:
+        client.close()
+
+
+def test_live_tts_connection():
+    """TTS WebSocket connects and returns at least one audio frame."""
+    client = TelnyxTTSClient(
+        api_key=os.environ["TELNYX_API_KEY"],
+        voice="Telnyx.NaturalHD.astra",
+    )
+    client.connect()
+    try:
+        client.send_init()
+        client.send_text("Hello.")
+        client.send_stop()
+
+        # Drain frames until the server closes the stream
+        frames_received = 0
+        for _ in range(20):
+            frame = client.recv_audio()
+            if frame is None:
+                break
+            mp3_bytes, is_final = frame
+            assert isinstance(mp3_bytes, bytes)
+            assert len(mp3_bytes) > 0
+            frames_received += 1
+            if is_final:
+                break
+
+        assert frames_received >= 1
+    finally:
+        client.close()

--- a/tests/test_telnyx_stt_protocol.py
+++ b/tests/test_telnyx_stt_protocol.py
@@ -191,8 +191,14 @@ def test_stt_client_url_encodes_params():
     query = parse_qs(urlparse(TelnyxSTTClient(api_key="k", engine="Deepgram", model="nova-3").url()).query)
     assert query["transcription_engine"] == ["Deepgram"]
     assert query["input_format"] == ["wav"]
-    assert query["partial_results"] == ["true"]
     assert query["model"] == ["nova-3"]
+
+    # The endpoint accepts `partial_results` and ignores it, returning finals
+    # only. `interim_results` is the parameter that actually works.
+    assert query["interim_results"] == ["true"]
+    assert "partial_results" not in query
+    off = parse_qs(urlparse(TelnyxSTTClient(api_key="k", partial_results=False).url()).query)
+    assert off["interim_results"] == ["false"]
 
     assert "model" not in parse_qs(urlparse(TelnyxSTTClient(api_key="k").url()).query)
 

--- a/tests/test_telnyx_stt_protocol.py
+++ b/tests/test_telnyx_stt_protocol.py
@@ -1,37 +1,36 @@
 """Tests for the Telnyx STT handler protocol.
 
-These tests mock the WebSocket client to verify the handler builds the right
-frames, parses transcript events correctly, and surfaces errors gracefully.
+The fake WebSocket returns frames in the shape Telnyx documents for the
+transcription endpoint: ``{"transcript", "is_final", "confidence"}``, with
+errors carried in an ``error`` key. There is no ``type`` discriminator.
 """
 
 from __future__ import annotations
 
+import io
 import json
-import os
-from queue import Queue
-from threading import Event
+import wave
 from unittest.mock import MagicMock, patch
+from urllib.parse import parse_qs, urlparse
 
 import numpy as np
 import pytest
 
-from speech_to_speech.pipeline.messages import Transcription, VADAudio
-from speech_to_speech.STT.telnyx_stt_handler import TelnyxSTTHandler
+pytest.importorskip("websocket")
+
+from speech_to_speech.pipeline.messages import PartialTranscription, Transcription, VADAudio  # noqa: E402
+from speech_to_speech.STT.telnyx_stt_handler import TelnyxSTTHandler  # noqa: E402
+from speech_to_speech.utils.telnyx_ws import TelnyxProtocolError, TelnyxSTTClient  # noqa: E402
 
 
 def _make_handler(**overrides):
-    """Build a TelnyxSTTHandler with a mocked WebSocket client."""
     kwargs = dict(
-        should_listen=Event(),
         api_key="test-key",
         engine="Telnyx",
         language="en",
         model="",
-        input_format="wav",
         partial_results=True,
         gen_kwargs={},
-        cancel_scope=None,
-        speculative_turns=None,
         enable_live_transcription=False,
         live_transcription_update_interval=0.25,
     )
@@ -41,33 +40,41 @@ def _make_handler(**overrides):
     return handler
 
 
+def _fake_ws(recv_frames, sent=None):
+    """A WebSocket stub that replays `recv_frames` then reports end-of-stream."""
+    queue = list(recv_frames)
+    ws = MagicMock()
+    ws.send = (lambda payload, opcode=None: sent.append(payload)) if sent is not None else MagicMock()
+    ws.recv = lambda: queue.pop(0) if queue else ""
+    return ws
+
+
+def _vad(**overrides):
+    kwargs = dict(
+        audio=np.zeros(16000, dtype=np.int16),
+        mode="final",
+        turn_id="turn_1",
+        turn_revision=1,
+        created_at_s=123.0,
+    )
+    kwargs.update(overrides)
+    return VADAudio(**kwargs)
+
+
 def test_stt_handler_yields_final_transcript():
-    """Handler yields one Transcription with the final text from the WS stream."""
+    """The handler yields one Transcription carrying the final text."""
     handler = _make_handler()
+    sent: list[bytes] = []
+    ws = _fake_ws(
+        [
+            json.dumps({"transcript": "hello ", "is_final": False, "confidence": 0.5}),
+            json.dumps({"transcript": "hello world", "is_final": True, "confidence": 0.95}),
+        ],
+        sent,
+    )
 
-    sent_frames: list[bytes] = []
-    recv_frames = [
-        json.dumps({"type": "transcript", "transcript": "hello ", "is_final": False, "confidence": 0.5}),
-        json.dumps({"type": "transcript", "transcript": "hello world", "is_final": True, "confidence": 0.95}),
-    ]
-
-    fake_ws = MagicMock()
-    fake_ws.send = lambda payload, opcode=None: sent_frames.append(payload)
-    fake_ws.recv = lambda: recv_frames.pop(0) if recv_frames else ""
-    fake_ws.close = MagicMock()
-
-    fake_websocket_module = MagicMock()
-    fake_websocket_module.WebSocket = MagicMock(return_value=fake_ws)
-
-    with patch.dict("sys.modules", {"websocket": fake_websocket_module}):
-        vad = VADAudio(
-            audio=np.zeros(16000, dtype=np.int16),
-            mode="final",
-            turn_id="turn_1",
-            turn_revision=1,
-            created_at_s=123.0,
-        )
-        results = list(handler.process(vad))
+    with patch("websocket.WebSocket", return_value=ws):
+        results = list(handler.process(_vad()))
 
     assert len(results) == 1
     assert isinstance(results[0], Transcription)
@@ -76,41 +83,89 @@ def test_stt_handler_yields_final_transcript():
     assert results[0].turn_id == "turn_1"
     assert results[0].turn_revision == 1
     assert results[0].speech_stopped_at_s == 123.0
-
-    # Exactly one binary audio frame was sent
-    assert len(sent_frames) == 1
-    assert sent_frames[0][:4] == b"RIFF"  # WAV container
-    fake_ws.close.assert_called_once()
+    ws.close.assert_called_once()
 
 
-def test_stt_handler_yields_empty_transcript_on_error():
-    """Handler yields an empty Transcription when the server reports an error."""
+def test_stt_handler_sends_chunked_wav():
+    """Audio goes out as a valid WAV split into 2 KB binary frames."""
     handler = _make_handler()
+    sent: list[bytes] = []
+    ws = _fake_ws([json.dumps({"transcript": "ok", "is_final": True})], sent)
 
-    recv_frames = [
-        json.dumps({"type": "error", "error": "boom"}),
-    ]
+    with patch("websocket.WebSocket", return_value=ws):
+        list(handler.process(_vad()))
 
-    fake_ws = MagicMock()
-    fake_ws.send = MagicMock()
-    fake_ws.recv = lambda: recv_frames.pop(0) if recv_frames else ""
-    fake_ws.close = MagicMock()
+    assert len(sent) > 1, "audio should be chunked, not sent as one frame"
+    assert all(len(frame) <= 2048 for frame in sent)
+    assert sent[0][:4] == b"RIFF"
 
-    fake_websocket_module = MagicMock()
-    fake_websocket_module.WebSocket = MagicMock(return_value=fake_ws)
+    with wave.open(io.BytesIO(b"".join(sent)), "rb") as wf:
+        assert wf.getnchannels() == 1
+        assert wf.getsampwidth() == 2
+        assert wf.getframerate() == 16000
+        assert wf.getnframes() == 16000
 
-    with patch.dict("sys.modules", {"websocket": fake_websocket_module}):
-        vad = VADAudio(
-            audio=np.zeros(16000, dtype=np.int16),
-            mode="final",
-            turn_id="turn_1",
-            turn_revision=1,
-        )
-        results = list(handler.process(vad))
+
+def test_stt_handler_yields_empty_transcript_on_error_frame():
+    """An `error` frame is logged and yields an empty Transcription."""
+    handler = _make_handler()
+    ws = _fake_ws([json.dumps({"error": "boom"})])
+
+    with patch("websocket.WebSocket", return_value=ws):
+        results = list(handler.process(_vad()))
+
+    assert len(results) == 1
+    assert results[0].text == ""
+
+
+def test_stt_handler_survives_stream_close_without_final():
+    """A stream that closes before is_final still yields a Transcription."""
+    handler = _make_handler()
+    ws = _fake_ws([json.dumps({"transcript": "partial only", "is_final": False})])
+
+    with patch("websocket.WebSocket", return_value=ws):
+        results = list(handler.process(_vad()))
+
+    assert len(results) == 1
+    assert results[0].text == ""
+
+
+def test_stt_handler_emits_partials_when_live_transcription_enabled():
+    """Interim transcripts surface as PartialTranscription."""
+    handler = _make_handler(enable_live_transcription=True, live_transcription_update_interval=0.0)
+    ws = _fake_ws(
+        [
+            json.dumps({"transcript": "hel", "is_final": False}),
+            json.dumps({"transcript": "hello", "is_final": False}),
+            json.dumps({"transcript": "hello world", "is_final": True}),
+        ]
+    )
+
+    with patch("websocket.WebSocket", return_value=ws):
+        results = list(handler.process(_vad()))
+
+    partials = [r for r in results if isinstance(r, PartialTranscription)]
+    finals = [r for r in results if isinstance(r, Transcription)]
+    assert [p.text for p in partials] == ["hel", "hello"]
+    assert len(finals) == 1
+    assert finals[0].text == "hello world"
+
+
+def test_stt_handler_suppresses_partials_when_disabled():
+    """Without live transcription only the final Transcription is emitted."""
+    handler = _make_handler(enable_live_transcription=False)
+    ws = _fake_ws(
+        [
+            json.dumps({"transcript": "hel", "is_final": False}),
+            json.dumps({"transcript": "hello world", "is_final": True}),
+        ]
+    )
+
+    with patch("websocket.WebSocket", return_value=ws):
+        results = list(handler.process(_vad()))
 
     assert len(results) == 1
     assert isinstance(results[0], Transcription)
-    assert results[0].text == ""
 
 
 def test_stt_handler_missing_api_key_raises(monkeypatch):
@@ -123,7 +178,7 @@ def test_stt_handler_missing_api_key_raises(monkeypatch):
 
 
 def test_stt_handler_reads_api_key_from_env(monkeypatch):
-    """Setup falls back to TELNYX_API_KEY env var when api_key is empty."""
+    """Setup falls back to TELNYX_API_KEY when api_key is empty."""
     monkeypatch.setenv("TELNYX_API_KEY", "env-key")
 
     handler = object.__new__(TelnyxSTTHandler)
@@ -131,33 +186,25 @@ def test_stt_handler_reads_api_key_from_env(monkeypatch):
     assert handler.api_key == "env-key"
 
 
-def test_stt_handler_emits_partial_when_live_transcription_enabled():
-    """Partial transcripts are yielded as PartialTranscription when enabled."""
-    handler = _make_handler(enable_live_transcription=True, live_transcription_update_interval=0.0)
+def test_stt_client_url_encodes_params():
+    """Query params are URL-encoded and the model is optional."""
+    query = parse_qs(urlparse(TelnyxSTTClient(api_key="k", engine="Deepgram", model="nova-3").url()).query)
+    assert query["transcription_engine"] == ["Deepgram"]
+    assert query["input_format"] == ["wav"]
+    assert query["partial_results"] == ["true"]
+    assert query["model"] == ["nova-3"]
 
-    recv_frames = [
-        json.dumps({"type": "transcript", "transcript": "hel", "is_final": False}),
-        json.dumps({"type": "transcript", "transcript": "hello", "is_final": False}),
-        json.dumps({"type": "transcript", "transcript": "hello world", "is_final": True}),
-    ]
+    assert "model" not in parse_qs(urlparse(TelnyxSTTClient(api_key="k").url()).query)
 
-    fake_ws = MagicMock()
-    fake_ws.send = MagicMock()
-    fake_ws.recv = lambda: recv_frames.pop(0) if recv_frames else ""
-    fake_ws.close = MagicMock()
+    encoded = TelnyxSTTClient(api_key="k", engine="Engine With Spaces&x").url()
+    assert " " not in encoded.split("?", 1)[1]
+    assert parse_qs(urlparse(encoded).query)["transcription_engine"] == ["Engine With Spaces&x"]
 
-    fake_websocket_module = MagicMock()
-    fake_websocket_module.WebSocket = MagicMock(return_value=fake_ws)
 
-    with patch.dict("sys.modules", {"websocket": fake_websocket_module}):
-        vad = VADAudio(
-            audio=np.zeros(16000, dtype=np.int16),
-            mode="final",
-            turn_id="turn_1",
-            turn_revision=1,
-        )
-        results = list(handler.process(vad))
+def test_stt_client_raises_on_error_frame():
+    """The client surfaces error frames instead of treating them as EOF."""
+    client = TelnyxSTTClient(api_key="k")
+    client._ws = _fake_ws([json.dumps({"error": "bad engine"})])
 
-    # At least one partial + one final
-    assert len(results) >= 2
-    assert any(r.text == "hello world" for r in results)
+    with pytest.raises(TelnyxProtocolError, match="bad engine"):
+        client.recv_transcript()

--- a/tests/test_telnyx_stt_protocol.py
+++ b/tests/test_telnyx_stt_protocol.py
@@ -1,0 +1,163 @@
+"""Tests for the Telnyx STT handler protocol.
+
+These tests mock the WebSocket client to verify the handler builds the right
+frames, parses transcript events correctly, and surfaces errors gracefully.
+"""
+
+from __future__ import annotations
+
+import json
+import os
+from queue import Queue
+from threading import Event
+from unittest.mock import MagicMock, patch
+
+import numpy as np
+import pytest
+
+from speech_to_speech.pipeline.messages import Transcription, VADAudio
+from speech_to_speech.STT.telnyx_stt_handler import TelnyxSTTHandler
+
+
+def _make_handler(**overrides):
+    """Build a TelnyxSTTHandler with a mocked WebSocket client."""
+    kwargs = dict(
+        should_listen=Event(),
+        api_key="test-key",
+        engine="Telnyx",
+        language="en",
+        model="",
+        input_format="wav",
+        partial_results=True,
+        gen_kwargs={},
+        cancel_scope=None,
+        speculative_turns=None,
+        enable_live_transcription=False,
+        live_transcription_update_interval=0.25,
+    )
+    kwargs.update(overrides)
+    handler = object.__new__(TelnyxSTTHandler)
+    handler.setup(**kwargs)
+    return handler
+
+
+def test_stt_handler_yields_final_transcript():
+    """Handler yields one Transcription with the final text from the WS stream."""
+    handler = _make_handler()
+
+    sent_frames: list[bytes] = []
+    recv_frames = [
+        json.dumps({"type": "transcript", "transcript": "hello ", "is_final": False, "confidence": 0.5}),
+        json.dumps({"type": "transcript", "transcript": "hello world", "is_final": True, "confidence": 0.95}),
+    ]
+
+    fake_ws = MagicMock()
+    fake_ws.send = lambda payload, opcode=None: sent_frames.append(payload)
+    fake_ws.recv = lambda: recv_frames.pop(0) if recv_frames else ""
+    fake_ws.close = MagicMock()
+
+    fake_websocket_module = MagicMock()
+    fake_websocket_module.WebSocket = MagicMock(return_value=fake_ws)
+
+    with patch.dict("sys.modules", {"websocket": fake_websocket_module}):
+        vad = VADAudio(
+            audio=np.zeros(16000, dtype=np.int16),
+            mode="final",
+            turn_id="turn_1",
+            turn_revision=1,
+            created_at_s=123.0,
+        )
+        results = list(handler.process(vad))
+
+    assert len(results) == 1
+    assert isinstance(results[0], Transcription)
+    assert results[0].text == "hello world"
+    assert results[0].language_code == "en"
+    assert results[0].turn_id == "turn_1"
+    assert results[0].turn_revision == 1
+    assert results[0].speech_stopped_at_s == 123.0
+
+    # Exactly one binary audio frame was sent
+    assert len(sent_frames) == 1
+    assert sent_frames[0][:4] == b"RIFF"  # WAV container
+    fake_ws.close.assert_called_once()
+
+
+def test_stt_handler_yields_empty_transcript_on_error():
+    """Handler yields an empty Transcription when the server reports an error."""
+    handler = _make_handler()
+
+    recv_frames = [
+        json.dumps({"type": "error", "error": "boom"}),
+    ]
+
+    fake_ws = MagicMock()
+    fake_ws.send = MagicMock()
+    fake_ws.recv = lambda: recv_frames.pop(0) if recv_frames else ""
+    fake_ws.close = MagicMock()
+
+    fake_websocket_module = MagicMock()
+    fake_websocket_module.WebSocket = MagicMock(return_value=fake_ws)
+
+    with patch.dict("sys.modules", {"websocket": fake_websocket_module}):
+        vad = VADAudio(
+            audio=np.zeros(16000, dtype=np.int16),
+            mode="final",
+            turn_id="turn_1",
+            turn_revision=1,
+        )
+        results = list(handler.process(vad))
+
+    assert len(results) == 1
+    assert isinstance(results[0], Transcription)
+    assert results[0].text == ""
+
+
+def test_stt_handler_missing_api_key_raises(monkeypatch):
+    """Setup raises ValueError when no API key is provided."""
+    monkeypatch.delenv("TELNYX_API_KEY", raising=False)
+
+    handler = object.__new__(TelnyxSTTHandler)
+    with pytest.raises(ValueError, match="Telnyx STT requires an API key"):
+        handler.setup(api_key="")
+
+
+def test_stt_handler_reads_api_key_from_env(monkeypatch):
+    """Setup falls back to TELNYX_API_KEY env var when api_key is empty."""
+    monkeypatch.setenv("TELNYX_API_KEY", "env-key")
+
+    handler = object.__new__(TelnyxSTTHandler)
+    handler.setup(api_key="")
+    assert handler.api_key == "env-key"
+
+
+def test_stt_handler_emits_partial_when_live_transcription_enabled():
+    """Partial transcripts are yielded as PartialTranscription when enabled."""
+    handler = _make_handler(enable_live_transcription=True, live_transcription_update_interval=0.0)
+
+    recv_frames = [
+        json.dumps({"type": "transcript", "transcript": "hel", "is_final": False}),
+        json.dumps({"type": "transcript", "transcript": "hello", "is_final": False}),
+        json.dumps({"type": "transcript", "transcript": "hello world", "is_final": True}),
+    ]
+
+    fake_ws = MagicMock()
+    fake_ws.send = MagicMock()
+    fake_ws.recv = lambda: recv_frames.pop(0) if recv_frames else ""
+    fake_ws.close = MagicMock()
+
+    fake_websocket_module = MagicMock()
+    fake_websocket_module.WebSocket = MagicMock(return_value=fake_ws)
+
+    with patch.dict("sys.modules", {"websocket": fake_websocket_module}):
+        vad = VADAudio(
+            audio=np.zeros(16000, dtype=np.int16),
+            mode="final",
+            turn_id="turn_1",
+            turn_revision=1,
+        )
+        results = list(handler.process(vad))
+
+    # At least one partial + one final
+    assert len(results) >= 2
+    assert any(r.text == "hello world" for r in results)

--- a/tests/test_telnyx_tts_protocol.py
+++ b/tests/test_telnyx_tts_protocol.py
@@ -1,26 +1,30 @@
 """Tests for the Telnyx TTS handler protocol.
 
-These tests mock the WebSocket client to verify the handler builds the right
-frames, decodes MP3 audio, and chunks it to the configured blocksize.
+The fake WebSocket replays frames the way Telnyx actually sends them: one
+continuous MP3 bitstream sliced across many small frames, terminated by an
+``isFinal`` frame with an empty audio payload.
 """
 
 from __future__ import annotations
 
 import base64
-import io
 import json
 from threading import Event
 from unittest.mock import MagicMock, patch
+from urllib.parse import parse_qs, urlparse
 
 import numpy as np
 import pytest
 
-from speech_to_speech.pipeline.messages import AUDIO_RESPONSE_DONE, EndOfResponse, TTSInput
-from speech_to_speech.TTS.telnyx_tts_handler import TelnyxTTSHandler
+pytest.importorskip("websocket")
+
+from speech_to_speech.pipeline.messages import AUDIO_RESPONSE_DONE, EndOfResponse, TTSInput  # noqa: E402
+from speech_to_speech.TTS.telnyx_tts_handler import TelnyxTTSHandler  # noqa: E402
+from speech_to_speech.utils.telnyx_ws import TelnyxProtocolError, TelnyxTTSClient  # noqa: E402
+from tests.telnyx_helpers import mp3_to_pcm, pcm_to_mp3, require_ffmpeg, sine_pcm, slice_stream  # noqa: E402
 
 
 def _make_handler(**overrides):
-    """Build a TelnyxTTSHandler with a mocked WebSocket client."""
     kwargs = dict(
         should_listen=Event(),
         api_key="test-key",
@@ -37,87 +41,131 @@ def _make_handler(**overrides):
     return handler
 
 
-def _make_mp3_b64(duration_s: float = 0.1, sample_rate: int = 16000) -> str:
-    """Build a base64-encoded MP3 frame of a sine wave."""
-    pytest.importorskip("pydub")
-    import shutil
-
-    if shutil.which("ffmpeg") is None:
-        pytest.skip("ffmpeg not available")
-
-    from pydub import AudioSegment
-
-    t = np.linspace(0, duration_s, int(sample_rate * duration_s), endpoint=False)
-    sine = (np.sin(2 * np.pi * 440 * t) * 16000).astype(np.int16)
-    audio = AudioSegment(
-        data=sine.tobytes(),
-        sample_width=2,
-        frame_rate=sample_rate,
-        channels=1,
-    )
-    buf = io.BytesIO()
-    audio.export(buf, format="mp3")
-    return base64.b64encode(buf.getvalue()).decode("ascii")
-
-
-def test_tts_handler_yields_audio_chunks():
-    """Handler yields int16 numpy arrays of blocksize length."""
-    handler = _make_handler(blocksize=512)
-
-    mp3_b64 = _make_mp3_b64(duration_s=0.2)
-
-    sent_frames: list[str] = []
-    recv_frames = [
-        json.dumps({"audio": mp3_b64, "isFinal": False}),
-        json.dumps({"audio": mp3_b64, "isFinal": True}),
+def _audio_frames(mp3: bytes, slice_size: int = 480) -> list[str]:
+    """Build the frame sequence Telnyx sends for one synthesis request."""
+    frames = [
+        json.dumps({"audio": base64.b64encode(s).decode("ascii"), "isFinal": False, "text": None})
+        for s in slice_stream(mp3, size=slice_size)
     ]
+    frames.append(json.dumps({"audio": "", "isFinal": True, "text": None}))
+    return frames
 
-    fake_ws = MagicMock()
-    fake_ws.send = lambda payload, opcode=None: sent_frames.append(payload)
-    fake_ws.recv = lambda: recv_frames.pop(0) if recv_frames else ""
-    fake_ws.close = MagicMock()
 
-    fake_websocket_module = MagicMock()
-    fake_websocket_module.WebSocket = MagicMock(return_value=fake_ws)
+def _fake_ws(recv_frames, sent=None):
+    queue = list(recv_frames)
+    ws = MagicMock()
+    ws.send = (lambda payload, opcode=None: sent.append(payload)) if sent is not None else MagicMock()
+    ws.recv = lambda: queue.pop(0) if queue else ""
+    return ws
 
-    with patch.dict("sys.modules", {"websocket": fake_websocket_module}):
-        tts_input = TTSInput(text="Hello world.", turn_id="turn_1", turn_revision=1)
-        results = list(handler.process(tts_input))
 
-    # Init + content + stop frames
-    assert len(sent_frames) == 3
-    assert json.loads(sent_frames[0]) == {"text": " "}
-    assert json.loads(sent_frames[1]) == {"text": "Hello world."}
-    assert json.loads(sent_frames[2]) == {"text": ""}
+def test_tts_handler_reconstructs_the_full_stream():
+    """Sliced frames decode to the same audio as the original bitstream."""
+    require_ffmpeg()
+    mp3 = pcm_to_mp3(sine_pcm(duration_s=1.0))
+    expected = mp3_to_pcm(mp3)
 
-    # At least one audio chunk yielded
-    assert len(results) >= 1
-    for chunk in results:
+    handler = _make_handler(blocksize=512)
+    ws = _fake_ws(_audio_frames(mp3))
+
+    with patch("websocket.WebSocket", return_value=ws):
+        chunks = list(handler.process(TTSInput(text="Hello world.", turn_id="turn_1", turn_revision=1)))
+
+    assert chunks, "handler produced no audio"
+    for chunk in chunks:
         assert isinstance(chunk, np.ndarray)
         assert chunk.dtype == np.int16
         assert len(chunk) == 512
 
-    fake_ws.close.assert_called_once()
+    produced = np.concatenate(chunks)
+    # The last block is zero-padded up to blocksize.
+    assert len(produced) - len(expected) < 512
+    np.testing.assert_array_equal(produced[: len(expected)], expected)
+    ws.close.assert_called_once()
+
+
+def test_tts_handler_sends_init_content_stop():
+    """The client emits the documented three-frame sequence."""
+    require_ffmpeg()
+    sent: list[str] = []
+    ws = _fake_ws(_audio_frames(pcm_to_mp3(sine_pcm(duration_s=0.2))), sent)
+    handler = _make_handler()
+
+    with patch("websocket.WebSocket", return_value=ws):
+        list(handler.process(TTSInput(text="Hello world.", turn_id="turn_1", turn_revision=1)))
+
+    assert [json.loads(f) for f in sent] == [{"text": " "}, {"text": "Hello world."}, {"text": ""}]
+
+
+def test_tts_handler_stops_at_is_final():
+    """Frames after isFinal are never read."""
+    require_ffmpeg()
+    mp3 = pcm_to_mp3(sine_pcm(duration_s=0.2))
+    frames = _audio_frames(mp3)
+    frames.append(json.dumps({"audio": base64.b64encode(mp3).decode("ascii"), "isFinal": False}))
+
+    remaining = list(frames)
+    ws = MagicMock()
+    ws.recv = lambda: remaining.pop(0) if remaining else ""
+    handler = _make_handler()
+
+    with patch("websocket.WebSocket", return_value=ws):
+        list(handler.process(TTSInput(text="Hi.", turn_id="turn_1", turn_revision=1)))
+
+    assert len(remaining) == 1, "handler kept reading past the final frame"
+
+
+def test_tts_handler_yields_nothing_on_error_frame():
+    """An error frame aborts synthesis instead of being read as end-of-stream."""
+    ws = _fake_ws([json.dumps({"error": "voice not found"})])
+    handler = _make_handler()
+
+    with patch("websocket.WebSocket", return_value=ws):
+        chunks = list(handler.process(TTSInput(text="Hi.", turn_id="turn_1", turn_revision=1)))
+
+    assert chunks == []
+    ws.close.assert_called_once()
 
 
 def test_tts_handler_end_of_response_yields_done():
-    """EndOfResponse yields AUDIO_RESPONSE_DONE."""
+    """EndOfResponse yields AUDIO_RESPONSE_DONE and touches no socket."""
+    ws = _fake_ws([])
     handler = _make_handler()
 
-    fake_ws = MagicMock()
-    fake_ws.send = MagicMock()
-    fake_ws.recv = MagicMock()
-    fake_ws.close = MagicMock()
-
-    fake_websocket_module = MagicMock()
-    fake_websocket_module.WebSocket = MagicMock(return_value=fake_ws)
-
-    with patch.dict("sys.modules", {"websocket": fake_websocket_module}):
+    with patch("websocket.WebSocket", return_value=ws):
         results = list(handler.process(EndOfResponse(turn_id="turn_1", turn_revision=1)))
 
     assert results == [AUDIO_RESPONSE_DONE]
-    # No WS interaction for EndOfResponse
-    fake_ws.send.assert_not_called()
+    ws.send.assert_not_called()
+
+
+def test_tts_handler_stops_mid_stream_on_cancel():
+    """Cancelling during playback abandons the rest of the stream."""
+    require_ffmpeg()
+    from speech_to_speech.pipeline.cancel_scope import CancelScope
+
+    scope = CancelScope()
+    handler = _make_handler(cancel_scope=scope, blocksize=512)
+
+    frames = _audio_frames(pcm_to_mp3(sine_pcm(duration_s=3.0)))
+    remaining = list(frames)
+
+    def recv():
+        # Interrupt part-way through, the way a barge-in would.
+        if len(remaining) == len(frames) // 2:
+            scope.cancel()
+        return remaining.pop(0) if remaining else ""
+
+    ws = MagicMock()
+    ws.recv = recv
+
+    with patch("websocket.WebSocket", return_value=ws):
+        chunks = list(handler.process(TTSInput(text="Hello.", turn_id="turn_1", turn_revision=1)))
+
+    assert remaining, "handler drained the stream instead of bailing out on cancel"
+    # Whatever was already decoded may be yielded; the tail must not be.
+    assert len(np.concatenate(chunks)) < 3 * 16000 if chunks else True
+    ws.close.assert_called_once()
 
 
 def test_tts_handler_missing_api_key_raises(monkeypatch):
@@ -130,7 +178,7 @@ def test_tts_handler_missing_api_key_raises(monkeypatch):
 
 
 def test_tts_handler_reads_api_key_from_env(monkeypatch):
-    """Setup falls back to TELNYX_API_KEY env var when api_key is empty."""
+    """Setup falls back to TELNYX_API_KEY when api_key is empty."""
     monkeypatch.setenv("TELNYX_API_KEY", "env-key")
 
     handler = object.__new__(TelnyxTTSHandler)
@@ -138,33 +186,25 @@ def test_tts_handler_reads_api_key_from_env(monkeypatch):
     assert handler.api_key == "env-key"
 
 
-def test_tts_handler_breaks_on_cancel():
-    """Handler stops yielding when cancel_scope marks the generation stale."""
-    from speech_to_speech.pipeline.cancel_scope import CancelScope
+def test_tts_client_url_encodes_voice():
+    """Voice identifiers are URL-encoded."""
+    url = TelnyxTTSClient(api_key="k", voice="ElevenLabs.Voice Name&x").url()
+    assert " " not in url.split("?", 1)[1]
+    assert parse_qs(urlparse(url).query)["voice"] == ["ElevenLabs.Voice Name&x"]
 
-    scope = CancelScope()
-    handler = _make_handler(cancel_scope=scope, blocksize=512)
 
-    mp3_b64 = _make_mp3_b64(duration_s=0.1)
+def test_tts_client_reports_final_frame():
+    """The terminal frame decodes to empty audio with is_final set."""
+    client = TelnyxTTSClient(api_key="k", voice="v")
+    client._ws = _fake_ws([json.dumps({"audio": "", "isFinal": True, "text": None})])
 
-    # Many frames so the cancel check fires
-    recv_frames = [json.dumps({"audio": mp3_b64, "isFinal": False}) for _ in range(20)]
+    assert client.recv_audio() == (b"", True)
 
-    fake_ws = MagicMock()
-    fake_ws.send = MagicMock()
-    fake_ws.recv = lambda: recv_frames.pop(0) if recv_frames else ""
-    fake_ws.close = MagicMock()
 
-    fake_websocket_module = MagicMock()
-    fake_websocket_module.WebSocket = MagicMock(return_value=fake_ws)
+def test_tts_client_raises_on_error_frame():
+    """The client surfaces error frames instead of treating them as EOF."""
+    client = TelnyxTTSClient(api_key="k", voice="v")
+    client._ws = _fake_ws([json.dumps({"error": "voice not found"})])
 
-    # Cancel before processing
-    scope.cancel()
-
-    with patch.dict("sys.modules", {"websocket": fake_websocket_module}):
-        tts_input = TTSInput(text="Hello.", turn_id="turn_1", turn_revision=1)
-        results = list(handler.process(tts_input))
-
-    # Should bail out early; may yield zero or one chunk depending on timing
-    assert len(results) <= 1
-    fake_ws.close.assert_called_once()
+    with pytest.raises(TelnyxProtocolError, match="voice not found"):
+        client.recv_audio()

--- a/tests/test_telnyx_tts_protocol.py
+++ b/tests/test_telnyx_tts_protocol.py
@@ -1,0 +1,170 @@
+"""Tests for the Telnyx TTS handler protocol.
+
+These tests mock the WebSocket client to verify the handler builds the right
+frames, decodes MP3 audio, and chunks it to the configured blocksize.
+"""
+
+from __future__ import annotations
+
+import base64
+import io
+import json
+from threading import Event
+from unittest.mock import MagicMock, patch
+
+import numpy as np
+import pytest
+
+from speech_to_speech.pipeline.messages import AUDIO_RESPONSE_DONE, EndOfResponse, TTSInput
+from speech_to_speech.TTS.telnyx_tts_handler import TelnyxTTSHandler
+
+
+def _make_handler(**overrides):
+    """Build a TelnyxTTSHandler with a mocked WebSocket client."""
+    kwargs = dict(
+        should_listen=Event(),
+        api_key="test-key",
+        voice="Telnyx.NaturalHD.astra",
+        sample_rate=16000,
+        blocksize=512,
+        gen_kwargs={},
+        cancel_scope=None,
+        speculative_turns=None,
+    )
+    kwargs.update(overrides)
+    handler = object.__new__(TelnyxTTSHandler)
+    handler.setup(**kwargs)
+    return handler
+
+
+def _make_mp3_b64(duration_s: float = 0.1, sample_rate: int = 16000) -> str:
+    """Build a base64-encoded MP3 frame of a sine wave."""
+    pytest.importorskip("pydub")
+    import shutil
+
+    if shutil.which("ffmpeg") is None:
+        pytest.skip("ffmpeg not available")
+
+    from pydub import AudioSegment
+
+    t = np.linspace(0, duration_s, int(sample_rate * duration_s), endpoint=False)
+    sine = (np.sin(2 * np.pi * 440 * t) * 16000).astype(np.int16)
+    audio = AudioSegment(
+        data=sine.tobytes(),
+        sample_width=2,
+        frame_rate=sample_rate,
+        channels=1,
+    )
+    buf = io.BytesIO()
+    audio.export(buf, format="mp3")
+    return base64.b64encode(buf.getvalue()).decode("ascii")
+
+
+def test_tts_handler_yields_audio_chunks():
+    """Handler yields int16 numpy arrays of blocksize length."""
+    handler = _make_handler(blocksize=512)
+
+    mp3_b64 = _make_mp3_b64(duration_s=0.2)
+
+    sent_frames: list[str] = []
+    recv_frames = [
+        json.dumps({"audio": mp3_b64, "isFinal": False}),
+        json.dumps({"audio": mp3_b64, "isFinal": True}),
+    ]
+
+    fake_ws = MagicMock()
+    fake_ws.send = lambda payload, opcode=None: sent_frames.append(payload)
+    fake_ws.recv = lambda: recv_frames.pop(0) if recv_frames else ""
+    fake_ws.close = MagicMock()
+
+    fake_websocket_module = MagicMock()
+    fake_websocket_module.WebSocket = MagicMock(return_value=fake_ws)
+
+    with patch.dict("sys.modules", {"websocket": fake_websocket_module}):
+        tts_input = TTSInput(text="Hello world.", turn_id="turn_1", turn_revision=1)
+        results = list(handler.process(tts_input))
+
+    # Init + content + stop frames
+    assert len(sent_frames) == 3
+    assert json.loads(sent_frames[0]) == {"text": " "}
+    assert json.loads(sent_frames[1]) == {"text": "Hello world."}
+    assert json.loads(sent_frames[2]) == {"text": ""}
+
+    # At least one audio chunk yielded
+    assert len(results) >= 1
+    for chunk in results:
+        assert isinstance(chunk, np.ndarray)
+        assert chunk.dtype == np.int16
+        assert len(chunk) == 512
+
+    fake_ws.close.assert_called_once()
+
+
+def test_tts_handler_end_of_response_yields_done():
+    """EndOfResponse yields AUDIO_RESPONSE_DONE."""
+    handler = _make_handler()
+
+    fake_ws = MagicMock()
+    fake_ws.send = MagicMock()
+    fake_ws.recv = MagicMock()
+    fake_ws.close = MagicMock()
+
+    fake_websocket_module = MagicMock()
+    fake_websocket_module.WebSocket = MagicMock(return_value=fake_ws)
+
+    with patch.dict("sys.modules", {"websocket": fake_websocket_module}):
+        results = list(handler.process(EndOfResponse(turn_id="turn_1", turn_revision=1)))
+
+    assert results == [AUDIO_RESPONSE_DONE]
+    # No WS interaction for EndOfResponse
+    fake_ws.send.assert_not_called()
+
+
+def test_tts_handler_missing_api_key_raises(monkeypatch):
+    """Setup raises ValueError when no API key is provided."""
+    monkeypatch.delenv("TELNYX_API_KEY", raising=False)
+
+    handler = object.__new__(TelnyxTTSHandler)
+    with pytest.raises(ValueError, match="Telnyx TTS requires an API key"):
+        handler.setup(should_listen=Event(), api_key="")
+
+
+def test_tts_handler_reads_api_key_from_env(monkeypatch):
+    """Setup falls back to TELNYX_API_KEY env var when api_key is empty."""
+    monkeypatch.setenv("TELNYX_API_KEY", "env-key")
+
+    handler = object.__new__(TelnyxTTSHandler)
+    handler.setup(should_listen=Event(), api_key="")
+    assert handler.api_key == "env-key"
+
+
+def test_tts_handler_breaks_on_cancel():
+    """Handler stops yielding when cancel_scope marks the generation stale."""
+    from speech_to_speech.pipeline.cancel_scope import CancelScope
+
+    scope = CancelScope()
+    handler = _make_handler(cancel_scope=scope, blocksize=512)
+
+    mp3_b64 = _make_mp3_b64(duration_s=0.1)
+
+    # Many frames so the cancel check fires
+    recv_frames = [json.dumps({"audio": mp3_b64, "isFinal": False}) for _ in range(20)]
+
+    fake_ws = MagicMock()
+    fake_ws.send = MagicMock()
+    fake_ws.recv = lambda: recv_frames.pop(0) if recv_frames else ""
+    fake_ws.close = MagicMock()
+
+    fake_websocket_module = MagicMock()
+    fake_websocket_module.WebSocket = MagicMock(return_value=fake_ws)
+
+    # Cancel before processing
+    scope.cancel()
+
+    with patch.dict("sys.modules", {"websocket": fake_websocket_module}):
+        tts_input = TTSInput(text="Hello.", turn_id="turn_1", turn_revision=1)
+        results = list(handler.process(tts_input))
+
+    # Should bail out early; may yield zero or one chunk depending on timing
+    assert len(results) <= 1
+    fake_ws.close.assert_called_once()


### PR DESCRIPTION
## Add Telnyx managed STT and TTS backends

Adds two backends that connect the speech-to-speech pipeline to Telnyx's
managed Speech-to-Text and Text-to-Speech WebSocket APIs. Telnyx is the first
managed voice provider in the pipeline: every existing backend (Parakeet,
Whisper, Qwen3-TTS, Kokoro, Pocket) runs models locally. These give developers
a one-flag path to managed speech without leaving the modular architecture.

### New modes

- `--stt telnyx` streams audio to `wss://api.telnyx.com/v2/speech-to-text/transcription`
- `--tts telnyx` streams text to `wss://api.telnyx.com/v2/text-to-speech/speech`

**STT engines**: Telnyx (Whisper-based), Deepgram, Google, Azure. Deepgram is
the only engine that returns interim results; the others return a single final.

**TTS voices**: Telnyx NaturalHD, AWS Polly, Azure, ElevenLabs, MiniMax,
ResembleAI, Inworld, Rime

### Installation

```bash
pip install "speech-to-speech[telnyx]"
```

System dependency: `ffmpeg`, used to decode the TTS MP3 stream. Install with
`brew install ffmpeg` (macOS) or `apt install ffmpeg` (Debian/Ubuntu).

### Usage

```bash
# Fully managed speech, OpenAI for LLM
export TELNYX_API_KEY=...
speech-to-speech \
    --stt telnyx --tts telnyx \
    --llm_backend responses-api \
    --model_name gpt-4o-mini \
    --responses_api_stream

# Deepgram STT + ElevenLabs TTS, still through Telnyx's unified API
speech-to-speech \
    --stt telnyx --telnyx_stt_engine Deepgram --telnyx_stt_model nova-3 \
    --tts telnyx --telnyx_tts_voice "ElevenLabs.<voice_id>" \
    --llm_backend responses-api --model_name gpt-4o-mini

# Mixed: local Qwen3-TTS, managed Telnyx STT
speech-to-speech \
    --stt telnyx --telnyx_stt_engine Telnyx \
    --tts qwen3 --qwen3_tts_speaker Aiden \
    --llm_backend responses-api --model_name gpt-4o-mini
```

### Implementation

**WebSocket lifecycle**: one connection per synthesis request for TTS and one
per VAD segment for STT. The TTS protocol has no per-utterance boundary marker
inside a session, and the LLM output processor emits sentence batches, so in
practice that is one connection per sentence batch. A persistent connection is
a follow-up if lower TTFB is needed.

**TTS audio**: Telnyx returns one continuous MP3 bitstream sliced across many
small frames (typically 480 bytes). Individual frames are *not* independently
decodable, so `Mp3StreamDecoder` pipes the stream through a long-lived ffmpeg
process and emits PCM as frames arrive rather than buffering the response.
Measured against the live API: 8.9s of audio streamed out in 5.2s wall clock
across 159 incremental emits, with a 1552-sample tail at flush.

**STT audio**: pipeline PCM (16 kHz int16 mono) wrapped in a WAV container via
the stdlib `wave` module and sent in the recommended 2 KB binary frames. Zero
codec dependency on the STT path.

**Live transcription**: STT forwards partial transcript events to the realtime
text output queue when `--enable_live_transcription` is set, mirroring the
parakeet-tdt pattern.

**Auth**: `TELNYX_API_KEY` env var, or override with `--telnyx_stt_api_key` and
`--telnyx_tts_api_key`. Both clients connect with `suppress_origin=True`:
websocket-client attaches an `Origin` header to wss:// handshakes and Telnyx's
edge rejects those with a `403` before the request reaches the API.

### Files

| File | Purpose |
|------|---------|
| `STT/telnyx_stt_handler.py` | Telnyx STT WebSocket handler |
| `TTS/telnyx_tts_handler.py` | Telnyx TTS WebSocket handler |
| `arguments_classes/telnyx_stt_arguments.py` | `--telnyx_stt_*` CLI args |
| `arguments_classes/telnyx_tts_arguments.py` | `--telnyx_tts_*` CLI args |
| `utils/telnyx_ws.py` | Sync WS clients, WAV container, streaming MP3 decoder |
| `s2s_pipeline.py` | Handler registration and wiring (mirrors pocket/kokoro) |
| `pyproject.toml` | `[telnyx]` optional extra (`websocket-client`) |
| `STT/README.md`, `TTS/README.md`, `README.md` | Docs |
| `tests/test_telnyx_*.py` | Unit + protocol tests, live tests behind env guard |

### Testing

- `tests/test_telnyx_audio_codec.py` — WAV round-trip; streaming MP3 decode
  matches a one-shot decode byte for byte, including 7-byte frame-misaligned
  slices; audio is emitted before flush rather than only at the end
- `tests/test_telnyx_stt_protocol.py` — transcript parsing against the
  documented event shape, chunked WAV framing, error frames, partial throttling
- `tests/test_telnyx_tts_protocol.py` — init/content/stop frame sequence,
  reconstruction of a sliced bitstream, stop-at-`isFinal`, mid-stream cancel
- `tests/test_telnyx_live.py` — hits the real API, asserts on decoded audio and
  transcript text; skipped without `TELNYX_API_KEY`

CI now installs the `telnyx` extra and ffmpeg so these actually run instead of
skipping.

Local run: 627 passed, 1 skipped. `mypy src/` and `ruff check`/`ruff format`
clean.

### Verified against the live API

Both directions are exercised end to end, not just mocked:

- TTS synthesizes a sentence, the streaming decoder reconstructs it, and the
  result is checked for plausible duration and non-silence
- STT takes that audio back and returns two interim results plus a final
  transcript matching the input
- `tests/test_telnyx_live.py` is 3 passed, 0 skipped with `TELNYX_API_KEY` set

Two protocol details that cost real debugging time and are worth flagging for
anyone else integrating this endpoint: the interim-results parameter is
`interim_results` (`partial_results` is accepted and silently ignored), and the
handshake must not carry an `Origin` header.

### Why Telnyx?

The pipeline's strength is modularity: every component is swappable. Until now
that meant choosing between local model variants. Telnyx adds a managed option
for teams that want production SLAs, telco integration (SIP, phone numbers,
call control), and a multi-provider voice catalog through one API, without
forking the pipeline.

It is also a clean upgrade path: prototype locally with Parakeet + Qwen3-TTS,
then swap to `--stt telnyx --tts telnyx` for production without changing the
rest of the stack.

### Maintenance

The Telnyx team will maintain these backends upstream.
