### PR TITLE
Add user audio replay to the realtime demo

### DIFF
--- a/demo/README.md
+++ b/demo/README.md
@@ -94,7 +94,10 @@ websocat ws://localhost:8765/v1/realtime
    `session.audio.output`, `session.output_modalities`).
 3. Client streams mic audio as PCM16 16 kHz mono base64 chunks
    (`input_audio_buffer.append`, one frame every ~40 ms).
-4. Server pushes `response.output_audio.delta` (PCM16 24 kHz mono base64)
+4. The browser keeps a bounded, in-memory copy of those sent frames and uses
+   the server VAD boundaries to add replayable user recordings to conversation
+   history. No recording is uploaded or persisted separately.
+5. Server pushes `response.output_audio.delta` (PCM16 24 kHz mono base64)
    and transcript deltas.
 
 The backend exposes one concurrent session per pipeline unit
@@ -127,6 +130,9 @@ answers 501 and the handshake fails with a clear message.
 
 Caveats vs. WebSocket:
 
+- **User recording replay**: conversation-history recordings currently use the
+  exact PCM frames sent through `input_audio_buffer.append`, so they are
+  available only on the WebSocket transport.
 - **NAT**: host ICE candidates only by default — fine when browser and backend
   are on the same machine/LAN. Across the internet, set `RTC_ICE_SERVERS` on
   *this* app (a JSON list of `RTCIceServer` dicts, or comma-separated
@@ -233,7 +239,7 @@ transport pick, and `s2s.audio.inputId` / `s2s.audio.outputId` for devices).
 |------|------|
 | `index.html` | Single page, orb + settings modal (identical UI to the WebRTC app) |
 | `main.js` | State machine, settings, tools, camera, noise-gate UI wiring |
-| `ui/chat.js` | `ChatView`: history panel, ephemeral bubbles, transcript/tool streaming |
+| `ui/chat.js` | `ChatView`: history panel, ephemeral bubbles, transcript/tool streaming, user recording replay |
 | `ui/account.js` | `Account`: HF login chip + popover, daily-limit modal |
 | `ui/dom.js` | Shared helpers: `$`, `escHtml`, `truncateError`, `DEBUG` |
 | `auth.py` | HF OAuth + per-request identity (tier, hashed keys) |
@@ -241,6 +247,7 @@ transport pick, and `s2s.audio.inputId` / `s2s.audio.outputId` for devices).
 | `ws/s2s-ws-client.js` | WebSocket handshake + OpenAI Realtime GA protocol |
 | `rtc/s2s-rtc-client.js` | WebRTC sibling: SDP handshake via `/api/calls`, events over the data channel, track audio |
 | `ws/codec.js` | base64 <-> PCM helpers + transcript extraction (pure) |
+| `ws/user-audio-recorder.js` | Bounded sent-PCM buffer + VAD slicing + browser-playable WAV wrapping |
 | `ws/orb-visualizer.js` | `OrbVisualiser`: FFT bands -> orb CSS custom properties |
 | `worklets/mic-capture.js` | AudioWorklet: 48 kHz Float32 -> 16 kHz Int16 PCM, posts ~40 ms chunks |
 | `worklets/audio-playback.js` | AudioWorklet: 24 kHz Float32 ring buffer -> 48 kHz, linear interp, fade in/out |
@@ -252,6 +259,10 @@ transport pick, and `s2s.audio.inputId` / `s2s.audio.outputId` for devices).
   feeds the `mic-capture` worklet at the `AudioContext` rate. The worklet
   resamples to 16 kHz (boxcar lowpass + decimation on the 48 -> 16 fast
   path, linear interpolation fallback for odd rates) and packs Int16 LE.
+- **User replay**: the WebSocket client retains only a bounded copy of PCM it
+  actually sends. `speech_started` / `speech_stopped` timestamps select each
+  utterance, which is wrapped as an in-memory WAV and attached to the user row.
+  Starting playback temporarily mutes outgoing mic audio to prevent feedback.
 - **Output**: `response.output_audio.delta` decodes to Int16 -> Float32
   and is posted to the `audio-playback` worklet. The worklet maintains a
   per-context ring buffer, linearly interpolates 24 -> 48, and applies

--- a/demo/main.js
+++ b/demo/main.js
@@ -1483,6 +1483,14 @@ async function doStart(audioContext = null) {
     const d = /** @type {CustomEvent<{ role: "user" | "assistant"; text: string; partial: boolean; itemId?: string; responseId?: string }>} */ (e).detail;
     chat.onTranscript(d);
   });
+  c.addEventListener("user-turn-started", (e) => {
+    const detail = /** @type {CustomEvent<{ itemId?: string }>} */ (e).detail;
+    chat.onUserTurnStarted(detail);
+  });
+  c.addEventListener("user-turn-stopped", (e) => {
+    const detail = /** @type {CustomEvent<{ itemId?: string }>} */ (e).detail;
+    chat.onUserTurnStopped(detail);
+  });
   c.addEventListener("user-audio", (e) => {
     const detail = /** @type {CustomEvent<{ itemId?: string; audio: Blob; durationMs?: number; truncated?: boolean }>} */ (e).detail;
     chat.onUserAudio(detail);

--- a/demo/main.js
+++ b/demo/main.js
@@ -1478,6 +1478,7 @@ async function doStart(audioContext = null) {
   c.addEventListener("status", (e) => {
     const detail = /** @type {CustomEvent<{ status: string }>} */ (e).detail;
     onClientStatus(detail.status);
+    if (detail.status === "ai-speaking") chat.onAssistantActivity();
   });
   c.addEventListener("transcript", (e) => {
     const d = /** @type {CustomEvent<{ role: "user" | "assistant"; text: string; partial: boolean; itemId?: string; responseId?: string }>} */ (e).detail;

--- a/demo/main.js
+++ b/demo/main.js
@@ -378,7 +378,13 @@ function pushToolsToSession() {
 // ── Chat view ───────────────────────────────────────────────────────────────
 // Owns the history panel, the ephemeral bubbles, and all transcript/tool
 // streaming state. The client's events are forwarded to its on* methods.
-const chat = new ChatView();
+let userAudioReplaying = false;
+const chat = new ChatView({
+  onUserAudioPlaybackChange(playing) {
+    userAudioReplaying = playing;
+    syncMicMuteState();
+  },
+});
 
 // ── Account / limiter ─────────────────────────────────────────────────────
 // Login chip + daily-limit modal (inert unless the deploy is in LB mode). The
@@ -398,6 +404,15 @@ let client = null;
 /** @type {MediaStream | null} */
 let micStream = null;
 let micMuted = false;
+
+/** Apply both the user's mute choice and the temporary replay guard. */
+function syncMicMuteState() {
+  const muted = micMuted || userAudioReplaying;
+  for (const track of micStream?.getAudioTracks() ?? []) {
+    track.enabled = !muted;
+  }
+  client?.setMuted(muted);
+}
 
 /** @param {AppState} next */
 function setState(next) {
@@ -1194,10 +1209,7 @@ async function handleStartError(err) {
 micBtn.addEventListener("click", () => {
   if (!micStream || !client) return;
   micMuted = !micMuted;
-  for (const track of micStream.getAudioTracks()) {
-    track.enabled = !micMuted;
-  }
-  client.setMuted(micMuted);
+  syncMicMuteState();
   micBtn.classList.toggle("muted", micMuted);
   micBtn.setAttribute("aria-label", micMuted ? "Unmute" : "Mute");
   micBtn.title = micMuted ? "Unmute" : "Mute";
@@ -1442,6 +1454,7 @@ async function doStart(audioContext = null) {
         ...common,
       });
   client = c;
+  c.setMuted(micMuted || userAudioReplaying);
 
   c.addEventListener("queue", (e) => {
     const { position, queueId } = /** @type {CustomEvent<{ position: number; queueId: string }>} */ (e).detail;
@@ -1469,6 +1482,10 @@ async function doStart(audioContext = null) {
   c.addEventListener("transcript", (e) => {
     const d = /** @type {CustomEvent<{ role: "user" | "assistant"; text: string; partial: boolean; itemId?: string; responseId?: string }>} */ (e).detail;
     chat.onTranscript(d);
+  });
+  c.addEventListener("user-audio", (e) => {
+    const detail = /** @type {CustomEvent<{ itemId?: string; audio: Blob; durationMs?: number; truncated?: boolean }>} */ (e).detail;
+    chat.onUserAudio(detail);
   });
 
   c.addEventListener("response-finished", (e) => {

--- a/demo/rtc/s2s-rtc-client.js
+++ b/demo/rtc/s2s-rtc-client.js
@@ -470,10 +470,20 @@ export class S2sRtcRealtimeClient extends EventTarget {
         // the server flushes its track buffer — so this is UI state only.
         this._aiSpeaking = false;
         this._lastAudibleAt = 0;
+        this.dispatchEvent(new CustomEvent("user-turn-started", {
+          detail: {
+            itemId: typeof event.item_id === "string" ? event.item_id : "",
+          },
+        }));
         this._setStatus("user-speaking");
         break;
 
       case "input_audio_buffer.speech_stopped":
+        this.dispatchEvent(new CustomEvent("user-turn-stopped", {
+          detail: {
+            itemId: typeof event.item_id === "string" ? event.item_id : "",
+          },
+        }));
         if (this._status === "user-speaking") this._setStatus("processing");
         break;
 

--- a/demo/style.css
+++ b/demo/style.css
@@ -1755,6 +1755,52 @@ body.cam-on .footer {
 .bubble.user .bubble-role { color: var(--voice-user); }
 .bubble.assistant .bubble-role { color: var(--voice-assistant); }
 
+.bubble.user.voice .bubble-body {
+  display: flex;
+  align-items: center;
+  gap: 9px;
+  min-width: 126px;
+  color: var(--text-dim);
+}
+.voice-turn-wave {
+  display: inline-flex;
+  align-items: center;
+  gap: 2px;
+  height: 16px;
+  color: var(--voice-user);
+}
+.voice-turn-wave i {
+  display: block;
+  width: 2px;
+  height: 12px;
+  border-radius: 999px;
+  background: currentColor;
+  transform-origin: center;
+  animation: user-turn-wave 0.85s ease-in-out infinite;
+}
+.voice-turn-wave i:nth-child(2),
+.voice-turn-wave i:nth-child(4) {
+  animation-delay: -0.22s;
+}
+.voice-turn-wave i:nth-child(3) {
+  animation-delay: -0.44s;
+}
+.voice-turn-wave i:nth-child(5) {
+  animation-delay: -0.11s;
+}
+.bubble.user.sending .voice-turn-wave i {
+  animation-duration: 1.15s;
+}
+.voice-turn-state {
+  font-family: var(--font-mono);
+  font-size: 11px;
+  letter-spacing: 0.02em;
+}
+@keyframes user-turn-wave {
+  0%, 100% { transform: scaleY(0.28); opacity: 0.5; }
+  50% { transform: scaleY(1); opacity: 1; }
+}
+
 /* ─── Conversation history panel ─────────────────────────────────────── */
 
 .chat-panel {
@@ -2575,6 +2621,9 @@ body.cam-on .footer {
   }
 }
 @media (prefers-reduced-motion: reduce) {
+  .voice-turn-wave i {
+    animation: none;
+  }
   .cam-pip {
     transition: opacity 0.22s ease;
     transform: none;

--- a/demo/style.css
+++ b/demo/style.css
@@ -1887,6 +1887,29 @@ body.cam-on .footer {
  * distinguishing, so the panel reads as one quiet column. */
 .hist-msg.user .hist-body.partial { opacity: 0.65; }
 
+.hist-audio {
+  display: flex;
+  flex-direction: column;
+  gap: 5px;
+  padding: 8px 10px;
+  border: 1px solid color-mix(in srgb, var(--voice-user) 22%, var(--border));
+  border-radius: var(--radius-md);
+  background: color-mix(in srgb, var(--voice-user) 6%, var(--bg-elev-2));
+}
+.hist-audio-label {
+  font-family: var(--font-mono);
+  font-size: 9px;
+  letter-spacing: 0.06em;
+  text-transform: uppercase;
+  color: color-mix(in srgb, var(--voice-user) 68%, var(--text-faint));
+}
+.hist-audio audio {
+  display: block;
+  width: min(260px, 100%);
+  height: 34px;
+  color-scheme: light dark;
+}
+
 /* ─── Tool call history item ─────────────────────────────────────────── */
 
 .hist-tool-header {

--- a/demo/ui/chat.js
+++ b/demo/ui/chat.js
@@ -59,6 +59,10 @@ export class ChatView {
     /** @type {HTMLElement | null} */
     this._activeUserBubble = null;
     this._activeUserItemId = "";
+    // RTC media and data-channel events are not ordered relative to each other.
+    // Remember the item whose placeholder assistant activity dismissed so a
+    // later speech_stopped event cannot recreate it as "Sending voice...".
+    this._assistantDismissedUserItemId = "";
     // Monotonic counter for synthesizing unique keys when the server omits an
     // item_id / response_id, so id-less messages never collapse onto each other.
     this._anonSeq = 0;
@@ -284,6 +288,7 @@ export class ChatView {
   onAssistantActivity() {
     const bubble = this._activeUserBubble;
     if (!bubble?.isConnected || !bubble.classList.contains("voice")) return;
+    this._assistantDismissedUserItemId = this._activeUserItemId;
     this._dismissBubble(bubble);
     this._activeUserBubble = null;
     this._scheduleBubbleReaper();
@@ -420,6 +425,7 @@ export class ChatView {
     this._userHistByItem.clear();
     this._activeUserBubble = null;
     this._activeUserItemId = "";
+    this._assistantDismissedUserItemId = "";
     this._asstByResp.clear();
   }
 
@@ -431,6 +437,9 @@ export class ChatView {
    */
   onUserTurnStarted(detail = {}) {
     const id = detail.itemId || `_u${++this._anonSeq}`;
+    // A reopened turn may legitimately reuse the same item id, so a fresh start
+    // supersedes any tombstone left by the prior assistant activity.
+    this._assistantDismissedUserItemId = "";
     const reusable = this._activeUserItemId === id
       && this._activeUserBubble?.isConnected
       && !this._activeUserBubble.classList.contains("out");
@@ -458,6 +467,7 @@ export class ChatView {
     const reusable = this._activeUserItemId === id
       && this._activeUserBubble?.isConnected
       && !this._activeUserBubble.classList.contains("out");
+    if (!reusable && this._assistantDismissedUserItemId === id) return;
     if (!reusable) {
       this._activeUserBubble = this._spawnVoiceBubble("sending");
       this._activeUserItemId = id;

--- a/demo/ui/chat.js
+++ b/demo/ui/chat.js
@@ -158,10 +158,50 @@ export class ChatView {
     return el;
   }
 
+  /**
+   * Show an immediate placeholder for a user voice turn. It occupies the same
+   * bubble as a transcript would, so a late STT event can replace the animation
+   * in place instead of adding a second user message.
+   * @param {"listening"|"sending"} state
+   * @returns {HTMLElement}
+   */
+  _spawnVoiceBubble(state) {
+    const el = this._spawnBubble("user", "");
+    el.classList.add("voice");
+    el.setAttribute("role", "status");
+    el.setAttribute("aria-live", "polite");
+    const body = /** @type {HTMLElement | null} */ (el.querySelector(".bubble-body"));
+    if (body) {
+      body.hidden = false;
+      body.innerHTML = `
+        <span class="voice-turn-wave" aria-hidden="true">
+          <i></i><i></i><i></i><i></i><i></i>
+        </span>
+        <span class="voice-turn-state"></span>
+      `;
+    }
+    this._setVoiceBubbleState(el, state);
+    return el;
+  }
+
+  /** @param {HTMLElement} el @param {"listening"|"sending"} state */
+  _setVoiceBubbleState(el, state) {
+    el.classList.toggle("listening", state === "listening");
+    el.classList.toggle("sending", state === "sending");
+    const label = el.querySelector(".voice-turn-state");
+    if (label) label.textContent = state === "listening" ? "Listening…" : "Sending voice…";
+  }
+
   /** @param {HTMLElement} el @param {string} text */
   _updateBubbleText(el, text) {
-    const t = el.querySelector(".bubble-body");
-    if (t) t.textContent = text;
+    el.classList.remove("voice", "listening", "sending");
+    el.removeAttribute("role");
+    el.removeAttribute("aria-live");
+    const t = /** @type {HTMLElement | null} */ (el.querySelector(".bubble-body"));
+    if (t) {
+      t.textContent = text;
+      t.hidden = !text;
+    }
   }
 
   /** @param {HTMLElement} el */
@@ -354,6 +394,45 @@ export class ChatView {
   // ── Client event handlers ─────────────────────────────────────────────────
 
   /**
+   * Show a voice bubble as soon as backend VAD recognizes speech.
+   * @param {{ itemId?: string }} [detail]
+   */
+  onUserTurnStarted(detail = {}) {
+    const id = detail.itemId || `_u${++this._anonSeq}`;
+    const reusable = this._activeUserItemId === id
+      && this._activeUserBubble?.isConnected
+      && !this._activeUserBubble.classList.contains("out");
+    if (!reusable) {
+      this._activeUserBubble = this._spawnVoiceBubble("listening");
+      this._activeUserItemId = id;
+    } else if (this._activeUserBubble.classList.contains("voice")) {
+      this._setVoiceBubbleState(this._activeUserBubble, "listening");
+    }
+    // Fail-safe for a lost speech_stopped event; the normal stop path shortens
+    // this to a few seconds.
+    this._bumpDismiss(this._activeUserBubble, 30000);
+  }
+
+  /**
+   * Transition the active voice bubble while the closed turn is in flight.
+   * If speech_started was missed, create the sending state directly.
+   * @param {{ itemId?: string }} [detail]
+   */
+  onUserTurnStopped(detail = {}) {
+    const id = detail.itemId || this._activeUserItemId || `_u${++this._anonSeq}`;
+    const reusable = this._activeUserItemId === id
+      && this._activeUserBubble?.isConnected
+      && !this._activeUserBubble.classList.contains("out");
+    if (!reusable) {
+      this._activeUserBubble = this._spawnVoiceBubble("sending");
+      this._activeUserItemId = id;
+    } else if (this._activeUserBubble.classList.contains("voice")) {
+      this._setVoiceBubbleState(this._activeUserBubble, "sending");
+    }
+    this._bumpDismiss(this._activeUserBubble, 6000);
+  }
+
+  /**
    * A streamed transcript delta (user or assistant).
    * @param {{ role: "user" | "assistant"; text: string; partial: boolean; itemId?: string; responseId?: string }} d
    */
@@ -375,7 +454,11 @@ export class ChatView {
       // refreshed on every delta, so it stays while the user keeps talking and
       // fades a few seconds after they stop — no dependency on a response ever
       // arriving, so it can never get stuck.
-      if (this._activeUserItemId !== id || !this._activeUserBubble) {
+      if (
+        this._activeUserItemId !== id
+        || !this._activeUserBubble?.isConnected
+        || this._activeUserBubble.classList.contains("out")
+      ) {
         this._activeUserBubble = this._spawnBubble("user", text);
         this._activeUserItemId = id;
       } else {

--- a/demo/ui/chat.js
+++ b/demo/ui/chat.js
@@ -246,6 +246,25 @@ export class ChatView {
   }
 
   /**
+   * Point the shared reaper at the current oldest bubble. This must run when an
+   * expiry moves earlier as well as later: a listening bubble starts with a
+   * long fail-safe, then gets a much shorter deadline once speech stops.
+   */
+  _scheduleBubbleReaper() {
+    if (this._reaperHandle) clearTimeout(this._reaperHandle);
+    this._reaperHandle = 0;
+    const oldest = /** @type {HTMLElement | null} */ (
+      this._bubbleStack.querySelector(".bubble:not(.out)")
+    );
+    if (!oldest) return;
+    const expiry = this._bubbleExpiry.get(oldest) ?? Date.now();
+    this._reaperHandle = setTimeout(
+      () => this._reapBubbles(),
+      Math.max(50, expiry - Date.now()),
+    );
+  }
+
+  /**
    * (Re)arm a bubble's auto-dismiss by pushing its expiry out by `delay`.
    * Calling it again resets the countdown — so a bubble that keeps updating
    * stays on screen and only fades once it goes quiet. Removal is ordered by the
@@ -254,7 +273,20 @@ export class ChatView {
    */
   _bumpDismiss(el, delay = 4000) {
     this._bubbleExpiry.set(el, Date.now() + delay);
-    if (!this._reaperHandle) this._reaperHandle = setTimeout(() => this._reapBubbles(), delay);
+    this._scheduleBubbleReaper();
+  }
+
+  /**
+   * Remove a pending voice placeholder once the assistant has visibly started
+   * answering. A transcript can arrive before audible output, while direct
+   * audio models may only trigger the ai-speaking status, so both call here.
+   */
+  onAssistantActivity() {
+    const bubble = this._activeUserBubble;
+    if (!bubble?.isConnected || !bubble.classList.contains("voice")) return;
+    this._dismissBubble(bubble);
+    this._activeUserBubble = null;
+    this._scheduleBubbleReaper();
   }
 
   // ── History ───────────────────────────────────────────────────────────────
@@ -403,6 +435,9 @@ export class ChatView {
       && this._activeUserBubble?.isConnected
       && !this._activeUserBubble.classList.contains("out");
     if (!reusable) {
+      if (this._activeUserBubble?.classList.contains("voice")) {
+        this._dismissBubble(this._activeUserBubble);
+      }
       this._activeUserBubble = this._spawnVoiceBubble("listening");
       this._activeUserItemId = id;
     } else if (this._activeUserBubble.classList.contains("voice")) {
@@ -467,6 +502,7 @@ export class ChatView {
       this._bumpDismiss(this._activeUserBubble, 6000);
       this._markUnread();
     } else if (d.role === "assistant") {
+      this.onAssistantActivity();
       // Assistant transcript arrives once, as the full text, keyed by
       // response_id so a cancelled speculative response can be removed later. A
       // missing id gets a unique key so two id-less replies never collide.
@@ -557,6 +593,7 @@ export class ChatView {
   onResponseFinished(detail) {
     const { responseId, status, audible, transcript } = detail;
     if (DEBUG) console.debug(`[ui] response-finished resp=${responseId} status=${status} audible=${audible} known=${this._asstByResp.has(responseId)}`);
+    this.onAssistantActivity();
     // Without an id we can't target a specific response; the bubble will
     // auto-dismiss on its own timer regardless.
     if (!responseId) return;

--- a/demo/ui/chat.js
+++ b/demo/ui/chat.js
@@ -2,8 +2,8 @@
 /**
  * ChatView — owns the whole conversation surface: the slide-in history panel,
  * the ephemeral on-orb bubbles, and all the transcript/tool/streaming
- * bookkeeping. main.js wires the realtime client's events straight to the
- * `on*` methods here and otherwise doesn't touch chat state.
+ * and user-audio bookkeeping. main.js wires the realtime client's events
+ * straight to the `on*` methods here and otherwise doesn't touch chat state.
  *
  * Two parallel surfaces share one shape (see `_buildMessageEl`):
  *   - ephemeral bubbles  (`.bubble` / `.bubble-*`)  fade on a timer
@@ -24,7 +24,10 @@ const CHAT_BUBBLE_SVG = `<svg width="28" height="28" viewBox="0 0 24 24" fill="n
 const EMPTY_STATE_HTML = `<div id="chat-empty" class="chat-empty">${CHAT_BUBBLE_SVG}<span class="chat-empty-title">No messages yet</span><span class="chat-empty-hint">Tap the orb and start talking</span></div>`;
 
 export class ChatView {
-  constructor() {
+  /**
+   * @param {{ onUserAudioPlaybackChange?: (playing: boolean) => void }} [options]
+   */
+  constructor(options = {}) {
     /** @type {HTMLButtonElement} */
     this._chatBtn = $("#chat-btn");
     /** @type {HTMLSpanElement} */
@@ -46,6 +49,13 @@ export class ChatView {
     // ── User transcript state (keyed by item_id) ───────────────────────────
     /** @type {Map<string, HTMLElement>} */
     this._userHistByItem = new Map();
+    /** @type {Map<string, { audio: HTMLAudioElement, url: string }>} */
+    this._userAudioByItem = new Map();
+    /** @type {Set<string>} */
+    this._audioUrls = new Set();
+    /** @type {HTMLAudioElement | null} */
+    this._activeUserAudio = null;
+    this._onUserAudioPlaybackChange = options.onUserAudioPlaybackChange ?? (() => {});
     /** @type {HTMLElement | null} */
     this._activeUserBubble = null;
     this._activeUserItemId = "";
@@ -121,7 +131,7 @@ export class ChatView {
     const el = document.createElement("div");
     el.className = `${container} ${role}`;
     const label = role === "user" ? "You" : "Assistant";
-    el.innerHTML = `<div class="${prefix}-role">${label}</div><div class="${prefix}-body${partial ? " partial" : ""}">${escHtml(text)}</div>`;
+    el.innerHTML = `<div class="${prefix}-role">${label}</div><div class="${prefix}-body${partial ? " partial" : ""}"${text ? "" : " hidden"}>${escHtml(text)}</div>`;
     return el;
   }
 
@@ -216,6 +226,11 @@ export class ChatView {
 
   /** Reset the panel to the empty state and clear the unread badge. */
   clear() {
+    this._stopUserAudioPlayback();
+    for (const url of this._audioUrls) URL.revokeObjectURL(url);
+    this._audioUrls.clear();
+    this._userAudioByItem.clear();
+    this._userHistByItem.clear();
     this.renderEmptyState();
     this._chatBadge.classList.remove("visible");
   }
@@ -236,8 +251,26 @@ export class ChatView {
     const body = /** @type {HTMLElement | null} */ (el.querySelector(".hist-body"));
     if (!body) return;
     body.textContent = text;
+    body.hidden = !text;
     body.classList.toggle("partial", partial);
     this._scrollToBottom();
+  }
+
+  /** @param {string} itemId */
+  _ensureUserHist(itemId) {
+    let hist = this._userHistByItem.get(itemId);
+    if (!hist) {
+      hist = this._appendHistMsg("user", "", false);
+      this._userHistByItem.set(itemId, hist);
+    }
+    return hist;
+  }
+
+  _stopUserAudioPlayback() {
+    const active = this._activeUserAudio;
+    this._activeUserAudio = null;
+    if (active && !active.paused) active.pause();
+    this._onUserAudioPlaybackChange(false);
   }
 
   /**
@@ -335,13 +368,8 @@ export class ChatView {
       const id = d.itemId || this._activeUserItemId || `_u${++this._anonSeq}`;
       const text = d.text;
 
-      let hist = this._userHistByItem.get(id);
-      if (!hist) {
-        hist = this._appendHistMsg("user", text, d.partial);
-        this._userHistByItem.set(id, hist);
-      } else {
-        this._updateHistMsg(hist, text, d.partial);
-      }
+      const hist = this._ensureUserHist(id);
+      this._updateHistMsg(hist, text, d.partial);
 
       // One ephemeral bubble per active item. Purely timer-based: the timer is
       // refreshed on every delta, so it stays while the user keeps talking and
@@ -372,6 +400,71 @@ export class ChatView {
       }
       this._markUnread();
     }
+  }
+
+  /**
+   * Attach the browser-local recording to its user turn. This also creates an
+   * audio-only row when STT is disabled and no transcript events arrive.
+   * Reopened VAD segments reuse item_id; the client sends a replacement WAV
+   * containing the accumulated utterance, so the row keeps one player.
+   * @param {{ itemId?: string, audio: Blob, durationMs?: number, truncated?: boolean }} detail
+   */
+  onUserAudio(detail) {
+    const id = detail.itemId || `_u${++this._anonSeq}`;
+    const hist = this._ensureUserHist(id);
+    let container = /** @type {HTMLElement | null} */ (hist.querySelector(".hist-audio"));
+    const isNewPlayer = !container;
+    if (!container) {
+      container = document.createElement("div");
+      container.className = "hist-audio";
+      container.innerHTML = `
+        <div class="hist-audio-label">Audio sent to the model</div>
+        <audio controls preload="metadata" aria-label="Replay your audio"></audio>
+      `;
+      hist.appendChild(container);
+    }
+
+    const audio = /** @type {HTMLAudioElement} */ (container.querySelector("audio"));
+    const previous = this._userAudioByItem.get(id);
+    if (previous) {
+      if (this._activeUserAudio === previous.audio) this._stopUserAudioPlayback();
+      URL.revokeObjectURL(previous.url);
+      this._audioUrls.delete(previous.url);
+    }
+
+    const url = URL.createObjectURL(detail.audio);
+    this._audioUrls.add(url);
+    this._userAudioByItem.set(id, { audio, url });
+    audio.src = url;
+    audio.title = detail.truncated
+      ? "Replay your audio (the beginning was no longer buffered)"
+      : "Replay the audio sent to the model";
+    const label = container.querySelector(".hist-audio-label");
+    if (label) {
+      label.textContent = detail.truncated
+        ? "Audio sent to the model · beginning unavailable"
+        : "Audio sent to the model";
+    }
+
+    if (isNewPlayer) {
+      audio.addEventListener("play", () => {
+        if (this._activeUserAudio && this._activeUserAudio !== audio) {
+          this._activeUserAudio.pause();
+        }
+        this._activeUserAudio = audio;
+        this._onUserAudioPlaybackChange(true);
+      });
+      const stopped = () => {
+        if (this._activeUserAudio !== audio) return;
+        this._activeUserAudio = null;
+        this._onUserAudioPlaybackChange(false);
+      };
+      audio.addEventListener("pause", stopped);
+      audio.addEventListener("ended", stopped);
+      audio.addEventListener("error", stopped);
+    }
+    this._scrollToBottom();
+    this._markUnread();
   }
 
   /**

--- a/demo/ws/s2s-ws-client.js
+++ b/demo/ws/s2s-ws-client.js
@@ -682,18 +682,27 @@ export class S2sWsRealtimeClient extends EventTarget {
           itemId: typeof event.item_id === "string" ? event.item_id : "",
           audioStartMs: Number(event.audio_start_ms),
         });
+        this.dispatchEvent(new CustomEvent("user-turn-started", {
+          detail: {
+            itemId: typeof event.item_id === "string" ? event.item_id : "",
+          },
+        }));
         this._setStatus("user-speaking");
         break;
 
       case "input_audio_buffer.speech_stopped":
         {
+          const itemId = typeof event.item_id === "string" ? event.item_id : "";
           const recording = this._userAudioRecorder.speechStopped({
-            itemId: typeof event.item_id === "string" ? event.item_id : "",
+            itemId,
             audioEndMs: Number(event.audio_end_ms),
           });
           if (recording) {
             this.dispatchEvent(new CustomEvent("user-audio", { detail: recording }));
           }
+          this.dispatchEvent(new CustomEvent("user-turn-stopped", {
+            detail: { itemId },
+          }));
         }
         if (this._status === "user-speaking") this._setStatus("processing");
         break;

--- a/demo/ws/s2s-ws-client.js
+++ b/demo/ws/s2s-ws-client.js
@@ -93,6 +93,7 @@ import {
   trimTrailingSlash,
 } from "./codec.js";
 import { OrbVisualiser, VIS_FFT_SIZE } from "./orb-visualizer.js";
+import { SentAudioRecorder } from "./user-audio-recorder.js";
 
 /** Build an Error carrying a `code` (and optional extra fields) so callers can
  *  branch on the failure kind: "limit" | "queue-full" | "queue-expired" | "aborted".
@@ -204,6 +205,9 @@ export class S2sWsRealtimeClient extends EventTarget {
     this._sessionConfigured = false;
     this._startupGreeting = options.startupGreeting?.trim() ?? "";
     this._startupGreetingSent = false;
+    // Bounded, browser-local copy of the exact PCM frames sent over this
+    // socket. Backend VAD timestamps turn it into replayable user utterances.
+    this._userAudioRecorder = new SentAudioRecorder();
     this._debug = (() => { try { return localStorage.getItem("s2s.debug") === "1"; } catch { return false; } })();
   }
 
@@ -607,6 +611,9 @@ export class S2sWsRealtimeClient extends EventTarget {
     if (this._muted) return;
     const b64 = base64FromArrayBuffer(pcm16Buffer);
     this._send({ type: "input_audio_buffer.append", audio: b64 });
+    // Record only after the append is accepted for sending. This intentionally
+    // excludes pre-configuration and muted audio, just like the backend input.
+    this._userAudioRecorder.append(pcm16Buffer);
   }
 
   /**
@@ -671,10 +678,23 @@ export class S2sWsRealtimeClient extends EventTarget {
         // otherwise keep playing over the user's barge-in.
         this._playbackNode?.port.postMessage({ kind: "clear" });
         this._aiSpeaking = false;
+        this._userAudioRecorder.speechStarted({
+          itemId: typeof event.item_id === "string" ? event.item_id : "",
+          audioStartMs: Number(event.audio_start_ms),
+        });
         this._setStatus("user-speaking");
         break;
 
       case "input_audio_buffer.speech_stopped":
+        {
+          const recording = this._userAudioRecorder.speechStopped({
+            itemId: typeof event.item_id === "string" ? event.item_id : "",
+            audioEndMs: Number(event.audio_end_ms),
+          });
+          if (recording) {
+            this.dispatchEvent(new CustomEvent("user-audio", { detail: recording }));
+          }
+        }
         if (this._status === "user-speaking") this._setStatus("processing");
         break;
 
@@ -1086,6 +1106,7 @@ export class S2sWsRealtimeClient extends EventTarget {
     // Abort a queue wait in progress: flag it and wake the poll sleep so
     // `_pollQueue` throws "aborted" and connect() unwinds cleanly.
     this._closed = true;
+    this._userAudioRecorder.reset();
     if (this._queueWake) {
       clearTimeout(this._queueTimer);
       const wake = this._queueWake;

--- a/demo/ws/user-audio-recorder.js
+++ b/demo/ws/user-audio-recorder.js
@@ -1,0 +1,198 @@
+// @ts-check
+/**
+ * Keep a bounded copy of the PCM16 frames sent over the realtime WebSocket and
+ * turn the backend's VAD boundaries into browser-playable WAV blobs.
+ *
+ * This records the post-resampling, post-noise-gate signal—not a second raw-mic
+ * capture—so replay is as close as the browser can get to the audio delivered
+ * to the backend. Nothing leaves the page beyond the existing realtime stream.
+ */
+
+export const USER_AUDIO_SAMPLE_RATE = 16000;
+const BYTES_PER_SAMPLE = 2;
+const DEFAULT_PREROLL_MS = 5000;
+const DEFAULT_MAX_BUFFER_MS = 120000;
+
+/** @param {DataView} view @param {number} offset @param {string} value */
+function _writeAscii(view, offset, value) {
+  for (let i = 0; i < value.length; i++) {
+    view.setUint8(offset + i, value.charCodeAt(i));
+  }
+}
+
+/**
+ * Wrap little-endian mono PCM16 in a standard WAV container.
+ * @param {Uint8Array} pcm
+ * @param {number} [sampleRate]
+ * @returns {Blob}
+ */
+export function pcm16ToWavBlob(pcm, sampleRate = USER_AUDIO_SAMPLE_RATE) {
+  const dataLength = pcm.byteLength - (pcm.byteLength % BYTES_PER_SAMPLE);
+  const wav = new ArrayBuffer(44 + dataLength);
+  const view = new DataView(wav);
+  _writeAscii(view, 0, "RIFF");
+  view.setUint32(4, 36 + dataLength, true);
+  _writeAscii(view, 8, "WAVE");
+  _writeAscii(view, 12, "fmt ");
+  view.setUint32(16, 16, true); // PCM fmt chunk length
+  view.setUint16(20, 1, true); // linear PCM
+  view.setUint16(22, 1, true); // mono
+  view.setUint32(24, sampleRate, true);
+  view.setUint32(28, sampleRate * BYTES_PER_SAMPLE, true);
+  view.setUint16(32, BYTES_PER_SAMPLE, true);
+  view.setUint16(34, 16, true);
+  _writeAscii(view, 36, "data");
+  view.setUint32(40, dataLength, true);
+  new Uint8Array(wav, 44).set(pcm.subarray(0, dataLength));
+  return new Blob([wav], { type: "audio/wav" });
+}
+
+/** @param {Uint8Array} first @param {Uint8Array} second */
+function _concat(first, second) {
+  const result = new Uint8Array(first.byteLength + second.byteLength);
+  result.set(first, 0);
+  result.set(second, first.byteLength);
+  return result;
+}
+
+export class SentAudioRecorder {
+  /**
+   * @param {{ sampleRate?: number, preRollMs?: number, maxBufferMs?: number }} [options]
+   */
+  constructor(options = {}) {
+    this.sampleRate = options.sampleRate ?? USER_AUDIO_SAMPLE_RATE;
+    this._preRollSamples = Math.round(
+      (this.sampleRate * (options.preRollMs ?? DEFAULT_PREROLL_MS)) / 1000,
+    );
+    this._maxBufferSamples = Math.round(
+      (this.sampleRate * (options.maxBufferMs ?? DEFAULT_MAX_BUFFER_MS)) / 1000,
+    );
+    /** @type {{ startSample: number, endSample: number, bytes: Uint8Array }[]} */
+    this._chunks = [];
+    this._sentSamples = 0;
+    /** @type {{ itemId: string, requestedStartSample: number } | null} */
+    this._active = null;
+    this._lastItemId = "";
+    this._lastItemPcm = new Uint8Array(0);
+  }
+
+  /** Store one PCM16 frame that was actually sent to the backend.
+   * @param {ArrayBuffer} buffer */
+  append(buffer) {
+    const evenLength = buffer.byteLength - (buffer.byteLength % BYTES_PER_SAMPLE);
+    if (evenLength <= 0) return;
+    const bytes = new Uint8Array(buffer.slice(0, evenLength));
+    const startSample = this._sentSamples;
+    const endSample = startSample + evenLength / BYTES_PER_SAMPLE;
+    this._chunks.push({ startSample, endSample, bytes });
+    this._sentSamples = endSample;
+    this._prune();
+  }
+
+  /**
+   * Remember where the backend says this speech item began. The event normally
+   * arrives after confirmation, so the bounded pre-roll retains its onset.
+   * @param {{ itemId?: string, audioStartMs?: number }} boundary
+   */
+  speechStarted(boundary) {
+    const itemId = boundary.itemId || `audio_${this._sentSamples}`;
+    const requestedStartSample = this._sampleAtMs(boundary.audioStartMs, this._sentSamples);
+    this._active = { itemId, requestedStartSample };
+    if (itemId !== this._lastItemId) {
+      this._lastItemId = itemId;
+      this._lastItemPcm = new Uint8Array(0);
+    }
+    this._prune();
+  }
+
+  /**
+   * Finalize the active VAD segment. Reopened segments carrying the same
+   * item_id replace the prior recording with their concatenation, matching the
+   * chat view's one-row-per-item behavior.
+   * @param {{ itemId?: string, audioEndMs?: number }} boundary
+   * @returns {{ itemId: string, audio: Blob, durationMs: number, truncated: boolean } | null}
+   */
+  speechStopped(boundary) {
+    const active = this._active;
+    if (!active) return null;
+    this._active = null;
+
+    const itemId = boundary.itemId || active.itemId;
+    const availableStart = this._chunks[0]?.startSample ?? this._sentSamples;
+    const startSample = Math.max(active.requestedStartSample, availableStart);
+    let endSample = this._sampleAtMs(boundary.audioEndMs, this._sentSamples);
+    if (endSample <= startSample) endSample = this._sentSamples;
+    endSample = Math.min(endSample, this._sentSamples);
+
+    const segment = this._slice(startSample, endSample);
+    if (segment.byteLength === 0) {
+      this._prune();
+      return null;
+    }
+
+    if (itemId !== this._lastItemId) {
+      this._lastItemId = itemId;
+      this._lastItemPcm = new Uint8Array(0);
+    }
+    this._lastItemPcm = _concat(this._lastItemPcm, segment);
+    const durationMs =
+      (this._lastItemPcm.byteLength / BYTES_PER_SAMPLE / this.sampleRate) * 1000;
+    const result = {
+      itemId,
+      audio: pcm16ToWavBlob(this._lastItemPcm, this.sampleRate),
+      durationMs,
+      truncated: active.requestedStartSample < availableStart,
+    };
+    this._prune();
+    return result;
+  }
+
+  reset() {
+    this._chunks = [];
+    this._sentSamples = 0;
+    this._active = null;
+    this._lastItemId = "";
+    this._lastItemPcm = new Uint8Array(0);
+  }
+
+  /** @param {number | undefined} ms @param {number} fallback */
+  _sampleAtMs(ms, fallback) {
+    if (!Number.isFinite(ms) || Number(ms) < 0) return fallback;
+    return Math.max(0, Math.min(Math.round((Number(ms) * this.sampleRate) / 1000), this._sentSamples));
+  }
+
+  /** @param {number} startSample @param {number} endSample */
+  _slice(startSample, endSample) {
+    /** @type {Uint8Array[]} */
+    const parts = [];
+    let length = 0;
+    for (const chunk of this._chunks) {
+      const overlapStart = Math.max(startSample, chunk.startSample);
+      const overlapEnd = Math.min(endSample, chunk.endSample);
+      if (overlapEnd <= overlapStart) continue;
+      const from = (overlapStart - chunk.startSample) * BYTES_PER_SAMPLE;
+      const to = (overlapEnd - chunk.startSample) * BYTES_PER_SAMPLE;
+      const part = chunk.bytes.slice(from, to);
+      parts.push(part);
+      length += part.byteLength;
+    }
+    const result = new Uint8Array(length);
+    let offset = 0;
+    for (const part of parts) {
+      result.set(part, offset);
+      offset += part.byteLength;
+    }
+    return result;
+  }
+
+  _prune() {
+    const hardFloor = Math.max(0, this._sentSamples - this._maxBufferSamples);
+    const softFloor = this._active
+      ? this._active.requestedStartSample
+      : Math.max(0, this._sentSamples - this._preRollSamples);
+    const floor = Math.max(hardFloor, softFloor);
+    while (this._chunks.length && this._chunks[0].endSample <= floor) {
+      this._chunks.shift();
+    }
+  }
+}

--- a/tests/test_demo_startup_greeting.py
+++ b/tests/test_demo_startup_greeting.py
@@ -143,3 +143,54 @@ if (JSON.stringify(timeline) !== JSON.stringify(expected)) {
         capture_output=True,
         text=True,
     )
+
+
+def test_rtc_client_emits_user_turn_lifecycle():
+    node = shutil.which("node")
+    if node is None:
+        pytest.skip("Node.js is required for demo client tests")
+
+    script = """
+globalThis.localStorage = { getItem() { return null; } };
+globalThis.CustomEvent = class CustomEvent extends Event {
+  constructor(type, init = {}) {
+    super(type);
+    this.detail = init.detail;
+  }
+};
+const { S2sRtcRealtimeClient } = await import("./demo/rtc/s2s-rtc-client.js");
+const client = new S2sRtcRealtimeClient({
+  voice: "Aiden",
+  instructions: "Be helpful.",
+  callsUrl: "api/calls",
+});
+const events = [];
+client.addEventListener("user-turn-started", (event) => {
+  events.push(["started", event.detail.itemId]);
+});
+client.addEventListener("user-turn-stopped", (event) => {
+  events.push(["stopped", event.detail.itemId]);
+});
+client._onDcMessage(JSON.stringify({
+  type: "input_audio_buffer.speech_started",
+  item_id: "item_voice",
+}));
+client._onDcMessage(JSON.stringify({
+  type: "input_audio_buffer.speech_stopped",
+  item_id: "item_voice",
+}));
+const expected = [
+  ["started", "item_voice"],
+  ["stopped", "item_voice"],
+];
+if (JSON.stringify(events) !== JSON.stringify(expected)) {
+  throw new Error(`unexpected lifecycle: ${JSON.stringify(events)}`);
+}
+"""
+    subprocess.run(
+        [node, "--input-type=module", "-e", script],
+        cwd=REPO_ROOT,
+        check=True,
+        capture_output=True,
+        text=True,
+    )

--- a/tests/test_demo_user_audio.py
+++ b/tests/test_demo_user_audio.py
@@ -1,0 +1,137 @@
+import shutil
+import subprocess
+from pathlib import Path
+
+import pytest
+
+REPO_ROOT = Path(__file__).resolve().parents[1]
+
+
+def _run_node(script: str) -> None:
+    node = shutil.which("node")
+    if node is None:
+        pytest.skip("Node.js is required for demo client tests")
+    subprocess.run(
+        [node, "--input-type=module", "-e", script],
+        cwd=REPO_ROOT,
+        check=True,
+        capture_output=True,
+        text=True,
+    )
+
+
+def test_sent_audio_recorder_uses_backend_vad_boundaries():
+    _run_node(
+        """
+const { SentAudioRecorder } = await import("./demo/ws/user-audio-recorder.js");
+const recorder = new SentAudioRecorder({
+  sampleRate: 16000,
+  preRollMs: 1000,
+  maxBufferMs: 10000,
+});
+
+// 300 ms of recognizable PCM, delivered in the same 40 ms frames as the demo.
+const samples = new Int16Array(4800);
+for (let i = 0; i < samples.length; i++) samples[i] = i - 2400;
+for (let offset = 0; offset < samples.length; offset += 640) {
+  recorder.append(samples.slice(offset, Math.min(offset + 640, samples.length)).buffer);
+}
+
+recorder.speechStarted({ itemId: "item_1", audioStartMs: 50 });
+const recording = recorder.speechStopped({ itemId: "item_1", audioEndMs: 250 });
+if (!recording) throw new Error("expected a recording");
+if (Math.abs(recording.durationMs - 200) > 0.001) {
+  throw new Error(`unexpected duration: ${recording.durationMs}`);
+}
+if (recording.truncated) throw new Error("recording should include its full onset");
+
+const wav = new DataView(await recording.audio.arrayBuffer());
+const ascii = (offset, length) =>
+  String.fromCharCode(...new Uint8Array(wav.buffer, offset, length));
+if (ascii(0, 4) !== "RIFF" || ascii(8, 4) !== "WAVE") {
+  throw new Error("invalid WAV header");
+}
+if (wav.getUint32(24, true) !== 16000) throw new Error("wrong sample rate");
+if (wav.getUint32(40, true) !== 6400) throw new Error("wrong PCM payload length");
+// 50 ms * 16 samples/ms = sample 800.
+if (wav.getInt16(44, true) !== samples[800]) {
+  throw new Error(`wrong first sample: ${wav.getInt16(44, true)}`);
+}
+"""
+    )
+
+
+def test_reopened_item_replaces_recording_with_accumulated_audio():
+    _run_node(
+        """
+const { SentAudioRecorder } = await import("./demo/ws/user-audio-recorder.js");
+const recorder = new SentAudioRecorder({ sampleRate: 16000 });
+const frame = (value, samples) => {
+  const pcm = new Int16Array(samples);
+  pcm.fill(value);
+  return pcm.buffer;
+};
+
+recorder.append(frame(100, 1600));
+recorder.speechStarted({ itemId: "item_same", audioStartMs: 0 });
+const first = recorder.speechStopped({ itemId: "item_same", audioEndMs: 100 });
+recorder.append(frame(200, 1600));
+recorder.speechStarted({ itemId: "item_same", audioStartMs: 100 });
+const reopened = recorder.speechStopped({ itemId: "item_same", audioEndMs: 200 });
+
+if (!first || !reopened) throw new Error("expected both recordings");
+if (first.durationMs !== 100 || reopened.durationMs !== 200) {
+  throw new Error(`unexpected accumulated durations: ${first.durationMs}, ${reopened.durationMs}`);
+}
+const wav = new DataView(await reopened.audio.arrayBuffer());
+if (wav.getInt16(44, true) !== 100) throw new Error("first segment missing");
+if (wav.getInt16(44 + 1600 * 2, true) !== 200) throw new Error("reopened segment missing");
+"""
+    )
+
+
+def test_websocket_client_emits_audio_only_user_turn():
+    _run_node(
+        """
+globalThis.localStorage = { getItem() { return null; } };
+globalThis.WebSocket = { OPEN: 1 };
+globalThis.CustomEvent = class CustomEvent extends Event {
+  constructor(type, init = {}) {
+    super(type);
+    this.detail = init.detail;
+  }
+};
+const { S2sWsRealtimeClient } = await import("./demo/ws/s2s-ws-client.js");
+const client = new S2sWsRealtimeClient({
+  voice: "Aiden",
+  instructions: "Be helpful.",
+  directUrl: "ws://unused",
+});
+client._ws = { readyState: 1, send() {} };
+client._sessionConfigured = true;
+
+let recording = null;
+client.addEventListener("user-audio", (event) => { recording = event.detail; });
+const frame = new Int16Array(640);
+frame.fill(123);
+for (let i = 0; i < 5; i++) client._onMicChunk(frame.buffer);
+await client._onWsMessage(JSON.stringify({
+  type: "input_audio_buffer.speech_started",
+  item_id: "item_audio_only",
+  audio_start_ms: 40,
+}));
+for (let i = 0; i < 3; i++) client._onMicChunk(frame.buffer);
+await client._onWsMessage(JSON.stringify({
+  type: "input_audio_buffer.speech_stopped",
+  item_id: "item_audio_only",
+  audio_end_ms: 280,
+}));
+
+if (!recording) throw new Error("user-audio event was not emitted");
+if (recording.itemId !== "item_audio_only") throw new Error("wrong item association");
+if (Math.abs(recording.durationMs - 240) > 0.001) {
+  throw new Error(`unexpected emitted duration: ${recording.durationMs}`);
+}
+if (recording.audio.type !== "audio/wav") throw new Error("recording is not WAV");
+"""
+    )

--- a/tests/test_demo_user_audio.py
+++ b/tests/test_demo_user_audio.py
@@ -111,7 +111,14 @@ client._ws = { readyState: 1, send() {} };
 client._sessionConfigured = true;
 
 let recording = null;
+const turnEvents = [];
 client.addEventListener("user-audio", (event) => { recording = event.detail; });
+client.addEventListener("user-turn-started", (event) => {
+  turnEvents.push(["started", event.detail.itemId]);
+});
+client.addEventListener("user-turn-stopped", (event) => {
+  turnEvents.push(["stopped", event.detail.itemId]);
+});
 const frame = new Int16Array(640);
 frame.fill(123);
 for (let i = 0; i < 5; i++) client._onMicChunk(frame.buffer);
@@ -133,5 +140,12 @@ if (Math.abs(recording.durationMs - 240) > 0.001) {
   throw new Error(`unexpected emitted duration: ${recording.durationMs}`);
 }
 if (recording.audio.type !== "audio/wav") throw new Error("recording is not WAV");
+const expectedTurns = [
+  ["started", "item_audio_only"],
+  ["stopped", "item_audio_only"],
+];
+if (JSON.stringify(turnEvents) !== JSON.stringify(expectedTurns)) {
+  throw new Error(`unexpected turn events: ${JSON.stringify(turnEvents)}`);
+}
 """
     )

--- a/tests/test_demo_user_audio.py
+++ b/tests/test_demo_user_audio.py
@@ -149,3 +149,61 @@ if (JSON.stringify(turnEvents) !== JSON.stringify(expectedTurns)) {
 }
 """
     )
+
+
+def test_voice_bubble_reaper_reschedules_shortened_deadline():
+    _run_node(
+        """
+const { ChatView } = await import("./demo/ui/chat.js");
+const bubble = {};
+const view = Object.create(ChatView.prototype);
+view._bubbleExpiry = new WeakMap();
+view._reaperHandle = 0;
+view._bubbleStack = {
+  querySelector() { return bubble; },
+};
+let reapCount = 0;
+view._reapBubbles = () => {
+  view._reaperHandle = 0;
+  reapCount += 1;
+};
+
+// Reproduce the listening -> sending transition: the second, shorter deadline
+// must replace the already scheduled long fail-safe.
+view._bumpDismiss(bubble, 1000);
+await new Promise((resolve) => setTimeout(resolve, 10));
+view._bumpDismiss(bubble, 40);
+await new Promise((resolve) => setTimeout(resolve, 100));
+
+if (reapCount !== 1) {
+  throw new Error(`shortened deadline did not reschedule reaper: ${reapCount}`);
+}
+"""
+    )
+
+
+def test_assistant_activity_dismisses_pending_voice_bubble():
+    _run_node(
+        """
+const { ChatView } = await import("./demo/ui/chat.js");
+const view = Object.create(ChatView.prototype);
+const bubble = {
+  isConnected: true,
+  classList: {
+    contains(name) { return name === "voice"; },
+  },
+};
+view._activeUserBubble = bubble;
+view._bubbleExpiry = new WeakMap();
+view._reaperHandle = 0;
+view._bubbleStack = {
+  querySelector() { return null; },
+};
+let dismissed = null;
+view._dismissBubble = (element) => { dismissed = element; };
+
+view.onAssistantActivity();
+if (dismissed !== bubble) throw new Error("pending voice bubble was not dismissed");
+if (view._activeUserBubble !== null) throw new Error("active voice bubble was not released");
+"""
+    )

--- a/tests/test_demo_user_audio.py
+++ b/tests/test_demo_user_audio.py
@@ -194,6 +194,8 @@ const bubble = {
   },
 };
 view._activeUserBubble = bubble;
+view._activeUserItemId = "item_voice";
+view._assistantDismissedUserItemId = "";
 view._bubbleExpiry = new WeakMap();
 view._reaperHandle = 0;
 view._bubbleStack = {
@@ -205,5 +207,56 @@ view._dismissBubble = (element) => { dismissed = element; };
 view.onAssistantActivity();
 if (dismissed !== bubble) throw new Error("pending voice bubble was not dismissed");
 if (view._activeUserBubble !== null) throw new Error("active voice bubble was not released");
+if (view._assistantDismissedUserItemId !== "item_voice") {
+  throw new Error("dismissed item was not remembered");
+}
+"""
+    )
+
+
+def test_late_user_turn_stop_does_not_recreate_dismissed_voice_bubble():
+    _run_node(
+        """
+const { ChatView } = await import("./demo/ui/chat.js");
+const view = Object.create(ChatView.prototype);
+const bubble = {
+  isConnected: true,
+  classList: {
+    contains(name) { return name === "voice"; },
+  },
+};
+view._activeUserBubble = bubble;
+view._activeUserItemId = "item_voice";
+view._assistantDismissedUserItemId = "";
+view._bubbleExpiry = new WeakMap();
+view._reaperHandle = 0;
+view._bubbleStack = {
+  querySelector() { return null; },
+};
+view._dismissBubble = () => {};
+view._scheduleBubbleReaper = () => {};
+let spawned = 0;
+view._spawnVoiceBubble = () => {
+  spawned += 1;
+  return bubble;
+};
+
+// RTC audio can become audible before the ordered data channel delivers the
+// speech_stopped event. The late stop must not recreate the dismissed bubble.
+view.onAssistantActivity();
+view.onUserTurnStopped({ itemId: "item_voice" });
+
+if (spawned !== 0) {
+  throw new Error(`late stop recreated ${spawned} voice bubble(s)`);
+}
+if (view._activeUserBubble !== null) {
+  throw new Error("late stop restored the active voice bubble");
+}
+
+// A genuine reopened turn may reuse the item id and must clear the tombstone.
+view.onUserTurnStarted({ itemId: "item_voice" });
+if (spawned !== 1 || view._activeUserBubble !== bubble) {
+  throw new Error("reopened turn did not create a fresh listening bubble");
+}
 """
     )


### PR DESCRIPTION
## What changed

- retain a bounded browser-local copy of the exact post-gate PCM frames sent over the WebSocket
- slice user utterances using the backend VAD `audio_start_ms`, `audio_end_ms`, and `item_id`
- wrap each utterance as an in-memory WAV and attach a native replay control to its user chat row
- create audio-only user rows when STT is disabled, while still allowing a later transcript to update the same row
- replace the player with accumulated audio when speculative/reopened speech reuses the same item
- temporarily mute outgoing microphone audio during replay to prevent the model from hearing the recording again
- revoke object URLs when conversation history is cleared and bound the rolling capture buffer
- show an animated user balloon as backend VAD moves through “Listening…” and “Sending voice…”
- replace that balloon in place when a transcript is available, and expose the same turn lifecycle in the WebSocket and WebRTC clients

## Why

With direct-audio models such as Inkling and `stt=none`, the conversation history has no visible user content. Replaying the exact audio sent by the browser makes those turns visible and helps users understand what the model heard without uploading or persisting a separate recording.

The animated balloon also closes the visual gap between the end of an utterance and the model’s reply. It gives non-transcribing audio models the same immediate turn feedback that users get when a text transcript is available.

Audio replay is intentionally WebSocket-specific because that transport already exposes the exact PCM16 frames sent through `input_audio_buffer.append`. The visual turn lifecycle works with both WebSocket and WebRTC.

## Validation

- `node --check` for all changed JavaScript modules
- `pytest -q tests/test_demo_user_audio.py tests/test_demo_startup_greeting.py tests/test_demo_server.py` — 15 passed
- regression coverage for shortened voice-bubble deadlines and assistant-start dismissal
- browser validation of listening, sending, transcript-replacement, assistant-start dismissal, and timeout fallback states
- browser validation of audio-only row rendering, late transcript attachment, native audio controls, and the replay mute callback
