### PR TITLE
Fix realtime audio transcript event semantics

### DIFF
--- a/src/speech_to_speech/api/openai_realtime/handlers/audio.py
+++ b/src/speech_to_speech/api/openai_realtime/handlers/audio.py
@@ -200,7 +200,6 @@ class AudioHandler(RealtimeBaseHandler):
 
     def encode_audio_chunk(self, conn_id: str, audio: bytes) -> list[ServerEvent]:
         """Encode a raw PCM audio chunk as a base64 delta event for the WebSocket transport."""
-        response = self._service.response
         st = self._state(conn_id)
 
         resp_id, assistant_item_id, assistant_output_index, events = self.begin_audio_output(conn_id)

--- a/src/speech_to_speech/api/openai_realtime/handlers/audio.py
+++ b/src/speech_to_speech/api/openai_realtime/handlers/audio.py
@@ -220,7 +220,7 @@ class AudioHandler(RealtimeBaseHandler):
             ResponseAudioDeltaEvent(
                 type="response.output_audio.delta",
                 event_id=self._next_event_id(),
-                content_index=response._next_content_index(conn_id),
+                content_index=0,
                 delta=b64,
                 item_id=assistant_item_id,
                 output_index=assistant_output_index,

--- a/src/speech_to_speech/api/openai_realtime/handlers/conversation.py
+++ b/src/speech_to_speech/api/openai_realtime/handlers/conversation.py
@@ -103,7 +103,7 @@ class ConversationHandler(RealtimeBaseHandler):
             ConversationItemInputAudioTranscriptionDeltaEvent(
                 type="conversation.item.input_audio_transcription.delta",
                 event_id=self._next_event_id(),
-                content_index=self._next_input_content_index(conn_id),
+                content_index=0,
                 item_id=self._input_item_id(conn_id),
                 delta=event.delta,
             )

--- a/tests/openai_realtime/test_realtime_service.py
+++ b/tests/openai_realtime/test_realtime_service.py
@@ -769,12 +769,12 @@ class TestEncodeAudioChunk:
         assert events[1].output_index == 0
         assert events[1].delta == base64.b64encode(audio).decode("ascii")
 
-    def test_subsequent_chunks_increment_content_index(self, service, conn_id):
+    def test_subsequent_chunks_keep_content_index(self, service, conn_id):
         service.encode_audio_chunk(conn_id, _pcm_bytes(256))  # first
         events = service.encode_audio_chunk(conn_id, _pcm_bytes(256))  # second
         assert len(events) == 1
         assert isinstance(events[0], ResponseAudioDeltaEvent)
-        assert events[0].content_index == 1
+        assert events[0].content_index == 0
 
     def test_response_created_includes_metadata(self, service, conn_id):
         from openai.types.realtime.realtime_response_create_params import RealtimeResponseCreateParams
@@ -1702,7 +1702,7 @@ class TestDispatchPipelineEvent:
         assert e1[0].content_index == 0
         assert e1[0].delta == "hel"
         assert isinstance(e2[0], ConversationItemInputAudioTranscriptionDeltaEvent)
-        assert e2[0].content_index == 1
+        assert e2[0].content_index == 0
 
     # -- transcription_completed --
 


### PR DESCRIPTION
## Summary

- emit `response.output_audio_transcript.delta` for each streamed assistant-text chunk
- emit one full `response.output_audio_transcript.done` event when the response ends
- keep all audio and input-transcription events on their single audio content part (`content_index: 0`)

## Root cause

The realtime adapter treated streaming chunks as separate content parts and emitted a terminal transcript event for every LLM chunk. This conflicted with the Realtime event contract and could make clients observe duplicate terminal transcript events.

## Validation

- `python3 -m compileall -q src/speech_to_speech/api/openai_realtime tests/openai_realtime/test_realtime_service.py`
- `node --check demo/ws/s2s-ws-client.js`
- `node --check demo/rtc/s2s-rtc-client.js`
- `git diff --check`
