### PR TITLE
Fix tool signature parameter ordering

### DIFF
--- a/src/speech_to_speech/LLM/tool_call/signature_from_schema.py
+++ b/src/speech_to_speech/LLM/tool_call/signature_from_schema.py
@@ -84,7 +84,23 @@ def signature_from_schema(schema: object | None) -> inspect.Signature:
     required = set(schema.get("required", []))
     params = []
 
-    for name, spec in props.items():
+    # JSON Schema does not require properties to list required fields first.
+    # Python signatures do: parameters without defaults must precede parameters
+    # with defaults. Keep the schema's order within both groups while moving
+    # required fields without schema defaults ahead of optional/defaulted ones.
+    property_items = list(props.items())
+    required_without_default = [
+        (name, spec)
+        for name, spec in property_items
+        if name in required and not (isinstance(spec, dict) and "default" in spec)
+    ]
+    defaulted_or_optional = [
+        (name, spec)
+        for name, spec in property_items
+        if not (name in required and not (isinstance(spec, dict) and "default" in spec))
+    ]
+
+    for name, spec in [*required_without_default, *defaulted_or_optional]:
         annotation = _annotation_from_spec(spec)
 
         has_schema_default = "default" in spec if isinstance(spec, dict) else False

--- a/tests/tool_call/test_signature_from_schema.py
+++ b/tests/tool_call/test_signature_from_schema.py
@@ -154,6 +154,21 @@ class TestSignatureFromSchema:
         assert "*" not in str(sig)
         assert str(sig) == "(query: str, limit: int = 10, verbose: bool = None)"
 
+    def test_required_property_after_optional_property(self):
+        """JSON Schema property order need not be valid Python parameter order."""
+        schema = {
+            "type": "object",
+            "properties": {
+                "limit": {"type": "integer"},
+                "query": {"type": "string"},
+            },
+            "required": ["query"],
+        }
+
+        sig = signature_from_schema(schema)
+
+        assert str(sig) == "(query: str, limit: int = None)"
+
     def test_all_required(self):
         schema = {
             "type": "object",


### PR DESCRIPTION
## Summary

Fixes tool prompt generation for valid JSON Schemas whose `properties` order places an optional field before a required field.

## Problem

`FunctionTool.to_code_prompt()` renders each tool as a Python-style function signature for the model prompt. It delegates signature construction to `signature_from_schema()`.

The previous implementation emitted parameters in the exact order found in JSON Schema `properties`. JSON Schema does not require required fields to appear before optional fields, but Python function signatures require parameters without defaults to precede parameters with defaults.

For example, this valid tool schema:

```json
{
  "type": "object",
  "properties": {
    "limit": { "type": "integer" },
    "query": { "type": "string" }
  },
  "required": ["query"]
}
```

was converted into this invalid Python signature:

```python
def search(limit: int = None, query: str):
```

As a result, `inspect.Signature` raised:

```text
ValueError: non-default argument follows default argument
```

This prevented the tool-calling system prompt from being built, so affected tool configurations failed before the LLM received a request.

## Fix

Parameters are now emitted in two stable groups:

1. Required parameters without a schema default.
2. Optional parameters and parameters with a schema default.

The original JSON Schema order is preserved within each group. The example above now renders as:

```python
def search(query: str, limit: int = None):
```

Required parameters that explicitly define a schema default remain in the second group because they are still defaulted Python parameters.

## Scope

This change only affects parameter ordering during Python-signature rendering. It does not change:

- JSON Schema type-to-annotation conversion;
- enum, `const`, `oneOf`, `anyOf`, `allOf`, or array handling;
- parameter names;
- schema defaults;
- tool-call argument validation.

## Tests

Added a regression test for an optional property declared before a required property.

Validated with:

```text
pytest tests/tool_call/test_function_parser.py tests/tool_call/test_signature_from_schema.py -q
77 passed

ruff check src/speech_to_speech/LLM/tool_call/signature_from_schema.py tests/tool_call/test_signature_from_schema.py
All checks passed

mypy src/speech_to_speech/LLM/tool_call/signature_from_schema.py
Success: no issues found
```