### PR TITLE
Stop SpeculativeTurnTracker from committing untracked turns

### DIFF
--- a/src/speech_to_speech/pipeline/speculative_turns.py
+++ b/src/speech_to_speech/pipeline/speculative_turns.py
@@ -100,26 +100,14 @@ class SpeculativeTurnTracker:
             return True
         with self._condition:
             self._wait_for_pending_reopen_locked(turn_id, revision, self._PENDING_REOPEN_WAIT_TIMEOUT_S)
-            latest = self._latest_revision.get(turn_id, revision)
-            if revision != latest:
-                return False
-            self._committed_revision[turn_id] = revision
-            logger.debug("Committed speculative turn %s revision %d", turn_id, revision)
-            self._condition.notify_all()
-            return True
+            return self._commit_locked(turn_id, revision)
 
     def commit_if_latest_after_reopen_grace(self, turn_id: str | None, revision: int | None) -> bool:
         if turn_id is None or revision is None:
             return True
         with self._condition:
             self._wait_for_reopen_gate_locked(turn_id, revision)
-            latest = self._latest_revision.get(turn_id, revision)
-            if revision != latest:
-                return False
-            self._committed_revision[turn_id] = revision
-            logger.debug("Committed speculative turn %s revision %d", turn_id, revision)
-            self._condition.notify_all()
-            return True
+            return self._commit_locked(turn_id, revision)
 
     def try_commit_if_latest_after_pending_reopen(self, turn_id: str | None, revision: int | None) -> bool | None:
         """Non-blocking variant of ``commit_if_latest_after_pending_reopen``.
@@ -132,13 +120,7 @@ class SpeculativeTurnTracker:
         with self._condition:
             if self._has_pending_reopen_locked(turn_id, revision):
                 return None
-            latest = self._latest_revision.get(turn_id, revision)
-            if revision != latest:
-                return False
-            self._committed_revision[turn_id] = revision
-            logger.debug("Committed speculative turn %s revision %d", turn_id, revision)
-            self._condition.notify_all()
-            return True
+            return self._commit_locked(turn_id, revision)
 
     def try_commit_if_latest_after_reopen_grace(self, turn_id: str | None, revision: int | None) -> bool | None:
         if turn_id is None or revision is None:
@@ -153,13 +135,7 @@ class SpeculativeTurnTracker:
                 > 0
             ):
                 return None
-            latest = self._latest_revision.get(turn_id, revision)
-            if revision != latest:
-                return False
-            self._committed_revision[turn_id] = revision
-            logger.debug("Committed speculative turn %s revision %d", turn_id, revision)
-            self._condition.notify_all()
-            return True
+            return self._commit_locked(turn_id, revision)
 
     def has_pending_reopen(self, turn_id: str | None, revision: int | None) -> bool:
         if turn_id is None or revision is None:
@@ -232,11 +208,7 @@ class SpeculativeTurnTracker:
                     "Deferring speculative turn %s revision %d commit while reopen is pending", turn_id, revision
                 )
                 return
-            latest = self._latest_revision.get(turn_id, revision)
-            if revision == latest:
-                self._committed_revision[turn_id] = revision
-                logger.debug("Committed speculative turn %s revision %d", turn_id, revision)
-                self._condition.notify_all()
+            self._commit_locked(turn_id, revision)
 
     def is_committed(self, turn_id: str | None, revision: int | None = None) -> bool:
         if turn_id is None:
@@ -339,6 +311,28 @@ class SpeculativeTurnTracker:
             return
         with self._condition:
             self._wait_for_pending_reopen_locked(turn_id, revision, timeout_s)
+
+    def _commit_locked(self, turn_id: str, revision: int) -> bool:
+        """Record *revision* as committed when it is still the tracked latest.
+
+        Returns whether the caller's output for *revision* is still valid.
+
+        A turn that is no longer tracked is deliberately not written back:
+        ``_prune_tracked_turns`` only walks ``_latest_revision``, so a committed
+        entry without a tracked turn would never be reclaimed, and a recycled
+        turn id would then read as already committed. Such a commit still
+        reports success, since dropping the output of a turn the tracker simply
+        no longer knows about would be worse than emitting it.
+        """
+        latest = self._latest_revision.get(turn_id)
+        if latest is None:
+            return True
+        if revision != latest:
+            return False
+        self._committed_revision[turn_id] = revision
+        logger.debug("Committed speculative turn %s revision %d", turn_id, revision)
+        self._condition.notify_all()
+        return True
 
     def _has_pending_reopen_locked(self, turn_id: str, revision: int) -> bool:
         pending = self._pending_reopen.get(turn_id)

--- a/tests/test_speculative_turns.py
+++ b/tests/test_speculative_turns.py
@@ -4,6 +4,7 @@ from threading import Event, Thread
 from typing import Literal
 
 import numpy as np
+import pytest
 import torch
 
 from speech_to_speech.pipeline.events import SpeechStartedEvent, SpeechStoppedEvent
@@ -161,6 +162,60 @@ def test_is_latest_after_stability_window_catches_reopen_started_during_wait():
 
     assert not tracker.is_latest_after_stability_window("turn_1", 0, settle_s=0.2)
     thread.join(timeout=1.0)
+
+
+def test_commit_after_reset_does_not_resurrect_untracked_turn():
+    tracker = SpeculativeTurnTracker()
+    tracker.observe("turn_1", 0)
+    tracker.reset()
+
+    tracker.commit("turn_1", 0)
+
+    assert tracker._committed_revision == {}
+    assert not tracker.is_committed("turn_1", 0)
+
+
+def test_commit_after_prune_does_not_resurrect_untracked_turn():
+    tracker = SpeculativeTurnTracker(max_tracked_turns=1)
+    tracker.observe("turn_1", 0)
+    tracker.observe("turn_2", 0)
+
+    tracker.commit("turn_1", 0)
+
+    assert list(tracker._latest_revision) == ["turn_2"]
+    assert tracker._committed_revision == {}
+
+
+@pytest.mark.parametrize(
+    "commit_method",
+    [
+        "commit_if_latest_after_pending_reopen",
+        "commit_if_latest_after_reopen_grace",
+        "try_commit_if_latest_after_pending_reopen",
+        "try_commit_if_latest_after_reopen_grace",
+    ],
+)
+def test_commit_if_latest_variants_keep_untracked_turn_out_of_committed_state(commit_method):
+    """An untracked turn still reports success -- callers treat `False` as "drop this
+    output" -- but it must not be written back into `_committed_revision`."""
+    tracker = SpeculativeTurnTracker()
+    tracker.observe("turn_1", 0)
+    tracker.reset()
+
+    assert getattr(tracker, commit_method)("turn_1", 0) is True
+    assert tracker._committed_revision == {}
+
+
+def test_reused_turn_id_after_reset_is_not_reported_as_committed():
+    tracker = SpeculativeTurnTracker()
+    tracker.observe("turn_1", 0)
+    tracker.reset()
+    tracker.commit("turn_1", 0)
+
+    tracker.observe("turn_1", 0)
+
+    assert not tracker.is_committed("turn_1", 0)
+    assert tracker.begin_reopen_candidate("turn_1", 0) == 1
 
 
 def test_vad_direct_reopen_path_uses_tracker_candidate_protocol():


### PR DESCRIPTION
`_prune_tracked_turns` only walks `_latest_revision`, but all five commit entry points decided whether a revision was still current with

```python
latest = self._latest_revision.get(turn_id, revision)
if revision != latest:
    return False
```

The default is the caller's own revision, so the comparison always succeeds for a turn that is *not* tracked, and `_committed_revision[turn_id]` is written for a turn the tracker no longer knows about. That entry is then unreclaimable — pruning never visits it — and any later turn reusing the id reads as already committed.

Both ways of leaving `_latest_revision` are reachable, and the consequence is not just a leak:

- `VAD/vad_handler.py`'s `on_session_end` resets `_turn_counter` to 0 and calls `speculative_turns.reset()`. The VAD thread resets while the downstream STT/LLM/TTS threads are still draining the previous session, so their late commits land on an empty tracker and re-add the old `turn_N`. Because the counter restarted, the next session produces that same id, and `_should_reopen_current_turn` sees `is_committed(...)` return True and bails out with `return False`. A turn that was never answered can no longer reopen: the user finishes speaking and the assistant stays silent until they speak again.
- LRU eviction reaches the same state without any reset, once a long session pushes a turn past `_MAX_TRACKED_TURNS`.

## Changes

- Extract `_commit_locked` and route all five commit entry points through it. It looks the turn up without a default, so an untracked turn is no longer written back, which establishes `_committed_revision` as a subset of `_latest_revision`. This also removes five copies of the same block.
- An untracked turn still reports success rather than `False`. The return value is the caller's "is my output still valid" answer: `api/openai_realtime/handlers/response.py` treats `False` as "drop this text", and discarding the output of a turn the tracker merely forgot is worse than emitting it. Every entry point keeps its previous return semantics exactly, so no caller changes behavior.

## Tests

Adds four tests — seven cases once the `commit_if_*` variants are expanded — and all of them fail against the previous code:

| Test | Covers |
|------|--------|
| `test_commit_after_reset_does_not_resurrect_untracked_turn` | late commit after `reset()` |
| `test_commit_after_prune_does_not_resurrect_untracked_turn` | late commit after LRU eviction |
| `test_commit_if_latest_variants_keep_untracked_turn_out_of_committed_state` | all four `commit_if_*` entry points, including their unchanged return value |
| `test_reused_turn_id_after_reset_is_not_reported_as_committed` | a turn id reused after a session reset can still reopen |

They exercise the tracker directly, so they need no model and run on Linux CI.

Locally: `ruff check`, `ruff format --check`, `mypy src/` clean, and `pytest tests/` is 622 passed.
