### PR TITLE
feat(llm): add short spoken filler sentences for delayed LLM responses (#315)

### DIFF
--- a/src/speech_to_speech/LLM/base_openai_compatible_language_model.py
+++ b/src/speech_to_speech/LLM/base_openai_compatible_language_model.py
@@ -29,7 +29,7 @@ from speech_to_speech.LLM.chat import (
 )
 from speech_to_speech.LLM.compaction_prompt import CompactGenerateFn, build_compactor
 from speech_to_speech.LLM.text_prompt import build_text_system_prompt
-from speech_to_speech.LLM.utils import remove_unspeechable, resolve_auto_language
+from speech_to_speech.LLM.utils import remove_unspeechable, resolve_auto_language, run_generator_with_filler_sentences
 from speech_to_speech.LLM.voice_prompt import build_voice_system_prompt
 from speech_to_speech.pipeline.cancel_scope import CancelScope
 from speech_to_speech.pipeline.handler_types import LLMIn, LLMOut
@@ -140,6 +140,9 @@ class BaseOpenAICompatibleHandler(BaseHandler[LLMIn, LLMOut], ABC):
         stream_batch_sentences: int = 3,
         enable_lang_prompt: bool = False,
         compact_history: bool = False,
+        enable_filler_sentences: bool = False,
+        filler_sentence_delay_s: float = 1.0,
+        filler_sentences: list[str] | tuple[str, ...] | None = None,
         **_kwargs: Any,
     ) -> None:
         self.cancel_scope = cancel_scope
@@ -148,6 +151,19 @@ class BaseOpenAICompatibleHandler(BaseHandler[LLMIn, LLMOut], ABC):
         self.stream = stream
         self.stream_batch_sentences = max(1, stream_batch_sentences)
         self.enable_lang_prompt = enable_lang_prompt
+        self.enable_filler_sentences = enable_filler_sentences
+        self.filler_sentence_delay_s = float(filler_sentence_delay_s)
+        self.filler_sentences = (
+            list(filler_sentences)
+            if filler_sentences is not None
+            else [
+                "Hmm, let me see.",
+                "Let me check that for you.",
+                "Give me a moment.",
+                "Thinking about that.",
+                "Let me think about that for a second.",
+            ]
+        )
         self.gen_kwargs = dict(gen_kwargs)
         self.request_timeout_s = float(request_timeout_s)
         self.request_timeout = httpx.Timeout(
@@ -160,6 +176,7 @@ class BaseOpenAICompatibleHandler(BaseHandler[LLMIn, LLMOut], ABC):
         self._extra_body = self._build_extra_body(base_url, disable_thinking, reasoning_effort)
         self.compactor = build_compactor(self._build_compaction_generate_fn()) if compact_history else None
         self.warmup()
+
 
     @staticmethod
     def _is_official_openai(base_url: Optional[str]) -> bool:
@@ -578,7 +595,26 @@ class BaseOpenAICompatibleHandler(BaseHandler[LLMIn, LLMOut], ABC):
             speech_stopped_at_s=speech_stopped_at_s,
             wants_audio=wants_audio,
         )
-        yield from self._generate(active_chat, original_chat, turn, optional_kwargs)
+        gen_fn = lambda: self._generate(active_chat, original_chat, turn, optional_kwargs)
+        def is_stale_fn() -> bool:
+            return self._generation_is_stale(turn.gen) or not self._turn_is_latest(turn.turn_id, turn.turn_revision)
+
+        yield from run_generator_with_filler_sentences(
+            gen_fn=gen_fn,
+            enable_filler_sentences=getattr(self, "enable_filler_sentences", False),
+            filler_sentence_delay_s=getattr(self, "filler_sentence_delay_s", 1.0),
+            filler_sentences=getattr(self, "filler_sentences", None),
+            language_code=language_code,
+            runtime_config=runtime_config,
+            response=response,
+            turn_id=turn_id,
+            turn_revision=turn_revision,
+            speech_stopped_at_s=speech_stopped_at_s,
+            gen=gen,
+            is_stale_fn=is_stale_fn,
+        )
+
+
 
     @property
     def timing_log_level(self) -> int:

--- a/src/speech_to_speech/LLM/language_model.py
+++ b/src/speech_to_speech/LLM/language_model.py
@@ -44,7 +44,7 @@ from speech_to_speech.LLM.text_prompt import build_text_system_prompt
 from speech_to_speech.LLM.tool_call.function_call import extract_function_calls_from_text
 from speech_to_speech.LLM.tool_call.function_tool import FunctionTool
 from speech_to_speech.LLM.tool_call.tool_prompt import END_CODE, ENTER_CODE, build_block_regex, build_tool_system_prompt
-from speech_to_speech.LLM.utils import image_url_to_pil, remove_unspeechable, resolve_auto_language
+from speech_to_speech.LLM.utils import image_url_to_pil, remove_unspeechable, resolve_auto_language, run_generator_with_filler_sentences
 from speech_to_speech.LLM.voice_prompt import build_voice_system_prompt
 from speech_to_speech.pipeline.cancel_scope import CancelScope
 from speech_to_speech.pipeline.handler_types import LLMIn, LLMOut
@@ -168,6 +168,9 @@ class BaseLanguageModelHandler(BaseHandler[LLMIn, LLMOut], ABC):
         stream_batch_sentences: int = 3,
         enable_lang_prompt: bool = False,
         compact_history: bool = False,
+        enable_filler_sentences: bool = False,
+        filler_sentence_delay_s: float = 1.0,
+        filler_sentences: list[str] | tuple[str, ...] | None = None,
         **_kwargs: Any,
     ) -> None:
         self.backend = backend
@@ -178,8 +181,22 @@ class BaseLanguageModelHandler(BaseHandler[LLMIn, LLMOut], ABC):
         self.enable_thinking = enable_thinking
         self.stream_batch_sentences = max(1, stream_batch_sentences)
         self.enable_lang_prompt = enable_lang_prompt
+        self.enable_filler_sentences = enable_filler_sentences
+        self.filler_sentence_delay_s = float(filler_sentence_delay_s)
+        self.filler_sentences = (
+            list(filler_sentences)
+            if filler_sentences is not None
+            else [
+                "Hmm, let me see.",
+                "Let me check that for you.",
+                "Give me a moment.",
+                "Thinking about that.",
+                "Let me think about that for a second.",
+            ]
+        )
 
         self._load_model(model_name, device, torch_dtype, gen_kwargs)
+
 
         self.user_role = user_role
         # Serializes transformers pipe/model.generate calls between the speech
@@ -548,9 +565,29 @@ class BaseLanguageModelHandler(BaseHandler[LLMIn, LLMOut], ABC):
         consumed_image_ids = active_chat.image_message_ids()
 
         try:
-            yield from self._generate(active_chat, language_code, gen, ctx, runtime_config, response)
+            gen_fn = lambda: self._generate(active_chat, language_code, gen, ctx, runtime_config, response)
+
+            def is_stale_fn() -> bool:
+                return ctx.cancelled or not self._turn_is_latest(ctx.turn_id, ctx.turn_revision)
+
+            yield from run_generator_with_filler_sentences(
+                gen_fn=gen_fn,
+                enable_filler_sentences=getattr(self, "enable_filler_sentences", False),
+                filler_sentence_delay_s=getattr(self, "filler_sentence_delay_s", 1.0),
+                filler_sentences=getattr(self, "filler_sentences", None),
+                language_code=language_code,
+                runtime_config=runtime_config,
+                response=response,
+                turn_id=ctx.turn_id,
+                turn_revision=ctx.turn_revision,
+                speech_stopped_at_s=ctx.speech_stopped_at_s,
+                gen=gen,
+                is_stale_fn=is_stale_fn,
+            )
+
 
             if ctx.stopped:
+
                 return
 
             turn_output_allowed = not ctx.cancelled and self._turn_output_allowed(ctx.turn_id, ctx.turn_revision)

--- a/src/speech_to_speech/LLM/utils.py
+++ b/src/speech_to_speech/LLM/utils.py
@@ -1,10 +1,18 @@
 import base64
 import io
+import logging
+import random
 import re
-from typing import Optional
+from queue import Empty, Queue
+from threading import Thread
+from time import perf_counter
+from typing import Any, Callable, Iterator, Optional, Sequence
 
 import requests  # type: ignore[import-untyped]
 from PIL import Image
+
+logger = logging.getLogger(__name__)
+
 
 SMART_PUNCT_TRANSLATION = str.maketrans(
     {
@@ -73,3 +81,94 @@ def image_url_to_pil(image_url: str) -> Image.Image:
     resp = requests.get(image_url, timeout=10)
     resp.raise_for_status()
     return Image.open(io.BytesIO(resp.content))
+
+
+def run_generator_with_filler_sentences(
+    gen_fn: Any,
+    enable_filler_sentences: bool,
+    filler_sentence_delay_s: float,
+    filler_sentences: Sequence[str],
+    language_code: Optional[str],
+    runtime_config: Any,
+    response: Any,
+    turn_id: str | None,
+    turn_revision: int | None,
+    speech_stopped_at_s: float | None,
+    gen: int | None,
+    is_stale_fn: Optional[Any] = None,
+) -> Iterator[Any]:
+    """Wrap a generator function ``gen_fn`` to emit a filler sentence if no output is produced within ``filler_sentence_delay_s``.
+
+    If ``enable_filler_sentences`` is False or ``filler_sentences`` is empty, yields directly from ``gen_fn()``.
+    Otherwise, runs ``gen_fn()`` in a worker thread and monitors output latency. If the delay threshold is exceeded before any spoken content is yielded,
+    a filler sentence chunk is emitted.
+    """
+    if not enable_filler_sentences or not filler_sentences:
+        yield from gen_fn()
+        return
+
+    out_queue: Queue[Any] = Queue()
+    _SENTINEL = object()
+
+    def worker() -> None:
+        try:
+            for item in gen_fn():
+                out_queue.put(item)
+        except Exception as exc:
+            out_queue.put(exc)
+        finally:
+            out_queue.put(_SENTINEL)
+
+    worker_thread = Thread(target=worker, daemon=True)
+    worker_thread.start()
+
+    start_time = perf_counter()
+    filler_emitted = False
+    first_chunk_yielded = False
+
+    while True:
+        try:
+            item = out_queue.get(timeout=0.05)
+            if item is _SENTINEL:
+                break
+            if isinstance(item, Exception):
+                raise item
+
+            from speech_to_speech.pipeline.messages import LLMResponseChunk
+
+            if isinstance(item, LLMResponseChunk) and (item.text.strip() or item.tools):
+                first_chunk_yielded = True
+
+            yield item
+
+        except Empty:
+            if not first_chunk_yielded and not filler_emitted:
+                elapsed = perf_counter() - start_time
+                if elapsed >= filler_sentence_delay_s:
+                    if is_stale_fn and is_stale_fn():
+                        filler_emitted = True
+                        continue
+
+                    filler_text = random.choice(list(filler_sentences))
+                    logger.info(
+                        "LLM response latency (%.2fs) exceeded threshold (%.2fs); emitting filler sentence: '%s'",
+                        elapsed,
+                        filler_sentence_delay_s,
+                        filler_text,
+                    )
+                    from speech_to_speech.pipeline.messages import LLMResponseChunk
+
+                    yield LLMResponseChunk(
+                        text=filler_text,
+                        language_code=language_code,
+                        runtime_config=runtime_config,
+                        response=response,
+                        turn_id=turn_id,
+                        turn_revision=turn_revision,
+                        speech_stopped_at_s=speech_stopped_at_s,
+                        cancel_generation=gen,
+                    )
+                    filler_emitted = True
+
+    worker_thread.join(timeout=1.0)
+

--- a/src/speech_to_speech/arguments_classes/language_model_base_arguments.py
+++ b/src/speech_to_speech/arguments_classes/language_model_base_arguments.py
@@ -44,3 +44,28 @@ class LanguageModelBaseArguments:
             "instead of synchronously evicting them. Adds an extra LLM call per compaction. Default is True."
         },
     )
+    enable_filler_sentences: bool = field(
+        default=False,
+        metadata={
+            "help": "When True, yield a short filler sentence if the LLM takes longer than filler_sentence_delay_s to generate an initial response. Default is False."
+        },
+    )
+    filler_sentence_delay_s: float = field(
+        default=1.0,
+        metadata={
+            "help": "Delay in seconds before yielding a filler sentence if LLM has not started producing output. Default is 1.0."
+        },
+    )
+    filler_sentences: list[str] = field(
+        default_factory=lambda: [
+            "Hmm, let me see.",
+            "Let me check that for you.",
+            "Give me a moment.",
+            "Thinking about that.",
+            "Let me think about that for a second.",
+        ],
+        metadata={
+            "help": "List of filler sentences to choose from when LLM response generation takes too long."
+        },
+    )
+

--- a/tests/test_filler_sentences.py
+++ b/tests/test_filler_sentences.py
@@ -1,0 +1,165 @@
+import time
+from unittest.mock import MagicMock
+
+import pytest
+
+from speech_to_speech.api.openai_realtime.runtime_config import RuntimeConfig
+from speech_to_speech.LLM.chat import make_user_message
+from speech_to_speech.LLM.chat_completions_language_model import ChatCompletionsApiModelHandler
+from speech_to_speech.LLM.utils import run_generator_with_filler_sentences
+from speech_to_speech.pipeline.messages import EndOfResponse, GenerateResponseRequest, LLMResponseChunk
+
+
+
+def test_filler_sentences_disabled_by_default():
+    def slow_gen():
+        time.sleep(0.15)
+        yield LLMResponseChunk(text="Hello world!")
+
+    chunks = list(
+        run_generator_with_filler_sentences(
+            gen_fn=slow_gen,
+            enable_filler_sentences=False,
+            filler_sentence_delay_s=0.05,
+            filler_sentences=["Thinking..."],
+            language_code="en",
+            runtime_config=None,
+            response=None,
+            turn_id="t1",
+            turn_revision=1,
+            speech_stopped_at_s=None,
+            gen=0,
+        )
+    )
+
+    assert len(chunks) == 1
+    assert chunks[0].text == "Hello world!"
+
+
+def test_filler_sentence_emitted_when_slow():
+    def slow_gen():
+        time.sleep(0.15)
+        yield LLMResponseChunk(text="Here is your response.")
+
+    chunks = list(
+        run_generator_with_filler_sentences(
+            gen_fn=slow_gen,
+            enable_filler_sentences=True,
+            filler_sentence_delay_s=0.05,
+            filler_sentences=["Let me check that for you."],
+            language_code="en",
+            runtime_config=None,
+            response=None,
+            turn_id="t1",
+            turn_revision=1,
+            speech_stopped_at_s=None,
+            gen=0,
+        )
+    )
+
+    assert len(chunks) == 2
+    assert chunks[0].text == "Let me check that for you."
+    assert chunks[1].text == "Here is your response."
+
+
+def test_no_filler_sentence_when_fast():
+    def fast_gen():
+        yield LLMResponseChunk(text="Immediate answer.")
+
+    chunks = list(
+        run_generator_with_filler_sentences(
+            gen_fn=fast_gen,
+            enable_filler_sentences=True,
+            filler_sentence_delay_s=0.5,
+            filler_sentences=["Thinking..."],
+            language_code="en",
+            runtime_config=None,
+            response=None,
+            turn_id="t1",
+            turn_revision=1,
+            speech_stopped_at_s=None,
+            gen=0,
+        )
+    )
+
+    assert len(chunks) == 1
+    assert chunks[0].text == "Immediate answer."
+
+
+def test_filler_sentence_skipped_if_stale():
+    def slow_gen():
+        time.sleep(0.15)
+        yield LLMResponseChunk(text="Late answer.")
+
+    chunks = list(
+        run_generator_with_filler_sentences(
+            gen_fn=slow_gen,
+            enable_filler_sentences=True,
+            filler_sentence_delay_s=0.05,
+            filler_sentences=["Thinking..."],
+            language_code="en",
+            runtime_config=None,
+            response=None,
+            turn_id="t1",
+            turn_revision=1,
+            speech_stopped_at_s=None,
+            gen=0,
+            is_stale_fn=lambda: True,
+        )
+    )
+
+    assert len(chunks) == 1
+    assert chunks[0].text == "Late answer."
+
+
+def test_handler_integration_filler_sentences(monkeypatch):
+    monkeypatch.setattr(ChatCompletionsApiModelHandler, "warmup", lambda self: None)
+    mock_stop_event = MagicMock()
+    mock_queue_in = MagicMock()
+    mock_queue_out = MagicMock()
+
+    handler = ChatCompletionsApiModelHandler(
+        stop_event=mock_stop_event,
+        queue_in=mock_queue_in,
+        queue_out=mock_queue_out,
+        setup_kwargs={
+            "api_key": "test-key",
+            "enable_filler_sentences": True,
+            "filler_sentence_delay_s": 0.05,
+            "filler_sentences": ["Hmm, let me see."],
+        },
+    )
+
+
+
+    def slow_request(*args, **kwargs):
+        time.sleep(0.15)
+        chunk = MagicMock()
+        chunk.choices = [
+            MagicMock(
+                delta=MagicMock(content=" Paris is the capital.", refusal=None, tool_calls=None),
+                finish_reason=None,
+            )
+        ]
+        chunk.usage = None
+        return [chunk]
+
+    handler.client = MagicMock()
+    handler.client.chat.completions.create = slow_request
+
+    rc = RuntimeConfig()
+    rc.chat.add_item(make_user_message("What is the capital of France?"))
+    req = GenerateResponseRequest(runtime_config=rc, turn_id="t1", turn_revision=1)
+
+
+    outputs = list(handler.process(req))
+
+    texts = [out.text for out in outputs if isinstance(out, LLMResponseChunk)]
+    assert "Hmm, let me see." in texts
+    assert any("Paris is the capital." in t for t in texts)
+
+    # Verify filler sentence was not saved to chat history
+    history = rc.chat.to_transformers_chat()
+    messages = [m.get("content") for m in history]
+    assert "Hmm, let me see." not in messages
+


### PR DESCRIPTION
### Summary
Resolves #315 by introducing short, customizable filler/thinking sentences (e.g., *"Hmm, let me see."*, *"Give me a moment."*) when LLM response generation takes longer than a configurable latency threshold.

In real-time voice interactions, high P90 LLM time-to-first-token (TTFT) can result in awkward silence after a user finishes speaking. This feature bridges the latency gap by providing immediate spoken feedback to the user while the language model is generating its response.

---

### Key Changes
1. **Configuration Flags (`LanguageModelBaseArguments`)**:
   - `enable_filler_sentences: bool` (default: `False`): Opt-in flag to enable filler sentences.
   - `filler_sentence_delay_s: float` (default: `1.0`): Latency threshold in seconds before emitting a filler phrase.
   - `filler_sentences: list[str]`: List of candidate filler phrases randomly selected upon timeout.

2. **Async Generation Monitoring (`LLM/utils.py`)**:
   - Added `run_generator_with_filler_sentences` wrapper function.
   - Runs generation in a worker thread and monitors time-to-first-chunk. If `filler_sentence_delay_s` elapses before initial output text is produced, a filler `LLMResponseChunk` is yielded downstream for immediate TTS synthesis.
   - Preserves fast responses without adding any filler when TTFT is within the threshold.

3. **Handler Integrations**:
   - Integrated across both `BaseLanguageModelHandler` (local Transformers / MLX backends) and `BaseOpenAICompatibleHandler` (Chat Completions and Responses API backends).
   - Filler sentences are emitted strictly as real-time audio output chunks and are not committed to conversation history (`Chat`), keeping chat context clean.

4. **Testing**:
   - Added comprehensive unit tests in `tests/test_filler_sentences.py` covering:
     - Disabled state behavior.
     - Delayed LLM responses emitting filler chunks.
     - Fast LLM responses bypassing filler sentences.
     - Stale/cancelled turns skipping filler sentence emission.
     - Verification that conversation history is preserved without filler text pollution.

---

### How to Test
```bash
# Run unit tests
PYTHONPATH=src pytest tests/test_filler_sentences.py
