### PR TITLE
Relax MLX dependency pins on macOS

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -51,10 +51,10 @@ dependencies = [
     "faster-qwen3-tts>=0.3.2; platform_system == 'Windows'",
     "lingua-language-detector>=2.0.2",
     "miniaudio==1.61; platform_system == 'Darwin'",
-    "mlx==0.31.1; platform_system == 'Darwin'",
+    "mlx>=0.31.2,<0.33; platform_system == 'Darwin'",
     "mlx-audio==0.4.2; platform_system == 'Darwin'",
-    "mlx-lm==0.31.1; platform_system == 'Darwin'",
-    "mlx-metal==0.31.1; platform_system == 'Darwin'",
+    "mlx-lm>=0.31.2,<0.33; platform_system == 'Darwin'",
+    "mlx-metal>=0.31.2,<0.33; platform_system == 'Darwin'",
     "misaki>=0.9.4; platform_system == 'Darwin'",
     "espeakng-loader>=0.2.4; platform_system == 'Darwin'",
     "spacy>=3.8.4; platform_system == 'Darwin'",
@@ -78,7 +78,7 @@ language-detection = [
     "lingua-language-detector>=2.0.2",
 ]
 mlx-lm = [
-    "mlx-lm==0.31.1; platform_system == 'Darwin'",
+    "mlx-lm>=0.31.2,<0.33; platform_system == 'Darwin'",
     "mlx-vlm==0.4.1; platform_system == 'Darwin'",
 ]
 paraformer = [

--- a/tests/install_smoke.py
+++ b/tests/install_smoke.py
@@ -122,24 +122,48 @@ def _validate_realtime_websocket_support() -> None:
     importlib.import_module("uvicorn.protocols.websockets.websockets_impl")
 
 
+def _parse_version(version_str: str) -> tuple[int, ...]:
+    try:
+        from packaging.version import Version
+        v = Version(version_str)
+        return (v.major, v.minor, v.micro)
+    except ImportError:
+        parts = []
+        for part in version_str.split("."):
+            digits = "".join(c for c in part if c.isdigit())
+            if digits:
+                parts.append(int(digits))
+        return tuple(parts[:3])
+
+
 def _validate_darwin_dependency_pins() -> None:
-    expected_versions = {
+    expected_exact_versions = {
         "miniaudio": "1.61",
-        "mlx": "0.31.1",
         "mlx-audio": "0.4.2",
-        "mlx-lm": "0.31.1",
-        "mlx-metal": "0.31.1",
         "sounddevice": "0.5.3",
         "transformers": "5.6.2",
     }
+    expected_version_ranges = {
+        "mlx": ((0, 31, 2), (0, 33, 0)),
+        "mlx-lm": ((0, 31, 2), (0, 33, 0)),
+        "mlx-metal": ((0, 31, 2), (0, 33, 0)),
+    }
     mismatches = []
-    for package_name, expected_version in expected_versions.items():
+    for package_name, expected_version in expected_exact_versions.items():
         actual_version = metadata.version(package_name)
         if actual_version != expected_version:
             mismatches.append(f"{package_name}=={actual_version} (expected {expected_version})")
 
+    for package_name, (min_ver, max_ver) in expected_version_ranges.items():
+        actual_version = metadata.version(package_name)
+        version_parts = _parse_version(actual_version)
+        if not (min_ver <= version_parts < max_ver):
+            min_str = ".".join(map(str, min_ver))
+            max_str = ".".join(map(str, max_ver))
+            mismatches.append(f"{package_name}=={actual_version} (expected >={min_str},<{max_str})")
+
     numpy_version = metadata.version("numpy")
-    numpy_version_parts = tuple(int(part) for part in numpy_version.split(".")[:3])
+    numpy_version_parts = _parse_version(numpy_version)
     if numpy_version_parts >= (2, 4, 4):
         mismatches.append(f"numpy=={numpy_version} (expected <2.4.4 on macOS)")
 


### PR DESCRIPTION
MLX 0.31.2 introduced thread safety for independent computations and fixed issues that originally motivated pinning to 0.31.1. Relaxing the pins allows users to benefit from upstream bug fixes while preserving compatibility bounds.

Fixes #386.