### PR TITLE
Add mic/speaker device selectors to the demo Settings UI.

### DIFF
--- a/demo/README.md
+++ b/demo/README.md
@@ -205,11 +205,13 @@ case-insensitively against the user's organisations from HF OAuth.
 |-----|------|
 | Speech-to-speech server URL | Direct realtime WebSocket URL (hidden/locked when pinned by env) |
 | Transport | WebSocket (default) or WebRTC; selectable only with an env-pinned URL |
+| Microphone | Input device for capture. Applies on the next conversation / Restart. |
+| Speakers | Output device for assistant audio. Chrome/Edge can switch live via `AudioContext.setSinkId`; other browsers keep the system default. |
 | Voice | Qwen3-TTS speaker name (Aiden, Ryan, Dylan, Eric, Ono_Anna, Serena, Sohee, Uncle_Fu, Vivian) |
 | Instructions | System prompt sent in `session.update` once the connection opens |
 
 LocalStorage keys are namespaced `s2s.ws.*` (plus `s2s.transport` for the
-transport pick).
+transport pick, and `s2s.audio.inputId` / `s2s.audio.outputId` for devices).
 
 ## Files
 

--- a/demo/index.html
+++ b/demo/index.html
@@ -273,6 +273,24 @@
               </label>
             </div>
 
+            <label class="field">
+              <span>Microphone</span>
+              <select id="audio-input">
+                <option value="">System default</option>
+              </select>
+              <small>Applies on the next conversation (or Restart).</small>
+            </label>
+
+            <label class="field" id="audio-output-field">
+              <span>Speakers</span>
+              <select id="audio-output">
+                <option value="">System default</option>
+              </select>
+              <small id="audio-output-hint">
+                Where assistant audio plays. Chrome/Edge support switching outputs.
+              </small>
+            </label>
+
             <!-- WS-only: the gate runs in the WebSocket capture worklet; the
                  WebRTC mic path sends the raw track, so this hides there. -->
             <div class="field" id="gate-field">

--- a/demo/main.js
+++ b/demo/main.js
@@ -49,6 +49,8 @@ const STORAGE_KEYS = {
   // "ws" | "webrtc". Not under the historical "s2s.ws." prefix — it selects
   // between the transports rather than configuring the WS one.
   transport: "s2s.transport",
+  audioInputId: "s2s.audio.inputId",
+  audioOutputId: "s2s.audio.outputId",
 };
 
 // ── Noise gate ──────────────────────────────────────────────────────────────
@@ -124,6 +126,8 @@ function loadSettings() {
     noiseGate: loadGateThreshold(),
     // Default WebSocket: the proven path stays the first-run experience.
     transport: localStorage.getItem(STORAGE_KEYS.transport) === "webrtc" ? "webrtc" : "ws",
+    audioInputId: localStorage.getItem(STORAGE_KEYS.audioInputId) || "",
+    audioOutputId: localStorage.getItem(STORAGE_KEYS.audioOutputId) || "",
   };
 }
 
@@ -147,6 +151,8 @@ function saveSettings(s) {
   localStorage.setItem(STORAGE_KEYS.instructions, s.instructions);
   localStorage.setItem(STORAGE_KEYS.noiseGate, String(s.noiseGate));
   localStorage.setItem(STORAGE_KEYS.transport, s.transport);
+  localStorage.setItem(STORAGE_KEYS.audioInputId, s.audioInputId || "");
+  localStorage.setItem(STORAGE_KEYS.audioOutputId, s.audioOutputId || "");
 }
 
 /** @returns {{ web_search: boolean, camera_snapshot: boolean }} */
@@ -269,6 +275,12 @@ const transportHint = $("#transport-hint");
 const gateField = $("#gate-field");
 /** @type {HTMLSelectElement} */
 const inputVoice = $("#voice");
+/** @type {HTMLSelectElement} */
+const inputAudioInput = $("#audio-input");
+/** @type {HTMLSelectElement} */
+const inputAudioOutput = $("#audio-output");
+/** @type {HTMLElement} */
+const audioOutputHint = $("#audio-output-hint");
 /** @type {HTMLTextAreaElement} */
 const inputInstructions = $("#instructions");
 /** @type {HTMLInputElement} */
@@ -450,6 +462,7 @@ function openSettings() {
   inputInstructions.value = settings.instructions;
   syncGateUi();
   updateRestartAvailability();
+  void refreshAudioDeviceLists();
   settingsModal.showModal();
 }
 
@@ -995,6 +1008,8 @@ function readSettingsFromForm() {
         ? (inputTransport.value === "webrtc" ? "webrtc" : "ws")
         : settings.transport
     ),
+    audioInputId: inputAudioInput.value || "",
+    audioOutputId: inputAudioOutput.value || "",
   };
 }
 
@@ -1082,9 +1097,14 @@ settingsForm.addEventListener("submit", (event) => {
   saveSettings(settings);
 
   // Voice + instructions can apply to a live session without reconnecting; a
-  // changed connection URL only takes effect on the next restart.
+  // changed connection URL only takes effect on the next restart. Speaker
+  // output can switch live when the browser supports AudioContext.setSinkId;
+  // mic device changes need a Restart (new getUserMedia stream).
   if (client && LIVE_STATES.has(currentState)) {
     client.updateSession({ voice: settings.voice, instructions: effectiveInstructions() });
+    if (typeof client.setAudioOutputDevice === "function") {
+      void client.setAudioOutputDevice(settings.audioOutputId);
+    }
   }
 });
 
@@ -1194,16 +1214,112 @@ joinQueueBtn.addEventListener("click", () => {
   if (client) client.join();
 });
 
-const MIC_CONSTRAINTS = {
-  audio: { echoCancellation: true, noiseSuppression: true, autoGainControl: true },
+const MIC_CONSTRAINTS_BASE = {
+  echoCancellation: true,
+  noiseSuppression: true,
+  autoGainControl: true,
 };
+
+/** @returns {MediaStreamConstraints} */
+function micConstraints() {
+  /** @type {MediaTrackConstraints} */
+  const audio = { ...MIC_CONSTRAINTS_BASE };
+  if (settings.audioInputId) {
+    // ideal (not exact): if the saved device was unplugged, fall back quietly.
+    audio.deviceId = { ideal: settings.audioInputId };
+  }
+  return { audio };
+}
+
+/** True when Web Audio can route playback to a chosen output device. */
+function supportsAudioOutputSelection() {
+  const Ctx = window.AudioContext || /** @type {any} */ (window).webkitAudioContext;
+  return typeof Ctx?.prototype?.setSinkId === "function";
+}
+
+/**
+ * Rebuild the mic/speaker <select>s from enumerateDevices. Labels are blank
+ * until mic permission has been granted at least once.
+ */
+async function refreshAudioDeviceLists() {
+  const canPickOutput = supportsAudioOutputSelection();
+  inputAudioOutput.disabled = !canPickOutput;
+  audioOutputHint.textContent = canPickOutput
+    ? "Where assistant audio plays. Can change live while connected."
+    : "Speaker selection needs a browser with AudioContext.setSinkId (Chrome/Edge).";
+
+  /** @type {MediaDeviceInfo[]} */
+  let devices = [];
+  try {
+    devices = await navigator.mediaDevices.enumerateDevices();
+  } catch (err) {
+    console.warn("[main] enumerateDevices failed:", err);
+  }
+
+  const inputs = devices.filter((d) => d.kind === "audioinput");
+  const outputs = devices.filter((d) => d.kind === "audiooutput");
+  const labelsReady = devices.some((d) => d.label);
+
+  fillDeviceSelect(inputAudioInput, inputs, settings.audioInputId, "Microphone");
+  fillDeviceSelect(inputAudioOutput, outputs, settings.audioOutputId, "Speaker");
+
+  if (!labelsReady) {
+    // Permission unlocks real device names; keep it quiet — user can tap Start
+    // or we unlock when they already connected once this session.
+    const hint = inputAudioInput.parentElement?.querySelector("small");
+    if (hint) {
+      hint.textContent =
+        "Allow microphone access (tap Start once) to see device names. Mic changes apply on Restart.";
+    }
+  } else {
+    const hint = inputAudioInput.parentElement?.querySelector("small");
+    if (hint) hint.textContent = "Applies on the next conversation (or Restart).";
+  }
+}
+
+/**
+ * @param {HTMLSelectElement} select
+ * @param {MediaDeviceInfo[]} devices
+ * @param {string} selectedId
+ * @param {string} fallbackLabel
+ */
+function fillDeviceSelect(select, devices, selectedId, fallbackLabel) {
+  const prev = selectedId || select.value || "";
+  select.replaceChildren();
+  const def = document.createElement("option");
+  def.value = "";
+  def.textContent = "System default";
+  select.appendChild(def);
+  devices.forEach((d, i) => {
+    const opt = document.createElement("option");
+    opt.value = d.deviceId;
+    opt.textContent = d.label || `${fallbackLabel} ${i + 1}`;
+    select.appendChild(opt);
+  });
+  // Keep a saved id even if it isn't currently listed (unplugged); browser
+  // will fall back via ideal constraints / setSinkId errors.
+  if (prev && ![...select.options].some((o) => o.value === prev)) {
+    const missing = document.createElement("option");
+    missing.value = prev;
+    missing.textContent = `${fallbackLabel} (saved, not found)`;
+    select.appendChild(missing);
+  }
+  select.value = prev;
+  if (select.value !== prev) select.value = "";
+}
+
+if (navigator.mediaDevices?.addEventListener) {
+  navigator.mediaDevices.addEventListener("devicechange", () => {
+    if (settingsModal.open) void refreshAudioDeviceLists();
+  });
+}
 
 /** Prompt for mic permission up front, then immediately release the tracks so no
  *  recording indicator lingers during a queue wait. Throws a friendly error if the
  *  user denies. */
 async function primeMicPermission() {
   try {
-    const s = await navigator.mediaDevices.getUserMedia(MIC_CONSTRAINTS);
+    const s = await navigator.mediaDevices.getUserMedia(micConstraints());
     for (const track of s.getTracks()) track.stop();
   } catch (err) {
     throw new Error(
@@ -1215,7 +1331,7 @@ async function primeMicPermission() {
 /** Acquire the live capture stream once a slot is granted. Permission was primed
  *  in the tap gesture, so this is silent. Stored module-side for mute + teardown. */
 async function acquireMicStream() {
-  micStream = await navigator.mediaDevices.getUserMedia(MIC_CONSTRAINTS);
+  micStream = await navigator.mediaDevices.getUserMedia(micConstraints());
   return micStream;
 }
 
@@ -1304,6 +1420,7 @@ async function doStart(audioContext = null) {
     instructions: effectiveInstructions(),
     acquireMic: acquireMicStream,
     tools: activeToolDefs(),
+    audioOutputId: settings.audioOutputId || "",
     ...(audioContext ? { audioContext } : {}),
   };
   const c = target === null

--- a/demo/rtc/s2s-rtc-client.js
+++ b/demo/rtc/s2s-rtc-client.js
@@ -51,6 +51,8 @@
  *   created inside the tap gesture so iOS lets it start.
  * @property {import("../ws/s2s-ws-client.js").ToolDef[]} [tools] Function tools
  *   declared in the initial `session.update`.
+ * @property {string} [audioOutputId] MediaDeviceInfo.deviceId for speakers
+ *   (AudioContext.setSinkId when supported).
  */
 
 import { extractResponseTranscript } from "../ws/codec.js";
@@ -334,8 +336,27 @@ export class S2sRtcRealtimeClient extends EventTarget {
     outAnalyser.connect(ctx.destination);
     this._outAnalyser = outAnalyser;
 
+    void this.setAudioOutputDevice(this.options.audioOutputId || "");
+
     this._visualiser = new OrbVisualiser(micAnalyser, outAnalyser, () => this._aiSpeaking);
     this._visualiser.start();
+  }
+
+  /**
+   * Route Web Audio playback to a specific output device (Chrome/Edge).
+   * @param {string} [deviceId]
+   * @returns {Promise<boolean>}
+   */
+  async setAudioOutputDevice(deviceId = "") {
+    const ctx = this._ctx;
+    if (!ctx || typeof /** @type {any} */ (ctx).setSinkId !== "function") return false;
+    try {
+      await /** @type {any} */ (ctx).setSinkId(deviceId || "");
+      return true;
+    } catch (err) {
+      console.warn("[rtc] setSinkId failed:", err);
+      return false;
+    }
   }
 
   /** @param {RTCTrackEvent} e */

--- a/demo/ws/s2s-ws-client.js
+++ b/demo/ws/s2s-ws-client.js
@@ -65,6 +65,8 @@
  *   executes and replies via `sendToolOutput` + `requestResponse`.
  * @property {NoiseGate} [noiseGate] Client-side noise gate applied to the mic
  *   before it's sent. Tunable live via `setNoiseGate`.
+ * @property {string} [audioOutputId] MediaDeviceInfo.deviceId for speakers.
+ *   Applied via AudioContext.setSinkId when the browser supports it.
  *
  * @typedef {Object} NoiseGate
  * @property {boolean} enabled
@@ -526,8 +528,28 @@ export class S2sWsRealtimeClient extends EventTarget {
     this._outAnalyser = outAnalyser;
     this._playbackNode = playbackNode;
 
+    await this.setAudioOutputDevice(this.options.audioOutputId || "");
+
     this._visualiser = new OrbVisualiser(micAnalyser, outAnalyser, () => this._aiSpeaking);
     this._visualiser.start();
+  }
+
+  /**
+   * Route Web Audio playback to a specific output device (Chrome/Edge).
+   * Empty string restores the system default.
+   * @param {string} [deviceId]
+   * @returns {Promise<boolean>}
+   */
+  async setAudioOutputDevice(deviceId = "") {
+    const ctx = this._ctx;
+    if (!ctx || typeof /** @type {any} */ (ctx).setSinkId !== "function") return false;
+    try {
+      await /** @type {any} */ (ctx).setSinkId(deviceId || "");
+      return true;
+    } catch (err) {
+      console.warn("[ws] setSinkId failed:", err);
+      return false;
+    }
   }
 
   /** @param {string} connectUrl */


### PR DESCRIPTION
Lets users pick capture and playback devices (persisted in localStorage); speaker routing uses AudioContext.setSinkId where supported.