### PR TITLE
fix: acquire MLX lock in LightningWhisperSTTHandler to prevent SIGSEGV

### DIFF
--- a/src/speech_to_speech/STT/lightning_whisper_mlx_handler.py
+++ b/src/speech_to_speech/STT/lightning_whisper_mlx_handler.py
@@ -11,6 +11,7 @@ from rich.console import Console
 from speech_to_speech.pipeline.handler_types import STTIn, STTOut
 from speech_to_speech.pipeline.messages import Transcription
 from speech_to_speech.STT.base_stt_handler import BaseSTTHandler
+from speech_to_speech.utils.mlx_lock import MLXLockContext
 
 logger = logging.getLogger(__name__)
 
@@ -63,21 +64,25 @@ class LightningWhisperSTTHandler(BaseSTTHandler):
         dummy_input = np.array([0] * 512)
 
         for _ in range(n_steps):
-            _ = self.model.transcribe(dummy_input)["text"].strip()
+            with MLXLockContext(handler_name=self.__class__.__name__):
+                _ = self.model.transcribe(dummy_input)["text"].strip()
 
     def process(self, vad_audio: STTIn) -> Iterator[STTOut]:
         logger.debug("infering whisper...")
 
         audio = vad_audio.audio
         if self.start_language != "auto":
-            transcription_dict = self.model.transcribe(audio, language=self.start_language)
+            with MLXLockContext(handler_name=self.__class__.__name__):
+                transcription_dict = self.model.transcribe(audio, language=self.start_language)
         else:
-            transcription_dict = self.model.transcribe(audio)
+            with MLXLockContext(handler_name=self.__class__.__name__):
+                transcription_dict = self.model.transcribe(audio)
             language_code = transcription_dict["language"]
             if language_code not in SUPPORTED_LANGUAGES:
                 logger.warning(f"Whisper detected unsupported language: {language_code}")
                 if self.last_language in SUPPORTED_LANGUAGES:  # reprocess with the last language
-                    transcription_dict = self.model.transcribe(audio, language=self.last_language)
+                    with MLXLockContext(handler_name=self.__class__.__name__):
+                        transcription_dict = self.model.transcribe(audio, language=self.last_language)
                 else:
                     transcription_dict = {"text": "", "language": "en"}
             else:


### PR DESCRIPTION
## Summary

Fixes #385

The `LightningWhisperSTTHandler` (the handler behind `--stt whisper-mlx`) was the only remaining MLX inference path that did not serialize through the global MLX lock. When STT and TTS ran concurrently on Apple Silicon, the shared Metal command buffer was corrupted, causing a SIGSEGV in `mlx::core::metal::CommandEncoder`.

PR #379 fixed the same bug in `mlx_audio_whisper_handler.py`, but `lightning_whisper_mlx_handler.py` was missed.

## Changes

- Import `MLXLockContext` from `speech_to_speech.utils.mlx_lock`
- Wrap `warmup()` transcribe call with `MLXLockContext`
- Wrap all three `process()` transcribe calls with `MLXLockContext` (forced-language path, auto-detect path, and re-transcribe fallback)

## Verification

```bash
$ git grep -l mlx_lock -- src/
src/speech_to_speech/LLM/language_model.py
src/speech_to_speech/STT/lightning_whisper_mlx_handler.py  # now listed
src/speech_to_speech/STT/mlx_audio_whisper_handler.py
src/speech_to_speech/STT/parakeet_tdt_handler.py
src/speech_to_speech/TTS/kokoro_handler.py
src/speech_to_speech/TTS/qwen3_tts_handler.py
src/speech_to_speech/s2s_pipeline.py
src/speech_to_speech/utils/mlx_lock.py
```

All four MLX inference call sites in the handler are now guarded, following the same pattern as the already-merged #379 fix.