### PR TITLE
Support per-session reasoning effort

### DIFF
--- a/src/speech_to_speech/LLM/base_openai_compatible_language_model.py
+++ b/src/speech_to_speech/LLM/base_openai_compatible_language_model.py
@@ -258,7 +258,7 @@ class BaseOpenAICompatibleHandler(BaseHandler[LLMIn, LLMOut], ABC):
         ...
 
     @abstractmethod
-    def _request(self, api_input: Any, optional_kwargs: dict[str, Any]) -> Any:
+    def _request(self, api_input: Any, optional_kwargs: dict[str, Any], runtime_config: Any) -> Any:
         """Issue the create() call and return the response or stream."""
         ...
 
@@ -305,8 +305,8 @@ class BaseOpenAICompatibleHandler(BaseHandler[LLMIn, LLMOut], ABC):
         kwargs.setdefault("temperature", self.audio_temperature)
         return kwargs
 
-    def _request_audio(self, api_input: Any, optional_kwargs: dict[str, Any]) -> Any:
-        return self._request(api_input, optional_kwargs)
+    def _request_audio(self, api_input: Any, optional_kwargs: dict[str, Any], runtime_config: Any) -> Any:
+        return self._request(api_input, optional_kwargs, runtime_config)
 
     def _iter_audio_events(self, api_response: Any) -> Iterator[ProviderEvent]:
         yield from self._iter_events(api_response)
@@ -597,7 +597,10 @@ class BaseOpenAICompatibleHandler(BaseHandler[LLMIn, LLMOut], ABC):
                     # would reject this; fail with a clear message instead of an opaque error.
                     error_message = "Cannot generate a response: no instructions and no input were provided."
                 else:
-                    api_response = (request_fn or self._request)(api_input, optional_kwargs)
+                    if request_fn is not None:
+                        api_response = request_fn(api_input, optional_kwargs)
+                    else:
+                        api_response = self._request(api_input, optional_kwargs, turn.runtime_config)
                 if api_response is not None:
                     events = (event_iterator_fn or self._iter_events)(api_response)
                     if self.stream:
@@ -757,7 +760,7 @@ class BaseOpenAICompatibleHandler(BaseHandler[LLMIn, LLMOut], ABC):
             turn,
             optional_kwargs,
             serialize_fn=self._serialize_audio,
-            request_fn=self._request_audio,
+            request_fn=lambda api_input, kwargs: self._request_audio(api_input, kwargs, runtime_config),
             event_iterator_fn=self._iter_audio_events,
             transactional_user_message_id=transactional_user_message_id,
             history_commit_fn=history_commit_fn,

--- a/src/speech_to_speech/LLM/chat_completions_language_model.py
+++ b/src/speech_to_speech/LLM/chat_completions_language_model.py
@@ -326,13 +326,22 @@ class ChatCompletionsApiModelHandler(BaseOpenAICompatibleHandler):
     def _build_optional_kwargs(self, req_tools: Any, req_tool_choice: Any) -> dict[str, Any]:
         return _build_chat_optional_kwargs(req_tools, req_tool_choice)
 
-    def _request(self, api_input: list[dict[str, Any]], optional_kwargs: dict[str, Any]) -> Any:
+    def _request(
+        self,
+        api_input: list[dict[str, Any]],
+        optional_kwargs: dict[str, Any],
+        runtime_config: Any,
+    ) -> Any:
+        extra_body = self._extra_body
+        session_reasoning_effort = getattr(runtime_config.session, "reasoning_effort", None)
+        if session_reasoning_effort:
+            extra_body = {"reasoning_effort": session_reasoning_effort}
         return _request_chat_completions(
             client=self.client,
             model_name=self.model_name,
             messages=api_input,
             stream=self.stream,
-            extra_body=self._extra_body,
+            extra_body=extra_body,
             timeout=self.request_timeout,
             optional_kwargs=optional_kwargs,
         )

--- a/src/speech_to_speech/LLM/responses_api_language_model.py
+++ b/src/speech_to_speech/LLM/responses_api_language_model.py
@@ -107,13 +107,18 @@ class ResponsesApiModelHandler(BaseOpenAICompatibleHandler):
         self,
         api_input: list[dict[str, Any]],
         optional_kwargs: dict[str, Any],
+        runtime_config: Any,
     ) -> Any:
+        extra_body = self._extra_body
+        session_reasoning_effort = getattr(runtime_config.session, "reasoning_effort", None)
+        if session_reasoning_effort:
+            extra_body = {"reasoning_effort": session_reasoning_effort}
         return _request_chat_completions(
             client=self.client,
             model_name=self.model_name,
             messages=api_input,
             stream=self.stream,
-            extra_body=self._extra_body,
+            extra_body=extra_body,
             timeout=self.request_timeout,
             optional_kwargs=optional_kwargs,
         )
@@ -137,12 +142,16 @@ class ResponsesApiModelHandler(BaseOpenAICompatibleHandler):
             optional_kwargs["tool_choice"] = req_tool_choice
         return optional_kwargs
 
-    def _request(self, api_input: Any, optional_kwargs: dict[str, Any]) -> Any:
+    def _request(self, api_input: Any, optional_kwargs: dict[str, Any], runtime_config: Any) -> Any:
+        extra_body = self._extra_body
+        session_reasoning_effort = getattr(runtime_config.session, "reasoning_effort", None)
+        if session_reasoning_effort:
+            extra_body = {"reasoning_effort": session_reasoning_effort}
         return self.client.responses.create(
             model=self.model_name,
             input=api_input,
             stream=self.stream,
-            extra_body=self._extra_body,
+            extra_body=extra_body,
             timeout=self.request_timeout,
             **optional_kwargs,
         )

--- a/tests/openai_realtime/test_runtime_config.py
+++ b/tests/openai_realtime/test_runtime_config.py
@@ -93,6 +93,15 @@ class TestApplySessionUpdate:
         assert cfg.session.audio.output.voice == "alloy"
         assert cfg.session.tool_choice == "required"
 
+    def test_provider_reasoning_effort_extension_updates_live(self):
+        """Unknown top-level fields are retained as provider extensions."""
+        cfg = RuntimeConfig()
+        cfg.apply_session_update(_parse_session(reasoning_effort="none"))
+        assert cfg.session.reasoning_effort == "none"
+
+        cfg.apply_session_update(_parse_session(reasoning_effort="medium"))
+        assert cfg.session.reasoning_effort == "medium"
+
     def test_deep_nested_leaf_update(self):
         """Changing only turn_detection.threshold preserves the rest."""
         cfg = RuntimeConfig()

--- a/tests/test_chat_completions_backend.py
+++ b/tests/test_chat_completions_backend.py
@@ -136,6 +136,7 @@ def _drive(
     *,
     tools=None,
     tool_choice=None,
+    reasoning_effort=None,
     user="Hallo",
     chat=None,
     response=None,
@@ -149,6 +150,8 @@ def _drive(
         session.tools = tools
     if tool_choice is not None:
         session.tool_choice = tool_choice
+    if reasoning_effort is not None:
+        session.reasoning_effort = reasoning_effort
     rc = RuntimeConfig(chat=chat, session=session)
     req = GenerateResponseRequest(
         runtime_config=rc, response=response, language_code="de", turn_id="t", turn_revision=0
@@ -348,6 +351,25 @@ def test_chat_completions_backend_processes_audio_without_responses_api():
     assert cfg.chat.buffer[0].content[0].type == "input_audio"
 
 
+def test_audio_turn_uses_session_reasoning_effort():
+    handler = _make_handler(stream=False)
+    session = RealtimeSessionCreateRequest(type="realtime", instructions="You are helpful.")
+    session.reasoning_effort = "medium"
+    cfg = RuntimeConfig(chat=Chat(5), session=session)
+
+    list(
+        handler.process(
+            GenerateResponseRequest(
+                runtime_config=cfg,
+                audio=np.zeros(1600, dtype=np.float32),
+                audio_sample_rate=16000,
+            )
+        )
+    )
+
+    assert handler.client.chat.completions.last_kwargs["extra_body"] == {"reasoning_effort": "medium"}
+
+
 def test_chat_completions_backend_uses_configured_audio_url_payload():
     handler = _make_handler(stream=False)
     handler.audio_content_type = "audio_url"
@@ -541,6 +563,35 @@ def test_tools_converted_to_chat_format_on_request():
     assert captured["tool_choice"] == "auto"
     assert captured["stream"] is True
     assert captured["stream_options"] == {"include_usage": True}
+
+
+def test_session_reasoning_effort_overrides_backend_default():
+    """A Realtime session can tune provider reasoning without restarting."""
+    h = _make_handler(stream=True)
+    captured = {}
+
+    def fake_create(**kwargs):
+        captured.update(kwargs)
+        return _FakeStream([_chunk(content="ok.")])
+
+    h.client.chat.completions.create = fake_create
+    _drive(h, reasoning_effort="low")
+
+    assert captured["extra_body"] == {"reasoning_effort": "low"}
+
+
+def test_missing_session_reasoning_effort_keeps_backend_default():
+    h = _make_handler(stream=True)
+    captured = {}
+
+    def fake_create(**kwargs):
+        captured.update(kwargs)
+        return _FakeStream([_chunk(content="ok.")])
+
+    h.client.chat.completions.create = fake_create
+    _drive(h)
+
+    assert captured["extra_body"] == {"chat_template_kwargs": {"enable_thinking": False}}
 
 
 # ── Text-only (output_modalities=["text"]) ────────────────────────────────────


### PR DESCRIPTION
## What changed

- Pass the active Realtime session configuration into OpenAI-compatible LLM requests.
- Allow the session-level `reasoning_effort` provider extension to override the backend default for both Chat Completions and Responses API paths.
- Apply the override to native audio-input turns as well as text turns.
- Preserve the configured backend default when the session does not specify an effort.

## Why

The realtime Inkling demo needs to expose reasoning effort as an interactive setting. Today, the setting can be supplied by the client as a Realtime session extension, but it never reaches the provider request, so changing it has no effect.

## Impact

After a reviewed image build and endpoint rollout, clients can send values such as `none`, `low`, or `medium` in `session.update`. The setting applies per session and can be changed without restarting the service. Existing clients retain the current backend default.

## Validation

- `uv run pytest -q tests/test_chat_completions_backend.py tests/test_responses_api_language_model.py tests/openai_realtime/test_runtime_config.py`
- 70 tests passed
- `git diff --check origin/audio-input-llm-stt-bypass...HEAD`
