### PR TITLE
Fix language leaking between Whisper STT handlers via a shared gen_kwargs default

### DIFF
--- a/src/speech_to_speech/STT/whisper_stt_handler.py
+++ b/src/speech_to_speech/STT/whisper_stt_handler.py
@@ -49,7 +49,11 @@ class WhisperSTTHandler(BaseSTTHandler):
         self.device = device
         self.torch_dtype = getattr(torch, torch_dtype)
         self.compile_mode = compile_mode
-        self.gen_kwargs = gen_kwargs
+        # Copied, not aliased: `language` is written into this dict below, and
+        # `gen_kwargs` defaults to a single dict shared by every call to `setup`,
+        # so writing through the alias would leave the language of one handler in
+        # the default and hand it to the next handler built without one.
+        self.gen_kwargs = dict(gen_kwargs)
         self.start_language = language
         self.last_language = language if language != "auto" else None
         if self.last_language is not None:

--- a/tests/test_whisper_stt_gen_kwargs_isolation.py
+++ b/tests/test_whisper_stt_gen_kwargs_isolation.py
@@ -1,0 +1,98 @@
+"""The whisper STT handler must not write its language into the shared default.
+
+`setup` takes `gen_kwargs: dict[str, Any] = {}`, so every call that omits the
+argument receives the same dict object. `setup` then stores `language` in it,
+which means the value survives in the default for the life of the process and is
+handed to the next handler built without an explicit `gen_kwargs`.
+"""
+
+from typing import Any
+
+import pytest
+import torch
+
+from speech_to_speech.STT import whisper_stt_handler
+from speech_to_speech.STT.whisper_stt_handler import WhisperSTTHandler
+
+
+class _FakeConfig:
+    num_mel_bins = 80
+
+
+class _FakeModel:
+    config = _FakeConfig()
+
+    def to(self, device: str) -> "_FakeModel":
+        return self
+
+    def generate(self, *args: Any, **kwargs: Any) -> torch.Tensor:
+        return torch.zeros((1, 4), dtype=torch.long)
+
+
+@pytest.fixture
+def stub_transformers(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Let the real `setup` run without downloading or loading a model."""
+    monkeypatch.setattr(
+        whisper_stt_handler.AutoProcessor, "from_pretrained", classmethod(lambda cls, *a, **k: object())
+    )
+    monkeypatch.setattr(
+        whisper_stt_handler.AutoModelForSpeechSeq2Seq,
+        "from_pretrained",
+        classmethod(lambda cls, *a, **k: _FakeModel()),
+    )
+
+
+def _make_handler(**setup_kwargs: Any) -> WhisperSTTHandler:
+    handler = object.__new__(WhisperSTTHandler)
+    handler.setup(device="cpu", torch_dtype="float32", **setup_kwargs)
+    return handler
+
+
+def test_setup_does_not_mutate_the_shared_default(stub_transformers: None) -> None:
+    default_gen_kwargs = WhisperSTTHandler.setup.__defaults__[-1]
+    assert default_gen_kwargs == {}, "precondition: the default starts empty"
+
+    _make_handler(language="fr")
+
+    assert default_gen_kwargs == {}
+
+
+def test_language_does_not_leak_into_a_later_handler(stub_transformers: None) -> None:
+    _make_handler(language="fr")
+
+    without_language = _make_handler()
+
+    assert "language" not in without_language.gen_kwargs
+    assert without_language.last_language is None
+
+
+def test_handlers_do_not_share_one_gen_kwargs_dict(stub_transformers: None) -> None:
+    first = _make_handler(language="fr")
+    second = _make_handler(language="ja")
+
+    assert first.gen_kwargs is not second.gen_kwargs
+    assert first.gen_kwargs["language"] == "fr"
+    assert second.gen_kwargs["language"] == "ja"
+
+
+def test_caller_supplied_gen_kwargs_is_left_alone(stub_transformers: None) -> None:
+    caller_dict: dict[str, Any] = {"max_new_tokens": 128}
+
+    handler = _make_handler(language="fr", gen_kwargs=caller_dict)
+
+    assert caller_dict == {"max_new_tokens": 128}
+    assert handler.gen_kwargs == {"max_new_tokens": 128, "language": "fr"}
+
+
+def test_explicit_gen_kwargs_still_carries_the_language(stub_transformers: None) -> None:
+    handler = _make_handler(language="es", gen_kwargs={"num_beams": 1})
+
+    assert handler.gen_kwargs == {"num_beams": 1, "language": "es"}
+
+
+def test_auto_language_is_not_written_into_gen_kwargs(stub_transformers: None) -> None:
+    handler = _make_handler(language="auto")
+
+    assert handler.gen_kwargs == {}
+    assert handler.start_language == "auto"
+    assert handler.last_language is None


### PR DESCRIPTION
### The bug

`WhisperSTTHandler.setup` has a mutable default argument, and then writes through it:

```python
def setup(self, ..., gen_kwargs: dict = {}):
    self.gen_kwargs = gen_kwargs          # alias, not a copy
    ...
    if self.last_language is not None:
        self.gen_kwargs["language"] = self.last_language   # writes into the default
```

`self.gen_kwargs = gen_kwargs` aliases the argument, so the `["language"] = ...` write lands in whatever dict was passed — and when the caller passes nothing, that is the single default dict shared by every call to `setup` for the lifetime of the process.

Two consequences:

1. **Language leaks between handlers.** Build a handler with `language="fr"` and no `gen_kwargs`; the default dict is now permanently `{"language": "fr"}`. Every handler built afterwards without an explicit `gen_kwargs` starts with French pre-set, including one built with `language="auto"` — which is meant to leave language unset so Whisper detects it. Auto-detection silently stops working, and the transcription comes back in the wrong language with no error anywhere.
2. **The caller's dict is mutated.** A caller who passes a config dict gets `language` written into it, so reusing that dict for a second handler carries the first handler's language along.

This is the "mutable default argument" footgun, but note it is a real bug here rather than a lint nit: the in-place write is what turns the shared default into cross-instance state.

### The fix

Copy instead of alias:

```python
self.gen_kwargs = dict(gen_kwargs)
```

with a comment explaining why the copy is load-bearing.

### Scope of the sweep

I checked all 12 `= {}` defaults in `src/` and grepped every `self.gen_kwargs[...] = ` write plus every `.pop`/`.update`/`.setdefault` on a `gen_kwargs` argument. Exactly two sites write in place: this one and `faster_whisper_handler.py`. There is no third instance of the bug class. The `faster_whisper` one has a different shape (a destructive `pop` in `adapt_gen_kwargs`) and is in a separate PR.

### Tests

New `tests/test_whisper_stt_gen_kwargs_isolation.py`, 6 tests. `AutoProcessor.from_pretrained` and `AutoModelForSpeechSeq2Seq.from_pretrained` are monkeypatched so the **real** `setup` runs without downloading a model:

- `test_setup_does_not_mutate_the_shared_default` — asserts `setup.__defaults__[-1] == {}` before and after
- `test_language_does_not_leak_into_a_later_handler` — the consequence users would actually hit
- `test_handlers_do_not_share_one_gen_kwargs_dict`
- `test_caller_supplied_gen_kwargs_is_left_alone`
- `test_explicit_gen_kwargs_still_carries_the_language` — the intended behaviour is preserved
- `test_auto_language_is_not_written_into_gen_kwargs`

Control experiment: with the fix reverted, **5 of the 6 fail**, naming the exact leak (`assert {'language': 'fr'} == {}`).

`ruff check src/ tests/` and `ruff format --check` clean at the pinned 0.15.20; `mypy src/` reports `Success: no issues found in 91 source files`.
