### PR TITLE
Give every STT language an LLM language name

### DIFF
--- a/src/speech_to_speech/LLM/utils.py
+++ b/src/speech_to_speech/LLM/utils.py
@@ -29,6 +29,13 @@ def remove_unspeechable(text: str) -> str:
     return SPEECHABLE_PATTERN.sub("", text)
 
 
+# Maps an STT language code to the language name used in the "Please reply ... in {name}"
+# prompt. Every language any bundled STT backend can report needs an entry here, otherwise
+# `--enable_lang_prompt` silently emits no instruction for it. The names are lowercase
+# because they are interpolated mid-sentence.
+#
+# `tests/test_llm_utils.py` asserts this covers the SUPPORTED_LANGUAGES of every bundled STT
+# handler, so adding a language to a handler without adding it here fails CI.
 WHISPER_LANGUAGE_TO_LLM_LANGUAGE = {
     "en": "english",
     "fr": "french",
@@ -42,6 +49,24 @@ WHISPER_LANGUAGE_TO_LLM_LANGUAGE = {
     "pl": "polish",
     "it": "italian",
     "nl": "dutch",
+    # The remaining languages Parakeet TDT v3 (the default STT) detects and reports.
+    "ru": "russian",
+    "uk": "ukrainian",
+    "cs": "czech",
+    "sk": "slovak",
+    "hu": "hungarian",
+    "ro": "romanian",
+    "bg": "bulgarian",
+    "hr": "croatian",
+    "sl": "slovenian",
+    "sr": "serbian",
+    "da": "danish",
+    "no": "norwegian",
+    "sv": "swedish",
+    "fi": "finnish",
+    "et": "estonian",
+    "lv": "latvian",
+    "lt": "lithuanian",
 }
 
 

--- a/tests/test_language_prompt.py
+++ b/tests/test_language_prompt.py
@@ -1,0 +1,127 @@
+"""End-to-end coverage for the ``--enable_lang_prompt`` language instruction.
+
+The instruction is gated on a language *name*, not on the language code:
+
+    language_code, lang_name = resolve_auto_language(language_code)
+    if lang_name and self.enable_lang_prompt:
+        active_chat.add_item(make_user_message(f"Please reply to my message in {lang_name}."))
+
+so any code missing from ``WHISPER_LANGUAGE_TO_LLM_LANGUAGE`` silently produces no
+instruction at all. Parakeet TDT is the default STT and reports 25 languages, so this
+asserts the instruction actually reaches the outgoing request for the ones it detects --
+not merely that the mapping dict has keys.
+
+The OpenAI client is faked, so this runs with no network and no GPU.
+"""
+
+from __future__ import annotations
+
+import queue
+import threading
+from types import SimpleNamespace
+
+import pytest
+from openai.types.realtime.realtime_session_create_request import RealtimeSessionCreateRequest
+
+import speech_to_speech.LLM.base_openai_compatible_language_model as base_mod
+from speech_to_speech.api.openai_realtime.runtime_config import RuntimeConfig
+from speech_to_speech.LLM.chat import Chat, make_user_message
+from speech_to_speech.LLM.chat_completions_language_model import ChatCompletionsApiModelHandler
+from speech_to_speech.pipeline.messages import GenerateResponseRequest
+from speech_to_speech.STT.parakeet_tdt_handler import SUPPORTED_LANGUAGES as PARAKEET_LANGUAGES
+
+
+class _FakeCompletions:
+    def __init__(self):
+        self.next_result = SimpleNamespace(
+            choices=[SimpleNamespace(message=SimpleNamespace(content="ok", tool_calls=[]))],
+            usage=SimpleNamespace(prompt_tokens=1, completion_tokens=1),
+        )
+        self.calls: list[dict] = []
+
+    def create(self, **kwargs):
+        self.calls.append(kwargs)
+        return self.next_result
+
+
+class _FakeClient:
+    def __init__(self, *a, **k):
+        self.chat = SimpleNamespace(completions=_FakeCompletions())
+
+    def with_options(self, **kwargs):
+        return self
+
+
+def _make_handler(*, enable_lang_prompt):
+    orig_openai = base_mod.OpenAI
+    base_mod.OpenAI = _FakeClient
+    try:
+        return ChatCompletionsApiModelHandler(
+            threading.Event(),
+            queue.Queue(),
+            queue.Queue(),
+            setup_kwargs=dict(
+                model_name="test-model",
+                base_url="http://fake/v1",
+                api_key="k",
+                stream=False,
+                disable_thinking=True,
+                compact_history=False,
+                enable_lang_prompt=enable_lang_prompt,
+            ),
+        )
+    finally:
+        base_mod.OpenAI = orig_openai
+
+
+def _sent_messages(handler, language_code, *, enable_lang_prompt=True):
+    """Drive one request and return the messages the backend actually sent."""
+    chat = Chat(10)
+    chat.add_item(make_user_message("Hej, hur mar du?"))
+    session = RealtimeSessionCreateRequest(type="realtime", instructions="You are a robot.")
+    rc = RuntimeConfig(chat=chat, session=session)
+    req = GenerateResponseRequest(runtime_config=rc, language_code=language_code, turn_id="t", turn_revision=0)
+
+    list(handler.process(req))
+
+    calls = handler.client.chat.completions.calls
+    assert calls, "the backend never issued a request"
+    return [m.get("content") for m in calls[-1]["messages"] if m.get("role") == "user"]
+
+
+def test_swedish_gets_a_language_instruction():
+    """Swedish is one of the 17 Parakeet languages that previously got nothing."""
+    handler = _make_handler(enable_lang_prompt=True)
+
+    contents = _sent_messages(handler, "sv-auto")
+
+    assert "Please reply to my message in swedish." in contents
+
+
+@pytest.mark.parametrize("code", sorted(PARAKEET_LANGUAGES))
+def test_every_parakeet_language_produces_an_instruction(code):
+    """No language the default STT can report may silently skip the instruction."""
+    handler = _make_handler(enable_lang_prompt=True)
+
+    contents = _sent_messages(handler, f"{code}-auto")
+
+    instructions = [c for c in contents if isinstance(c, str) and c.startswith("Please reply to my message in ")]
+    assert len(instructions) == 1, f"no language instruction emitted for {code!r}"
+
+
+def test_no_instruction_when_the_flag_is_disabled():
+    """The flag still gates the instruction; this is the default configuration."""
+    handler = _make_handler(enable_lang_prompt=False)
+
+    contents = _sent_messages(handler, "sv-auto")
+
+    assert not [c for c in contents if isinstance(c, str) and c.startswith("Please reply to my message in ")]
+
+
+def test_unknown_language_code_still_emits_no_instruction():
+    """An unnameable code must not produce 'reply in None.' -- absent is correct here."""
+    handler = _make_handler(enable_lang_prompt=True)
+
+    contents = _sent_messages(handler, "xx-auto")
+
+    assert not [c for c in contents if isinstance(c, str) and c.startswith("Please reply to my message in ")]

--- a/tests/test_llm_utils.py
+++ b/tests/test_llm_utils.py
@@ -1,4 +1,12 @@
-from speech_to_speech.LLM.utils import remove_unspeechable
+import importlib
+
+import pytest
+
+from speech_to_speech.LLM.utils import (
+    WHISPER_LANGUAGE_TO_LLM_LANGUAGE,
+    remove_unspeechable,
+    resolve_auto_language,
+)
 
 
 def test_remove_unspeechable_normalizes_smart_apostrophes() -> None:
@@ -7,3 +15,99 @@ def test_remove_unspeechable_normalizes_smart_apostrophes() -> None:
 
 def test_remove_unspeechable_keeps_text_and_drops_emoji() -> None:
     assert remove_unspeechable("Hello 👋 lobster 🦞") == "Hello  lobster "
+
+
+# --- language name coverage ---------------------------------------------------------------
+#
+# A language code with no entry in WHISPER_LANGUAGE_TO_LLM_LANGUAGE resolves to a `None`
+# language name, and both LLM backends gate the prompt on it:
+#
+#     if lang_name and self.enable_lang_prompt:
+#         active_chat.add_item(make_user_message(f"Please reply to my message in {lang_name}."))
+#
+# so `--enable_lang_prompt` silently emits nothing for that language. Parakeet TDT is the
+# default STT and reports 25 languages, of which only 8 overlapped the original 12-entry map.
+
+# Modules that declare a SUPPORTED_LANGUAGES list of codes they can report.
+_STT_HANDLER_MODULES = [
+    "speech_to_speech.STT.parakeet_tdt_handler",
+    "speech_to_speech.STT.whisper_stt_handler",
+    "speech_to_speech.STT.mlx_audio_whisper_handler",
+    "speech_to_speech.STT.lightning_whisper_mlx_handler",
+]
+
+# These have no optional top-level dependency, so a skip here means something is wrong
+# rather than merely uninstalled.
+_ALWAYS_IMPORTABLE = {
+    "speech_to_speech.STT.parakeet_tdt_handler",
+    "speech_to_speech.STT.whisper_stt_handler",
+    "speech_to_speech.STT.mlx_audio_whisper_handler",
+}
+
+
+def _supported_languages(module_name):
+    try:
+        module = importlib.import_module(module_name)
+    except ImportError:
+        return None
+    return list(module.SUPPORTED_LANGUAGES)
+
+
+@pytest.mark.parametrize("module_name", _STT_HANDLER_MODULES)
+def test_every_stt_language_has_an_llm_language_name(module_name):
+    """Any language a bundled STT backend can report must be nameable for the prompt."""
+    languages = _supported_languages(module_name)
+    if languages is None:
+        if module_name in _ALWAYS_IMPORTABLE:
+            pytest.fail(f"{module_name} should be importable without optional extras")
+        pytest.skip(f"{module_name} requires an optional dependency")
+
+    missing = sorted(code for code in languages if code not in WHISPER_LANGUAGE_TO_LLM_LANGUAGE)
+    assert missing == [], (
+        f"{module_name} can report {missing}, which have no entry in "
+        f"WHISPER_LANGUAGE_TO_LLM_LANGUAGE, so --enable_lang_prompt would emit no "
+        f"instruction for them"
+    )
+
+
+def test_parakeet_default_stt_is_fully_covered():
+    """Explicit guard for the default backend, independent of the parametrized sweep."""
+    parakeet = importlib.import_module("speech_to_speech.STT.parakeet_tdt_handler")
+
+    assert len(parakeet.SUPPORTED_LANGUAGES) == 25
+    assert set(parakeet.SUPPORTED_LANGUAGES) <= set(WHISPER_LANGUAGE_TO_LLM_LANGUAGE)
+
+
+def test_language_names_are_lowercase_and_non_empty():
+    """The name is interpolated mid-sentence, so it must read as lowercase prose."""
+    for code, name in WHISPER_LANGUAGE_TO_LLM_LANGUAGE.items():
+        assert name and name == name.lower(), f"{code} -> {name!r}"
+        assert name.isalpha(), f"{code} -> {name!r}"
+
+
+# --- resolve_auto_language ----------------------------------------------------------------
+
+
+@pytest.mark.parametrize(
+    ("code", "expected"),
+    [
+        ("sv", ("sv", "swedish")),
+        ("sv-auto", ("sv", "swedish")),
+        ("ru-auto", ("ru", "russian")),
+        ("no-auto", ("no", "norwegian")),
+        ("lt", ("lt", "lithuanian")),
+        ("en-auto", ("en", "english")),
+    ],
+)
+def test_resolve_auto_language_names_parakeet_languages(code, expected):
+    assert resolve_auto_language(code) == expected
+
+
+@pytest.mark.parametrize("code", [None, ""])
+def test_resolve_auto_language_passes_through_empty_codes(code):
+    assert resolve_auto_language(code) == (code, None)
+
+
+def test_resolve_auto_language_returns_no_name_for_unknown_code():
+    """Unknown codes still round-trip the code, they just cannot be named."""
+    assert resolve_auto_language("xx-auto") == ("xx", None)


### PR DESCRIPTION
Fixes #394

## Problem

`--enable_lang_prompt` appends *"Please reply to my message in {name}."*, but the instruction is gated on the resolved language **name**, not the code:

```python
language_code, lang_name = resolve_auto_language(language_code)
if lang_name and self.enable_lang_prompt:
    active_chat.add_item(make_user_message(f"Please reply to my message in {lang_name}."))
```

`resolve_auto_language()` returns `None` for any code missing from `WHISPER_LANGUAGE_TO_LLM_LANGUAGE`, so the instruction is **silently skipped** — no warning, no log.

That map had 12 entries, sized to the Whisper handlers' `SUPPORTED_LANGUAGES`. Parakeet TDT v3 is the **default** STT and reports 25 languages, only 8 of which overlapped. So in the configuration the README documents, 17 detectable languages got no instruction at all:

```
bg cs da et fi hr hu lt lv no ro ru sk sl sr sv uk
```

```python
>>> resolve_auto_language("sv-auto")
('sv', None)          # no instruction emitted
>>> resolve_auto_language("de-auto")
('de', 'german')
```

The STT transcribes those languages correctly and the code reaches the LLM turn intact — only the instruction goes missing. So the flag quietly does nothing for 17 of 25 languages, which is precisely the case it exists for: the README notes it's there to help smaller models that don't infer the language from context.

This reads as an oversight rather than a deliberate limit — `TTS/kokoro_handler.py:41` already carries an `# Additional European languages from Parakeet` block mapping `ru`/`uk`, so covering Parakeet's set downstream was already the intent, and the README's table advertises the 25 languages with no mention of a narrower subset.

## Fix

Adds the 17 missing names. Deliberately minimal:

- No behaviour change when `--enable_lang_prompt` is off, which is the default.
- Nothing else consumes this map, so the blast radius is the instruction string.
- I left the `WHISPER_LANGUAGE_TO_LLM_LANGUAGE` name alone rather than renaming it to something backend-neutral — happy to rename if you'd prefer, but it seemed like avoidable churn for a bug fix.

I did **not** extend `WHISPER_LANGUAGE_TO_KOKORO_LANG`: it already falls back with `.get(language_code, self.lang_code)`, so unmapped languages degrade to the configured voice instead of failing. And Qwen3-TTS (the default) uses its own `--qwen3_tts_language`, defaulting to `auto`, so it isn't affected either way.

## Tests

**`tests/test_llm_utils.py`** — an invariant test: every bundled STT handler's `SUPPORTED_LANGUAGES` must be covered by the map, so a handler gaining a language can't silently regress this again. Handlers behind optional extras are skipped; the three with no optional top-level dependency are asserted importable, so the sweep can't pass by skipping everything. Against the previous map it fails with the exact gap:

```
AssertionError: speech_to_speech.STT.parakeet_tdt_handler can report
['bg', 'cs', 'da', 'et', 'fi', 'hr', 'hu', 'lt', 'lv', 'no', 'ro', 'ru', 'sk', 'sl', 'sr', 'sv', 'uk'],
which have no entry in WHISPER_LANGUAGE_TO_LLM_LANGUAGE, so --enable_lang_prompt
would emit no instruction for them
```

**`tests/test_language_prompt.py`** — end-to-end, not just dict keys. It drives the chat-completions backend with a faked OpenAI client and asserts the instruction actually reaches the outgoing request for every language Parakeet can report, that the flag still gates it, and that an unnameable code emits nothing rather than `"reply in None."`.

18 tests fail against the previous map. Full suite: 657 passed, 1 skipped. `ruff check`, `ruff format --check`, `mypy src/` clean.
