### PR TITLE
Add demo startup greeting and HF user attribution

### DIFF
--- a/demo/README.md
+++ b/demo/README.md
@@ -45,6 +45,7 @@ backend, speaking the OpenAI Realtime **GA** protocol over **WebSocket**
    uv pip install -r demo/requirements.txt
    export SPEECH_TO_SPEECH_URL=ws://localhost:8765/v1/realtime
    export SERPER_API_KEY=...   # optional; web search is disabled without it
+   export STARTUP_GREETING=... # optional; empty disables the automatic greeting
    uv run uvicorn --app-dir demo server:app --reload --port 7860
    ```
 
@@ -155,7 +156,10 @@ Three modes, picked by env (`/api/config` tells the client which one is active):
 - **`LOAD_BALANCER_URL` env** — multi-compute deployments only: the browser
   POSTs the same-origin `/api/session` proxy, the server forwards to the LB,
   and the browser dials the per-session compute URL the LB hands back. The LB
-  address never reaches the browser; the Settings URL field is hidden.
+  address never reaches the browser; the Settings URL field is hidden. On
+  OAuth-enabled Spaces, the proxy forwards the signed-in user's HF access token
+  to the LB through `X-Reachy-Mini-Authorization` so the backend can attribute
+  usage. The token stays server-side; anonymous requests include no credential.
 
 | `SPEECH_TO_SPEECH_URL` | `LOAD_BALANCER_URL` | `SPACE_ID` | Connection | URL field | Transport | Metering |
 |:---:|:---:|:---:|---|---|---|---|
@@ -165,6 +169,16 @@ Three modes, picked by env (`/api/config` tells the client which one is active):
 | – | ✅ | – | LB proxy | hidden | WS only | off |
 
 **Settings → Restart** reconnects with the current voice, instructions and URL.
+
+## Startup greeting
+
+By default, each new connection creates one hidden user item asking the model
+for a brief greeting, then requests a response. Besides opening the conversation
+naturally, this warms the same prompt prefix used by the first spoken turn.
+
+Set `STARTUP_GREETING` to customize the hidden prompt, or set it to an empty
+value to disable automatic generation. The WebSocket and WebRTC clients both
+guard the greeting so it is sent at most once per connection.
 
 ## Tools
 

--- a/demo/auth.py
+++ b/demo/auth.py
@@ -106,6 +106,18 @@ def current_user(request):
     return _field(current_oauth(request), "user_info")
 
 
+def current_access_token(request) -> "str | None":
+    """The signed-in user's HF OAuth access token, or None.
+
+    Keep this server-side: the demo uses it to attribute load-balancer session
+    requests to the signed-in HF account, but never returns it to the browser.
+    """
+    token = _field(current_oauth(request), "access_token")
+    if token is None:
+        return None
+    return str(token).strip() or None
+
+
 def _user_org_names(user) -> "set[str]":
     """The user's organisations from the OAuth userinfo, by username/name/id."""
     names = set()

--- a/demo/main.js
+++ b/demo/main.js
@@ -329,6 +329,9 @@ let rtcAvailable = false;
 /** @type {RTCIceServer[]} STUN/TURN servers for the browser peer connection
  * (deploy-provided via RTC_ICE_SERVERS; empty -> host candidates only). */
 let iceServers = [];
+// Optional hidden user prompt supplied by the deployment. When non-empty, the
+// client asks the model to greet once after the initial session configuration.
+let startupGreeting = "";
 // Transport of the LIVE (or starting) conversation — as opposed to
 // `settings.transport`, which is what the NEXT one will use. Drives the
 // camera-snapshot size budget while a call is running.
@@ -918,6 +921,9 @@ async function fetchConfig() {
       // /api/calls proxy refuses to forward anywhere else).
       rtcAvailable = !!json.rtc;
       iceServers = Array.isArray(json.iceServers) ? json.iceServers : [];
+      startupGreeting = typeof json.startupGreeting === "string"
+        ? json.startupGreeting.trim()
+        : "";
       // The conversation-time limiter rides on the LB being present.
       limiterOn = lbMode;
     }
@@ -1418,6 +1424,7 @@ async function doStart(audioContext = null) {
   const common = {
     voice: settings.voice,
     instructions: effectiveInstructions(),
+    startupGreeting,
     acquireMic: acquireMicStream,
     tools: activeToolDefs(),
     audioOutputId: settings.audioOutputId || "",

--- a/demo/rtc/s2s-rtc-client.js
+++ b/demo/rtc/s2s-rtc-client.js
@@ -44,6 +44,8 @@
  *   candidates only — fine locally, may not traverse NATs).
  * @property {string} voice
  * @property {string} instructions
+ * @property {string} [startupGreeting] Hidden user prompt that asks the model
+ *   to greet once after the initial session configuration is sent.
  * @property {MediaStream} [micStream] Live mic stream. Provide this OR `acquireMic`.
  * @property {() => Promise<MediaStream>} [acquireMic] Lazily obtain the mic
  *   stream once connect() actually runs (same contract as the WS client).
@@ -146,6 +148,8 @@ export class S2sRtcRealtimeClient extends EventTarget {
     /** @type {{ image?: string }[]} */
     this._createQueue = [];
     this._sessionConfigured = false;
+    this._startupGreeting = options.startupGreeting?.trim() ?? "";
+    this._startupGreetingSent = false;
     this._debug = (() => { try { return localStorage.getItem("s2s.debug") === "1"; } catch { return false; } })();
   }
 
@@ -445,6 +449,9 @@ export class S2sRtcRealtimeClient extends EventTarget {
         // user-tunable bits (voice, instructions, tools) — same as WS.
         this._sendSessionUpdate();
         this._sessionConfigured = true;
+        // Data-channel messages are ordered, so the hidden item and
+        // response.create are handled after the session.update above.
+        this._sendStartupGreeting();
         if (this._status === "connecting") this._setStatus("connected");
         break;
 
@@ -712,6 +719,26 @@ export class S2sRtcRealtimeClient extends EventTarget {
         content: [{ type: "input_image", image_url: dataUrl }],
       },
     });
+  }
+
+  /**
+   * Ask the model to open the conversation exactly once. The synthetic user
+   * prompt stays in conversation history, warming the prompt prefix reused by
+   * the first spoken turn.
+   */
+  _sendStartupGreeting() {
+    if (!this._startupGreeting || this._startupGreetingSent) return;
+    this._startupGreetingSent = true;
+    this._send({
+      type: "conversation.item.create",
+      item: {
+        type: "message",
+        role: "user",
+        content: [{ type: "input_text", text: this._startupGreeting }],
+      },
+    });
+    this.requestResponse();
+    if (this._debug) console.debug("[rtc] startup greeting queued");
   }
 
   /** Ask the model to respond now (after tool results). Serialized behind the

--- a/demo/rtc/s2s-rtc-client.js
+++ b/demo/rtc/s2s-rtc-client.js
@@ -205,7 +205,11 @@ export class S2sRtcRealtimeClient extends EventTarget {
 
     const micTrack = this.options.micStream?.getAudioTracks()[0];
     if (!micTrack) throw new Error("No microphone track available");
-    micTrack.enabled = !this._muted;
+    // Negotiate the audio track immediately, but transmit silence until the
+    // server has received session.update and the optional greeting sequence.
+    // Otherwise background noise during the WebRTC handshake can create the
+    // first user turn before the greeting is queued.
+    this._syncMicTransmission();
     pc.addTrack(micTrack, /** @type {MediaStream} */ (this.options.micStream));
 
     // The client opens the events channel (OpenAI convention); the server
@@ -452,6 +456,9 @@ export class S2sRtcRealtimeClient extends EventTarget {
         // Data-channel messages are ordered, so the hidden item and
         // response.create are handled after the session.update above.
         this._sendStartupGreeting();
+        // Only open the microphone after the configuration and greeting events
+        // above have been queued on the ordered data channel.
+        this._syncMicTransmission();
         if (this._status === "connecting") this._setStatus("connected");
         break;
 
@@ -777,10 +784,15 @@ export class S2sRtcRealtimeClient extends EventTarget {
   setMuted(muted) {
     this._muted = muted;
     // The caller (main.js) also toggles the shared micStream tracks; doing it
-    // here too keeps the client correct when driven standalone. A disabled
-    // track makes the browser transmit silence — the server VAD stays quiet.
+    // here too keeps the client correct when driven standalone. Before the
+    // session is configured, even an explicit unmute must continue sending
+    // silence so no user turn can race the startup greeting.
+    this._syncMicTransmission();
+  }
+
+  _syncMicTransmission() {
     for (const track of this.options.micStream?.getAudioTracks() ?? []) {
-      track.enabled = !muted;
+      track.enabled = this._sessionConfigured && !this._muted;
     }
   }
 

--- a/demo/server.py
+++ b/demo/server.py
@@ -104,6 +104,13 @@ def _parse_ice_servers(raw: str) -> list:
 
 
 RTC_ICE_SERVERS = _parse_ice_servers(os.environ.get("RTC_ICE_SERVERS", ""))
+DEFAULT_STARTUP_GREETING = (
+    "Start the conversation now with a brief, spontaneous greeting in character. "
+    "Keep it to one sentence, invite the user in naturally, and vary the wording each time."
+)
+# Exposed to the browser through /api/config. Set an empty value to disable the
+# automatic greeting without changing the client bundle.
+STARTUP_GREETING = os.environ.get("STARTUP_GREETING", DEFAULT_STARTUP_GREETING).strip()
 
 
 def _webrtc_calls_url(s2s_url: str) -> str:
@@ -125,6 +132,7 @@ SERPER_URL = "https://google.serper.dev/search"
 # Cap results so the tool output stays small enough to feed back to the model.
 MAX_RESULTS = 5
 HERE = os.path.dirname(os.path.abspath(__file__))
+LB_USER_AGENT = "speech-to-speech-demo"
 
 app = FastAPI(title="s2s-demo")
 
@@ -176,6 +184,7 @@ def config():
         # offered exactly when that URL exists.
         "rtc": bool(SPEECH_TO_SPEECH_URL),
         "iceServers": RTC_ICE_SERVERS,
+        "startupGreeting": STARTUP_GREETING,
         "auth": AUTH_ENABLED,
     }
 
@@ -339,7 +348,11 @@ async def session(request: Request):
     url = f"{LOAD_BALANCER_URL.rstrip('/')}/session"
     try:
         async with httpx.AsyncClient(timeout=15.0) as http:
-            lb = await http.post(url, headers={"Content-Type": "application/json"}, content="{}")
+            lb = await http.post(
+                url,
+                headers=_load_balancer_headers(request),
+                content="{}",
+            )
     except httpx.RequestError as exc:
         logger.warning("Load balancer unreachable: %r", exc)
         raise HTTPException(status_code=502, detail="Speech service unreachable.")
@@ -373,6 +386,23 @@ async def session(request: Request):
 
     # A slot was free: reserve the first chunk now and return the grant.
     return await _finalize_grant(data, keys, tier, tracked, set_cookie)
+
+
+def _load_balancer_headers(request: Request) -> dict[str, str]:
+    """Headers for the server-to-server session allocation request.
+
+    The dedicated authorization header matches the Reachy Mini client and lets
+    the load balancer validate and attribute an optional HF user token without
+    exposing it to browser JavaScript. Anonymous visitors send no credential.
+    """
+    headers = {
+        "Content-Type": "application/json",
+        "User-Agent": LB_USER_AGENT,
+    }
+    token = auth.current_access_token(request)
+    if token:
+        headers["X-Reachy-Mini-Authorization"] = f"Bearer {token}"
+    return headers
 
 
 @app.get("/api/queue/{queue_id}")

--- a/demo/ws/s2s-ws-client.js
+++ b/demo/ws/s2s-ws-client.js
@@ -51,6 +51,8 @@
  *   session POST and dials it directly — no load balancer in between.
  * @property {string} voice
  * @property {string} instructions
+ * @property {string} [startupGreeting] Hidden user prompt that asks the model
+ *   to greet once after the initial session configuration is sent.
  * @property {MediaStream} [micStream] Live mic stream. Provide this OR `acquireMic`.
  * @property {() => Promise<MediaStream>} [acquireMic] Lazily obtain the mic stream,
  *   called only once a session is actually granted (after any queue wait). Lets the
@@ -200,6 +202,8 @@ export class S2sWsRealtimeClient extends EventTarget {
     /** @type {Promise<void> | null} */
     this._readyPromise = null;
     this._sessionConfigured = false;
+    this._startupGreeting = options.startupGreeting?.trim() ?? "";
+    this._startupGreetingSent = false;
     this._debug = (() => { try { return localStorage.getItem("s2s.debug") === "1"; } catch { return false; } })();
   }
 
@@ -647,11 +651,16 @@ export class S2sWsRealtimeClient extends EventTarget {
         // out). We only push the user-tunable bits: voice + instructions.
         this._sendSessionUpdate();
         this._sessionConfigured = true;
+        // The s2s server does not echo session.updated. WebSocket messages are
+        // ordered, so this hidden item and response.create are handled only
+        // after the session.update sent immediately above.
+        this._sendStartupGreeting();
         if (this._status === "connecting") this._setStatus("connected");
         break;
 
       case "session.updated":
-        // Acknowledged by server, nothing to do.
+        // Some Realtime servers acknowledge session.update; the greeting was
+        // already queued from session.created and is guarded against repeats.
         break;
 
       case "input_audio_buffer.speech_started":
@@ -985,6 +994,26 @@ export class S2sWsRealtimeClient extends EventTarget {
         content: [{ type: "input_image", image_url: dataUrl }],
       },
     });
+  }
+
+  /**
+   * Ask the model to open the conversation exactly once. The synthetic user
+   * prompt stays in conversation history, so the greeting warms the actual
+   * prompt prefix reused by the first spoken turn.
+   */
+  _sendStartupGreeting() {
+    if (!this._startupGreeting || this._startupGreetingSent) return;
+    this._startupGreetingSent = true;
+    this._send({
+      type: "conversation.item.create",
+      item: {
+        type: "message",
+        role: "user",
+        content: [{ type: "input_text", text: this._startupGreeting }],
+      },
+    });
+    this.requestResponse();
+    if (this._debug) console.debug("[ws] startup greeting queued");
   }
 
   /**

--- a/tests/test_demo_server.py
+++ b/tests/test_demo_server.py
@@ -1,0 +1,51 @@
+import importlib
+import sys
+from pathlib import Path
+
+DEMO_DIR = Path(__file__).resolve().parents[1] / "demo"
+sys.path.insert(0, str(DEMO_DIR))
+demo_auth = importlib.import_module("auth")
+demo_server = importlib.import_module("server")
+
+
+def test_current_access_token_normalizes_oauth_token(monkeypatch):
+    monkeypatch.setattr(
+        demo_auth,
+        "current_oauth",
+        lambda request: {"access_token": "  hf_user_token  "},
+    )
+
+    assert demo_auth.current_access_token(object()) == "hf_user_token"
+
+
+def test_current_access_token_rejects_missing_or_empty_token(monkeypatch):
+    monkeypatch.setattr(demo_auth, "current_oauth", lambda request: None)
+    assert demo_auth.current_access_token(object()) is None
+
+    monkeypatch.setattr(demo_auth, "current_oauth", lambda request: {"access_token": "  "})
+    assert demo_auth.current_access_token(object()) is None
+
+
+def test_load_balancer_headers_forward_signed_in_user_token(monkeypatch):
+    monkeypatch.setattr(
+        demo_server.auth,
+        "current_access_token",
+        lambda request: "hf_user_token",
+    )
+
+    assert demo_server._load_balancer_headers(object()) == {
+        "Content-Type": "application/json",
+        "User-Agent": "speech-to-speech-demo",
+        "X-Reachy-Mini-Authorization": "Bearer hf_user_token",
+    }
+
+
+def test_load_balancer_headers_keep_anonymous_requests_credential_free(monkeypatch):
+    monkeypatch.setattr(demo_server.auth, "current_access_token", lambda request: None)
+
+    headers = demo_server._load_balancer_headers(object())
+
+    assert headers == {
+        "Content-Type": "application/json",
+        "User-Agent": "speech-to-speech-demo",
+    }

--- a/tests/test_demo_startup_greeting.py
+++ b/tests/test_demo_startup_greeting.py
@@ -87,3 +87,59 @@ if (sends !== 0) throw new Error(`expected no events, got ${{sends}}`);
         capture_output=True,
         text=True,
     )
+
+
+def test_rtc_microphone_opens_after_startup_events_are_queued():
+    node = shutil.which("node")
+    if node is None:
+        pytest.skip("Node.js is required for demo client tests")
+
+    script = """
+globalThis.localStorage = { getItem() { return null; } };
+const { S2sRtcRealtimeClient } = await import("./demo/rtc/s2s-rtc-client.js");
+const timeline = [];
+let enabled = true;
+const track = {};
+Object.defineProperty(track, "enabled", {
+  get() { return enabled; },
+  set(value) {
+    enabled = value;
+    timeline.push(`mic:${value}`);
+  },
+});
+const client = new S2sRtcRealtimeClient({
+  voice: "Aiden",
+  instructions: "Be helpful.",
+  callsUrl: "api/calls",
+  startupGreeting: "Say hello.",
+  micStream: { getAudioTracks() { return [track]; } },
+});
+client._sendSessionUpdate = () => timeline.push("session.update");
+client._send = (event) => timeline.push(event.type);
+client.requestResponse = () => timeline.push("response.create");
+
+// This is the gate applied before addTrack() during connect().
+client._syncMicTransmission();
+// An unmute while connecting must not bypass the gate.
+client.setMuted(false);
+client._onDcMessage(JSON.stringify({ type: "session.created" }));
+
+const expected = [
+  "mic:false",
+  "mic:false",
+  "session.update",
+  "conversation.item.create",
+  "response.create",
+  "mic:true",
+];
+if (JSON.stringify(timeline) !== JSON.stringify(expected)) {
+  throw new Error(`unexpected ordering: ${JSON.stringify(timeline)}`);
+}
+"""
+    subprocess.run(
+        [node, "--input-type=module", "-e", script],
+        cwd=REPO_ROOT,
+        check=True,
+        capture_output=True,
+        text=True,
+    )

--- a/tests/test_demo_startup_greeting.py
+++ b/tests/test_demo_startup_greeting.py
@@ -1,0 +1,89 @@
+import json
+import shutil
+import subprocess
+from pathlib import Path
+
+import pytest
+
+REPO_ROOT = Path(__file__).resolve().parents[1]
+
+
+@pytest.mark.parametrize(
+    "module_path,class_name",
+    [
+        ("./demo/ws/s2s-ws-client.js", "S2sWsRealtimeClient"),
+        ("./demo/rtc/s2s-rtc-client.js", "S2sRtcRealtimeClient"),
+    ],
+)
+def test_startup_greeting_is_sent_once(module_path, class_name):
+    node = shutil.which("node")
+    if node is None:
+        pytest.skip("Node.js is required for demo client tests")
+
+    script = f"""
+globalThis.localStorage = {{ getItem() {{ return null; }} }};
+const {{ {class_name} }} = await import({json.dumps(module_path)});
+const client = new {class_name}({{
+  voice: "Aiden",
+  instructions: "Be helpful.",
+  directUrl: "ws://unused",
+  callsUrl: "api/calls",
+  startupGreeting: "  Say hello.  ",
+}});
+const sent = [];
+client._send = (event) => sent.push(event);
+client.requestResponse = () => sent.push({{ type: "response.create" }});
+client._sendStartupGreeting();
+client._sendStartupGreeting();
+if (sent.length !== 2) throw new Error(`expected 2 events, got ${{sent.length}}`);
+if (sent[0]?.item?.content?.[0]?.text !== "Say hello.") {{
+  throw new Error(`unexpected greeting event: ${{JSON.stringify(sent[0])}}`);
+}}
+if (sent[1]?.type !== "response.create") {{
+  throw new Error(`unexpected response event: ${{JSON.stringify(sent[1])}}`);
+}}
+"""
+    subprocess.run(
+        [node, "--input-type=module", "-e", script],
+        cwd=REPO_ROOT,
+        check=True,
+        capture_output=True,
+        text=True,
+    )
+
+
+@pytest.mark.parametrize(
+    "module_path,class_name",
+    [
+        ("./demo/ws/s2s-ws-client.js", "S2sWsRealtimeClient"),
+        ("./demo/rtc/s2s-rtc-client.js", "S2sRtcRealtimeClient"),
+    ],
+)
+def test_empty_startup_greeting_is_disabled(module_path, class_name):
+    node = shutil.which("node")
+    if node is None:
+        pytest.skip("Node.js is required for demo client tests")
+
+    script = f"""
+globalThis.localStorage = {{ getItem() {{ return null; }} }};
+const {{ {class_name} }} = await import({json.dumps(module_path)});
+const client = new {class_name}({{
+  voice: "Aiden",
+  instructions: "Be helpful.",
+  directUrl: "ws://unused",
+  callsUrl: "api/calls",
+  startupGreeting: "   ",
+}});
+let sends = 0;
+client._send = () => sends += 1;
+client.requestResponse = () => sends += 1;
+client._sendStartupGreeting();
+if (sends !== 0) throw new Error(`expected no events, got ${{sends}}`);
+"""
+    subprocess.run(
+        [node, "--input-type=module", "-e", script],
+        cwd=REPO_ROOT,
+        check=True,
+        capture_output=True,
+        text=True,
+    )


### PR DESCRIPTION
## Summary

- add a configurable startup greeting to the realtime demo
- support the greeting in both WebSocket and WebRTC clients
- forward signed-in HF OAuth tokens server-side when allocating a load-balanced session
- document both behaviors and add focused regression tests

## Why

The startup greeting lets the assistant open the conversation naturally while
warming the same prompt prefix used by the first spoken turn. The demo serves a
default prompt through `/api/config`; deployments can customize it with
`STARTUP_GREETING` or set an empty value to disable it.

The demo already knows the signed-in HF user for usage limits, but the load
balancer could only see the Space proxy as the requester. Session allocation now
forwards the OAuth access token through `X-Reachy-Mini-Authorization`, matching
the existing Reachy Mini convention so the backend can validate and attribute
the user.

The OAuth token remains server-side and is never returned to browser JavaScript.
Anonymous allocation requests carry no credential header.

## Validation

- `uv run pytest tests/ -x -q` — 624 passed
- `uv run ruff check demo/auth.py demo/server.py tests/test_demo_server.py tests/test_demo_startup_greeting.py`
- `node --check demo/main.js`
- `node --check demo/ws/s2s-ws-client.js`
- `node --check demo/rtc/s2s-rtc-client.js`
- `git diff --check`
