### PR TITLE
Acquire the global MLX lock in MLXAudioWhisperSTTHandler

### DIFF
--- a/src/speech_to_speech/STT/mlx_audio_whisper_handler.py
+++ b/src/speech_to_speech/STT/mlx_audio_whisper_handler.py
@@ -9,10 +9,13 @@ from rich.console import Console
 from speech_to_speech.pipeline.handler_types import STTIn, STTOut
 from speech_to_speech.pipeline.messages import Transcription
 from speech_to_speech.STT.base_stt_handler import BaseSTTHandler
+from speech_to_speech.utils.mlx_lock import MLXLockContext
 
 logger = logging.getLogger(__name__)
 
 console = Console()
+
+DEFAULT_LANGUAGE = "en"
 
 SUPPORTED_LANGUAGES = [
     "en",
@@ -47,7 +50,9 @@ class MLXAudioWhisperSTTHandler(BaseSTTHandler):
 
         self.model_name = model_name
         self.start_language = language
-        self.last_language = language
+        # "auto" is a request to detect, not a language code, so it must never leak into
+        # last_language -- it would fail every SUPPORTED_LANGUAGES check downstream.
+        self.last_language = language if language != "auto" else None
         self.gen_kwargs = gen_kwargs
 
         # Load the model directly
@@ -90,10 +95,37 @@ class MLXAudioWhisperSTTHandler(BaseSTTHandler):
 
         try:
             # Pre-warm the model by running a transcription
-            _ = self.model.generate(dummy_audio, verbose=False)
+            with MLXLockContext(handler_name=self.__class__.__name__):
+                _ = self.model.generate(dummy_audio, verbose=False)
             logger.info("Model warmed up and ready")
         except Exception as e:
             logger.warning(f"Warmup failed: {e}")
+
+    def _forced_language(self) -> Optional[str]:
+        """The language explicitly requested by the user, if any."""
+        if self.start_language and self.start_language != "auto":
+            return self.start_language
+        return None
+
+    def _resolve_language(self, result: Any) -> str:
+        """Pick the language code to report, updating the sticky fallback on success."""
+        forced = self._forced_language()
+        if forced is not None:
+            # generate() ran with this language, so it is authoritative.
+            self.last_language = forced
+            return forced
+
+        detected = getattr(result, "language", None)
+        if isinstance(detected, str) and detected:
+            if detected in SUPPORTED_LANGUAGES:
+                self.last_language = detected
+                return detected
+            logger.warning("Detected unsupported language: %s", detected)
+
+        last_language = self.last_language
+        if last_language is not None and last_language in SUPPORTED_LANGUAGES:
+            return last_language
+        return DEFAULT_LANGUAGE
 
     def process(self, vad_audio: STTIn) -> Iterator[STTOut]:
         logger.debug("inferring mlx-audio whisper...")
@@ -105,39 +137,26 @@ class MLXAudioWhisperSTTHandler(BaseSTTHandler):
         gen_kwargs = {}
 
         # Add language if specified
-        if self.start_language and self.start_language != "auto":
-            gen_kwargs["language"] = self.start_language
+        forced_language = self._forced_language()
+        if forced_language is not None:
+            gen_kwargs["language"] = forced_language
 
         try:
-            # Generate transcription directly using model.generate
-            result = self.model.generate(audio_input, verbose=False, **gen_kwargs)
+            # MLX models share a single Metal command queue, so concurrent inference from
+            # the STT/LLM/TTS threads aborts the process with
+            # "Completed handler provided after commit call". Every other MLX path in the
+            # pipeline serializes through this lock; this one must too.
+            with MLXLockContext(handler_name=self.__class__.__name__):
+                result = self.model.generate(audio_input, verbose=False, **gen_kwargs)
 
             # Extract text from result
             pred_text = result.text.strip() if hasattr(result, "text") else str(result).strip()
-
-            # Try to detect language from result if available
-            if hasattr(result, "language"):
-                language_code = result.language
-            elif self.start_language and self.start_language != "auto":
-                language_code = self.start_language
-            else:
-                # Default to last known language or English
-                language_code = self.last_language if self.last_language else "en"
-
-            # Validate language code
-            if language_code not in SUPPORTED_LANGUAGES:
-                logger.warning(f"Detected unsupported language: {language_code}")
-                if self.last_language in SUPPORTED_LANGUAGES:
-                    language_code = self.last_language
-                else:
-                    language_code = "en"
-            else:
-                self.last_language = language_code
+            language_code = self._resolve_language(result)
 
         except Exception as e:
             logger.error(f"MLX Audio Whisper inference failed: {e}")
             pred_text = ""
-            language_code = self.last_language if self.last_language else "en"
+            language_code = self.last_language if self.last_language else DEFAULT_LANGUAGE
 
         logger.debug("finished mlx-audio whisper inference")
         console.print(f"[yellow]USER: {pred_text}")

--- a/tests/test_mlx_audio_whisper_handler.py
+++ b/tests/test_mlx_audio_whisper_handler.py
@@ -1,0 +1,248 @@
+"""Tests for MLXAudioWhisperSTTHandler's MLX lock usage and language resolution.
+
+`utils/mlx_lock.py` documents the global lock as mandatory for every MLX handler: MLX
+models share one Metal command queue, so concurrent inference from the STT/LLM/TTS threads
+aborts the process with
+
+    -[_MTLCommandBuffer addCompletedHandler:]:1011: failed assertion
+    `Completed handler provided after commit call'
+
+This handler was the only MLX inference path that did not acquire it. These tests pin the
+lock down (including that it is actually *held* while `generate()` runs, not merely
+imported) and cover the language-resolution edge cases around it. No MLX or mlx-audio
+install is needed -- the model is faked.
+"""
+
+from __future__ import annotations
+
+import sys
+import threading
+import types
+
+import numpy as np
+import pytest
+
+from speech_to_speech.pipeline.messages import VADAudio
+from speech_to_speech.STT.mlx_audio_whisper_handler import MLXAudioWhisperSTTHandler
+from speech_to_speech.utils import mlx_lock
+
+
+class FakeResult:
+    def __init__(self, text: str, language=None) -> None:
+        self.text = text
+        if language is not None:
+            self.language = language
+
+
+class FakeModel:
+    """Records lock ownership at the moment `generate()` is entered."""
+
+    def __init__(self, result) -> None:
+        self.result = result
+        self.calls: list[dict] = []
+        self.lock_held_during_generate: list[bool] = []
+
+    def generate(self, audio, verbose=False, **gen_kwargs):
+        self.calls.append(gen_kwargs)
+        # The global MLX lock is an RLock; a non-blocking acquire from another thread
+        # fails only if this thread's caller already holds it.
+        self.lock_held_during_generate.append(_lock_held_by_other_thread())
+        if isinstance(self.result, Exception):
+            raise self.result
+        return self.result
+
+
+def _lock_held_by_other_thread() -> bool:
+    """True if the global MLX lock is currently held (probed from a separate thread)."""
+    acquired_elsewhere: list[bool] = []
+
+    def probe():
+        got = mlx_lock._mlx_lock.acquire(blocking=False)
+        acquired_elsewhere.append(got)
+        if got:
+            mlx_lock._mlx_lock.release()
+
+    thread = threading.Thread(target=probe)
+    thread.start()
+    thread.join()
+    return not acquired_elsewhere[0]
+
+
+def make_handler(*, start_language, result, last_language=...):
+    handler = object.__new__(MLXAudioWhisperSTTHandler)
+    handler.model_name = "mlx-community/whisper-large-v3-turbo"
+    handler.start_language = start_language
+    handler.last_language = (
+        (start_language if start_language != "auto" else None) if last_language is ... else last_language
+    )
+    handler.gen_kwargs = {}
+    handler.model = FakeModel(result)
+    return handler
+
+
+def vad_audio():
+    return VADAudio(audio=np.zeros(16000, dtype=np.float32), turn_id="turn_1", turn_revision=0)
+
+
+def run(handler):
+    outputs = list(handler.process(vad_audio()))
+    assert len(outputs) == 1
+    return outputs[0]
+
+
+# --- the MLX lock ------------------------------------------------------------------------
+
+
+def test_process_holds_the_global_mlx_lock_during_generate():
+    handler = make_handler(start_language="en", result=FakeResult("Hello.", "en"))
+
+    run(handler)
+
+    assert handler.model.lock_held_during_generate == [True]
+
+
+def test_warmup_holds_the_global_mlx_lock_during_generate():
+    handler = make_handler(start_language="en", result=FakeResult("", "en"))
+
+    handler.warmup()
+
+    assert handler.model.lock_held_during_generate == [True]
+
+
+def test_mlx_lock_is_released_after_process():
+    handler = make_handler(start_language="en", result=FakeResult("Hello.", "en"))
+
+    run(handler)
+
+    assert not _lock_held_by_other_thread()
+
+
+def test_mlx_lock_is_released_when_inference_raises():
+    """A failed transcription must not leave the whole pipeline's MLX lock held."""
+    handler = make_handler(start_language="en", result=RuntimeError("metal boom"))
+
+    result = run(handler)
+
+    assert result.text == ""
+    assert not _lock_held_by_other_thread()
+
+
+def test_mlx_lock_is_released_when_warmup_raises():
+    handler = make_handler(start_language="en", result=RuntimeError("metal boom"))
+
+    handler.warmup()  # warmup swallows failures by design
+
+    assert not _lock_held_by_other_thread()
+
+
+def test_concurrent_process_calls_are_serialized():
+    """Two threads must never be inside generate() at the same time."""
+    overlap_detected = []
+    inside = []
+    inside_lock = threading.Lock()
+    barrier_wait_s = 0.05
+
+    class OverlapDetectingModel:
+        def generate(self, audio, verbose=False, **gen_kwargs):
+            with inside_lock:
+                inside.append(1)
+                overlap_detected.append(len(inside) > 1)
+            # Hold the "GPU" long enough that an unserialized second caller would overlap.
+            threading.Event().wait(barrier_wait_s)
+            with inside_lock:
+                inside.pop()
+            return FakeResult("Hello.", "en")
+
+    handlers = [make_handler(start_language="en", result=None) for _ in range(2)]
+    for handler in handlers:
+        handler.model = OverlapDetectingModel()
+
+    threads = [threading.Thread(target=run, args=(handler,)) for handler in handlers]
+    for thread in threads:
+        thread.start()
+    for thread in threads:
+        thread.join()
+
+    assert overlap_detected == [False, False]
+
+
+# --- language resolution -----------------------------------------------------------------
+
+
+@pytest.mark.parametrize(
+    ("language", "expected_last_language"),
+    [("auto", None), ("de", "de"), (None, None)],
+)
+def test_setup_does_not_store_auto_as_last_language(monkeypatch, language, expected_last_language):
+    """`--language auto` is a request to detect, not a language code. Storing it as
+    `last_language` makes it fail every SUPPORTED_LANGUAGES check downstream."""
+    fake_model = FakeModel(FakeResult("", "en"))
+    fake_model._processor = object()  # skip the WhisperProcessor fallback path
+
+    stt_generate = types.ModuleType("mlx_audio.stt.generate")
+    stt_generate.load_model = lambda model_name: fake_model  # type: ignore[attr-defined]
+    monkeypatch.setitem(sys.modules, "mlx_audio", types.ModuleType("mlx_audio"))
+    monkeypatch.setitem(sys.modules, "mlx_audio.stt", types.ModuleType("mlx_audio.stt"))
+    monkeypatch.setitem(sys.modules, "mlx_audio.stt.generate", stt_generate)
+
+    handler = object.__new__(MLXAudioWhisperSTTHandler)
+    handler.setup(model_name="mlx-community/whisper-large-v3-turbo", language=language)
+
+    assert handler.start_language == language
+    assert handler.last_language == expected_last_language
+    # setup() warms up, and that warmup must hold the lock too.
+    assert fake_model.lock_held_during_generate == [True]
+
+
+def test_auto_language_reports_the_detected_language():
+    handler = make_handler(start_language="auto", result=FakeResult("Hallo.", "de"))
+
+    assert run(handler).language_code == "de-auto"
+    assert handler.last_language == "de"
+
+
+def test_forced_language_is_authoritative_and_passed_to_generate():
+    handler = make_handler(start_language="de", result=FakeResult("Hallo.", "it"))
+
+    result = run(handler)
+
+    assert handler.model.calls == [{"language": "de"}]
+    assert result.language_code == "de"
+
+
+def test_missing_language_attribute_falls_back_without_warning_noise():
+    handler = make_handler(start_language="auto", result=FakeResult("Hello."), last_language="de")
+
+    assert run(handler).language_code == "de-auto"
+
+
+def test_none_language_attribute_is_treated_as_absent(caplog):
+    """`hasattr(result, "language")` was true even when the value was None, so the handler
+    reported `None` as an "unsupported language"."""
+    handler = make_handler(start_language="auto", result=FakeResult("Hello.", None), last_language="de")
+    # FakeResult only sets .language when non-None, so set it explicitly.
+    handler.model.result.language = None
+
+    result = run(handler)
+
+    assert result.language_code == "de-auto"
+    assert "unsupported language: None" not in caplog.text.lower()
+
+
+def test_unsupported_detected_language_falls_back_to_last_language():
+    handler = make_handler(start_language="auto", result=FakeResult("Privet.", "ru"), last_language="de")
+
+    assert run(handler).language_code == "de-auto"
+
+
+def test_unsupported_detected_language_defaults_to_english_without_fallback():
+    handler = make_handler(start_language="auto", result=FakeResult("Privet.", "ru"), last_language=None)
+
+    assert run(handler).language_code == "en-auto"
+
+
+@pytest.mark.parametrize("start_language", ["auto", None, "de"])
+def test_language_code_is_always_a_string(start_language):
+    handler = make_handler(start_language=start_language, result=FakeResult("Hello."), last_language=None)
+
+    assert isinstance(run(handler).language_code, str)


### PR DESCRIPTION
Fixes #377

## Problem

`utils/mlx_lock.py` documents the global lock as mandatory for every MLX handler:

> MLX models (STT, LLM, TTS) cannot be used concurrently from multiple threads on Apple Silicon due to Metal command buffer limitations. This module provides a global lock that all MLX handlers should acquire before using their models.

`STT/mlx_audio_whisper_handler.py` was the only MLX inference path that did not import or acquire it. `parakeet_tdt_handler.py`, `TTS/qwen3_tts_handler.py`, `TTS/kokoro_handler.py` and `LLM/language_model.py` all already honor it.

When Whisper STT inference overlaps Qwen3-TTS generation, both touch the same Metal command buffer and the process aborts:

```
-[_MTLCommandBuffer addCompletedHandler:]:1011: failed assertion `Completed handler provided after commit call'
```

It dies with SIGABRT and **no Python traceback**, so it looks like the server silently disappeared rather than crashed. Barge-in and speculative turn reopens (`VAD: reopened speculative turn …`) make this easy to hit, since they issue an STT request while TTS is still generating.

## Fix

Wrap the `generate()` call in both `warmup()` and `process()` in `MLXLockContext`, so this handler serializes against every other MLX consumer. `MLXLockContext.__exit__` releases on the exception path too, so a failed transcription can no longer strand the lock and wedge the whole pipeline.

While in the same language-resolution block, two related defects in the code the lock now wraps:

- `hasattr(result, "language")` was true even when the value was `None`, so the handler logged `Detected unsupported language: None` and skipped the language the user had explicitly requested. Absent and `None` are now both treated as "no language reported", and an explicitly requested language wins outright since `generate()` already ran with it.
- `setup()` stored `--language auto` verbatim in `last_language`, where it then failed every `SUPPORTED_LANGUAGES` check it was consulted for. It is now normalized to `None`, matching what `WhisperSTTHandler` already does.

## Tests

`tests/test_mlx_audio_whisper_handler.py` fakes the model, so it needs no MLX/mlx-audio install and runs on Linux CI.

The lock tests assert the lock is actually **held** while `generate()` runs — probed with a non-blocking acquire from a second thread — rather than just checking the import. One test drives two handlers concurrently and asserts they are never inside `generate()` at the same time, which is the condition that produced the Metal assertion. Others cover release on the exception path for both `process()` and `warmup()`.

7 of the 18 tests fail against `main`. Full suite: 615 passed. `ruff check`, `ruff format --check` and `mypy src/` are clean.

## Verification on device

Reported in #377 from a 12-turn stress run on macOS 26.5.1 / Apple M5, `mlx` 0.31.1, `mlx-audio` 0.4.2, with `--stt mlx-audio-whisper --tts qwen3`: 12/12 turns completed, no Metal assertions. End-to-end latency (last speech detected → first speech out) unchanged — min 1.16 s, median 1.50 s, max 3.20 s. The lock's own contention logging never crossed its 0.25 s reporting threshold, so serializing STT against TTS cost nothing measurable in that configuration.
