### PR TITLE
Add Qwen3-ASR STT backend

### DIFF
--- a/README.md
+++ b/README.md
@@ -132,6 +132,7 @@ pip install "speech-to-speech[facebook-mms]"    # MMS TTS
 pip install "speech-to-speech[faster-whisper]"  # Faster Whisper STT
 pip install "speech-to-speech[whisper-mlx]"     # Lightning Whisper MLX STT on macOS
 pip install "speech-to-speech[paraformer]"      # Paraformer STT through FunASR
+pip install "speech-to-speech[qwen3-asr]"       # Qwen3-ASR STT through Transformers >=5.13.0
 pip install "speech-to-speech[mlx-lm]"          # mlx-vlm support for vision models on macOS
 ```
 
@@ -160,6 +161,7 @@ This installs the package in editable mode and makes the `speech-to-speech` CLI 
 | STT | [Lightning Whisper MLX](https://github.com/mustafaaljadery/lightning-whisper-mlx) | Apple Silicon | `whisper-mlx` |
 | STT | [MLX Audio Whisper](https://github.com/huggingface/mlx-audio) | Apple Silicon | built-in on macOS |
 | STT | [Paraformer](https://github.com/modelscope/FunASR) | CUDA / CPU | `paraformer` |
+| STT | [Qwen3-ASR](https://huggingface.co/Qwen/Qwen3-ASR-0.6B-hf) through Transformers | CUDA / CPU / MPS | `qwen3-asr`; requires Transformers >=5.13.0 |
 | LLM | OpenAI-compatible API (`responses-api`, `chat-completions`) | hosted providers or self-hosted servers | built-in |
 | LLM | [Transformers](https://huggingface.co/models?pipeline_tag=text-generation&sort=trending) | CUDA / CPU | built-in |
 | LLM | [mlx-lm](https://github.com/ml-explore/mlx-lm) | Apple Silicon | built-in on macOS |
@@ -456,6 +458,7 @@ Language coverage depends on the STT and TTS backends you pick, not on the pipel
 | STT | Parakeet TDT (default) | 25 European languages |
 | STT | Whisper / Whisper MLX / Faster Whisper | Broad multilingual coverage, depending on the selected Whisper checkpoint |
 | STT | Paraformer | Depends on the selected FunASR checkpoint; the default is Chinese-oriented |
+| STT | Qwen3-ASR | 30 languages and 22 Chinese dialects, depending on the selected Qwen3-ASR checkpoint |
 | TTS | Qwen3-TTS (default) | Multilingual, with `--qwen3_tts_language auto` by default |
 | TTS | Kokoro | Multiple language/voice mappings, depending on backend availability |
 | TTS | ChatTTS | English and Chinese |

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -89,6 +89,9 @@ paraformer = [
 pocket = [
     "pocket-tts>=0.1.0",
 ]
+qwen3-asr = [
+    "transformers>=5.13.0",
+]
 webrtc = [
     "aiortc>=1.9.0",
 ]

--- a/src/speech_to_speech/STT/README.md
+++ b/src/speech_to_speech/STT/README.md
@@ -10,6 +10,7 @@ This document summarizes the Speech-to-Text (STT) implementations in the `STT/` 
 - `faster-whisper` → `STT/faster_whisper_handler.py`
 - `parakeet-tdt` → `STT/parakeet_tdt_handler.py`
 - `paraformer` → `STT/paraformer_handler.py`
+- `qwen3-asr` → `STT/qwen3_asr_handler.py`
 
 ## Language Support by Handler
 
@@ -74,6 +75,20 @@ This document summarizes the Speech-to-Text (STT) implementations in the `STT/` 
 - Practical support:
   - Depends on selected FunASR model checkpoint
   - Default setup is Chinese-oriented (`zh`)
+
+### 7) Qwen3-ASR (`--stt qwen3-asr`)
+
+- Handler: `Qwen3ASRSTTHandler`
+- Model flag: `--qwen3_asr_model_name`
+- Default model: `Qwen/Qwen3-ASR-0.6B-hf`
+- Language flag: `--qwen3_asr_language` (optional)
+- Context/hotwords flag: `--qwen3_asr_prompt` (optional)
+- Dependency note:
+  - Requires `transformers>=5.13.0`; older Transformers versions do not recognize `model_type: qwen3_asr`
+- Practical support:
+  - Depends on selected Qwen3-ASR checkpoint
+  - The default checkpoint supports 30 languages and 22 Chinese dialects
+  - Initial integration emits final transcripts only
 
 ## Language Abbreviations (ISO-style codes seen in STT handlers)
 
@@ -160,4 +175,18 @@ python s2s_pipeline.py --stt parakeet-tdt \
 
 ```bash
 python s2s_pipeline.py --stt paraformer --paraformer_stt_model_name paraformer-zh
+```
+
+### Qwen3-ASR
+
+```bash
+python s2s_pipeline.py --stt qwen3-asr \
+  --qwen3_asr_model_name Qwen/Qwen3-ASR-0.6B-hf \
+  --qwen3_asr_device auto
+```
+
+With an explicit language hint:
+
+```bash
+python s2s_pipeline.py --stt qwen3-asr --qwen3_asr_language en
 ```

--- a/src/speech_to_speech/STT/qwen3_asr_handler.py
+++ b/src/speech_to_speech/STT/qwen3_asr_handler.py
@@ -1,0 +1,165 @@
+from __future__ import annotations
+
+import logging
+from importlib.metadata import PackageNotFoundError, version
+from sys import platform
+from typing import Any, Iterator, Optional
+
+import numpy as np
+import torch
+from rich.console import Console
+
+from speech_to_speech.pipeline.handler_types import STTIn, STTOut
+from speech_to_speech.pipeline.messages import Transcription
+from speech_to_speech.STT.base_stt_handler import BaseSTTHandler
+
+logger = logging.getLogger(__name__)
+console = Console()
+
+MIN_TRANSFORMERS_VERSION = (5, 13, 0)
+QWEN3_ASR_LANGUAGE_TO_CODE = {
+    "arabic": "ar",
+    "cantonese": "yue",
+    "chinese": "zh",
+    "czech": "cs",
+    "danish": "da",
+    "dutch": "nl",
+    "english": "en",
+    "filipino": "fil",
+    "finnish": "fi",
+    "french": "fr",
+    "german": "de",
+    "greek": "el",
+    "hindi": "hi",
+    "hungarian": "hu",
+    "indonesian": "id",
+    "italian": "it",
+    "japanese": "ja",
+    "korean": "ko",
+    "macedonian": "mk",
+    "malay": "ms",
+    "persian": "fa",
+    "polish": "pl",
+    "portuguese": "pt",
+    "romanian": "ro",
+    "russian": "ru",
+    "spanish": "es",
+    "swedish": "sv",
+    "thai": "th",
+    "turkish": "tr",
+    "vietnamese": "vi",
+}
+
+
+def _version_tuple(value: str) -> tuple[int, int, int]:
+    parts = []
+    for part in value.split(".")[:3]:
+        digits = ""
+        for char in part:
+            if char.isdigit():
+                digits += char
+            else:
+                break
+        parts.append(int(digits or 0))
+    return tuple([*parts, 0, 0, 0][:3])
+
+
+def _require_qwen3_asr_transformers() -> None:
+    try:
+        installed = version("transformers")
+    except PackageNotFoundError as exc:
+        raise ModuleNotFoundError(
+            "Qwen3-ASR STT requires Transformers. Install it with "
+            "`pip install speech-to-speech[qwen3-asr]`."
+        ) from exc
+
+    if _version_tuple(installed) < MIN_TRANSFORMERS_VERSION:
+        raise ImportError(
+            "Qwen3-ASR STT requires transformers>=5.13.0 because older versions do not recognize "
+            "`model_type: qwen3_asr`. Install it with `pip install speech-to-speech[qwen3-asr]` "
+            f"or upgrade Transformers. Found transformers=={installed}."
+        )
+
+
+def _resolve_device(device: str) -> str:
+    if device != "auto":
+        return device
+    if torch.cuda.is_available():
+        return "cuda"
+    if platform == "darwin" and torch.backends.mps.is_available():
+        return "mps"
+    return "cpu"
+
+
+def _language_to_code(language: Optional[str]) -> Optional[str]:
+    if language is None:
+        return None
+    normalized = language.strip().lower()
+    return QWEN3_ASR_LANGUAGE_TO_CODE.get(normalized, normalized)
+
+
+class Qwen3ASRSTTHandler(BaseSTTHandler):
+    """Final-transcript STT handler for Qwen3-ASR Transformers checkpoints."""
+
+    def setup(
+        self,
+        model_name: str = "Qwen/Qwen3-ASR-0.6B-hf",
+        device: str = "auto",
+        torch_dtype: str = "bfloat16",
+        language: Optional[str] = None,
+        prompt: Optional[str] = None,
+        compile_mode: Optional[str] = None,
+        gen_kwargs: dict[str, Any] = {},
+    ) -> None:
+        _require_qwen3_asr_transformers()
+
+        from transformers import AutoModelForMultimodalLM, AutoProcessor
+
+        self.device = _resolve_device(device)
+        self.torch_dtype = getattr(torch, torch_dtype)
+        self.language = language
+        self.prompt = prompt
+        self.gen_kwargs = gen_kwargs
+
+        self.processor = AutoProcessor.from_pretrained(model_name)
+        self.model = AutoModelForMultimodalLM.from_pretrained(model_name, dtype=self.torch_dtype).to(self.device)
+        self.model.eval()
+
+        if compile_mode:
+            self.model.forward = torch.compile(self.model.forward, mode=compile_mode)
+
+    def _prepare_inputs(self, audio: np.ndarray) -> Any:
+        kwargs: dict[str, Any] = {"audio": audio}
+        if self.language:
+            kwargs["language"] = self.language
+        if self.prompt:
+            kwargs["prompt"] = self.prompt
+
+        inputs = self.processor.apply_transcription_request(**kwargs)
+        return inputs.to(self.device, self.torch_dtype)
+
+    def process(self, vad_audio: STTIn) -> Iterator[STTOut]:
+        if vad_audio.mode == "progressive":
+            return
+
+        logger.debug("inferring qwen3-asr...")
+        inputs = self._prepare_inputs(vad_audio.audio)
+        with torch.inference_mode():
+            output_ids = self.model.generate(**inputs, **self.gen_kwargs)
+
+        generated_ids = output_ids[:, inputs["input_ids"].shape[1] :]
+        pred_text = self.processor.decode(generated_ids, return_format="transcription_only")[0]
+        parsed = self.processor.decode(generated_ids, return_format="parsed")[0]
+        parsed_language = parsed.get("language") if isinstance(parsed, dict) else None
+        language_code = _language_to_code(parsed_language)
+
+        logger.debug("finished qwen3-asr inference")
+        console.print(f"[yellow]USER: {pred_text}")
+
+        yield Transcription(
+            text=pred_text,
+            language_code=language_code,
+            turn_id=vad_audio.turn_id,
+            turn_revision=vad_audio.turn_revision,
+            speech_stopped_at_s=vad_audio.created_at_s,
+        )

--- a/src/speech_to_speech/arguments_classes/module_arguments.py
+++ b/src/speech_to_speech/arguments_classes/module_arguments.py
@@ -21,11 +21,11 @@ class ModuleArguments:
         },
     )
     stt: Optional[
-        Literal["whisper", "whisper-mlx", "mlx-audio-whisper", "faster-whisper", "parakeet-tdt", "paraformer"]
+        Literal["whisper", "whisper-mlx", "mlx-audio-whisper", "faster-whisper", "parakeet-tdt", "paraformer", "qwen3-asr",]
     ] = field(
         default="parakeet-tdt",
         metadata={
-            "help": "The STT to use. Either 'whisper', 'whisper-mlx', 'mlx-audio-whisper', 'faster-whisper', 'parakeet-tdt', or 'paraformer'. Default is 'parakeet-tdt'."
+            "help": "The STT to use. Either 'whisper', 'whisper-mlx', 'mlx-audio-whisper', 'faster-whisper', 'parakeet-tdt', 'paraformer', or 'qwen3-asr'. Default is 'parakeet-tdt'."
         },
     )
     llm_backend: Optional[Literal["transformers", "mlx-lm", "responses-api", "chat-completions"]] = field(

--- a/src/speech_to_speech/arguments_classes/qwen3_asr_stt_arguments.py
+++ b/src/speech_to_speech/arguments_classes/qwen3_asr_stt_arguments.py
@@ -1,0 +1,51 @@
+from dataclasses import dataclass, field
+from typing import Optional
+
+
+@dataclass
+class Qwen3ASRSTTHandlerArguments:
+    qwen3_asr_model_name: str = field(
+        default="Qwen/Qwen3-ASR-0.6B-hf",
+        metadata={"help": "The Qwen3-ASR model to use. Default is 'Qwen/Qwen3-ASR-0.6B-hf'."},
+    )
+    qwen3_asr_device: str = field(
+        default="auto",
+        metadata={
+            "help": "Device to run Qwen3-ASR on. 'auto' will use CUDA when available, then MPS, then CPU. "
+            "Options: 'auto', 'cuda', 'mps', 'cpu'. Default is 'auto'."
+        },
+    )
+    qwen3_asr_torch_dtype: str = field(
+        default="bfloat16",
+        metadata={
+            "help": "PyTorch dtype for Qwen3-ASR. One of 'float32', 'float16', or 'bfloat16'. Default is 'bfloat16'."
+        },
+    )
+    qwen3_asr_language: Optional[str] = field(
+        default=None,
+        metadata={
+            "help": "Optional transcription language hint, such as 'English' or 'en'. "
+            "If omitted, Qwen3-ASR auto-detects the language."
+        },
+    )
+    qwen3_asr_prompt: Optional[str] = field(
+        default=None,
+        metadata={
+            "help": "Optional context or hotwords prompt to bias Qwen3-ASR transcription. Default is None."
+        },
+    )
+    qwen3_asr_compile_mode: Optional[str] = field(
+        default=None,
+        metadata={
+            "help": "Optional torch.compile mode for Qwen3-ASR. Use values like 'default', "
+            "'reduce-overhead', or 'max-autotune'. Default is None."
+        },
+    )
+    qwen3_asr_gen_max_new_tokens: int = field(
+        default=256,
+        metadata={"help": "Maximum number of new tokens to generate for Qwen3-ASR transcription. Default is 256."},
+    )
+    qwen3_asr_gen_do_sample: bool = field(
+        default=False,
+        metadata={"help": "Whether to sample during Qwen3-ASR generation. Default is False."},
+    )

--- a/src/speech_to_speech/s2s_pipeline.py
+++ b/src/speech_to_speech/s2s_pipeline.py
@@ -40,6 +40,7 @@ from speech_to_speech.arguments_classes.parakeet_tdt_arguments import (
     ParakeetTDTSTTHandlerArguments,
 )
 from speech_to_speech.arguments_classes.pocket_tts_arguments import PocketTTSHandlerArguments
+from speech_to_speech.arguments_classes.qwen3_asr_stt_arguments import Qwen3ASRSTTHandlerArguments
 from speech_to_speech.arguments_classes.qwen3_tts_arguments import Qwen3TTSHandlerArguments
 from speech_to_speech.arguments_classes.responses_api_language_model_arguments import (
     ResponsesApiLanguageModelHandlerArguments,
@@ -100,6 +101,7 @@ class ParsedArguments:
     faster_whisper_stt_handler_kwargs: FasterWhisperSTTHandlerArguments
     mlx_audio_whisper_stt_handler_kwargs: MLXAudioWhisperSTTHandlerArguments
     parakeet_tdt_stt_handler_kwargs: ParakeetTDTSTTHandlerArguments
+    qwen3_asr_stt_handler_kwargs: Qwen3ASRSTTHandlerArguments
     language_model_handler_kwargs: LanguageModelHandlerArguments
     responses_api_language_model_handler_kwargs: ResponsesApiLanguageModelHandlerArguments
     chat_tts_handler_kwargs: ChatTTSHandlerArguments
@@ -159,6 +161,7 @@ def parse_arguments() -> ParsedArguments:
             FasterWhisperSTTHandlerArguments,
             MLXAudioWhisperSTTHandlerArguments,
             ParakeetTDTSTTHandlerArguments,
+            Qwen3ASRSTTHandlerArguments,
             _lm_class,
             ChatTTSHandlerArguments,
             FacebookMMSTTSHandlerArguments,
@@ -188,6 +191,7 @@ def parse_arguments() -> ParsedArguments:
         faster_whisper_stt_handler_kwargs=by_type[FasterWhisperSTTHandlerArguments],
         mlx_audio_whisper_stt_handler_kwargs=by_type[MLXAudioWhisperSTTHandlerArguments],
         parakeet_tdt_stt_handler_kwargs=by_type[ParakeetTDTSTTHandlerArguments],
+        qwen3_asr_stt_handler_kwargs=by_type[Qwen3ASRSTTHandlerArguments],
         language_model_handler_kwargs=by_type.get(LanguageModelHandlerArguments, LanguageModelHandlerArguments()),
         # The OpenAI-compatible slot holds whichever class was registered:
         # ChatCompletions... (a subclass) for chat-completions, else ResponsesApi....
@@ -275,6 +279,8 @@ def overwrite_device_argument(common_device: Optional[str], *handler_kwargs: Any
                 kwargs.facebook_mms_device = common_device
             if hasattr(kwargs, "qwen3_tts_device"):
                 kwargs.qwen3_tts_device = common_device
+            if hasattr(kwargs, "qwen3_asr_device"):
+                kwargs.qwen3_asr_device = common_device
 
 
 def prepare_module_args(module_kwargs: ModuleArguments, *handler_kwargs: Any) -> None:
@@ -293,6 +299,7 @@ def prepare_all_args(
     faster_whisper_stt_handler_kwargs: FasterWhisperSTTHandlerArguments,
     mlx_audio_whisper_stt_handler_kwargs: MLXAudioWhisperSTTHandlerArguments,
     parakeet_tdt_stt_handler_kwargs: ParakeetTDTSTTHandlerArguments,
+    qwen3_asr_stt_handler_kwargs: Qwen3ASRSTTHandlerArguments,
     language_model_handler_kwargs: LanguageModelHandlerArguments,
     responses_api_language_model_handler_kwargs: ResponsesApiLanguageModelHandlerArguments,
     chat_tts_handler_kwargs: ChatTTSHandlerArguments,
@@ -308,6 +315,7 @@ def prepare_all_args(
         paraformer_stt_handler_kwargs,
         mlx_audio_whisper_stt_handler_kwargs,
         parakeet_tdt_stt_handler_kwargs,
+        qwen3_asr_stt_handler_kwargs,
         language_model_handler_kwargs,
         responses_api_language_model_handler_kwargs,
         chat_tts_handler_kwargs,
@@ -322,6 +330,7 @@ def prepare_all_args(
     rename_args(paraformer_stt_handler_kwargs, "paraformer_stt")
     rename_args(mlx_audio_whisper_stt_handler_kwargs, "mlx_audio_whisper")
     rename_args(parakeet_tdt_stt_handler_kwargs, "parakeet_tdt")
+    rename_args(qwen3_asr_stt_handler_kwargs, "qwen3_asr")
     rename_args(language_model_handler_kwargs, "llm")
     rename_args(responses_api_language_model_handler_kwargs, "responses_api")
     rename_args(chat_tts_handler_kwargs, "chat_tts")
@@ -368,6 +377,7 @@ def _build_pipeline_handlers(
     paraformer_stt_handler_kwargs: ParaformerSTTHandlerArguments,
     mlx_audio_whisper_stt_handler_kwargs: MLXAudioWhisperSTTHandlerArguments,
     parakeet_tdt_stt_handler_kwargs: ParakeetTDTSTTHandlerArguments,
+    qwen3_asr_stt_handler_kwargs: Qwen3ASRSTTHandlerArguments,
     language_model_handler_kwargs: LanguageModelHandlerArguments,
     responses_api_language_model_handler_kwargs: ResponsesApiLanguageModelHandlerArguments,
     chat_tts_handler_kwargs: ChatTTSHandlerArguments,
@@ -411,6 +421,7 @@ def _build_pipeline_handlers(
         paraformer_stt_handler_kwargs,
         mlx_audio_whisper_stt_handler_kwargs,
         parakeet_tdt_stt_handler_kwargs,
+        qwen3_asr_stt_handler_kwargs,
     )
 
     lm = get_llm_handler(
@@ -456,6 +467,7 @@ def _build_realtime_pipeline_unit(
     paraformer_stt_handler_kwargs: ParaformerSTTHandlerArguments,
     mlx_audio_whisper_stt_handler_kwargs: MLXAudioWhisperSTTHandlerArguments,
     parakeet_tdt_stt_handler_kwargs: ParakeetTDTSTTHandlerArguments,
+    qwen3_asr_stt_handler_kwargs: Qwen3ASRSTTHandlerArguments,
     language_model_handler_kwargs: LanguageModelHandlerArguments,
     responses_api_language_model_handler_kwargs: ResponsesApiLanguageModelHandlerArguments,
     chat_tts_handler_kwargs: ChatTTSHandlerArguments,
@@ -479,6 +491,7 @@ def _build_realtime_pipeline_unit(
     paraformer_kw = deepcopy(paraformer_stt_handler_kwargs)
     mlx_audio_whisper_kw = deepcopy(mlx_audio_whisper_stt_handler_kwargs)
     parakeet_kw = deepcopy(parakeet_tdt_stt_handler_kwargs)
+    qwen3_asr_kw = deepcopy(qwen3_asr_stt_handler_kwargs)
     lm_kw = deepcopy(language_model_handler_kwargs)
     responses_api_kw = deepcopy(responses_api_language_model_handler_kwargs)
     chat_tts_kw = deepcopy(chat_tts_handler_kwargs)
@@ -552,6 +565,7 @@ def _build_realtime_pipeline_unit(
         paraformer_stt_handler_kwargs=paraformer_kw,
         mlx_audio_whisper_stt_handler_kwargs=mlx_audio_whisper_kw,
         parakeet_tdt_stt_handler_kwargs=parakeet_kw,
+        qwen3_asr_stt_handler_kwargs=qwen3_asr_kw,
         language_model_handler_kwargs=lm_kw,
         responses_api_language_model_handler_kwargs=responses_api_kw,
         chat_tts_handler_kwargs=chat_tts_kw,
@@ -589,6 +603,7 @@ def build_pipeline(
     paraformer_stt_handler_kwargs: ParaformerSTTHandlerArguments,
     mlx_audio_whisper_stt_handler_kwargs: MLXAudioWhisperSTTHandlerArguments,
     parakeet_tdt_stt_handler_kwargs: ParakeetTDTSTTHandlerArguments,
+    qwen3_asr_stt_handler_kwargs: Qwen3ASRSTTHandlerArguments,
     language_model_handler_kwargs: LanguageModelHandlerArguments,
     responses_api_language_model_handler_kwargs: ResponsesApiLanguageModelHandlerArguments,
     chat_tts_handler_kwargs: ChatTTSHandlerArguments,
@@ -651,6 +666,7 @@ def build_pipeline(
                 paraformer_stt_handler_kwargs=paraformer_stt_handler_kwargs,
                 mlx_audio_whisper_stt_handler_kwargs=mlx_audio_whisper_stt_handler_kwargs,
                 parakeet_tdt_stt_handler_kwargs=parakeet_tdt_stt_handler_kwargs,
+                qwen3_asr_stt_handler_kwargs=qwen3_asr_stt_handler_kwargs,
                 language_model_handler_kwargs=language_model_handler_kwargs,
                 responses_api_language_model_handler_kwargs=responses_api_language_model_handler_kwargs,
                 chat_tts_handler_kwargs=chat_tts_handler_kwargs,
@@ -735,6 +751,7 @@ def build_pipeline(
         paraformer_stt_handler_kwargs=paraformer_stt_handler_kwargs,
         mlx_audio_whisper_stt_handler_kwargs=mlx_audio_whisper_stt_handler_kwargs,
         parakeet_tdt_stt_handler_kwargs=parakeet_tdt_stt_handler_kwargs,
+        qwen3_asr_stt_handler_kwargs=qwen3_asr_stt_handler_kwargs,
         language_model_handler_kwargs=language_model_handler_kwargs,
         responses_api_language_model_handler_kwargs=responses_api_language_model_handler_kwargs,
         chat_tts_handler_kwargs=chat_tts_handler_kwargs,
@@ -758,6 +775,7 @@ def get_stt_handler(
     paraformer_stt_handler_kwargs: ParaformerSTTHandlerArguments,
     mlx_audio_whisper_stt_handler_kwargs: MLXAudioWhisperSTTHandlerArguments,
     parakeet_tdt_stt_handler_kwargs: ParakeetTDTSTTHandlerArguments,
+    qwen3_asr_stt_handler_kwargs: Qwen3ASRSTTHandlerArguments,
 ) -> BaseHandler[STTIn, STTOut]:
     from speech_to_speech.STT.base_stt_handler import BaseSTTHandler
 
@@ -841,9 +859,20 @@ def get_stt_handler(
                 setup_kwargs=setup_kwargs,
             )
         )
+    elif module_kwargs.stt == "qwen3-asr":
+        from speech_to_speech.STT.qwen3_asr_handler import Qwen3ASRSTTHandler
+
+        return with_speculative_turns(
+            Qwen3ASRSTTHandler(
+                stop_event,
+                queue_in=spoken_prompt_queue,
+                queue_out=text_prompt_queue,
+                setup_kwargs=vars(qwen3_asr_stt_handler_kwargs),
+            )
+        )
     else:
         raise ValueError(
-            "The STT should be either whisper, whisper-mlx, mlx-audio-whisper, faster-whisper, parakeet-tdt, or paraformer."
+            "The STT should be either whisper, whisper-mlx, mlx-audio-whisper, faster-whisper, parakeet-tdt, paraformer, or qwen3-asr."
         )
 
 
@@ -996,6 +1025,7 @@ def main() -> None:
         args.faster_whisper_stt_handler_kwargs,
         args.mlx_audio_whisper_stt_handler_kwargs,
         args.parakeet_tdt_stt_handler_kwargs,
+        args.qwen3_asr_stt_handler_kwargs,
         args.language_model_handler_kwargs,
         args.responses_api_language_model_handler_kwargs,
         args.chat_tts_handler_kwargs,
@@ -1040,6 +1070,7 @@ def main() -> None:
         args.paraformer_stt_handler_kwargs,
         args.mlx_audio_whisper_stt_handler_kwargs,
         args.parakeet_tdt_stt_handler_kwargs,
+        args.qwen3_asr_stt_handler_kwargs,
         args.language_model_handler_kwargs,
         args.responses_api_language_model_handler_kwargs,
         args.chat_tts_handler_kwargs,

--- a/tests/test_cli_defaults.py
+++ b/tests/test_cli_defaults.py
@@ -11,6 +11,7 @@ from speech_to_speech.arguments_classes.module_arguments import ModuleArguments
 from speech_to_speech.arguments_classes.paraformer_stt_arguments import ParaformerSTTHandlerArguments
 from speech_to_speech.arguments_classes.parakeet_tdt_arguments import ParakeetTDTSTTHandlerArguments
 from speech_to_speech.arguments_classes.pocket_tts_arguments import PocketTTSHandlerArguments
+from speech_to_speech.arguments_classes.qwen3_asr_stt_arguments import Qwen3ASRSTTHandlerArguments
 from speech_to_speech.arguments_classes.qwen3_tts_arguments import Qwen3TTSHandlerArguments
 from speech_to_speech.arguments_classes.responses_api_language_model_arguments import (
     ResponsesApiLanguageModelHandlerArguments,
@@ -67,6 +68,7 @@ EXPECTED_FIELD_TYPES = {
     "faster_whisper_stt_handler_kwargs": FasterWhisperSTTHandlerArguments,
     "mlx_audio_whisper_stt_handler_kwargs": MLXAudioWhisperSTTHandlerArguments,
     "parakeet_tdt_stt_handler_kwargs": ParakeetTDTSTTHandlerArguments,
+    "qwen3_asr_stt_handler_kwargs": Qwen3ASRSTTHandlerArguments,
     "language_model_handler_kwargs": LanguageModelHandlerArguments,
     "responses_api_language_model_handler_kwargs": ResponsesApiLanguageModelHandlerArguments,
     "chat_tts_handler_kwargs": ChatTTSHandlerArguments,
@@ -114,6 +116,30 @@ def test_parse_arguments_accepts_qwen3_tts_backend_override():
         sys.argv = original_argv
 
     assert args.qwen3_tts_handler_kwargs.qwen3_tts_backend == "torch"
+
+
+def test_parse_arguments_accepts_qwen3_asr_stt_backend():
+    original_argv = sys.argv[:]
+    try:
+        sys.argv = [
+            "speech-to-speech",
+            "--stt",
+            "qwen3-asr",
+            "--qwen3_asr_model_name",
+            "Qwen/Qwen3-ASR-0.6B-hf",
+            "--qwen3_asr_language",
+            "en",
+            "--qwen3_asr_gen_max_new_tokens",
+            "64",
+        ]
+        args = parse_arguments()
+    finally:
+        sys.argv = original_argv
+
+    assert args.module_kwargs.stt == "qwen3-asr"
+    assert args.qwen3_asr_stt_handler_kwargs.qwen3_asr_model_name == "Qwen/Qwen3-ASR-0.6B-hf"
+    assert args.qwen3_asr_stt_handler_kwargs.qwen3_asr_language == "en"
+    assert args.qwen3_asr_stt_handler_kwargs.qwen3_asr_gen_max_new_tokens == 64
 
 
 def test_parse_arguments_transformers_backend():

--- a/tests/test_qwen3_asr_handler.py
+++ b/tests/test_qwen3_asr_handler.py
@@ -1,0 +1,30 @@
+import pytest
+
+from speech_to_speech.STT.qwen3_asr_handler import _language_to_code, _version_tuple
+
+
+@pytest.mark.parametrize(
+    ("raw", "expected"),
+    [
+        ("5.13.0", (5, 13, 0)),
+        ("5.14.0.dev0", (5, 14, 0)),
+        ("5.13.0rc1", (5, 13, 0)),
+    ],
+)
+def test_version_tuple_handles_transformers_versions(raw, expected):
+    assert _version_tuple(raw) == expected
+
+
+@pytest.mark.parametrize(
+    ("raw", "expected"),
+    [
+        ("English", "en"),
+        ("Chinese", "zh"),
+        ("Filipino", "fil"),
+        ("Cantonese", "yue"),
+        ("en", "en"),
+        (None, None),
+    ],
+)
+def test_language_to_code_normalizes_qwen3_asr_language_names(raw, expected):
+    assert _language_to_code(raw) == expected


### PR DESCRIPTION
Closes #337

- Add `qwen3-asr` as an STT backend option.
- Add `Qwen3ASRSTTHandler` using Transformers `AutoModelForMultimodalLM` and `AutoProcessor`.
- Add Qwen3-ASR CLI arguments for model, device, dtype, language, prompt, compile mode, and generation options.
- Document the optional `qwen3-asr` extra and Transformers `>=5.13.0` requirement.
