### PR TITLE
Fix faster-whisper adapt_gen_kwargs consuming its caller's config dict

### DIFF
--- a/src/speech_to_speech/STT/faster_whisper_handler.py
+++ b/src/speech_to_speech/STT/faster_whisper_handler.py
@@ -63,6 +63,15 @@ class FasterWhisperSTTHandler(BaseSTTHandler):
         del self.model
 
     def adapt_gen_kwargs(self, gen_kwargs: dict[str, Any]) -> dict[str, Any]:
-        gen_kwargs["without_timestamps"] = not gen_kwargs.pop("return_timestamps", True)
+        """Translate the pipeline's `return_timestamps` into faster-whisper's inverse.
 
-        return gen_kwargs
+        Builds a new dict rather than popping from the argument. Popping consumes
+        the source key, so passing the same config to a second handler would read
+        the default instead of the caller's value and flip the setting; it also
+        mutates the shared `gen_kwargs = {}` default of `setup`, leaving
+        `without_timestamps` behind for every later handler.
+        """
+        adapted = dict(gen_kwargs)
+        adapted["without_timestamps"] = not adapted.pop("return_timestamps", True)
+
+        return adapted

--- a/tests/test_faster_whisper_gen_kwargs_adaptation.py
+++ b/tests/test_faster_whisper_gen_kwargs_adaptation.py
@@ -1,0 +1,72 @@
+"""`adapt_gen_kwargs` must translate its argument without consuming it.
+
+It maps the pipeline's `return_timestamps` onto faster-whisper's inverse
+`without_timestamps`. Popping the source key out of the caller's dict makes the
+translation single-use: the second handler built from the same config reads the
+default instead of the supplied value, and the setting silently inverts.
+"""
+
+from typing import Any
+
+import pytest
+
+faster_whisper = pytest.importorskip("faster_whisper")
+
+from speech_to_speech.STT.faster_whisper_handler import FasterWhisperSTTHandler  # noqa: E402
+
+
+@pytest.fixture
+def handler() -> FasterWhisperSTTHandler:
+    """A handler instance without running `setup`, which loads a model."""
+    return object.__new__(FasterWhisperSTTHandler)
+
+
+@pytest.mark.parametrize(
+    "return_timestamps,expected",
+    [(True, False), (False, True)],
+)
+def test_return_timestamps_is_inverted(
+    handler: FasterWhisperSTTHandler, return_timestamps: bool, expected: bool
+) -> None:
+    adapted = handler.adapt_gen_kwargs({"return_timestamps": return_timestamps})
+
+    assert adapted == {"without_timestamps": expected}
+
+
+def test_default_is_timestamps_on(handler: FasterWhisperSTTHandler) -> None:
+    assert handler.adapt_gen_kwargs({}) == {"without_timestamps": False}
+
+
+def test_caller_dict_is_not_consumed(handler: FasterWhisperSTTHandler) -> None:
+    config: dict[str, Any] = {"return_timestamps": False, "beam_size": 5}
+
+    handler.adapt_gen_kwargs(config)
+
+    assert config == {"return_timestamps": False, "beam_size": 5}
+
+
+def test_one_config_reused_gives_both_handlers_the_same_setting(
+    handler: FasterWhisperSTTHandler,
+) -> None:
+    """The sharpest consequence: the second read used to flip the setting."""
+    config: dict[str, Any] = {"return_timestamps": False}
+
+    first = handler.adapt_gen_kwargs(config)
+    second = handler.adapt_gen_kwargs(config)
+
+    assert first == second == {"without_timestamps": True}
+
+
+def test_shared_setup_default_is_not_polluted(handler: FasterWhisperSTTHandler) -> None:
+    default_gen_kwargs = FasterWhisperSTTHandler.setup.__defaults__[-1]
+    assert default_gen_kwargs == {}, "precondition: the default starts empty"
+
+    handler.adapt_gen_kwargs(default_gen_kwargs)
+
+    assert default_gen_kwargs == {}
+
+
+def test_other_kwargs_pass_through(handler: FasterWhisperSTTHandler) -> None:
+    adapted = handler.adapt_gen_kwargs({"beam_size": 5, "language": "fr"})
+
+    assert adapted == {"beam_size": 5, "language": "fr", "without_timestamps": False}


### PR DESCRIPTION
### The bug

`FasterWhisperSTTHandler.adapt_gen_kwargs` translated the pipeline's `return_timestamps` into faster-whisper's inverse `without_timestamps` by popping from its argument:

```python
def adapt_gen_kwargs(self, gen_kwargs):
    gen_kwargs["without_timestamps"] = not gen_kwargs.pop("return_timestamps", True)
    return gen_kwargs
```

The `pop` consumes the source key out of the caller's dict, which makes the translation single-use. Three consequences, all silent:

1. **The second read flips the setting.** Pass one config dict to two handlers — the first call consumes `return_timestamps`, so the second call falls back to the `True` default and produces `without_timestamps=False`. A user who asked for `return_timestamps=False` gets timestamps enabled on the second handler.

   ```python
   config = {"return_timestamps": False}
   h.adapt_gen_kwargs(config)   # -> {'without_timestamps': True}   correct
   h.adapt_gen_kwargs(config)   # -> {'without_timestamps': False}  inverted
   ```

2. **The caller's dict is consumed**, so any other code that reads `config["return_timestamps"]` afterwards sees it gone.

3. **The shared `gen_kwargs = {}` default of `setup` is polluted.** `setup` passes its default straight in, so after one no-argument `setup` the class default is permanently `{"without_timestamps": False}`, and every later handler inherits it.

### The fix

Build a new dict instead of mutating the argument:

```python
adapted = dict(gen_kwargs)
adapted["without_timestamps"] = not adapted.pop("return_timestamps", True)
return adapted
```

The `pop` is now on the copy, so it still strips the key faster-whisper does not accept from what is forwarded to `transcribe`, while leaving the caller's dict alone. Also added a docstring, since the inversion is not obvious from the code.

### Scope

Part of a two-site sweep: I grepped every in-place write to a `gen_kwargs` argument across `src/` and found exactly two, this one and `whisper_stt_handler.py` (separate PR, different shape — aliasing rather than popping). No third instance exists.

### Tests

New `tests/test_faster_whisper_gen_kwargs_adaptation.py`, 7 tests behind `pytest.importorskip("faster_whisper")`, covering the inversion in both directions, the default, that the caller's dict survives, that other kwargs pass through, that the shared `setup` default stays empty, and the sharpest one:

```python
def test_one_config_reused_gives_both_handlers_the_same_setting(handler):
    config = {"return_timestamps": False}
    first = handler.adapt_gen_kwargs(config)
    second = handler.adapt_gen_kwargs(config)
    assert first == second == {"without_timestamps": True}
```

Control experiment: with the fix reverted, **3 failed / 4 passed**, one failure per consequence above.

`ruff check` + `ruff format --check` clean at the pinned 0.15.20, `mypy src/` clean. Full suite: this branch 15 failed / 565 passed vs. 16 failed / 557 passed on `main`. The one differing test, `test_speculative_turns.py::test_try_is_latest_after_reopen_grace_reports_pending_without_blocking`, passes 3/3 in isolation — it is a timing flake, unrelated to this change.
