### PR TITLE
fix(stt): serialize MLX Audio Whisper inference

### DIFF
--- a/src/speech_to_speech/STT/mlx_audio_whisper_handler.py
+++ b/src/speech_to_speech/STT/mlx_audio_whisper_handler.py
@@ -9,6 +9,7 @@ from rich.console import Console
 from speech_to_speech.pipeline.handler_types import STTIn, STTOut
 from speech_to_speech.pipeline.messages import Transcription
 from speech_to_speech.STT.base_stt_handler import BaseSTTHandler
+from speech_to_speech.utils.mlx_lock import MLXLockContext
 
 logger = logging.getLogger(__name__)
 
@@ -90,7 +91,8 @@ class MLXAudioWhisperSTTHandler(BaseSTTHandler):
 
         try:
             # Pre-warm the model by running a transcription
-            _ = self.model.generate(dummy_audio, verbose=False)
+            with MLXLockContext(handler_name=self.__class__.__name__):
+                _ = self.model.generate(dummy_audio, verbose=False)
             logger.info("Model warmed up and ready")
         except Exception as e:
             logger.warning(f"Warmup failed: {e}")
@@ -110,7 +112,8 @@ class MLXAudioWhisperSTTHandler(BaseSTTHandler):
 
         try:
             # Generate transcription directly using model.generate
-            result = self.model.generate(audio_input, verbose=False, **gen_kwargs)
+            with MLXLockContext(handler_name=self.__class__.__name__):
+                result = self.model.generate(audio_input, verbose=False, **gen_kwargs)
 
             # Extract text from result
             pred_text = result.text.strip() if hasattr(result, "text") else str(result).strip()

--- a/tests/test_mlx_audio_whisper_handler.py
+++ b/tests/test_mlx_audio_whisper_handler.py
@@ -1,0 +1,80 @@
+from types import SimpleNamespace
+
+import numpy as np
+
+from speech_to_speech.pipeline.messages import Transcription, VADAudio
+from speech_to_speech.STT import mlx_audio_whisper_handler
+from speech_to_speech.STT.mlx_audio_whisper_handler import MLXAudioWhisperSTTHandler
+
+
+class _FakeModel:
+    def __init__(self):
+        self.calls = []
+
+    def generate(self, audio, **kwargs):
+        self.calls.append((audio, kwargs))
+        return SimpleNamespace(text=" hello ", language="de")
+
+
+class _RecordingMLXLock:
+    handler_names = []
+
+    def __init__(self, handler_name):
+        self.handler_name = handler_name
+
+    def __enter__(self):
+        self.handler_names.append(self.handler_name)
+        return True
+
+    def __exit__(self, exc_type, exc_val, exc_tb):
+        return False
+
+
+def _handler():
+    handler = object.__new__(MLXAudioWhisperSTTHandler)
+    handler.model = _FakeModel()
+    handler.start_language = "auto"
+    handler.last_language = None
+    return handler
+
+
+def test_mlx_audio_whisper_warmup_uses_global_mlx_lock(monkeypatch):
+    _RecordingMLXLock.handler_names = []
+    handler = _handler()
+    monkeypatch.setattr(mlx_audio_whisper_handler, "MLXLockContext", _RecordingMLXLock)
+
+    handler.warmup()
+
+    assert _RecordingMLXLock.handler_names == ["MLXAudioWhisperSTTHandler"]
+    assert len(handler.model.calls) == 1
+    assert handler.model.calls[0][1] == {"verbose": False}
+
+
+def test_mlx_audio_whisper_process_uses_global_mlx_lock(monkeypatch):
+    _RecordingMLXLock.handler_names = []
+    handler = _handler()
+    monkeypatch.setattr(mlx_audio_whisper_handler, "MLXLockContext", _RecordingMLXLock)
+    monkeypatch.setattr(mlx_audio_whisper_handler.console, "print", lambda *args, **kwargs: None)
+
+    result = list(
+        handler.process(
+            VADAudio(
+                audio=np.zeros(16000, dtype=np.float32),
+                mode="final",
+                turn_id="turn_1",
+                turn_revision=2,
+                created_at_s=123.0,
+            )
+        )
+    )
+
+    assert _RecordingMLXLock.handler_names == ["MLXAudioWhisperSTTHandler"]
+    assert len(handler.model.calls) == 1
+    assert handler.model.calls[0][1] == {"verbose": False}
+    assert len(result) == 1
+    assert isinstance(result[0], Transcription)
+    assert result[0].text == "hello"
+    assert result[0].language_code == "de-auto"
+    assert result[0].turn_id == "turn_1"
+    assert result[0].turn_revision == 2
+    assert result[0].speech_stopped_at_s == 123.0


### PR DESCRIPTION
## Summary

- Serialize MLX Audio Whisper warmup and transcription inference with the existing global `MLXLockContext`.
- Add regression tests for both inference paths.

## Root cause

`MLXAudioWhisperSTTHandler` called `model.generate()` directly, while the other MLX handlers use the repository-wide lock to prevent concurrent Metal command-buffer access.

## Validation

- `uv run pytest tests/test_mlx_audio_whisper_handler.py -q` — 2 passed
- `uv run ruff check src/speech_to_speech/STT/mlx_audio_whisper_handler.py tests/test_mlx_audio_whisper_handler.py`
- `git diff --check`

## Hardware validation

The regression tests mock the model and lock. I do not have Apple Silicon hardware for the reported concurrent MLX stress scenario, so that scenario has not been run locally.

Fixes #377
