### PR TITLE
Fix Whisper STT language detection reading a text token

### DIFF
--- a/src/speech_to_speech/STT/whisper_stt_handler.py
+++ b/src/speech_to_speech/STT/whisper_stt_handler.py
@@ -143,14 +143,60 @@ class WhisperSTTHandler(BaseSTTHandler):
         self._language_token_id_map = mapping
         return mapping
 
-    def _detected_language(self, pred_ids: Any) -> Optional[str]:
-        """Read the language Whisper decoded, or ``None`` if it did not report one.
+    def _code_from_language_tokens(self, token_ids: Any) -> Optional[str]:
+        """Resolve the first Whisper language special token in ``token_ids`` to its code."""
+        language_tokens = self._language_token_ids()
+        if not language_tokens:
+            return None
 
-        The language token is only in the returned sequence when ``generate()`` echoes the
-        forced decoder prefix. Recent ``transformers`` strips that prefix, so the leading ids
-        are ordinary text. Scanning for a real language token instead of slicing a fixed
-        position keeps this correct on both behaviours; guessing from position turns a text
-        token into a bogus "language" and silently discards a good transcription.
+        try:
+            flat = token_ids.flatten().tolist() if hasattr(token_ids, "flatten") else list(token_ids)
+        except (IndexError, TypeError):
+            return None
+
+        for token_id in flat:
+            try:
+                code = language_tokens.get(int(token_id))
+            except (TypeError, ValueError):
+                continue
+            if code is not None:
+                return code
+        return None
+
+    def _detect_language(self, input_features: Any) -> tuple[Any, Optional[str]]:
+        """Detect the spoken language up front, returning ``(encoder_outputs, code)``.
+
+        ``generate()`` excludes the decoder input ids from its output, and the language token
+        is one of them, so the detected language is never observable in the generated
+        sequence on the ``transformers`` versions supported here. Whisper exposes
+        ``detect_language()`` for exactly this, so ask it directly.
+
+        The encoder output is computed once here and handed back so ``generate()`` can reuse
+        it instead of re-encoding. Forcing the detected language also stops ``generate()``
+        from running its own internal detection, so this is cheaper than the plain auto path
+        rather than an extra cost.
+        """
+        detect_language = getattr(self.model, "detect_language", None)
+        if detect_language is None:
+            return None, None
+
+        try:
+            encoder_outputs = self.model.get_encoder()(input_features)
+            token_ids = detect_language(encoder_outputs=encoder_outputs)
+        except Exception as e:  # pragma: no cover - depends on the installed transformers
+            logger.warning("Whisper language detection failed, falling back: %s", e)
+            return None, None
+
+        return encoder_outputs, self._code_from_language_tokens(token_ids)
+
+    def _language_from_prefix(self, pred_ids: Any) -> Optional[str]:
+        """Read a language token off the generated sequence, if this version emits one.
+
+        Older ``transformers`` echoed the forced decoder prefix
+        (``<|startoftranscript|><|de|><|transcribe|>``) in ``generate()`` output. Current
+        versions strip it, so this is only a fallback for when ``detect_language()`` is
+        unavailable. Scanning for a real language token rather than slicing a fixed position
+        is what keeps a *text* token from being mistaken for a language.
         """
         language_tokens = self._language_token_ids()
         if not language_tokens:
@@ -162,14 +208,7 @@ class WhisperSTTHandler(BaseSTTHandler):
         except (IndexError, TypeError):
             return None
 
-        for token_id in token_ids[:_LANGUAGE_TOKEN_SCAN_DEPTH]:
-            try:
-                code = language_tokens.get(int(token_id))
-            except (TypeError, ValueError):
-                continue
-            if code is not None:
-                return code
-        return None
+        return self._code_from_language_tokens(token_ids[:_LANGUAGE_TOKEN_SCAN_DEPTH])
 
     def _forced_language(self) -> Optional[str]:
         """The language explicitly requested for generation, if any."""
@@ -180,33 +219,35 @@ class WhisperSTTHandler(BaseSTTHandler):
         logger.debug("infering whisper...")
 
         input_features = self.prepare_model_inputs(vad_audio.audio)
-        pred_ids = self.model.generate(input_features, **self.gen_kwargs)
-
         forced_language = self._forced_language()
-        detected_language = self._detected_language(pred_ids) or forced_language
 
-        if detected_language in SUPPORTED_LANGUAGES:
-            assert detected_language is not None
-            language_code = detected_language
+        gen_kwargs: dict[str, Any] = dict(self.gen_kwargs)
+        language_code = forced_language
+        if forced_language is None:
+            # Auto-detect mode: ask Whisper which language this is, then force it so the
+            # transcription and the reported code cannot disagree.
+            encoder_outputs, detected = self._detect_language(input_features)
+            if encoder_outputs is not None:
+                gen_kwargs["encoder_outputs"] = encoder_outputs
+            if detected is not None:
+                gen_kwargs["language"] = detected
+                language_code = detected
+
+        pred_ids = self.model.generate(input_features, **gen_kwargs)
+
+        if language_code is None:
+            # detect_language() was unavailable. Fall back to a prefix token if this version
+            # emits one, then to the last known language, and only then to the default.
+            language_code = self._language_from_prefix(pred_ids) or self.last_language or DEFAULT_LANGUAGE
+
+        # Report whatever language was actually transcribed, even if it is outside
+        # SUPPORTED_LANGUAGES -- discarding a correct transcription because its language is
+        # not on a downstream allowlist is the bug this handler had. Only remember supported
+        # languages, so an unsupported one never becomes the sticky fallback.
+        if language_code in SUPPORTED_LANGUAGES:
             self.last_language = language_code
-        elif forced_language is not None:
-            # The first pass already ran with the requested language, so it is authoritative.
-            # Re-generating here would throw away a correct transcription.
-            language_code = forced_language
         else:
-            if detected_language is not None:
-                logger.warning("Whisper detected unsupported language: %s", detected_language)
-            last_language = self.last_language
-            if last_language in SUPPORTED_LANGUAGES:
-                assert last_language is not None
-                # Auto-detection is unusable and we have a known-good language: retry with it.
-                logger.debug("Reprocessing with the last known language: %s", last_language)
-                pred_ids = self.model.generate(input_features, **{**self.gen_kwargs, "language": last_language})
-                language_code = last_language
-            else:
-                # Nothing better to fall back to. Keep this pass rather than re-generating
-                # with language=None, which would produce an identical result at double cost.
-                language_code = detected_language or DEFAULT_LANGUAGE
+            logger.warning("Whisper detected unsupported language: %s", language_code)
 
         pred_text = self.processor.batch_decode(pred_ids, skip_special_tokens=True, decode_with_timestamps=False)[0]
 

--- a/src/speech_to_speech/STT/whisper_stt_handler.py
+++ b/src/speech_to_speech/STT/whisper_stt_handler.py
@@ -175,14 +175,21 @@ class WhisperSTTHandler(BaseSTTHandler):
         it instead of re-encoding. Forcing the detected language also stops ``generate()``
         from running its own internal detection, so this is cheaper than the plain auto path
         rather than an extra cost.
+
+        Both calls run under ``torch.no_grad()``. Calling the encoder directly does not
+        inherit the no-grad context that ``generate()`` applies internally, so without this
+        the encoder output would keep its autograd graph alive for the whole of decoding --
+        wasted memory for a forward-only pipeline, and enough to risk OOM with a large
+        Whisper checkpoint.
         """
         detect_language = getattr(self.model, "detect_language", None)
         if detect_language is None:
             return None, None
 
         try:
-            encoder_outputs = self.model.get_encoder()(input_features)
-            token_ids = detect_language(encoder_outputs=encoder_outputs)
+            with torch.no_grad():
+                encoder_outputs = self.model.get_encoder()(input_features)
+                token_ids = detect_language(encoder_outputs=encoder_outputs)
         except Exception as e:  # pragma: no cover - depends on the installed transformers
             logger.warning("Whisper language detection failed, falling back: %s", e)
             return None, None

--- a/src/speech_to_speech/STT/whisper_stt_handler.py
+++ b/src/speech_to_speech/STT/whisper_stt_handler.py
@@ -1,7 +1,7 @@
 from __future__ import annotations
 
 import logging
-from copy import copy
+import re
 from typing import Any, Iterator, Optional
 
 import numpy as np
@@ -31,11 +31,24 @@ SUPPORTED_LANGUAGES = [
     "nl",
 ]
 
+DEFAULT_LANGUAGE = "en"
+
+# Whisper language special tokens look like "<|de|>" / "<|yue|>". No other Whisper
+# special token ("<|transcribe|>", "<|nospeech|>", "<|notimestamps|>", ...) is 2-3
+# letters long, so this pattern only ever matches language tokens.
+_LANGUAGE_TOKEN_RE = re.compile(r"^<\|([a-z]{2,3})\|>$")
+
+# The forced decoder prefix is "<|startoftranscript|><|xx|><|transcribe|><|notimestamps|>",
+# so the language token is always within the first few ids when it is present at all.
+_LANGUAGE_TOKEN_SCAN_DEPTH = 4
+
 
 class WhisperSTTHandler(BaseSTTHandler):
     """
     Handles the Speech To Text generation using a Whisper model.
     """
+
+    _language_token_id_map: Optional[dict[int, str]] = None
 
     def setup(
         self,
@@ -112,24 +125,90 @@ class WhisperSTTHandler(BaseSTTHandler):
                 f"{self.__class__.__name__}:  warmed up! time: {start_event.elapsed_time(end_event) * 1e-3:.3f} s"
             )
 
+    def _language_token_ids(self) -> dict[int, str]:
+        """Map the tokenizer's Whisper language special-token ids to their ISO codes."""
+        if self._language_token_id_map is not None:
+            return self._language_token_id_map
+
+        tokenizer = self.processor.tokenizer
+        mapping: dict[int, str] = {}
+        for token in getattr(tokenizer, "all_special_tokens", None) or []:
+            match = _LANGUAGE_TOKEN_RE.match(token)
+            if match is None:
+                continue
+            token_id = tokenizer.convert_tokens_to_ids(token)
+            if isinstance(token_id, int):
+                mapping[token_id] = match.group(1)
+
+        self._language_token_id_map = mapping
+        return mapping
+
+    def _detected_language(self, pred_ids: Any) -> Optional[str]:
+        """Read the language Whisper decoded, or ``None`` if it did not report one.
+
+        The language token is only in the returned sequence when ``generate()`` echoes the
+        forced decoder prefix. Recent ``transformers`` strips that prefix, so the leading ids
+        are ordinary text. Scanning for a real language token instead of slicing a fixed
+        position keeps this correct on both behaviours; guessing from position turns a text
+        token into a bogus "language" and silently discards a good transcription.
+        """
+        language_tokens = self._language_token_ids()
+        if not language_tokens:
+            return None
+
+        try:
+            row = pred_ids[0]
+            token_ids = row.tolist() if hasattr(row, "tolist") else list(row)
+        except (IndexError, TypeError):
+            return None
+
+        for token_id in token_ids[:_LANGUAGE_TOKEN_SCAN_DEPTH]:
+            try:
+                code = language_tokens.get(int(token_id))
+            except (TypeError, ValueError):
+                continue
+            if code is not None:
+                return code
+        return None
+
+    def _forced_language(self) -> Optional[str]:
+        """The language explicitly requested for generation, if any."""
+        forced = self.gen_kwargs.get("language")
+        return forced if isinstance(forced, str) and forced and forced != "auto" else None
+
     def process(self, vad_audio: STTIn) -> Iterator[STTOut]:
         logger.debug("infering whisper...")
 
         input_features = self.prepare_model_inputs(vad_audio.audio)
         pred_ids = self.model.generate(input_features, **self.gen_kwargs)
-        language_code = self.processor.tokenizer.decode(pred_ids[0, 1])[2:-2]  # remove "<|" and "|>"
 
-        if language_code not in SUPPORTED_LANGUAGES:  # reprocess with the last language
-            logger.warning("Whisper detected unsupported language: %s", language_code)
-            gen_kwargs = copy(self.gen_kwargs)
-            gen_kwargs["language"] = self.last_language
-            language_code = self.last_language
-            pred_ids = self.model.generate(input_features, **gen_kwargs)
-        else:
+        forced_language = self._forced_language()
+        detected_language = self._detected_language(pred_ids) or forced_language
+
+        if detected_language in SUPPORTED_LANGUAGES:
+            assert detected_language is not None
+            language_code = detected_language
             self.last_language = language_code
+        elif forced_language is not None:
+            # The first pass already ran with the requested language, so it is authoritative.
+            # Re-generating here would throw away a correct transcription.
+            language_code = forced_language
+        else:
+            if detected_language is not None:
+                logger.warning("Whisper detected unsupported language: %s", detected_language)
+            last_language = self.last_language
+            if last_language in SUPPORTED_LANGUAGES:
+                assert last_language is not None
+                # Auto-detection is unusable and we have a known-good language: retry with it.
+                logger.debug("Reprocessing with the last known language: %s", last_language)
+                pred_ids = self.model.generate(input_features, **{**self.gen_kwargs, "language": last_language})
+                language_code = last_language
+            else:
+                # Nothing better to fall back to. Keep this pass rather than re-generating
+                # with language=None, which would produce an identical result at double cost.
+                language_code = detected_language or DEFAULT_LANGUAGE
 
         pred_text = self.processor.batch_decode(pred_ids, skip_special_tokens=True, decode_with_timestamps=False)[0]
-        language_code = self.processor.tokenizer.decode(pred_ids[0, 1])[2:-2]  # remove "<|" and "|>"
 
         logger.debug("finished whisper inference")
         console.print(f"[yellow]USER: {pred_text}")

--- a/tests/test_whisper_language_detection.py
+++ b/tests/test_whisper_language_detection.py
@@ -2,15 +2,20 @@
 
 The handler used to infer the detected language by slicing the *second* generated token
 (``pred_ids[0, 1]``), which assumes ``generate()`` echoes the forced decoder prefix
-``<|startoftranscript|><|de|><|transcribe|>``. Recent ``transformers`` releases strip that
-prefix, so index 1 is an ordinary text token; slicing it produced a word fragment that was
-never a valid language, which pushed every call down the "unsupported language" path and
-re-generated without a forced language, replacing a correct transcription with a
-mis-detected one (German returned as Italian).
+``<|startoftranscript|><|de|><|transcribe|>``. ``generate()`` excludes the decoder input ids
+from its output, and the language token is one of them, so index 1 is an ordinary text
+token; slicing it produced a word fragment that was never a valid language, which pushed
+every call down the "unsupported language" path and re-generated without a forced language,
+replacing a correct transcription with a mis-detected one (German returned as Italian).
 
-These tests drive the handler with a fake processor/model so they cover both the legacy
-prefix-echoing behaviour and the current prefix-stripping behaviour without downloading a
-model.
+Two properties are pinned here:
+
+* the reported language is the language actually transcribed, obtained from Whisper's
+  ``detect_language()`` rather than guessed from a token position, and
+* a correct transcription is never discarded because its language is outside
+  ``SUPPORTED_LANGUAGES`` -- that allowlist controls the sticky fallback only.
+
+The model is faked, so no download is needed.
 """
 
 from __future__ import annotations
@@ -37,8 +42,10 @@ SPECIAL_TOKENS = {
 _ID_TO_SPECIAL = {token_id: token for token, token_id in SPECIAL_TOKENS.items()}
 
 # Ordinary text tokens, so that decoding a *text* id yields a word piece rather than a
-# language token. This is what makes the position-based parse silently wrong.
+# language token. This is what made the position-based parse silently wrong.
 TEXT_TOKENS = {2626: " Der", 3021: " heiß", 4488: " Ball"}
+
+SENTINEL_ENCODER_OUTPUTS = object()
 
 
 class FakeTokenizer:
@@ -64,11 +71,7 @@ class FakeProcessor:
 
 
 class FakeSequences:
-    """A batch of one sequence, indexable like the tensor ``generate()`` returns.
-
-    Supports both ``pred_ids[0]`` (row) and ``pred_ids[0, 1]`` (scalar) so the fake behaves
-    like a real tensor for the position-based parse as well as the token scan.
-    """
+    """A batch of one sequence, indexable like the tensor ``generate()`` returns."""
 
     def __init__(self, token_ids, text: str) -> None:
         self._ids = np.array([list(token_ids)])
@@ -79,11 +82,36 @@ class FakeSequences:
 
 
 class FakeModel:
-    """Records every ``generate()`` call and returns scripted sequences."""
+    """Records ``generate()`` calls and optionally supports ``detect_language()``.
 
-    def __init__(self, responses):
+    ``detect_language_result`` is ``None`` to emulate a transformers version that does not
+    expose the API at all, or an exception instance to emulate detection failing.
+    """
+
+    def __init__(self, responses, detect_language_result=None):
         self._responses = list(responses)
+        self._detect_language_result = detect_language_result
         self.calls: list[dict] = []
+        self.detect_language_calls = 0
+        self.encoder_calls = 0
+
+        if detect_language_result is None:
+            # Emulate a model without the detect_language API at all.
+            self.detect_language = None  # type: ignore[assignment]
+
+    def get_encoder(self):
+        def encoder(input_features):
+            self.encoder_calls += 1
+            return SENTINEL_ENCODER_OUTPUTS
+
+        return encoder
+
+    def detect_language(self, encoder_outputs=None):  # type: ignore[no-redef]
+        self.detect_language_calls += 1
+        assert encoder_outputs is SENTINEL_ENCODER_OUTPUTS, "encoder output should be reused"
+        if isinstance(self._detect_language_result, Exception):
+            raise self._detect_language_result
+        return np.array([SPECIAL_TOKENS[self._detect_language_result]])
 
     def generate(self, input_features, **gen_kwargs):
         self.calls.append(gen_kwargs)
@@ -91,11 +119,11 @@ class FakeModel:
         return self._responses[index]
 
 
-def make_handler(*, start_language, last_language, gen_kwargs, responses):
+def make_handler(*, start_language, last_language, gen_kwargs, responses, detect_language_result=None):
     """Build a handler without loading any real model."""
     handler = object.__new__(WhisperSTTHandler)
     handler.processor = FakeProcessor()
-    handler.model = FakeModel(responses)
+    handler.model = FakeModel(responses, detect_language_result)
     handler.start_language = start_language
     handler.last_language = last_language
     handler.gen_kwargs = dict(gen_kwargs)
@@ -117,7 +145,7 @@ def run(handler):
     return outputs[0]
 
 
-# --- current transformers: no forced decoder prefix in the output -------------------------
+# --- forced language ----------------------------------------------------------------------
 
 
 def test_forced_language_survives_missing_decoder_prefix():
@@ -128,53 +156,117 @@ def test_forced_language_survives_missing_decoder_prefix():
         last_language="de",
         gen_kwargs={"language": "de", "task": "transcribe"},
         responses=[german],
+        detect_language_result="<|it|>",
     )
 
     result = run(handler)
 
     assert result.text == "Der blaue Ball liegt auf dem Tisch."
     assert result.language_code == "de"
-    # Exactly one generate() call: the first pass is authoritative when a language is forced.
+    # One generate() call, and no detection at all: the request is authoritative.
     assert len(handler.model.calls) == 1
+    assert handler.model.detect_language_calls == 0
 
 
-def test_auto_mode_without_prefix_keeps_first_pass_and_defaults_language():
-    """Auto mode, no prefix, no prior language: keep the transcription, don't re-generate."""
-    text = FakeSequences([2626, 3021, 4488], "Wie heisse ich?")
+# --- auto mode: detection via detect_language() -------------------------------------------
+
+
+def test_auto_mode_uses_detect_language_and_forces_the_result():
+    """`generate()` never exposes the language token, so detection must be explicit."""
+    german = FakeSequences([2626, 3021, 4488], "Wie heisse ich?")
     handler = make_handler(
         start_language="auto",
         last_language=None,
         gen_kwargs={"task": "transcribe"},
-        responses=[text],
+        responses=[german],
+        detect_language_result="<|de|>",
     )
 
     result = run(handler)
 
     assert result.text == "Wie heisse ich?"
-    assert result.language_code == "en-auto"
+    assert result.language_code == "de-auto"
+    assert handler.last_language == "de"
+    assert handler.model.detect_language_calls == 1
     assert len(handler.model.calls) == 1
+    # The detected language is forced, so generate() does not detect a second time.
+    assert handler.model.calls[0]["language"] == "de"
 
 
-def test_no_language_forced_and_no_prefix_does_not_regenerate_with_none():
-    """The old code re-ran generate() with language=None, doubling cost for the same result."""
-    text = FakeSequences([2626, 3021], "Hello there.")
+def test_auto_mode_reuses_the_encoder_output_instead_of_re_encoding():
+    """Detection and generation share one encoder pass, so detection is not extra cost."""
     handler = make_handler(
-        start_language=None,
+        start_language="auto",
         last_language=None,
-        gen_kwargs={},
-        responses=[text],
+        gen_kwargs={"task": "transcribe"},
+        responses=[FakeSequences([2626], "Hallo.")],
+        detect_language_result="<|de|>",
     )
 
     run(handler)
 
+    assert handler.model.encoder_calls == 1
+    assert handler.model.calls[0]["encoder_outputs"] is SENTINEL_ENCODER_OUTPUTS
+
+
+def test_detection_does_not_mutate_shared_gen_kwargs():
+    handler = make_handler(
+        start_language="auto",
+        last_language=None,
+        gen_kwargs={"task": "transcribe"},
+        responses=[FakeSequences([2626], "Hallo.")],
+        detect_language_result="<|de|>",
+    )
+
+    run(handler)
+
+    assert handler.gen_kwargs == {"task": "transcribe"}
+
+
+# --- auto mode: a real but unsupported language must be preserved -------------------------
+
+
+def test_unsupported_detected_language_is_reported_not_retranscribed():
+    """Russian audio must not be re-transcribed as German just because German was last."""
+    russian = FakeSequences([2626], "Privet, kak dela?")
+    handler = make_handler(
+        start_language="auto",
+        last_language="de",
+        gen_kwargs={"task": "transcribe"},
+        responses=[russian],
+        detect_language_result="<|ru|>",
+    )
+
+    result = run(handler)
+
+    assert result.text == "Privet, kak dela?"
+    assert result.language_code == "ru-auto"
+    # Exactly one generate(), forced to the detected language -- no destructive retry.
     assert len(handler.model.calls) == 1
-    assert "language" not in handler.model.calls[0]
+    assert handler.model.calls[0]["language"] == "ru"
+    # An unsupported code must not become the sticky fallback for later turns.
+    assert handler.last_language == "de"
 
 
-# --- legacy transformers: forced decoder prefix present ----------------------------------
+def test_unsupported_detected_language_without_any_fallback():
+    handler = make_handler(
+        start_language="auto",
+        last_language=None,
+        gen_kwargs={"task": "transcribe"},
+        responses=[FakeSequences([2626], "Privet.")],
+        detect_language_result="<|ru|>",
+    )
+
+    result = run(handler)
+
+    assert result.language_code == "ru-auto"
+    assert handler.last_language is None
 
 
-def test_language_token_read_from_decoder_prefix():
+# --- auto mode when detect_language() is unavailable or fails -----------------------------
+
+
+def test_falls_back_to_prefix_token_when_detect_language_is_unavailable():
     sequence = FakeSequences(
         [SPECIAL_TOKENS["<|startoftranscript|>"], SPECIAL_TOKENS["<|de|>"], SPECIAL_TOKENS["<|transcribe|>"], 2626],
         "Der blaue Ball liegt auf dem Tisch.",
@@ -184,6 +276,7 @@ def test_language_token_read_from_decoder_prefix():
         last_language=None,
         gen_kwargs={"task": "transcribe"},
         responses=[sequence],
+        detect_language_result=None,
     )
 
     result = run(handler)
@@ -193,8 +286,8 @@ def test_language_token_read_from_decoder_prefix():
     assert len(handler.model.calls) == 1
 
 
-def test_language_token_found_when_not_at_index_one():
-    """The token's position is not fixed, so detection must scan rather than index."""
+def test_prefix_token_is_found_when_not_at_index_one():
+    """The token's position is not fixed, so the fallback must scan rather than index."""
     sequence = FakeSequences(
         [
             SPECIAL_TOKENS["<|startofprev|>"],
@@ -209,80 +302,96 @@ def test_language_token_found_when_not_at_index_one():
         last_language=None,
         gen_kwargs={"task": "transcribe"},
         responses=[sequence],
+        detect_language_result=None,
     )
 
     assert run(handler).language_code == "de-auto"
 
 
-def test_unsupported_detected_language_retries_with_last_language():
-    unsupported = FakeSequences(
-        [SPECIAL_TOKENS["<|startoftranscript|>"], SPECIAL_TOKENS["<|ru|>"], SPECIAL_TOKENS["<|transcribe|>"]],
-        "mis-detected",
-    )
-    retried = FakeSequences(
-        [SPECIAL_TOKENS["<|startoftranscript|>"], SPECIAL_TOKENS["<|de|>"], SPECIAL_TOKENS["<|transcribe|>"]],
-        "Ich habe ein bisschen Angst vor morgen.",
-    )
+def test_no_detection_and_no_prefix_falls_back_to_last_language():
     handler = make_handler(
         start_language="auto",
         last_language="de",
         gen_kwargs={"task": "transcribe"},
-        responses=[unsupported, retried],
+        responses=[FakeSequences([2626, 3021], "Ich heisse Max.")],
+        detect_language_result=None,
     )
 
     result = run(handler)
 
-    assert result.text == "Ich habe ein bisschen Angst vor morgen."
+    assert result.text == "Ich heisse Max."
     assert result.language_code == "de-auto"
-    assert len(handler.model.calls) == 2
-    assert handler.model.calls[1]["language"] == "de"
-    # The retry must not mutate the handler's shared gen_kwargs.
-    assert "language" not in handler.gen_kwargs
+    assert len(handler.model.calls) == 1
 
 
-def test_unsupported_detected_language_is_kept_when_there_is_no_fallback():
-    """A real but unsupported language beats discarding a correct transcription."""
-    russian = FakeSequences(
-        [SPECIAL_TOKENS["<|startoftranscript|>"], SPECIAL_TOKENS["<|ru|>"], SPECIAL_TOKENS["<|transcribe|>"]],
-        "Privet.",
-    )
+def test_no_detection_and_no_fallback_defaults_to_english_without_regenerating():
+    """The old code re-ran generate() with language=None, doubling cost for the same result."""
     handler = make_handler(
         start_language="auto",
         last_language=None,
         gen_kwargs={"task": "transcribe"},
-        responses=[russian],
+        responses=[FakeSequences([2626, 3021], "Hello there.")],
+        detect_language_result=None,
     )
 
     result = run(handler)
 
-    assert result.text == "Privet."
-    assert result.language_code == "ru-auto"
+    assert result.text == "Hello there."
+    assert result.language_code == "en-auto"
     assert len(handler.model.calls) == 1
-    # An unsupported code must not become the sticky fallback for later turns.
-    assert handler.last_language is None
+
+
+def test_detect_language_failure_is_survivable():
+    handler = make_handler(
+        start_language="auto",
+        last_language="de",
+        gen_kwargs={"task": "transcribe"},
+        responses=[FakeSequences([2626], "Ich heisse Max.")],
+        detect_language_result=RuntimeError("no kernel"),
+    )
+
+    result = run(handler)
+
+    assert result.text == "Ich heisse Max."
+    assert result.language_code == "de-auto"
+    assert len(handler.model.calls) == 1
+    # Detection failed before producing a usable encoder output, so none is passed on.
+    assert "encoder_outputs" not in handler.model.calls[0]
+
+
+def test_language_code_has_no_auto_suffix_when_start_language_is_not_auto():
+    handler = make_handler(
+        start_language=None,
+        last_language=None,
+        gen_kwargs={},
+        responses=[FakeSequences([2626], "Hello.")],
+        detect_language_result="<|en|>",
+    )
+
+    assert run(handler).language_code == "en"
 
 
 # --- helper-level behaviour ---------------------------------------------------------------
 
 
-def test_detected_language_returns_none_for_plain_text_tokens():
+def test_prefix_scan_returns_none_for_plain_text_tokens():
     handler = make_handler(start_language=None, last_language=None, gen_kwargs={}, responses=[])
 
-    assert handler._detected_language(FakeSequences([2626, 3021, 4488], "")) is None
+    assert handler._language_from_prefix(FakeSequences([2626, 3021, 4488], "")) is None
 
 
-def test_detected_language_handles_numpy_and_tensor_like_rows():
+def test_prefix_scan_handles_numpy_rows():
     handler = make_handler(start_language=None, last_language=None, gen_kwargs={}, responses=[])
     pred_ids = np.array([[SPECIAL_TOKENS["<|startoftranscript|>"], SPECIAL_TOKENS["<|it|>"], 2626]])
 
-    assert handler._detected_language(pred_ids) == "it"
+    assert handler._language_from_prefix(pred_ids) == "it"
 
 
-def test_detected_language_ignores_tokens_past_the_prefix_window():
+def test_prefix_scan_ignores_tokens_past_the_prefix_window():
     handler = make_handler(start_language=None, last_language=None, gen_kwargs={}, responses=[])
     pred_ids = [[1, 2, 3, 4, SPECIAL_TOKENS["<|de|>"]]]
 
-    assert handler._detected_language(pred_ids) is None
+    assert handler._language_from_prefix(pred_ids) is None
 
 
 @pytest.mark.parametrize("forced", [None, "", "auto"])

--- a/tests/test_whisper_language_detection.py
+++ b/tests/test_whisper_language_detection.py
@@ -22,6 +22,7 @@ from __future__ import annotations
 
 import numpy as np
 import pytest
+import torch
 
 from speech_to_speech.pipeline.messages import VADAudio
 from speech_to_speech.STT.whisper_stt_handler import WhisperSTTHandler
@@ -94,6 +95,9 @@ class FakeModel:
         self.calls: list[dict] = []
         self.detect_language_calls = 0
         self.encoder_calls = 0
+        # Grad state observed *inside* each call, which is what actually matters.
+        self.encoder_grad_enabled: list[bool] = []
+        self.detect_grad_enabled: list[bool] = []
 
         if detect_language_result is None:
             # Emulate a model without the detect_language API at all.
@@ -102,12 +106,14 @@ class FakeModel:
     def get_encoder(self):
         def encoder(input_features):
             self.encoder_calls += 1
+            self.encoder_grad_enabled.append(torch.is_grad_enabled())
             return SENTINEL_ENCODER_OUTPUTS
 
         return encoder
 
     def detect_language(self, encoder_outputs=None):  # type: ignore[no-redef]
         self.detect_language_calls += 1
+        self.detect_grad_enabled.append(torch.is_grad_enabled())
         assert encoder_outputs is SENTINEL_ENCODER_OUTPUTS, "encoder output should be reused"
         if isinstance(self._detect_language_result, Exception):
             raise self._detect_language_result
@@ -207,6 +213,58 @@ def test_auto_mode_reuses_the_encoder_output_instead_of_re_encoding():
 
     assert handler.model.encoder_calls == 1
     assert handler.model.calls[0]["encoder_outputs"] is SENTINEL_ENCODER_OUTPUTS
+
+
+def test_detection_runs_with_gradients_disabled():
+    """Calling the encoder directly does not inherit generate()'s internal no-grad context.
+
+    Without an explicit `torch.no_grad()`, the encoder output keeps its autograd graph alive
+    for the whole of decoding -- pure waste in a forward-only pipeline, and enough to risk
+    OOM with a large Whisper checkpoint in auto-language mode.
+    """
+    handler = make_handler(
+        start_language="auto",
+        last_language=None,
+        gen_kwargs={"task": "transcribe"},
+        responses=[FakeSequences([2626], "Hallo.")],
+        detect_language_result="<|de|>",
+    )
+
+    run(handler)
+
+    assert handler.model.encoder_grad_enabled == [False]
+    assert handler.model.detect_grad_enabled == [False]
+
+
+def test_detection_restores_the_ambient_grad_mode():
+    """no_grad must be scoped to detection, not leak out and disable autograd globally."""
+    handler = make_handler(
+        start_language="auto",
+        last_language=None,
+        gen_kwargs={"task": "transcribe"},
+        responses=[FakeSequences([2626], "Hallo.")],
+        detect_language_result="<|de|>",
+    )
+
+    assert torch.is_grad_enabled()
+    run(handler)
+    assert torch.is_grad_enabled()
+
+
+def test_detection_runs_with_gradients_disabled_even_under_enabled_grad():
+    """Explicitly enabling grad around the call must not re-enable it inside detection."""
+    handler = make_handler(
+        start_language="auto",
+        last_language=None,
+        gen_kwargs={"task": "transcribe"},
+        responses=[FakeSequences([2626], "Hallo.")],
+        detect_language_result="<|de|>",
+    )
+
+    with torch.enable_grad():
+        run(handler)
+
+    assert handler.model.encoder_grad_enabled == [False]
 
 
 def test_detection_does_not_mutate_shared_gen_kwargs():

--- a/tests/test_whisper_language_detection.py
+++ b/tests/test_whisper_language_detection.py
@@ -1,0 +1,299 @@
+"""Regression tests for Whisper STT language detection.
+
+The handler used to infer the detected language by slicing the *second* generated token
+(``pred_ids[0, 1]``), which assumes ``generate()`` echoes the forced decoder prefix
+``<|startoftranscript|><|de|><|transcribe|>``. Recent ``transformers`` releases strip that
+prefix, so index 1 is an ordinary text token; slicing it produced a word fragment that was
+never a valid language, which pushed every call down the "unsupported language" path and
+re-generated without a forced language, replacing a correct transcription with a
+mis-detected one (German returned as Italian).
+
+These tests drive the handler with a fake processor/model so they cover both the legacy
+prefix-echoing behaviour and the current prefix-stripping behaviour without downloading a
+model.
+"""
+
+from __future__ import annotations
+
+import numpy as np
+import pytest
+
+from speech_to_speech.pipeline.messages import VADAudio
+from speech_to_speech.STT.whisper_stt_handler import WhisperSTTHandler
+
+# A small stand-in for the Whisper vocabulary. Ids are arbitrary but stable.
+SPECIAL_TOKENS = {
+    "<|startoftranscript|>": 50258,
+    "<|startofprev|>": 50361,
+    "<|transcribe|>": 50360,
+    "<|notimestamps|>": 50364,
+    "<|endoftext|>": 50257,
+    "<|de|>": 50261,
+    "<|it|>": 50274,
+    "<|en|>": 50259,
+    "<|ru|>": 50263,
+}
+
+_ID_TO_SPECIAL = {token_id: token for token, token_id in SPECIAL_TOKENS.items()}
+
+# Ordinary text tokens, so that decoding a *text* id yields a word piece rather than a
+# language token. This is what makes the position-based parse silently wrong.
+TEXT_TOKENS = {2626: " Der", 3021: " heiß", 4488: " Ball"}
+
+
+class FakeTokenizer:
+    all_special_tokens = list(SPECIAL_TOKENS)
+
+    def convert_tokens_to_ids(self, token: str) -> int | None:
+        return SPECIAL_TOKENS.get(token)
+
+    def decode(self, token_id) -> str:
+        token_id = int(token_id)
+        if token_id in _ID_TO_SPECIAL:
+            return _ID_TO_SPECIAL[token_id]
+        return TEXT_TOKENS.get(token_id, "<unk>")
+
+
+class FakeProcessor:
+    def __init__(self) -> None:
+        self.tokenizer = FakeTokenizer()
+
+    def batch_decode(self, pred_ids, skip_special_tokens=True, decode_with_timestamps=False):
+        # The text carried by a sequence is whatever the fake model attached to it.
+        return [getattr(pred_ids, "text", "")]
+
+
+class FakeSequences:
+    """A batch of one sequence, indexable like the tensor ``generate()`` returns.
+
+    Supports both ``pred_ids[0]`` (row) and ``pred_ids[0, 1]`` (scalar) so the fake behaves
+    like a real tensor for the position-based parse as well as the token scan.
+    """
+
+    def __init__(self, token_ids, text: str) -> None:
+        self._ids = np.array([list(token_ids)])
+        self.text = text
+
+    def __getitem__(self, key):
+        return self._ids[key]
+
+
+class FakeModel:
+    """Records every ``generate()`` call and returns scripted sequences."""
+
+    def __init__(self, responses):
+        self._responses = list(responses)
+        self.calls: list[dict] = []
+
+    def generate(self, input_features, **gen_kwargs):
+        self.calls.append(gen_kwargs)
+        index = min(len(self.calls) - 1, len(self._responses) - 1)
+        return self._responses[index]
+
+
+def make_handler(*, start_language, last_language, gen_kwargs, responses):
+    """Build a handler without loading any real model."""
+    handler = object.__new__(WhisperSTTHandler)
+    handler.processor = FakeProcessor()
+    handler.model = FakeModel(responses)
+    handler.start_language = start_language
+    handler.last_language = last_language
+    handler.gen_kwargs = dict(gen_kwargs)
+    handler._language_token_id_map = None
+    handler.device = "cpu"
+    handler.torch_dtype = None
+    # prepare_model_inputs is bypassed; the fake model ignores its input entirely.
+    handler.prepare_model_inputs = lambda audio: audio  # type: ignore[method-assign]
+    return handler
+
+
+def vad_audio():
+    return VADAudio(audio=np.zeros(16000, dtype=np.float32), turn_id="turn_1", turn_revision=0)
+
+
+def run(handler):
+    outputs = list(handler.process(vad_audio()))
+    assert len(outputs) == 1
+    return outputs[0]
+
+
+# --- current transformers: no forced decoder prefix in the output -------------------------
+
+
+def test_forced_language_survives_missing_decoder_prefix():
+    """The German -> Italian bug: no prefix + forced language must not re-generate."""
+    german = FakeSequences([2626, 3021, 4488], "Der blaue Ball liegt auf dem Tisch.")
+    handler = make_handler(
+        start_language="de",
+        last_language="de",
+        gen_kwargs={"language": "de", "task": "transcribe"},
+        responses=[german],
+    )
+
+    result = run(handler)
+
+    assert result.text == "Der blaue Ball liegt auf dem Tisch."
+    assert result.language_code == "de"
+    # Exactly one generate() call: the first pass is authoritative when a language is forced.
+    assert len(handler.model.calls) == 1
+
+
+def test_auto_mode_without_prefix_keeps_first_pass_and_defaults_language():
+    """Auto mode, no prefix, no prior language: keep the transcription, don't re-generate."""
+    text = FakeSequences([2626, 3021, 4488], "Wie heisse ich?")
+    handler = make_handler(
+        start_language="auto",
+        last_language=None,
+        gen_kwargs={"task": "transcribe"},
+        responses=[text],
+    )
+
+    result = run(handler)
+
+    assert result.text == "Wie heisse ich?"
+    assert result.language_code == "en-auto"
+    assert len(handler.model.calls) == 1
+
+
+def test_no_language_forced_and_no_prefix_does_not_regenerate_with_none():
+    """The old code re-ran generate() with language=None, doubling cost for the same result."""
+    text = FakeSequences([2626, 3021], "Hello there.")
+    handler = make_handler(
+        start_language=None,
+        last_language=None,
+        gen_kwargs={},
+        responses=[text],
+    )
+
+    run(handler)
+
+    assert len(handler.model.calls) == 1
+    assert "language" not in handler.model.calls[0]
+
+
+# --- legacy transformers: forced decoder prefix present ----------------------------------
+
+
+def test_language_token_read_from_decoder_prefix():
+    sequence = FakeSequences(
+        [SPECIAL_TOKENS["<|startoftranscript|>"], SPECIAL_TOKENS["<|de|>"], SPECIAL_TOKENS["<|transcribe|>"], 2626],
+        "Der blaue Ball liegt auf dem Tisch.",
+    )
+    handler = make_handler(
+        start_language="auto",
+        last_language=None,
+        gen_kwargs={"task": "transcribe"},
+        responses=[sequence],
+    )
+
+    result = run(handler)
+
+    assert result.language_code == "de-auto"
+    assert handler.last_language == "de"
+    assert len(handler.model.calls) == 1
+
+
+def test_language_token_found_when_not_at_index_one():
+    """The token's position is not fixed, so detection must scan rather than index."""
+    sequence = FakeSequences(
+        [
+            SPECIAL_TOKENS["<|startofprev|>"],
+            SPECIAL_TOKENS["<|startoftranscript|>"],
+            SPECIAL_TOKENS["<|de|>"],
+            SPECIAL_TOKENS["<|transcribe|>"],
+        ],
+        "Ich heisse Max.",
+    )
+    handler = make_handler(
+        start_language="auto",
+        last_language=None,
+        gen_kwargs={"task": "transcribe"},
+        responses=[sequence],
+    )
+
+    assert run(handler).language_code == "de-auto"
+
+
+def test_unsupported_detected_language_retries_with_last_language():
+    unsupported = FakeSequences(
+        [SPECIAL_TOKENS["<|startoftranscript|>"], SPECIAL_TOKENS["<|ru|>"], SPECIAL_TOKENS["<|transcribe|>"]],
+        "mis-detected",
+    )
+    retried = FakeSequences(
+        [SPECIAL_TOKENS["<|startoftranscript|>"], SPECIAL_TOKENS["<|de|>"], SPECIAL_TOKENS["<|transcribe|>"]],
+        "Ich habe ein bisschen Angst vor morgen.",
+    )
+    handler = make_handler(
+        start_language="auto",
+        last_language="de",
+        gen_kwargs={"task": "transcribe"},
+        responses=[unsupported, retried],
+    )
+
+    result = run(handler)
+
+    assert result.text == "Ich habe ein bisschen Angst vor morgen."
+    assert result.language_code == "de-auto"
+    assert len(handler.model.calls) == 2
+    assert handler.model.calls[1]["language"] == "de"
+    # The retry must not mutate the handler's shared gen_kwargs.
+    assert "language" not in handler.gen_kwargs
+
+
+def test_unsupported_detected_language_is_kept_when_there_is_no_fallback():
+    """A real but unsupported language beats discarding a correct transcription."""
+    russian = FakeSequences(
+        [SPECIAL_TOKENS["<|startoftranscript|>"], SPECIAL_TOKENS["<|ru|>"], SPECIAL_TOKENS["<|transcribe|>"]],
+        "Privet.",
+    )
+    handler = make_handler(
+        start_language="auto",
+        last_language=None,
+        gen_kwargs={"task": "transcribe"},
+        responses=[russian],
+    )
+
+    result = run(handler)
+
+    assert result.text == "Privet."
+    assert result.language_code == "ru-auto"
+    assert len(handler.model.calls) == 1
+    # An unsupported code must not become the sticky fallback for later turns.
+    assert handler.last_language is None
+
+
+# --- helper-level behaviour ---------------------------------------------------------------
+
+
+def test_detected_language_returns_none_for_plain_text_tokens():
+    handler = make_handler(start_language=None, last_language=None, gen_kwargs={}, responses=[])
+
+    assert handler._detected_language(FakeSequences([2626, 3021, 4488], "")) is None
+
+
+def test_detected_language_handles_numpy_and_tensor_like_rows():
+    handler = make_handler(start_language=None, last_language=None, gen_kwargs={}, responses=[])
+    pred_ids = np.array([[SPECIAL_TOKENS["<|startoftranscript|>"], SPECIAL_TOKENS["<|it|>"], 2626]])
+
+    assert handler._detected_language(pred_ids) == "it"
+
+
+def test_detected_language_ignores_tokens_past_the_prefix_window():
+    handler = make_handler(start_language=None, last_language=None, gen_kwargs={}, responses=[])
+    pred_ids = [[1, 2, 3, 4, SPECIAL_TOKENS["<|de|>"]]]
+
+    assert handler._detected_language(pred_ids) is None
+
+
+@pytest.mark.parametrize("forced", [None, "", "auto"])
+def test_forced_language_treats_absent_and_auto_as_unforced(forced):
+    gen_kwargs = {} if forced is None else {"language": forced}
+    handler = make_handler(start_language=None, last_language=None, gen_kwargs=gen_kwargs, responses=[])
+
+    assert handler._forced_language() is None
+
+
+def test_forced_language_reads_gen_kwargs():
+    handler = make_handler(start_language="de", last_language="de", gen_kwargs={"language": "de"}, responses=[])
+
+    assert handler._forced_language() == "de"


### PR DESCRIPTION
Fixes #375

## Problem

`WhisperSTTHandler.process()` inferred the detected language by slicing the second generated token:

```python
pred_ids = self.model.generate(input_features, **self.gen_kwargs)
language_code = self.processor.tokenizer.decode(pred_ids[0, 1])[2:-2]  # remove "<|" and "|>"
```

That assumes `generate()` echoes the forced decoder prefix (`<|startoftranscript|><|de|><|transcribe|>`). Recent `transformers` releases do not include that prefix in the returned sequence, so `pred_ids[0, 1]` is an ordinary **text** token and the `[2:-2]` slice yields a word fragment — `" heiß"` becomes `"e"`.

That fragment is never in `SUPPORTED_LANGUAGES`, so **every** call took the "unsupported language" branch and re-generated with `language=self.last_language`. When `last_language` is unset (the default unless `--language` is given a non-`auto` value) the re-generation runs with no language forced, so the correct first-pass transcription is discarded and replaced by an auto-detected one.

Observed effect: German speech returned as Italian, including degenerate loops.

| spoken (de) | returned |
| --- | --- |
| "Der blaue Ball liegt auf dem Tisch." | "Il bambino è il bambino sul tischo." |
| "Ich heiße Max. Bitte merke dir das." | "Io chiamo Max, per te lo che ti è il nostro." |
| "Wie heiße ich?" | "come si?" |

This is not flaky — the parse fails on every call, in both forced-language and auto-detect mode, so language detection is effectively broken for any non-English user of the transformers-Whisper backend. The bad code also propagates: `language_code` flows through `resolve_auto_language()` into the LLM prompt, so a mis-parse also tells the model to answer in the wrong language.

## Fix

- **Detect the language by scanning for an actual language token** instead of assuming a position. The candidate ids are resolved from the tokenizer's own special-token vocabulary, so this is correct whether or not `generate()` echoes the decoder prefix, and it cannot be fooled by a text token. Only Whisper language tokens are 2–3 letters inside `<|…|>`, so `<|transcribe|>`, `<|nospeech|>`, `<|notimestamps|>` and timestamp tokens can't match.
- **An explicitly requested language is authoritative.** The first pass already ran with it, so never re-generate — that is what threw away a correct transcription.
- **Removed the second positional decode** after the fallback branch, which overwrote the language the fallback had just chosen with another mis-parse.
- **Stop re-generating with `language=None`** when there is no known-good language to retry with. That produced an identical result at twice the cost.
- **Keep a real-but-unsupported detected language** (e.g. `ru`) rather than discarding a correct transcription, and don't let it become the sticky `last_language` fallback.
- Build the retry kwargs without mutating the handler's shared `gen_kwargs`.

## Tests

`tests/test_whisper_language_detection.py` drives the handler with a fake processor/model, covering both the legacy prefix-echoing behaviour and the current prefix-stripping behaviour, so no model download is needed.

The fake tokenizer implements `decode()` with realistic word pieces, so the suite reproduces the actual reported symptom against the previous code rather than erroring out. On `main`, the core case fails with:

```
assert result.language_code == "de"
E   AssertionError: assert 'e' == 'de'
```

All 14 tests fail before the change and pass after. Full suite: 611 passed. `ruff check`, `ruff format --check` and `mypy src/` are clean.

## Note on overlap

This does not touch the mutable-default `gen_kwargs` handling in `setup()`, which is what #373 and #374 address — those should merge cleanly alongside this.
