### PR TITLE
Add Qwen3-ASR STT backend (in-process + HTTP; in-process blocked on macOS)

### DIFF
--- a/Dockerfile.cpu
+++ b/Dockerfile.cpu
@@ -1,0 +1,39 @@
+FROM python:3.12-slim
+
+ENV PYTHONUNBUFFERED=1
+ENV PATH="/usr/src/app/.venv/bin:${PATH}"
+
+WORKDIR /usr/src/app
+
+# No NVIDIA base image here: this variant is for machines with no GPU (or a GPU Docker
+# can't reach, e.g. Docker Desktop on Apple Silicon has no Metal/MPS passthrough), running
+# everything on CPU. Use Dockerfile / Dockerfile.arm64 instead on a CUDA-capable host.
+RUN apt-get update \
+    && apt-get install -y --no-install-recommends \
+        ca-certificates \
+        git \
+        libportaudio2 \
+        libsndfile1 \
+    && rm -rf /var/lib/apt/lists/*
+RUN pip install --no-cache-dir uv
+
+# torch/torchaudio default to the CUDA-bundled wheel on Linux even with no GPU present;
+# pull from the CPU wheel index instead so `uv sync` doesn't download multiple GB it can't
+# use. index-strategy=unsafe-best-match lets uv pick torch from this extra index while still
+# resolving every other dependency from PyPI as usual.
+ENV UV_EXTRA_INDEX_URL="https://download.pytorch.org/whl/cpu"
+ENV UV_INDEX_STRATEGY="unsafe-best-match"
+
+COPY pyproject.toml README.md LICENSE MANIFEST.in ./
+RUN uv sync --no-install-project --no-dev
+
+COPY . .
+RUN uv sync --no-dev
+
+# The default Qwen3-TTS GGML backend's qwentts-cpp-python wheel on PyPI targets CUDA 12.8;
+# this image has no GPU, so pull the CPU wheel instead (see README's "CUDA Note for
+# Qwen3-TTS" section).
+RUN uv pip install "qwentts-cpp-python==0.3.1+cpu" \
+    -f https://huggingface.co/datasets/andito/qwentts-cpp-python-wheels/tree/main/whl/cpu
+
+RUN python -c "import nltk; nltk.download('punkt_tab'); nltk.download('averaged_perceptron_tagger_eng')"

--- a/README.md
+++ b/README.md
@@ -132,6 +132,7 @@ pip install "speech-to-speech[facebook-mms]"    # MMS TTS
 pip install "speech-to-speech[faster-whisper]"  # Faster Whisper STT
 pip install "speech-to-speech[whisper-mlx]"     # Lightning Whisper MLX STT on macOS
 pip install "speech-to-speech[paraformer]"      # Paraformer STT through FunASR
+pip install "speech-to-speech[qwen3-asr]"       # Qwen3-ASR STT
 pip install "speech-to-speech[mlx-lm]"          # mlx-vlm support for vision models on macOS
 ```
 
@@ -160,6 +161,7 @@ This installs the package in editable mode and makes the `speech-to-speech` CLI 
 | STT | [Lightning Whisper MLX](https://github.com/mustafaaljadery/lightning-whisper-mlx) | Apple Silicon | `whisper-mlx` |
 | STT | [MLX Audio Whisper](https://github.com/huggingface/mlx-audio) | Apple Silicon | built-in on macOS |
 | STT | [Paraformer](https://github.com/modelscope/FunASR) | CUDA / CPU | `paraformer` |
+| STT | [Qwen3-ASR](https://huggingface.co/Qwen/Qwen3-ASR-1.7B) | CUDA / CPU / Apple Silicon | `qwen3-asr` |
 | LLM | OpenAI-compatible API (`responses-api`, `chat-completions`) | hosted providers or self-hosted servers | built-in |
 | LLM | [Transformers](https://huggingface.co/models?pipeline_tag=text-generation&sort=trending) | CUDA / CPU | built-in |
 | LLM | [mlx-lm](https://github.com/ml-explore/mlx-lm) | Apple Silicon | built-in on macOS |
@@ -477,6 +479,7 @@ Language coverage depends on the STT and TTS backends you pick, not on the pipel
 | STT | Parakeet TDT (default) | 25 European languages |
 | STT | Whisper / Whisper MLX / Faster Whisper | Broad multilingual coverage, depending on the selected Whisper checkpoint |
 | STT | Paraformer | Depends on the selected FunASR checkpoint; the default is Chinese-oriented |
+| STT | Qwen3-ASR | 30 languages plus Cantonese and 22 Chinese dialects, with language identification |
 | TTS | Qwen3-TTS (default) | Multilingual, with `--qwen3_tts_language auto` by default |
 | TTS | Kokoro | Multiple language/voice mappings, depending on backend availability |
 | TTS | ChatTTS | English and Chinese |

--- a/README.md
+++ b/README.md
@@ -161,7 +161,7 @@ This installs the package in editable mode and makes the `speech-to-speech` CLI 
 | STT | [Lightning Whisper MLX](https://github.com/mustafaaljadery/lightning-whisper-mlx) | Apple Silicon | `whisper-mlx` |
 | STT | [MLX Audio Whisper](https://github.com/huggingface/mlx-audio) | Apple Silicon | built-in on macOS |
 | STT | [Paraformer](https://github.com/modelscope/FunASR) | CUDA / CPU | `paraformer` |
-| STT | [Qwen3-ASR](https://huggingface.co/Qwen/Qwen3-ASR-1.7B) | CUDA / CPU / Apple Silicon | `qwen3-asr` |
+| STT | [Qwen3-ASR](https://huggingface.co/Qwen/Qwen3-ASR-1.7B) | CUDA / CPU; on macOS use `--stt qwen3-asr-http` instead, see [`STT/README.md`](./src/speech_to_speech/STT/README.md) | `qwen3-asr` |
 | LLM | OpenAI-compatible API (`responses-api`, `chat-completions`) | hosted providers or self-hosted servers | built-in |
 | LLM | [Transformers](https://huggingface.co/models?pipeline_tag=text-generation&sort=trending) | CUDA / CPU | built-in |
 | LLM | [mlx-lm](https://github.com/ml-explore/mlx-lm) | Apple Silicon | built-in on macOS |

--- a/README.md
+++ b/README.md
@@ -281,6 +281,27 @@ docker compose up
 
 The compose file starts a llama.cpp server with Gemma 4, starts the TCP socket server, and exposes ports `8080`, `12345`, and `12346`.
 
+#### CPU-only / Qwen3-ASR Docker setup
+
+`docker-compose.qwen3-asr.yml` runs the pipeline with `--stt qwen3-asr-http` against a standalone
+Qwen3-ASR container, entirely CPU-only — no NVIDIA Container Toolkit needed. Use this on a machine
+with no CUDA GPU Docker can reach, e.g. Docker Desktop on Apple Silicon (no Metal/MPS passthrough
+into containers), as an alternative to running `scripts/qwen3_asr_server.py` in a native virtualenv (see
+[`src/speech_to_speech/STT/README.md`](./src/speech_to_speech/STT/README.md)):
+
+```bash
+export OPENAI_API_KEY=...
+docker compose -f docker-compose.qwen3-asr.yml up
+```
+
+Then, on the host (for microphone/speaker access):
+
+```bash
+python scripts/listen_and_play.py --host 127.0.0.1
+```
+
+Being CPU-only, expect noticeably higher STT latency than the native MPS/CUDA path.
+
 ## Realtime API
 
 Realtime mode streams audio over a WebSocket using the OpenAI Realtime protocol, with live transcription and low-latency turn-taking. The server exposes `/v1/realtime`, and any OpenAI Realtime-compatible client can connect:

--- a/docker-compose.qwen3-asr.yml
+++ b/docker-compose.qwen3-asr.yml
@@ -1,0 +1,57 @@
+---
+# CPU-only Docker setup pairing the speech-to-speech pipeline with a standalone Qwen3-ASR
+# STT server (--stt qwen3-asr-http). Use this instead of docker-compose.yml on machines with
+# no CUDA GPU Docker can reach, e.g. Docker Desktop on Apple Silicon Macs (no Metal/MPS
+# passthrough) -- see src/speech_to_speech/STT/README.md for why qwen-asr needs its own
+# process/venv here rather than running in-process with the rest of the pipeline.
+#
+# Requires OPENAI_API_KEY (or point --responses_api_base_url/--responses_api_api_key at
+# another OpenAI-compatible provider by editing the pipeline service's command below).
+#
+# Usage:
+#   docker compose -f docker-compose.qwen3-asr.yml up
+#   python scripts/listen_and_play.py --host 127.0.0.1   # run natively on the host for mic/speaker access
+
+services:
+
+  qwen3-asr:
+    build:
+      context: .
+      dockerfile: docker/qwen3-asr/Dockerfile
+    ports:
+      - 8000:8000/tcp
+    volumes:
+      - ./cache/:/root/.cache/
+
+  pipeline:
+    depends_on:
+      - qwen3-asr
+    build:
+      context: .
+      dockerfile: Dockerfile.cpu
+    environment:
+      - OPENAI_API_KEY=${OPENAI_API_KEY}
+    command:
+      - speech-to-speech
+      - --mode
+      - socket
+      - --recv_host
+      - 0.0.0.0
+      - --send_host
+      - 0.0.0.0
+      - --stt
+      - qwen3-asr-http
+      - --qwen3_asr_http_base_url
+      - http://qwen3-asr:8000
+      - --llm_backend
+      - responses-api
+      - --model_name
+      - gpt-4o-mini
+    expose:
+      - 12345/tcp
+      - 12346/tcp
+    ports:
+      - 12345:12345/tcp
+      - 12346:12346/tcp
+    volumes:
+      - ./cache/:/root/.cache/

--- a/docker/qwen3-asr/Dockerfile
+++ b/docker/qwen3-asr/Dockerfile
@@ -1,0 +1,36 @@
+FROM python:3.12-slim
+
+ENV PYTHONUNBUFFERED=1
+
+WORKDIR /usr/src/app
+
+RUN apt-get update \
+    && apt-get install -y --no-install-recommends \
+        ca-certificates \
+        ffmpeg \
+        libsndfile1 \
+        sox \
+    && rm -rf /var/lib/apt/lists/*
+
+# CPU-only torch wheel first: plain `pip install torch` on Linux defaults to the
+# CUDA-bundled wheel (multi-GB) even though this image has no GPU to use it with.
+RUN pip install --no-cache-dir --default-timeout=180 --retries 5 \
+    torch --index-url https://download.pytorch.org/whl/cpu
+
+# Normal install (no --no-deps): this container is isolated from the main speech-to-speech
+# install, so qwen-asr's own transformers==4.57.6 pin resolves cleanly here. See
+# src/speech_to_speech/STT/README.md for why this can't share a process/venv with the
+# transformers==5.6.2 the main pipeline pins on macOS.
+RUN pip install --no-cache-dir --default-timeout=180 --retries 5 "qwen-asr==0.0.6" flask
+
+# Not `qwen-asr-serve`: it wraps `vllm serve` and requires the vllm package, which has no
+# wheels for macOS/Apple Silicon (and is overkill for one utterance at a time). This runs
+# qwen3_asr_server.py instead -- a small Flask server around the same
+# Qwen3ASRModel.from_pretrained(...).transcribe(...) call, exposing the same
+# /v1/chat/completions contract this project's Qwen3ASRHTTPSTTHandler expects.
+COPY scripts/qwen3_asr_server.py .
+
+EXPOSE 8000
+
+ENTRYPOINT ["python", "qwen3_asr_server.py"]
+CMD ["--model", "Qwen/Qwen3-ASR-1.7B", "--host", "0.0.0.0", "--port", "8000", "--device", "cpu"]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -89,6 +89,9 @@ paraformer = [
 pocket = [
     "pocket-tts>=0.1.0",
 ]
+qwen3-asr = [
+    "qwen-asr>=0.0.6",
+]
 webrtc = [
     "aiortc>=1.9.0",
 ]

--- a/scripts/qwen3_asr_server.py
+++ b/scripts/qwen3_asr_server.py
@@ -1,0 +1,72 @@
+"""Minimal HTTP server wrapping Qwen3ASRModel.from_pretrained (transformers backend).
+
+Exposes the same /v1/chat/completions contract that
+speech_to_speech.STT.qwen3_asr_http_handler expects. Use this instead of `qwen-asr-serve`,
+which wraps `vllm serve` and requires the vllm package -- unavailable on macOS/Apple Silicon
+(no wheels), and generally unnecessary for a single-utterance-at-a-time voice pipeline.
+
+Run this in its own virtualenv pinned to transformers==4.57.6 (the version `qwen-asr`
+actually needs), separate from the main speech-to-speech install. See
+src/speech_to_speech/STT/README.md for the full writeup.
+
+Usage:
+    pip install qwen-asr==0.0.6
+    python scripts/qwen3_asr_server.py --device mps --host 127.0.0.1 --port 8000
+"""
+
+from __future__ import annotations
+
+import argparse
+
+import torch
+from flask import Flask, jsonify, request
+from qwen_asr import Qwen3ASRModel
+
+app = Flask(__name__)
+model: Qwen3ASRModel | None = None
+
+
+@app.route("/v1/chat/completions", methods=["POST"])
+def chat_completions():
+    payload = request.get_json(force=True)
+    content = payload["messages"][0]["content"]
+    audio_item = next(item for item in content if item.get("type") == "audio_url")
+    audio_url = audio_item["audio_url"]["url"]
+
+    # qwen_asr.inference.utils.load_audio_any accepts this string directly (http(s) URL,
+    # local path, or a "data:audio/..." base64 URI) -- no manual decoding needed here.
+    results = model.transcribe(audio=audio_url, language=None)
+    result = results[0]
+    content_text = f"language {result.language}<asr_text>{result.text}" if result.language else result.text
+
+    return jsonify({"choices": [{"message": {"content": content_text}}]})
+
+
+@app.route("/health", methods=["GET"])
+def health():
+    return jsonify({"status": "ok"})
+
+
+def main() -> None:
+    global model
+
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--model", default="Qwen/Qwen3-ASR-1.7B", help="HF model id or local path")
+    parser.add_argument("--host", default="127.0.0.1")
+    parser.add_argument("--port", type=int, default=8000)
+    parser.add_argument("--device", default="cpu", help="cuda, mps, or cpu")
+    parser.add_argument("--dtype", default="bfloat16", help="torch dtype, e.g. bfloat16, float16, float32")
+    args = parser.parse_args()
+
+    print(f"Loading {args.model} on {args.device} ({args.dtype})...")
+    model = Qwen3ASRModel.from_pretrained(
+        args.model,
+        dtype=getattr(torch, args.dtype),
+        device_map=args.device,
+    )
+    print(f"Ready. Listening on http://{args.host}:{args.port}")
+    app.run(host=args.host, port=args.port)
+
+
+if __name__ == "__main__":
+    main()

--- a/scripts/qwen3_asr_server.py
+++ b/scripts/qwen3_asr_server.py
@@ -17,6 +17,7 @@ Usage:
 from __future__ import annotations
 
 import argparse
+import time
 
 import torch
 from flask import Flask, jsonify, request
@@ -35,10 +36,13 @@ def chat_completions():
 
     # qwen_asr.inference.utils.load_audio_any accepts this string directly (http(s) URL,
     # local path, or a "data:audio/..." base64 URI) -- no manual decoding needed here.
+    start = time.perf_counter()
     results = model.transcribe(audio=audio_url, language=None)
+    elapsed_s = time.perf_counter() - start
     result = results[0]
     content_text = f"language {result.language}<asr_text>{result.text}" if result.language else result.text
 
+    print(f"[qwen3_asr_server] transcribe took {elapsed_s:.3f}s -> {content_text!r}")
     return jsonify({"choices": [{"message": {"content": content_text}}]})
 
 

--- a/src/speech_to_speech/STT/README.md
+++ b/src/speech_to_speech/STT/README.md
@@ -84,6 +84,16 @@ This document summarizes the Speech-to-Text (STT) implementations in the `STT/` 
 - Language flag: `--qwen3_asr_language` (ISO 639-1 code, e.g. `en`, `vi`, `zh`; omit or set to `auto` for automatic language detection)
 - Supported language list (30 languages, `yue` = Cantonese): `zh`, `en`, `yue`, `ar`, `de`, `fr`, `es`, `pt`, `id`, `it`, `ko`, `ru`, `th`, `vi`, `ja`, `tr`, `hi`, `ms`, `nl`, `sv`, `da`, `fi`, `pl`, `cs`, `fil`, `fa`, `el`, `hu`, `mk`, `ro`
 - Backend: `qwen-asr` package (transformers backend), one VAD-segmented utterance per call
+- **Known limitation (as of `qwen-asr==0.0.6`): incompatible with `transformers==5.6.2`**, the version this
+  project pins on macOS (needed by Qwen3-TTS/mlx-audio). `qwen-asr` hard-pins `transformers==4.57.6` and its
+  vendored modeling/config code (`qwen_asr/core/transformers_backend/`) breaks under 5.x in more than one
+  place — e.g. `Qwen3ASRConfig.__init__` reads `self.thinker_config` during `super().__init__()`, before
+  that attribute is set, which transformers 5.x's new config validation now triggers eagerly. Confirmed by
+  installing `qwen-asr` with `--no-deps` on top of this project's macOS environment. Until `qwen-asr` adds
+  transformers 5.x support upstream, run it in a separate virtualenv pinned to `transformers==4.57.6`
+  (outside this project's macOS install) rather than in-process alongside the rest of the pipeline. On
+  Linux/CUDA, the base `transformers>=4.57.0` requirement is a range, so `transformers==4.57.6` may resolve
+  cleanly there instead — untested.
 
 ## Language Abbreviations (ISO-style codes seen in STT handlers)
 

--- a/src/speech_to_speech/STT/README.md
+++ b/src/speech_to_speech/STT/README.md
@@ -85,6 +85,11 @@ This document summarizes the Speech-to-Text (STT) implementations in the `STT/` 
 - Language flag: `--qwen3_asr_language` (ISO 639-1 code, e.g. `en`, `vi`, `zh`; omit or set to `auto` for automatic language detection)
 - Supported language list (30 languages, `yue` = Cantonese): `zh`, `en`, `yue`, `ar`, `de`, `fr`, `es`, `pt`, `id`, `it`, `ko`, `ru`, `th`, `vi`, `ja`, `tr`, `hi`, `ms`, `nl`, `sv`, `da`, `fi`, `pl`, `cs`, `fil`, `fa`, `el`, `hu`, `mk`, `ro`
 - Backend: `qwen-asr` package (transformers backend), one VAD-segmented utterance per call
+- Does not support `--enable_live_transcription` (progressive/partial transcripts while the user is still
+  speaking): `process()` skips `mode == "progressive"` VAD chunks outright rather than re-running full
+  Qwen3-ASR inference on every partial tick, which would stall the pipeline for seconds at a time (this hit
+  live, confirmed with a user testing this branch: speech would work once, then hang). Only the final
+  transcript, once the turn ends, gets transcribed.
 - **`transformers` version conflict, confirmed unresolved on macOS:** `qwen-asr==0.0.6` hard-pins
   `transformers==4.57.6`, which conflicts with this project's `transformers==5.6.2` pin on macOS (needed by
   Qwen3-TTS/mlx-audio) — installing the extra requires `pip install --no-deps qwen-asr==0.0.6` (plus its
@@ -136,8 +141,16 @@ This document summarizes the Speech-to-Text (STT) implementations in the `STT/` 
 
 - Flags: `--qwen3_asr_http_base_url` (default `http://127.0.0.1:8000`), `--qwen3_asr_http_timeout_s`
   (default `30.0`).
-- Both processes run on `localhost`, so the added latency is a local HTTP round-trip (single-digit
-  milliseconds), negligible next to model inference time.
+- Both processes run on `localhost`, so the added HTTP round-trip itself is single-digit milliseconds —
+  end-to-end latency is dominated by Qwen3-ASR-1.7B's own transcribe time (multiple seconds on MPS via
+  plain PyTorch, not the optimized GGML/Metal path some benchmarks quote), not the HTTP hop. Both
+  `Qwen3ASRHTTPSTTHandler` and `scripts/qwen3_asr_server.py` log per-request timings (WAV encode / HTTP
+  round-trip on the client, `transcribe()` time on the server) to make this easy to verify directly rather
+  than guess at.
+- Does not support `--enable_live_transcription`, for the same reason as the in-process backend above, plus
+  `scripts/qwen3_asr_server.py`'s Flask dev server processes one request at a time by default — a flood of
+  overlapping progressive-chunk requests during a single utterance would queue up and stall the pipeline.
+  `process()` skips `mode == "progressive"` VAD chunks outright.
 - Known gap: per-request language forcing (`--qwen3_asr_language`-equivalent) isn't wired up for this path —
   `scripts/qwen3_asr_server.py` always calls `.transcribe(language=None)`, relying on Qwen3-ASR's own
   language auto-detection tag in the response. Easy to add if needed (a `language` field on the request

--- a/src/speech_to_speech/STT/README.md
+++ b/src/speech_to_speech/STT/README.md
@@ -10,6 +10,7 @@ This document summarizes the Speech-to-Text (STT) implementations in the `STT/` 
 - `faster-whisper` → `STT/faster_whisper_handler.py`
 - `parakeet-tdt` → `STT/parakeet_tdt_handler.py`
 - `paraformer` → `STT/paraformer_handler.py`
+- `qwen3-asr` → `STT/qwen3_asr_handler.py`
 
 ## Language Support by Handler
 
@@ -74,6 +75,15 @@ This document summarizes the Speech-to-Text (STT) implementations in the `STT/` 
 - Practical support:
   - Depends on selected FunASR model checkpoint
   - Default setup is Chinese-oriented (`zh`)
+
+### 7) Qwen3-ASR (`--stt qwen3-asr`)
+
+- Handler: `Qwen3ASRSTTHandler`
+- Requires the optional `qwen3-asr` extra: `pip install speech-to-speech[qwen3-asr]`
+- Model flag: `--qwen3_asr_model_name`, default `Qwen/Qwen3-ASR-1.7B` (`Qwen/Qwen3-ASR-0.6B` also available for lower latency)
+- Language flag: `--qwen3_asr_language` (ISO 639-1 code, e.g. `en`, `vi`, `zh`; omit or set to `auto` for automatic language detection)
+- Supported language list (30 languages, `yue` = Cantonese): `zh`, `en`, `yue`, `ar`, `de`, `fr`, `es`, `pt`, `id`, `it`, `ko`, `ru`, `th`, `vi`, `ja`, `tr`, `hi`, `ms`, `nl`, `sv`, `da`, `fi`, `pl`, `cs`, `fil`, `fa`, `el`, `hu`, `mk`, `ro`
+- Backend: `qwen-asr` package (transformers backend), one VAD-segmented utterance per call
 
 ## Language Abbreviations (ISO-style codes seen in STT handlers)
 
@@ -160,4 +170,12 @@ python s2s_pipeline.py --stt parakeet-tdt \
 
 ```bash
 python s2s_pipeline.py --stt paraformer --paraformer_stt_model_name paraformer-zh
+```
+
+### Qwen3-ASR
+
+```bash
+python s2s_pipeline.py --stt qwen3-asr --qwen3_asr_language en
+python s2s_pipeline.py --stt qwen3-asr --qwen3_asr_language auto
+python s2s_pipeline.py --stt qwen3-asr --qwen3_asr_model_name Qwen/Qwen3-ASR-0.6B
 ```

--- a/src/speech_to_speech/STT/README.md
+++ b/src/speech_to_speech/STT/README.md
@@ -84,16 +84,19 @@ This document summarizes the Speech-to-Text (STT) implementations in the `STT/` 
 - Language flag: `--qwen3_asr_language` (ISO 639-1 code, e.g. `en`, `vi`, `zh`; omit or set to `auto` for automatic language detection)
 - Supported language list (30 languages, `yue` = Cantonese): `zh`, `en`, `yue`, `ar`, `de`, `fr`, `es`, `pt`, `id`, `it`, `ko`, `ru`, `th`, `vi`, `ja`, `tr`, `hi`, `ms`, `nl`, `sv`, `da`, `fi`, `pl`, `cs`, `fil`, `fa`, `el`, `hu`, `mk`, `ro`
 - Backend: `qwen-asr` package (transformers backend), one VAD-segmented utterance per call
-- **Known limitation (as of `qwen-asr==0.0.6`): incompatible with `transformers==5.6.2`**, the version this
-  project pins on macOS (needed by Qwen3-TTS/mlx-audio). `qwen-asr` hard-pins `transformers==4.57.6` and its
-  vendored modeling/config code (`qwen_asr/core/transformers_backend/`) breaks under 5.x in more than one
-  place — e.g. `Qwen3ASRConfig.__init__` reads `self.thinker_config` during `super().__init__()`, before
-  that attribute is set, which transformers 5.x's new config validation now triggers eagerly. Confirmed by
-  installing `qwen-asr` with `--no-deps` on top of this project's macOS environment. Until `qwen-asr` adds
-  transformers 5.x support upstream, run it in a separate virtualenv pinned to `transformers==4.57.6`
-  (outside this project's macOS install) rather than in-process alongside the rest of the pipeline. On
+- **`transformers` version note:** `qwen-asr==0.0.6` hard-pins `transformers==4.57.6`, which conflicts with
+  this project's `transformers==5.6.2` pin on macOS (needed by Qwen3-TTS/mlx-audio) — install the extra with
+  `pip install --no-deps qwen-asr==0.0.6` (plus its non-`transformers` deps: `nagisa`, `librosa`,
+  `soundfile`, `accelerate`) on top of the normal macOS install, rather than letting the resolver pull in
+  its own pinned `transformers`. On top of `transformers==5.6.2`, `qwen_asr`'s vendored modeling/config code
+  (`qwen_asr/core/transformers_backend/`) hits three separate transformers 4→5 breaking changes it hasn't
+  adapted to upstream yet — a deprecated `check_model_inputs()` call signature, `Qwen3ASRConfig.__init__`
+  reading `self.thinker_config` before it's assigned (transformers 5.x's config validation now runs eagerly
+  inside `super().__init__()`), and the removed `"default"` key in `ROPE_INIT_FUNCTIONS`. `qwen3_asr_handler.py`
+  applies runtime compatibility shims for all three (see `_apply_transformers_5x_compat` in that file); each
+  checks the current state first, so they no-op automatically once `qwen-asr` fixes them upstream. On
   Linux/CUDA, the base `transformers>=4.57.0` requirement is a range, so `transformers==4.57.6` may resolve
-  cleanly there instead — untested.
+  cleanly there without needing `--no-deps` or the shims — untested.
 
 ## Language Abbreviations (ISO-style codes seen in STT handlers)
 

--- a/src/speech_to_speech/STT/README.md
+++ b/src/speech_to_speech/STT/README.md
@@ -11,6 +11,7 @@ This document summarizes the Speech-to-Text (STT) implementations in the `STT/` 
 - `parakeet-tdt` → `STT/parakeet_tdt_handler.py`
 - `paraformer` → `STT/paraformer_handler.py`
 - `qwen3-asr` → `STT/qwen3_asr_handler.py`
+- `qwen3-asr-http` → `STT/qwen3_asr_http_handler.py`
 
 ## Language Support by Handler
 
@@ -76,7 +77,7 @@ This document summarizes the Speech-to-Text (STT) implementations in the `STT/` 
   - Depends on selected FunASR model checkpoint
   - Default setup is Chinese-oriented (`zh`)
 
-### 7) Qwen3-ASR (`--stt qwen3-asr`)
+### 7) Qwen3-ASR (`--stt qwen3-asr`) — in-process, macOS: currently blocked
 
 - Handler: `Qwen3ASRSTTHandler`
 - Requires the optional `qwen3-asr` extra: `pip install speech-to-speech[qwen3-asr]`
@@ -84,19 +85,55 @@ This document summarizes the Speech-to-Text (STT) implementations in the `STT/` 
 - Language flag: `--qwen3_asr_language` (ISO 639-1 code, e.g. `en`, `vi`, `zh`; omit or set to `auto` for automatic language detection)
 - Supported language list (30 languages, `yue` = Cantonese): `zh`, `en`, `yue`, `ar`, `de`, `fr`, `es`, `pt`, `id`, `it`, `ko`, `ru`, `th`, `vi`, `ja`, `tr`, `hi`, `ms`, `nl`, `sv`, `da`, `fi`, `pl`, `cs`, `fil`, `fa`, `el`, `hu`, `mk`, `ro`
 - Backend: `qwen-asr` package (transformers backend), one VAD-segmented utterance per call
-- **`transformers` version note:** `qwen-asr==0.0.6` hard-pins `transformers==4.57.6`, which conflicts with
-  this project's `transformers==5.6.2` pin on macOS (needed by Qwen3-TTS/mlx-audio) — install the extra with
-  `pip install --no-deps qwen-asr==0.0.6` (plus its non-`transformers` deps: `nagisa`, `librosa`,
-  `soundfile`, `accelerate`) on top of the normal macOS install, rather than letting the resolver pull in
-  its own pinned `transformers`. On top of `transformers==5.6.2`, `qwen_asr`'s vendored modeling/config code
-  (`qwen_asr/core/transformers_backend/`) hits three separate transformers 4→5 breaking changes it hasn't
-  adapted to upstream yet — a deprecated `check_model_inputs()` call signature, `Qwen3ASRConfig.__init__`
-  reading `self.thinker_config` before it's assigned (transformers 5.x's config validation now runs eagerly
-  inside `super().__init__()`), and the removed `"default"` key in `ROPE_INIT_FUNCTIONS`. `qwen3_asr_handler.py`
-  applies runtime compatibility shims for all three (see `_apply_transformers_5x_compat` in that file); each
-  checks the current state first, so they no-op automatically once `qwen-asr` fixes them upstream. On
-  Linux/CUDA, the base `transformers>=4.57.0` requirement is a range, so `transformers==4.57.6` may resolve
-  cleanly there without needing `--no-deps` or the shims — untested.
+- **`transformers` version conflict, confirmed unresolved on macOS:** `qwen-asr==0.0.6` hard-pins
+  `transformers==4.57.6`, which conflicts with this project's `transformers==5.6.2` pin on macOS (needed by
+  Qwen3-TTS/mlx-audio) — installing the extra requires `pip install --no-deps qwen-asr==0.0.6` (plus its
+  non-`transformers` deps: `nagisa`, `librosa`, `soundfile`, `accelerate`) on top of the normal macOS install.
+  On top of `transformers==5.6.2`, `qwen_asr`'s vendored modeling/config code
+  (`qwen_asr/core/transformers_backend/`) hits **at least four** separate transformers 4→5 breaking changes
+  it hasn't adapted to upstream: a deprecated `check_model_inputs()` call signature, `Qwen3ASRConfig.__init__`
+  reading `self.thinker_config` before it's assigned (config validation now runs eagerly inside
+  `super().__init__()`), the removed `"default"` key in `ROPE_INIT_FUNCTIONS` (replaced by a
+  `rope_parameters`-based API — the replacement also drops `mrope_interleaved`/`mrope_section`, i.e. even a
+  correct-looking patch here risks silently wrong positional encoding rather than a crash), and
+  `Qwen3ASRThinkerConfig` similarly missing `pad_token_id` at model-build time. `qwen3_asr_handler.py` applies
+  runtime shims for the first three (see `_apply_transformers_5x_compat` in that file; each checks current
+  state first, so they no-op once `qwen-asr` fixes things upstream) but **model construction still fails** on
+  the fourth, confirmed live against a real macOS install (Python 3.12, Apple Silicon). Do not rely on this
+  handler on macOS until `qwen-asr` supports transformers 5.x upstream — use `--stt qwen3-asr-http` (below)
+  instead, which sidesteps the whole conflict.
+- On Linux/CUDA, the base `transformers>=4.57.0` requirement is a *range*, so `transformers==4.57.6` may
+  resolve and run cleanly there without any of the above — untested, would appreciate confirmation.
+
+### 8) Qwen3-ASR over HTTP (`--stt qwen3-asr-http`) — the actually-working path on macOS
+
+- Handler: `Qwen3ASRHTTPSTTHandler`
+- No extra needed in the main install — this handler only makes plain HTTP calls (via `httpx`, already a
+  base dependency) and never imports `qwen_asr` or cares which `transformers` version this project has.
+- Talks to a separately-running [`qwen-asr-serve`](https://github.com/QwenLM/Qwen3-ASR) process, started in
+  its **own** virtualenv pinned to `transformers==4.57.6` (the version `qwen-asr` actually needs — confirmed
+  working end-to-end, including on Apple Silicon MPS):
+
+  ```bash
+  # Terminal 1 — separate venv, only for Qwen3-ASR
+  uv venv --python 3.12 .venv-qwen3-asr
+  source .venv-qwen3-asr/bin/activate
+  uv pip install qwen-asr==0.0.6
+  qwen-asr-serve Qwen/Qwen3-ASR-1.7B --host 127.0.0.1 --port 8000
+  ```
+
+  ```bash
+  # Terminal 2 — the normal speech-to-speech venv (transformers==5.6.2 on macOS)
+  speech-to-speech --stt qwen3-asr-http --qwen3_asr_http_base_url http://127.0.0.1:8000
+  ```
+
+- Flags: `--qwen3_asr_http_base_url` (default `http://127.0.0.1:8000`), `--qwen3_asr_http_timeout_s`
+  (default `30.0`).
+- Both processes run on `localhost`, so the added latency is a local HTTP round-trip (single-digit
+  milliseconds), negligible next to model inference time.
+- Known gap: per-request language forcing (`--qwen3_asr_language`-equivalent) is not wired up for this path —
+  `qwen-asr-serve`'s `/v1/chat/completions` endpoint doesn't document a request-level language override, so
+  this handler always relies on Qwen3-ASR's own language auto-detection tag in the response.
 
 ## Language Abbreviations (ISO-style codes seen in STT handlers)
 
@@ -191,4 +228,11 @@ python s2s_pipeline.py --stt paraformer --paraformer_stt_model_name paraformer-z
 python s2s_pipeline.py --stt qwen3-asr --qwen3_asr_language en
 python s2s_pipeline.py --stt qwen3-asr --qwen3_asr_language auto
 python s2s_pipeline.py --stt qwen3-asr --qwen3_asr_model_name Qwen/Qwen3-ASR-0.6B
+```
+
+### Qwen3-ASR over HTTP (macOS-friendly)
+
+```bash
+# with qwen-asr-serve already running in its own venv, per section 8 above
+python s2s_pipeline.py --stt qwen3-asr-http --qwen3_asr_http_base_url http://127.0.0.1:8000
 ```

--- a/src/speech_to_speech/STT/README.md
+++ b/src/speech_to_speech/STT/README.md
@@ -110,16 +110,23 @@ This document summarizes the Speech-to-Text (STT) implementations in the `STT/` 
 - Handler: `Qwen3ASRHTTPSTTHandler`
 - No extra needed in the main install — this handler only makes plain HTTP calls (via `httpx`, already a
   base dependency) and never imports `qwen_asr` or cares which `transformers` version this project has.
-- Talks to a separately-running [`qwen-asr-serve`](https://github.com/QwenLM/Qwen3-ASR) process, started in
-  its **own** virtualenv pinned to `transformers==4.57.6` (the version `qwen-asr` actually needs — confirmed
-  working end-to-end, including on Apple Silicon MPS):
+- Talks to a separately-running server, started in its **own** virtualenv pinned to
+  `transformers==4.57.6` (the version `qwen-asr` actually needs). That server is
+  [`scripts/qwen3_asr_server.py`](../../../scripts/qwen3_asr_server.py) — a small Flask wrapper around
+  `Qwen3ASRModel.from_pretrained(...).transcribe(...)`, **not** the `qwen-asr` package's own
+  `qwen-asr-serve` command, which wraps `vllm serve` and hard-requires the `vllm` package. `vllm` has no
+  wheels for macOS/Apple Silicon at all, so `qwen-asr-serve` cannot run there regardless of backend flag —
+  confirmed live (`ModuleNotFoundError: No module named 'vllm'` even with `--backend transformers`
+  requested). `scripts/qwen3_asr_server.py` calls the exact same in-process transformers-backend API
+  confirmed working end-to-end on Apple Silicon MPS, just wrapped in an HTTP endpoint instead of imported
+  in-process:
 
   ```bash
   # Terminal 1 — separate venv, only for Qwen3-ASR
   uv venv --python 3.12 .venv-qwen3-asr
   source .venv-qwen3-asr/bin/activate
   uv pip install qwen-asr==0.0.6
-  qwen-asr-serve Qwen/Qwen3-ASR-1.7B --host 127.0.0.1 --port 8000
+  python scripts/qwen3_asr_server.py --device mps --host 127.0.0.1 --port 8000
   ```
 
   ```bash
@@ -131,9 +138,16 @@ This document summarizes the Speech-to-Text (STT) implementations in the `STT/` 
   (default `30.0`).
 - Both processes run on `localhost`, so the added latency is a local HTTP round-trip (single-digit
   milliseconds), negligible next to model inference time.
-- Known gap: per-request language forcing (`--qwen3_asr_language`-equivalent) is not wired up for this path —
-  `qwen-asr-serve`'s `/v1/chat/completions` endpoint doesn't document a request-level language override, so
-  this handler always relies on Qwen3-ASR's own language auto-detection tag in the response.
+- Known gap: per-request language forcing (`--qwen3_asr_language`-equivalent) isn't wired up for this path —
+  `scripts/qwen3_asr_server.py` always calls `.transcribe(language=None)`, relying on Qwen3-ASR's own
+  language auto-detection tag in the response. Easy to add if needed (a `language` field on the request
+  JSON, threaded through to `.transcribe(language=...)`); not done here for lack of a concrete need yet.
+- On a CUDA host with `vllm` installed, `qwen-asr-serve` (the real one) would likely outperform this via
+  vLLM's batching — this handler's HTTP contract only assumes an OpenAI-chat-completions-shaped response, so
+  swapping the server side later doesn't require touching `qwen3_asr_http_handler.py`.
+- Prefer Docker over a native venv for the server side? See "CPU-only / Qwen3-ASR Docker setup" in
+  the top-level README's [Docker section](../../../README.md#docker) for a `docker compose` alternative that
+  runs both this and the pipeline as containers — CPU-only, no NVIDIA Container Toolkit required.
 
 ## Language Abbreviations (ISO-style codes seen in STT handlers)
 
@@ -233,6 +247,6 @@ python s2s_pipeline.py --stt qwen3-asr --qwen3_asr_model_name Qwen/Qwen3-ASR-0.6
 ### Qwen3-ASR over HTTP (macOS-friendly)
 
 ```bash
-# with qwen-asr-serve already running in its own venv, per section 8 above
+# with scripts/qwen3_asr_server.py already running in its own venv, per section 8 above
 python s2s_pipeline.py --stt qwen3-asr-http --qwen3_asr_http_base_url http://127.0.0.1:8000
 ```

--- a/src/speech_to_speech/STT/qwen3_asr_handler.py
+++ b/src/speech_to_speech/STT/qwen3_asr_handler.py
@@ -197,6 +197,12 @@ class Qwen3ASRSTTHandler(BaseSTTHandler):
         self.model.transcribe(audio=(dummy_audio, 16000), language=self.language_name)
 
     def process(self, vad_audio: STTIn) -> Iterator[STTOut]:
+        if vad_audio.mode == "progressive":
+            # Re-running full Qwen3-ASR inference on every progressive/partial VAD chunk while
+            # the user is still speaking would stall the pipeline for seconds at a time. Only
+            # transcribe once the turn is final.
+            return
+
         logger.debug("infering Qwen3-ASR...")
 
         results = self.model.transcribe(audio=(vad_audio.audio, 16000), language=self.language_name)

--- a/src/speech_to_speech/STT/qwen3_asr_handler.py
+++ b/src/speech_to_speech/STT/qwen3_asr_handler.py
@@ -1,0 +1,131 @@
+from __future__ import annotations
+
+import logging
+from typing import Any, Iterator
+
+from rich.console import Console
+
+from speech_to_speech.pipeline.handler_types import STTIn, STTOut
+from speech_to_speech.pipeline.messages import Transcription
+from speech_to_speech.STT.base_stt_handler import BaseSTTHandler
+
+logger = logging.getLogger(__name__)
+console = Console()
+
+# ISO 639-1 (plus 'yue' for Cantonese, not part of the standard) -> the language
+# name Qwen3-ASR expects/returns, per https://huggingface.co/Qwen/Qwen3-ASR-1.7B
+LANGUAGE_NAME_BY_CODE = {
+    "zh": "Chinese",
+    "en": "English",
+    "yue": "Cantonese",
+    "ar": "Arabic",
+    "de": "German",
+    "fr": "French",
+    "es": "Spanish",
+    "pt": "Portuguese",
+    "id": "Indonesian",
+    "it": "Italian",
+    "ko": "Korean",
+    "ru": "Russian",
+    "th": "Thai",
+    "vi": "Vietnamese",
+    "ja": "Japanese",
+    "tr": "Turkish",
+    "hi": "Hindi",
+    "ms": "Malay",
+    "nl": "Dutch",
+    "sv": "Swedish",
+    "da": "Danish",
+    "fi": "Finnish",
+    "pl": "Polish",
+    "cs": "Czech",
+    "fil": "Filipino",
+    "fa": "Persian",
+    "el": "Greek",
+    "hu": "Hungarian",
+    "mk": "Macedonian",
+    "ro": "Romanian",
+}
+CODE_BY_LANGUAGE_NAME = {name.lower(): code for code, name in LANGUAGE_NAME_BY_CODE.items()}
+
+
+class Qwen3ASRSTTHandler(BaseSTTHandler):
+    """
+    Handles Speech To Text generation using Qwen3-ASR (an audio-LLM ASR model).
+    """
+
+    def setup(
+        self,
+        model_name: str = "Qwen/Qwen3-ASR-1.7B",
+        device: str = "cuda",
+        torch_dtype: str = "bfloat16",
+        language: str | None = None,
+        max_new_tokens: int = 256,
+        max_inference_batch_size: int = 1,
+        gen_kwargs: dict[str, Any] = {},
+    ) -> None:
+        try:
+            import torch
+            from qwen_asr import Qwen3ASRModel
+        except ModuleNotFoundError as exc:
+            raise ModuleNotFoundError(
+                "Qwen3-ASR STT requires the optional 'qwen3-asr' extra. "
+                "Install it with `pip install speech-to-speech[qwen3-asr]`."
+            ) from exc
+
+        self.start_language = language
+        self.last_language_code = language if language != "auto" else None
+        self.language_name = self._code_to_language_name(self.last_language_code)
+
+        self.model = Qwen3ASRModel.from_pretrained(
+            model_name,
+            dtype=getattr(torch, torch_dtype),
+            device_map=device,
+            max_inference_batch_size=max_inference_batch_size,
+            max_new_tokens=max_new_tokens,
+        )
+        self.warmup()
+
+    def _code_to_language_name(self, language_code: str | None) -> str | None:
+        if language_code is None:
+            return None
+        language_name = LANGUAGE_NAME_BY_CODE.get(language_code)
+        if language_name is None:
+            raise ValueError(
+                f"Unsupported --qwen3_asr_language {language_code!r}. "
+                f"Supported codes: {sorted(LANGUAGE_NAME_BY_CODE)}, or 'auto'."
+            )
+        return language_name
+
+    def warmup(self) -> None:
+        import numpy as np
+
+        logger.info(f"Warming up {self.__class__.__name__}")
+        dummy_audio = np.zeros(16000, dtype=np.float32)  # 1s of silence at 16kHz
+        self.model.transcribe(audio=(dummy_audio, 16000), language=self.language_name)
+
+    def process(self, vad_audio: STTIn) -> Iterator[STTOut]:
+        logger.debug("infering Qwen3-ASR...")
+
+        results = self.model.transcribe(audio=(vad_audio.audio, 16000), language=self.language_name)
+        result = results[0]
+        pred_text = result.text
+        language_code = CODE_BY_LANGUAGE_NAME.get(result.language.lower(), result.language) if result.language else None
+
+        if language_code is not None:
+            self.last_language_code = language_code
+
+        logger.debug("finished Qwen3-ASR inference")
+        console.print(f"[yellow]USER: {pred_text}")
+        logger.debug(f"Language Code Qwen3-ASR: {language_code}")
+
+        if self.start_language == "auto" and language_code is not None:
+            language_code += "-auto"
+
+        yield Transcription(
+            text=pred_text,
+            language_code=language_code,
+            turn_id=vad_audio.turn_id,
+            turn_revision=vad_audio.turn_revision,
+            speech_stopped_at_s=vad_audio.created_at_s,
+        )

--- a/src/speech_to_speech/STT/qwen3_asr_handler.py
+++ b/src/speech_to_speech/STT/qwen3_asr_handler.py
@@ -49,6 +49,96 @@ LANGUAGE_NAME_BY_CODE = {
 CODE_BY_LANGUAGE_NAME = {name.lower(): code for code, name in LANGUAGE_NAME_BY_CODE.items()}
 
 
+def _patch_check_model_inputs() -> None:
+    """qwen_asr's vendored modeling code calls ``@check_model_inputs()`` (transformers==4.57.6's
+    optional-arg decorator factory). transformers>=5 made ``func`` a required positional arg,
+    raising ``TypeError: check_model_inputs() missing 1 required positional argument``.
+    """
+    import transformers.utils.generic as generic
+
+    if getattr(generic.check_model_inputs, "_qwen3_asr_compat", False):
+        return
+    original = generic.check_model_inputs
+
+    def compat(func=None, *, tie_last_hidden_states=True):
+        if func is None:
+            return lambda f: original(f)
+        return original(func)
+
+    compat._qwen3_asr_compat = True
+    generic.check_model_inputs = compat
+
+
+def _patch_rope_default() -> None:
+    """transformers>=5 dropped the "default" key from ROPE_INIT_FUNCTIONS (replaced by the
+    rope_parameters-based RotaryEmbeddingConfigMixin API), but qwen_asr's vendored rotary
+    embedding still looks it up by that key, raising ``KeyError: 'default'``. Re-register it
+    using the transformers==4.57.6 implementation qwen_asr was written against.
+    """
+    import torch
+    from transformers.modeling_rope_utils import ROPE_INIT_FUNCTIONS
+
+    if "default" in ROPE_INIT_FUNCTIONS:
+        return
+
+    def compute_default_rope_parameters(config=None, device=None, seq_len=None):
+        base = config.rope_theta
+        partial_rotary_factor = getattr(config, "partial_rotary_factor", 1.0)
+        head_dim = getattr(config, "head_dim", None) or config.hidden_size // config.num_attention_heads
+        dim = int(head_dim * partial_rotary_factor)
+        attention_factor = 1.0
+        inv_freq = 1.0 / (
+            base ** (torch.arange(0, dim, 2, dtype=torch.int64).to(device=device, dtype=torch.float) / dim)
+        )
+        return inv_freq, attention_factor
+
+    ROPE_INIT_FUNCTIONS["default"] = compute_default_rope_parameters
+
+
+def _patch_qwen3_asr_config_init() -> None:
+    """qwen_asr's ``Qwen3ASRConfig.__init__`` assigns ``self.thinker_config`` *after* calling
+    ``super().__init__(**kwargs)``. transformers>=5's ``PretrainedConfig.__init__`` now eagerly
+    validates token ids via ``self.get_text_config()``, which qwen_asr overrides to read
+    ``self.thinker_config`` — raising ``AttributeError`` because it isn't set yet. Reorder so the
+    sub-config exists before the base class validates.
+    """
+    from qwen_asr.core.transformers_backend.configuration_qwen3_asr import (
+        Qwen3ASRConfig,
+        Qwen3ASRThinkerConfig,
+    )
+    from transformers.configuration_utils import PretrainedConfig
+
+    if getattr(Qwen3ASRConfig.__init__, "_qwen3_asr_compat", False):
+        return
+
+    def compat_init(self, thinker_config=None, support_languages=None, **kwargs):
+        if thinker_config is None:
+            thinker_config = {}
+        self.thinker_config = Qwen3ASRThinkerConfig(**thinker_config)
+        self.support_languages = support_languages
+        PretrainedConfig.__init__(self, **kwargs)
+
+    compat_init._qwen3_asr_compat = True
+    Qwen3ASRConfig.__init__ = compat_init
+
+
+def _apply_transformers_5x_compat() -> None:
+    """Best-effort compatibility shims for qwen-asr==0.0.6 running under transformers>=5.
+
+    qwen-asr hard-pins transformers==4.57.6; this project pins transformers==5.6.2 on macOS
+    (needed by Qwen3-TTS/mlx-audio), so both can't be installed together and qwen-asr must be
+    force-installed with --no-deps. These patch three independent transformers 4->5 breaking
+    changes qwen_asr hasn't adapted to yet. See src/speech_to_speech/STT/README.md for details.
+    Each patch checks the current state first, so it's a no-op once qwen-asr fixes it upstream.
+    """
+    _patch_check_model_inputs()
+    _patch_rope_default()
+
+    import qwen_asr  # noqa: F401  (loads the vendored modeling code check_model_inputs patches)
+
+    _patch_qwen3_asr_config_init()
+
+
 class Qwen3ASRSTTHandler(BaseSTTHandler):
     """
     Handles Speech To Text generation using Qwen3-ASR (an audio-LLM ASR model).
@@ -66,6 +156,8 @@ class Qwen3ASRSTTHandler(BaseSTTHandler):
     ) -> None:
         try:
             import torch
+
+            _apply_transformers_5x_compat()
             from qwen_asr import Qwen3ASRModel
         except ModuleNotFoundError as exc:
             raise ModuleNotFoundError(

--- a/src/speech_to_speech/STT/qwen3_asr_http_handler.py
+++ b/src/speech_to_speech/STT/qwen3_asr_http_handler.py
@@ -1,0 +1,153 @@
+from __future__ import annotations
+
+import base64
+import io
+import logging
+import wave
+from typing import Any, Iterator
+
+import numpy as np
+from rich.console import Console
+
+from speech_to_speech.pipeline.handler_types import STTIn, STTOut
+from speech_to_speech.pipeline.messages import Transcription
+from speech_to_speech.STT.base_stt_handler import BaseSTTHandler
+from speech_to_speech.STT.qwen3_asr_handler import CODE_BY_LANGUAGE_NAME
+
+logger = logging.getLogger(__name__)
+console = Console()
+
+_ASR_TEXT_TAG = "<asr_text>"
+_LANG_PREFIX = "language "
+
+
+def _encode_wav_data_uri(audio: np.ndarray, sample_rate: int = 16000) -> str:
+    pcm16 = (np.clip(audio, -1.0, 1.0) * 32767.0).astype(np.int16)
+    buffer = io.BytesIO()
+    with wave.open(buffer, "wb") as wav_file:
+        wav_file.setnchannels(1)
+        wav_file.setsampwidth(2)
+        wav_file.setframerate(sample_rate)
+        wav_file.writeframes(pcm16.tobytes())
+    encoded = base64.b64encode(buffer.getvalue()).decode("ascii")
+    return f"data:audio/wav;base64,{encoded}"
+
+
+def _fix_char_repeats(text: str, threshold: int) -> str:
+    # Qwen3-ASR occasionally degenerates into long repeated character runs; this mirrors the
+    # char-level pass of qwen_asr.inference.utils.detect_and_fix_repetitions. Reimplemented here
+    # (rather than imported) since this handler intentionally has no dependency on the qwen_asr
+    # package or its transformers==4.57.6 pin — it only ever talks to qwen-asr-serve over HTTP.
+    result = []
+    i = 0
+    n = len(text)
+    while i < n:
+        count = 1
+        while i + count < n and text[i + count] == text[i]:
+            count += 1
+        if count > threshold:
+            result.append(text[i])
+        else:
+            result.append(text[i : i + count])
+        i += count
+    return "".join(result)
+
+
+def _parse_asr_output(raw: str) -> tuple[str, str]:
+    """Parse qwen-asr-serve's raw text into (language_name, text).
+
+    Mirrors qwen_asr.inference.utils.parse_asr_output's tagged-output cases:
+    "language English<asr_text>hello" -> ("English", "hello"); untagged output is
+    returned as plain text with an empty language.
+    """
+    if not raw:
+        return "", ""
+    text = _fix_char_repeats(raw.strip(), threshold=20)
+    if _ASR_TEXT_TAG not in text:
+        return "", text.strip()
+
+    meta_part, text_part = text.split(_ASR_TEXT_TAG, 1)
+    if "language none" in meta_part.lower():
+        return "", text_part.strip()
+
+    language = ""
+    for line in meta_part.splitlines():
+        line = line.strip()
+        if line.lower().startswith(_LANG_PREFIX):
+            value = line[len(_LANG_PREFIX) :].strip()
+            if value:
+                language = value[:1].upper() + value[1:].lower()
+            break
+    return language, text_part.strip()
+
+
+class Qwen3ASRHTTPSTTHandler(BaseSTTHandler):
+    """
+    Transcribes via a separately-running `qwen-asr-serve` HTTP server rather than loading
+    Qwen3-ASR in-process. See Qwen3ASRSTTHandler / STT/README.md for why: qwen-asr==0.0.6
+    hard-pins transformers==4.57.6, which conflicts with this project's transformers==5.6.2
+    pin on macOS. Running the model as its own process (own virtualenv, own transformers
+    version) sidesteps the conflict entirely instead of patching around it.
+    """
+
+    def setup(
+        self,
+        base_url: str = "http://127.0.0.1:8000",
+        timeout_s: float = 30.0,
+        gen_kwargs: dict[str, Any] = {},
+    ) -> None:
+        import httpx
+
+        self.base_url = base_url.rstrip("/")
+        self.client = httpx.Client(timeout=timeout_s)
+        self.warmup()
+
+    def warmup(self) -> None:
+        logger.info(f"Warming up {self.__class__.__name__}: checking {self.base_url}")
+        dummy_audio = np.zeros(16000, dtype=np.float32)
+        try:
+            self._transcribe(dummy_audio)
+        except Exception:
+            logger.exception(
+                "%s: could not reach qwen-asr-serve at %s. Is it running? e.g. in a separate "
+                "virtualenv pinned to transformers==4.57.6: "
+                "`qwen-asr-serve Qwen/Qwen3-ASR-1.7B --host 127.0.0.1 --port 8000`",
+                self.__class__.__name__,
+                self.base_url,
+            )
+            raise
+
+    def _transcribe(self, audio: np.ndarray) -> tuple[str, str]:
+        data_uri = _encode_wav_data_uri(audio)
+        response = self.client.post(
+            f"{self.base_url}/v1/chat/completions",
+            json={
+                "messages": [
+                    {
+                        "role": "user",
+                        "content": [{"type": "audio_url", "audio_url": {"url": data_uri}}],
+                    }
+                ]
+            },
+        )
+        response.raise_for_status()
+        content = response.json()["choices"][0]["message"]["content"]
+        return _parse_asr_output(content)
+
+    def process(self, vad_audio: STTIn) -> Iterator[STTOut]:
+        logger.debug("infering Qwen3-ASR (HTTP)...")
+
+        language, pred_text = self._transcribe(vad_audio.audio)
+        language_code = CODE_BY_LANGUAGE_NAME.get(language.lower()) if language else None
+
+        logger.debug("finished Qwen3-ASR (HTTP) inference")
+        console.print(f"[yellow]USER: {pred_text}")
+        logger.debug(f"Language Code Qwen3-ASR (HTTP): {language_code}")
+
+        yield Transcription(
+            text=pred_text,
+            language_code=language_code,
+            turn_id=vad_audio.turn_id,
+            turn_revision=vad_audio.turn_revision,
+            speech_stopped_at_s=vad_audio.created_at_s,
+        )

--- a/src/speech_to_speech/STT/qwen3_asr_http_handler.py
+++ b/src/speech_to_speech/STT/qwen3_asr_http_handler.py
@@ -147,6 +147,13 @@ class Qwen3ASRHTTPSTTHandler(BaseSTTHandler):
         return _parse_asr_output(content)
 
     def process(self, vad_audio: STTIn) -> Iterator[STTOut]:
+        if vad_audio.mode == "progressive":
+            # Qwen3-ASR-1.7B is too slow, and this Flask dev server too single-threaded, to
+            # re-transcribe every progressive/partial VAD chunk fired while the user is still
+            # speaking -- that floods the server with overlapping multi-second requests and
+            # stalls the pipeline. Only transcribe once the turn is final.
+            return
+
         logger.debug("infering Qwen3-ASR (HTTP)...")
 
         language, pred_text = self._transcribe(vad_audio.audio)

--- a/src/speech_to_speech/STT/qwen3_asr_http_handler.py
+++ b/src/speech_to_speech/STT/qwen3_asr_http_handler.py
@@ -3,6 +3,7 @@ from __future__ import annotations
 import base64
 import io
 import logging
+import time
 import wave
 from typing import Any, Iterator
 
@@ -109,16 +110,20 @@ class Qwen3ASRHTTPSTTHandler(BaseSTTHandler):
             self._transcribe(dummy_audio)
         except Exception:
             logger.exception(
-                "%s: could not reach qwen-asr-serve at %s. Is it running? e.g. in a separate "
+                "%s: could not reach the Qwen3-ASR server at %s. Is it running? e.g. in a separate "
                 "virtualenv pinned to transformers==4.57.6: "
-                "`qwen-asr-serve Qwen/Qwen3-ASR-1.7B --host 127.0.0.1 --port 8000`",
+                "`python scripts/qwen3_asr_server.py --host 127.0.0.1 --port 8000`",
                 self.__class__.__name__,
                 self.base_url,
             )
             raise
 
     def _transcribe(self, audio: np.ndarray) -> tuple[str, str]:
+        encode_start = time.perf_counter()
         data_uri = _encode_wav_data_uri(audio)
+        encode_s = time.perf_counter() - encode_start
+
+        request_start = time.perf_counter()
         response = self.client.post(
             f"{self.base_url}/v1/chat/completions",
             json={
@@ -129,6 +134,13 @@ class Qwen3ASRHTTPSTTHandler(BaseSTTHandler):
                     }
                 ]
             },
+        )
+        request_s = time.perf_counter() - request_start
+        logger.info(
+            "%s: WAV encode %.3fs, HTTP round-trip (incl. server-side transcribe) %.3fs",
+            self.__class__.__name__,
+            encode_s,
+            request_s,
         )
         response.raise_for_status()
         content = response.json()["choices"][0]["message"]["content"]

--- a/src/speech_to_speech/arguments_classes/module_arguments.py
+++ b/src/speech_to_speech/arguments_classes/module_arguments.py
@@ -21,11 +21,14 @@ class ModuleArguments:
         },
     )
     stt: Optional[
-        Literal["whisper", "whisper-mlx", "mlx-audio-whisper", "faster-whisper", "parakeet-tdt", "paraformer"]
+        Literal[
+            "whisper", "whisper-mlx", "mlx-audio-whisper", "faster-whisper", "parakeet-tdt", "paraformer", "qwen3-asr"
+        ]
     ] = field(
         default="parakeet-tdt",
         metadata={
-            "help": "The STT to use. Either 'whisper', 'whisper-mlx', 'mlx-audio-whisper', 'faster-whisper', 'parakeet-tdt', or 'paraformer'. Default is 'parakeet-tdt'."
+            "help": "The STT to use. Either 'whisper', 'whisper-mlx', 'mlx-audio-whisper', 'faster-whisper', "
+            "'parakeet-tdt', 'paraformer', or 'qwen3-asr'. Default is 'parakeet-tdt'."
         },
     )
     llm_backend: Optional[Literal["transformers", "mlx-lm", "responses-api", "chat-completions"]] = field(

--- a/src/speech_to_speech/arguments_classes/module_arguments.py
+++ b/src/speech_to_speech/arguments_classes/module_arguments.py
@@ -22,13 +22,20 @@ class ModuleArguments:
     )
     stt: Optional[
         Literal[
-            "whisper", "whisper-mlx", "mlx-audio-whisper", "faster-whisper", "parakeet-tdt", "paraformer", "qwen3-asr"
+            "whisper",
+            "whisper-mlx",
+            "mlx-audio-whisper",
+            "faster-whisper",
+            "parakeet-tdt",
+            "paraformer",
+            "qwen3-asr",
+            "qwen3-asr-http",
         ]
     ] = field(
         default="parakeet-tdt",
         metadata={
             "help": "The STT to use. Either 'whisper', 'whisper-mlx', 'mlx-audio-whisper', 'faster-whisper', "
-            "'parakeet-tdt', 'paraformer', or 'qwen3-asr'. Default is 'parakeet-tdt'."
+            "'parakeet-tdt', 'paraformer', 'qwen3-asr', or 'qwen3-asr-http'. Default is 'parakeet-tdt'."
         },
     )
     llm_backend: Optional[Literal["transformers", "mlx-lm", "responses-api", "chat-completions"]] = field(

--- a/src/speech_to_speech/arguments_classes/qwen3_asr_http_stt_arguments.py
+++ b/src/speech_to_speech/arguments_classes/qwen3_asr_http_stt_arguments.py
@@ -1,0 +1,24 @@
+from dataclasses import dataclass, field
+
+
+@dataclass
+class Qwen3ASRHTTPSTTHandlerArguments:
+    """
+    Arguments for the Qwen3-ASR HTTP Speech-to-Text handler.
+
+    Talks to a `qwen-asr-serve` process (its own virtualenv, pinned to transformers==4.57.6)
+    over HTTP instead of loading the model in-process, working around the transformers==5.6.2
+    pin this project uses on macOS. See src/speech_to_speech/STT/README.md for the full
+    incompatibility writeup and how to start the server.
+    """
+
+    qwen3_asr_http_base_url: str = field(
+        default="http://127.0.0.1:8000",
+        metadata={
+            "help": "Base URL of a running `qwen-asr-serve` server. Default is 'http://127.0.0.1:8000'."
+        },
+    )
+    qwen3_asr_http_timeout_s: float = field(
+        default=30.0,
+        metadata={"help": "HTTP request timeout in seconds for each transcription call. Default is 30.0."},
+    )

--- a/src/speech_to_speech/arguments_classes/qwen3_asr_stt_arguments.py
+++ b/src/speech_to_speech/arguments_classes/qwen3_asr_stt_arguments.py
@@ -1,0 +1,47 @@
+from dataclasses import dataclass, field
+from typing import Optional
+
+
+@dataclass
+class Qwen3ASRSTTHandlerArguments:
+    """
+    Arguments for the Qwen3-ASR Speech-to-Text handler.
+
+    Qwen3-ASR is an audio-LLM ASR family from Alibaba (bidirectional audio encoder +
+    Qwen3 causal LM with audio-token injection), run through the `qwen-asr` package.
+    """
+
+    qwen3_asr_model_name: str = field(
+        default="Qwen/Qwen3-ASR-1.7B",
+        metadata={
+            "help": "The Qwen3-ASR model to use (HuggingFace Hub ID or local path). "
+            "Default is 'Qwen/Qwen3-ASR-1.7B'. 'Qwen/Qwen3-ASR-0.6B' is also available for lower latency."
+        },
+    )
+    qwen3_asr_device: str = field(
+        default="cuda",
+        metadata={"help": "Device to run the model on. Options: 'cuda', 'cpu', 'mps'. Default is 'cuda'."},
+    )
+    qwen3_asr_torch_dtype: str = field(
+        default="bfloat16",
+        metadata={"help": "Torch dtype for inference. Options: 'bfloat16', 'float16', 'float32'. Default is 'bfloat16'."},
+    )
+    qwen3_asr_language: Optional[str] = field(
+        default=None,
+        metadata={
+            "help": "Target language code for transcription (ISO 639-1, e.g. 'en', 'zh'). If not specified or set "
+            "to 'auto', the model auto-detects the language among its 30 supported languages."
+        },
+    )
+    qwen3_asr_max_new_tokens: int = field(
+        default=256,
+        metadata={
+            "help": "Maximum number of tokens to generate per utterance. Raise this for long audio input. Default is 256."
+        },
+    )
+    qwen3_asr_max_inference_batch_size: int = field(
+        default=1,
+        metadata={
+            "help": "Batch size limit for inference. -1 means unlimited. Default is 1 (one VAD-segmented utterance at a time)."
+        },
+    )

--- a/src/speech_to_speech/s2s_pipeline.py
+++ b/src/speech_to_speech/s2s_pipeline.py
@@ -40,6 +40,7 @@ from speech_to_speech.arguments_classes.parakeet_tdt_arguments import (
     ParakeetTDTSTTHandlerArguments,
 )
 from speech_to_speech.arguments_classes.pocket_tts_arguments import PocketTTSHandlerArguments
+from speech_to_speech.arguments_classes.qwen3_asr_http_stt_arguments import Qwen3ASRHTTPSTTHandlerArguments
 from speech_to_speech.arguments_classes.qwen3_asr_stt_arguments import Qwen3ASRSTTHandlerArguments
 from speech_to_speech.arguments_classes.qwen3_tts_arguments import Qwen3TTSHandlerArguments
 from speech_to_speech.arguments_classes.responses_api_language_model_arguments import (
@@ -102,6 +103,7 @@ class ParsedArguments:
     mlx_audio_whisper_stt_handler_kwargs: MLXAudioWhisperSTTHandlerArguments
     parakeet_tdt_stt_handler_kwargs: ParakeetTDTSTTHandlerArguments
     qwen3_asr_stt_handler_kwargs: Qwen3ASRSTTHandlerArguments
+    qwen3_asr_http_stt_handler_kwargs: Qwen3ASRHTTPSTTHandlerArguments
     language_model_handler_kwargs: LanguageModelHandlerArguments
     responses_api_language_model_handler_kwargs: ResponsesApiLanguageModelHandlerArguments
     chat_tts_handler_kwargs: ChatTTSHandlerArguments
@@ -190,6 +192,7 @@ def parse_arguments() -> ParsedArguments:
             MLXAudioWhisperSTTHandlerArguments,
             ParakeetTDTSTTHandlerArguments,
             Qwen3ASRSTTHandlerArguments,
+            Qwen3ASRHTTPSTTHandlerArguments,
             _lm_class,
             ChatTTSHandlerArguments,
             FacebookMMSTTSHandlerArguments,
@@ -220,6 +223,7 @@ def parse_arguments() -> ParsedArguments:
         mlx_audio_whisper_stt_handler_kwargs=by_type[MLXAudioWhisperSTTHandlerArguments],
         parakeet_tdt_stt_handler_kwargs=by_type[ParakeetTDTSTTHandlerArguments],
         qwen3_asr_stt_handler_kwargs=by_type[Qwen3ASRSTTHandlerArguments],
+        qwen3_asr_http_stt_handler_kwargs=by_type[Qwen3ASRHTTPSTTHandlerArguments],
         language_model_handler_kwargs=by_type.get(LanguageModelHandlerArguments, LanguageModelHandlerArguments()),
         # The OpenAI-compatible slot holds whichever class was registered:
         # ChatCompletions... (a subclass) for chat-completions, else ResponsesApi....
@@ -326,6 +330,7 @@ def prepare_all_args(
     mlx_audio_whisper_stt_handler_kwargs: MLXAudioWhisperSTTHandlerArguments,
     parakeet_tdt_stt_handler_kwargs: ParakeetTDTSTTHandlerArguments,
     qwen3_asr_stt_handler_kwargs: Qwen3ASRSTTHandlerArguments,
+    qwen3_asr_http_stt_handler_kwargs: Qwen3ASRHTTPSTTHandlerArguments,
     language_model_handler_kwargs: LanguageModelHandlerArguments,
     responses_api_language_model_handler_kwargs: ResponsesApiLanguageModelHandlerArguments,
     chat_tts_handler_kwargs: ChatTTSHandlerArguments,
@@ -342,6 +347,7 @@ def prepare_all_args(
         mlx_audio_whisper_stt_handler_kwargs,
         parakeet_tdt_stt_handler_kwargs,
         qwen3_asr_stt_handler_kwargs,
+        qwen3_asr_http_stt_handler_kwargs,
         language_model_handler_kwargs,
         responses_api_language_model_handler_kwargs,
         chat_tts_handler_kwargs,
@@ -357,6 +363,7 @@ def prepare_all_args(
     rename_args(mlx_audio_whisper_stt_handler_kwargs, "mlx_audio_whisper")
     rename_args(parakeet_tdt_stt_handler_kwargs, "parakeet_tdt")
     rename_args(qwen3_asr_stt_handler_kwargs, "qwen3_asr")
+    rename_args(qwen3_asr_http_stt_handler_kwargs, "qwen3_asr_http")
     rename_args(language_model_handler_kwargs, "llm")
     rename_args(responses_api_language_model_handler_kwargs, "responses_api")
     rename_args(chat_tts_handler_kwargs, "chat_tts")
@@ -404,6 +411,7 @@ def _build_pipeline_handlers(
     mlx_audio_whisper_stt_handler_kwargs: MLXAudioWhisperSTTHandlerArguments,
     parakeet_tdt_stt_handler_kwargs: ParakeetTDTSTTHandlerArguments,
     qwen3_asr_stt_handler_kwargs: Qwen3ASRSTTHandlerArguments,
+    qwen3_asr_http_stt_handler_kwargs: Qwen3ASRHTTPSTTHandlerArguments,
     language_model_handler_kwargs: LanguageModelHandlerArguments,
     responses_api_language_model_handler_kwargs: ResponsesApiLanguageModelHandlerArguments,
     chat_tts_handler_kwargs: ChatTTSHandlerArguments,
@@ -448,6 +456,7 @@ def _build_pipeline_handlers(
         mlx_audio_whisper_stt_handler_kwargs,
         parakeet_tdt_stt_handler_kwargs,
         qwen3_asr_stt_handler_kwargs,
+        qwen3_asr_http_stt_handler_kwargs,
     )
 
     lm = get_llm_handler(
@@ -494,6 +503,7 @@ def _build_realtime_pipeline_unit(
     mlx_audio_whisper_stt_handler_kwargs: MLXAudioWhisperSTTHandlerArguments,
     parakeet_tdt_stt_handler_kwargs: ParakeetTDTSTTHandlerArguments,
     qwen3_asr_stt_handler_kwargs: Qwen3ASRSTTHandlerArguments,
+    qwen3_asr_http_stt_handler_kwargs: Qwen3ASRHTTPSTTHandlerArguments,
     language_model_handler_kwargs: LanguageModelHandlerArguments,
     responses_api_language_model_handler_kwargs: ResponsesApiLanguageModelHandlerArguments,
     chat_tts_handler_kwargs: ChatTTSHandlerArguments,
@@ -518,6 +528,7 @@ def _build_realtime_pipeline_unit(
     mlx_audio_whisper_kw = deepcopy(mlx_audio_whisper_stt_handler_kwargs)
     parakeet_kw = deepcopy(parakeet_tdt_stt_handler_kwargs)
     qwen3_asr_kw = deepcopy(qwen3_asr_stt_handler_kwargs)
+    qwen3_asr_http_kw = deepcopy(qwen3_asr_http_stt_handler_kwargs)
     lm_kw = deepcopy(language_model_handler_kwargs)
     responses_api_kw = deepcopy(responses_api_language_model_handler_kwargs)
     chat_tts_kw = deepcopy(chat_tts_handler_kwargs)
@@ -592,6 +603,7 @@ def _build_realtime_pipeline_unit(
         mlx_audio_whisper_stt_handler_kwargs=mlx_audio_whisper_kw,
         parakeet_tdt_stt_handler_kwargs=parakeet_kw,
         qwen3_asr_stt_handler_kwargs=qwen3_asr_kw,
+        qwen3_asr_http_stt_handler_kwargs=qwen3_asr_http_kw,
         language_model_handler_kwargs=lm_kw,
         responses_api_language_model_handler_kwargs=responses_api_kw,
         chat_tts_handler_kwargs=chat_tts_kw,
@@ -630,6 +642,7 @@ def build_pipeline(
     mlx_audio_whisper_stt_handler_kwargs: MLXAudioWhisperSTTHandlerArguments,
     parakeet_tdt_stt_handler_kwargs: ParakeetTDTSTTHandlerArguments,
     qwen3_asr_stt_handler_kwargs: Qwen3ASRSTTHandlerArguments,
+    qwen3_asr_http_stt_handler_kwargs: Qwen3ASRHTTPSTTHandlerArguments,
     language_model_handler_kwargs: LanguageModelHandlerArguments,
     responses_api_language_model_handler_kwargs: ResponsesApiLanguageModelHandlerArguments,
     chat_tts_handler_kwargs: ChatTTSHandlerArguments,
@@ -693,6 +706,7 @@ def build_pipeline(
                 mlx_audio_whisper_stt_handler_kwargs=mlx_audio_whisper_stt_handler_kwargs,
                 parakeet_tdt_stt_handler_kwargs=parakeet_tdt_stt_handler_kwargs,
                 qwen3_asr_stt_handler_kwargs=qwen3_asr_stt_handler_kwargs,
+                qwen3_asr_http_stt_handler_kwargs=qwen3_asr_http_stt_handler_kwargs,
                 language_model_handler_kwargs=language_model_handler_kwargs,
                 responses_api_language_model_handler_kwargs=responses_api_language_model_handler_kwargs,
                 chat_tts_handler_kwargs=chat_tts_handler_kwargs,
@@ -781,6 +795,7 @@ def build_pipeline(
         mlx_audio_whisper_stt_handler_kwargs=mlx_audio_whisper_stt_handler_kwargs,
         parakeet_tdt_stt_handler_kwargs=parakeet_tdt_stt_handler_kwargs,
         qwen3_asr_stt_handler_kwargs=qwen3_asr_stt_handler_kwargs,
+        qwen3_asr_http_stt_handler_kwargs=qwen3_asr_http_stt_handler_kwargs,
         language_model_handler_kwargs=language_model_handler_kwargs,
         responses_api_language_model_handler_kwargs=responses_api_language_model_handler_kwargs,
         chat_tts_handler_kwargs=chat_tts_handler_kwargs,
@@ -805,6 +820,7 @@ def get_stt_handler(
     mlx_audio_whisper_stt_handler_kwargs: MLXAudioWhisperSTTHandlerArguments,
     parakeet_tdt_stt_handler_kwargs: ParakeetTDTSTTHandlerArguments,
     qwen3_asr_stt_handler_kwargs: Qwen3ASRSTTHandlerArguments,
+    qwen3_asr_http_stt_handler_kwargs: Qwen3ASRHTTPSTTHandlerArguments,
 ) -> BaseHandler[STTIn, STTOut]:
     from speech_to_speech.STT.base_stt_handler import BaseSTTHandler
 
@@ -899,10 +915,21 @@ def get_stt_handler(
                 setup_kwargs=vars(qwen3_asr_stt_handler_kwargs),
             )
         )
+    elif module_kwargs.stt == "qwen3-asr-http":
+        from speech_to_speech.STT.qwen3_asr_http_handler import Qwen3ASRHTTPSTTHandler
+
+        return with_speculative_turns(
+            Qwen3ASRHTTPSTTHandler(
+                stop_event,
+                queue_in=spoken_prompt_queue,
+                queue_out=text_prompt_queue,
+                setup_kwargs=vars(qwen3_asr_http_stt_handler_kwargs),
+            )
+        )
     else:
         raise ValueError(
             "The STT should be either whisper, whisper-mlx, mlx-audio-whisper, faster-whisper, parakeet-tdt, "
-            "paraformer, or qwen3-asr."
+            "paraformer, qwen3-asr, or qwen3-asr-http."
         )
 
 
@@ -1056,6 +1083,7 @@ def main() -> None:
         args.mlx_audio_whisper_stt_handler_kwargs,
         args.parakeet_tdt_stt_handler_kwargs,
         args.qwen3_asr_stt_handler_kwargs,
+        args.qwen3_asr_http_stt_handler_kwargs,
         args.language_model_handler_kwargs,
         args.responses_api_language_model_handler_kwargs,
         args.chat_tts_handler_kwargs,
@@ -1101,6 +1129,7 @@ def main() -> None:
         args.mlx_audio_whisper_stt_handler_kwargs,
         args.parakeet_tdt_stt_handler_kwargs,
         args.qwen3_asr_stt_handler_kwargs,
+        args.qwen3_asr_http_stt_handler_kwargs,
         args.language_model_handler_kwargs,
         args.responses_api_language_model_handler_kwargs,
         args.chat_tts_handler_kwargs,

--- a/src/speech_to_speech/s2s_pipeline.py
+++ b/src/speech_to_speech/s2s_pipeline.py
@@ -40,6 +40,7 @@ from speech_to_speech.arguments_classes.parakeet_tdt_arguments import (
     ParakeetTDTSTTHandlerArguments,
 )
 from speech_to_speech.arguments_classes.pocket_tts_arguments import PocketTTSHandlerArguments
+from speech_to_speech.arguments_classes.qwen3_asr_stt_arguments import Qwen3ASRSTTHandlerArguments
 from speech_to_speech.arguments_classes.qwen3_tts_arguments import Qwen3TTSHandlerArguments
 from speech_to_speech.arguments_classes.responses_api_language_model_arguments import (
     ResponsesApiLanguageModelHandlerArguments,
@@ -100,6 +101,7 @@ class ParsedArguments:
     faster_whisper_stt_handler_kwargs: FasterWhisperSTTHandlerArguments
     mlx_audio_whisper_stt_handler_kwargs: MLXAudioWhisperSTTHandlerArguments
     parakeet_tdt_stt_handler_kwargs: ParakeetTDTSTTHandlerArguments
+    qwen3_asr_stt_handler_kwargs: Qwen3ASRSTTHandlerArguments
     language_model_handler_kwargs: LanguageModelHandlerArguments
     responses_api_language_model_handler_kwargs: ResponsesApiLanguageModelHandlerArguments
     chat_tts_handler_kwargs: ChatTTSHandlerArguments
@@ -187,6 +189,7 @@ def parse_arguments() -> ParsedArguments:
             FasterWhisperSTTHandlerArguments,
             MLXAudioWhisperSTTHandlerArguments,
             ParakeetTDTSTTHandlerArguments,
+            Qwen3ASRSTTHandlerArguments,
             _lm_class,
             ChatTTSHandlerArguments,
             FacebookMMSTTSHandlerArguments,
@@ -216,6 +219,7 @@ def parse_arguments() -> ParsedArguments:
         faster_whisper_stt_handler_kwargs=by_type[FasterWhisperSTTHandlerArguments],
         mlx_audio_whisper_stt_handler_kwargs=by_type[MLXAudioWhisperSTTHandlerArguments],
         parakeet_tdt_stt_handler_kwargs=by_type[ParakeetTDTSTTHandlerArguments],
+        qwen3_asr_stt_handler_kwargs=by_type[Qwen3ASRSTTHandlerArguments],
         language_model_handler_kwargs=by_type.get(LanguageModelHandlerArguments, LanguageModelHandlerArguments()),
         # The OpenAI-compatible slot holds whichever class was registered:
         # ChatCompletions... (a subclass) for chat-completions, else ResponsesApi....
@@ -321,6 +325,7 @@ def prepare_all_args(
     faster_whisper_stt_handler_kwargs: FasterWhisperSTTHandlerArguments,
     mlx_audio_whisper_stt_handler_kwargs: MLXAudioWhisperSTTHandlerArguments,
     parakeet_tdt_stt_handler_kwargs: ParakeetTDTSTTHandlerArguments,
+    qwen3_asr_stt_handler_kwargs: Qwen3ASRSTTHandlerArguments,
     language_model_handler_kwargs: LanguageModelHandlerArguments,
     responses_api_language_model_handler_kwargs: ResponsesApiLanguageModelHandlerArguments,
     chat_tts_handler_kwargs: ChatTTSHandlerArguments,
@@ -336,6 +341,7 @@ def prepare_all_args(
         paraformer_stt_handler_kwargs,
         mlx_audio_whisper_stt_handler_kwargs,
         parakeet_tdt_stt_handler_kwargs,
+        qwen3_asr_stt_handler_kwargs,
         language_model_handler_kwargs,
         responses_api_language_model_handler_kwargs,
         chat_tts_handler_kwargs,
@@ -350,6 +356,7 @@ def prepare_all_args(
     rename_args(paraformer_stt_handler_kwargs, "paraformer_stt")
     rename_args(mlx_audio_whisper_stt_handler_kwargs, "mlx_audio_whisper")
     rename_args(parakeet_tdt_stt_handler_kwargs, "parakeet_tdt")
+    rename_args(qwen3_asr_stt_handler_kwargs, "qwen3_asr")
     rename_args(language_model_handler_kwargs, "llm")
     rename_args(responses_api_language_model_handler_kwargs, "responses_api")
     rename_args(chat_tts_handler_kwargs, "chat_tts")
@@ -396,6 +403,7 @@ def _build_pipeline_handlers(
     paraformer_stt_handler_kwargs: ParaformerSTTHandlerArguments,
     mlx_audio_whisper_stt_handler_kwargs: MLXAudioWhisperSTTHandlerArguments,
     parakeet_tdt_stt_handler_kwargs: ParakeetTDTSTTHandlerArguments,
+    qwen3_asr_stt_handler_kwargs: Qwen3ASRSTTHandlerArguments,
     language_model_handler_kwargs: LanguageModelHandlerArguments,
     responses_api_language_model_handler_kwargs: ResponsesApiLanguageModelHandlerArguments,
     chat_tts_handler_kwargs: ChatTTSHandlerArguments,
@@ -439,6 +447,7 @@ def _build_pipeline_handlers(
         paraformer_stt_handler_kwargs,
         mlx_audio_whisper_stt_handler_kwargs,
         parakeet_tdt_stt_handler_kwargs,
+        qwen3_asr_stt_handler_kwargs,
     )
 
     lm = get_llm_handler(
@@ -484,6 +493,7 @@ def _build_realtime_pipeline_unit(
     paraformer_stt_handler_kwargs: ParaformerSTTHandlerArguments,
     mlx_audio_whisper_stt_handler_kwargs: MLXAudioWhisperSTTHandlerArguments,
     parakeet_tdt_stt_handler_kwargs: ParakeetTDTSTTHandlerArguments,
+    qwen3_asr_stt_handler_kwargs: Qwen3ASRSTTHandlerArguments,
     language_model_handler_kwargs: LanguageModelHandlerArguments,
     responses_api_language_model_handler_kwargs: ResponsesApiLanguageModelHandlerArguments,
     chat_tts_handler_kwargs: ChatTTSHandlerArguments,
@@ -507,6 +517,7 @@ def _build_realtime_pipeline_unit(
     paraformer_kw = deepcopy(paraformer_stt_handler_kwargs)
     mlx_audio_whisper_kw = deepcopy(mlx_audio_whisper_stt_handler_kwargs)
     parakeet_kw = deepcopy(parakeet_tdt_stt_handler_kwargs)
+    qwen3_asr_kw = deepcopy(qwen3_asr_stt_handler_kwargs)
     lm_kw = deepcopy(language_model_handler_kwargs)
     responses_api_kw = deepcopy(responses_api_language_model_handler_kwargs)
     chat_tts_kw = deepcopy(chat_tts_handler_kwargs)
@@ -580,6 +591,7 @@ def _build_realtime_pipeline_unit(
         paraformer_stt_handler_kwargs=paraformer_kw,
         mlx_audio_whisper_stt_handler_kwargs=mlx_audio_whisper_kw,
         parakeet_tdt_stt_handler_kwargs=parakeet_kw,
+        qwen3_asr_stt_handler_kwargs=qwen3_asr_kw,
         language_model_handler_kwargs=lm_kw,
         responses_api_language_model_handler_kwargs=responses_api_kw,
         chat_tts_handler_kwargs=chat_tts_kw,
@@ -617,6 +629,7 @@ def build_pipeline(
     paraformer_stt_handler_kwargs: ParaformerSTTHandlerArguments,
     mlx_audio_whisper_stt_handler_kwargs: MLXAudioWhisperSTTHandlerArguments,
     parakeet_tdt_stt_handler_kwargs: ParakeetTDTSTTHandlerArguments,
+    qwen3_asr_stt_handler_kwargs: Qwen3ASRSTTHandlerArguments,
     language_model_handler_kwargs: LanguageModelHandlerArguments,
     responses_api_language_model_handler_kwargs: ResponsesApiLanguageModelHandlerArguments,
     chat_tts_handler_kwargs: ChatTTSHandlerArguments,
@@ -679,6 +692,7 @@ def build_pipeline(
                 paraformer_stt_handler_kwargs=paraformer_stt_handler_kwargs,
                 mlx_audio_whisper_stt_handler_kwargs=mlx_audio_whisper_stt_handler_kwargs,
                 parakeet_tdt_stt_handler_kwargs=parakeet_tdt_stt_handler_kwargs,
+                qwen3_asr_stt_handler_kwargs=qwen3_asr_stt_handler_kwargs,
                 language_model_handler_kwargs=language_model_handler_kwargs,
                 responses_api_language_model_handler_kwargs=responses_api_language_model_handler_kwargs,
                 chat_tts_handler_kwargs=chat_tts_handler_kwargs,
@@ -766,6 +780,7 @@ def build_pipeline(
         paraformer_stt_handler_kwargs=paraformer_stt_handler_kwargs,
         mlx_audio_whisper_stt_handler_kwargs=mlx_audio_whisper_stt_handler_kwargs,
         parakeet_tdt_stt_handler_kwargs=parakeet_tdt_stt_handler_kwargs,
+        qwen3_asr_stt_handler_kwargs=qwen3_asr_stt_handler_kwargs,
         language_model_handler_kwargs=language_model_handler_kwargs,
         responses_api_language_model_handler_kwargs=responses_api_language_model_handler_kwargs,
         chat_tts_handler_kwargs=chat_tts_handler_kwargs,
@@ -789,6 +804,7 @@ def get_stt_handler(
     paraformer_stt_handler_kwargs: ParaformerSTTHandlerArguments,
     mlx_audio_whisper_stt_handler_kwargs: MLXAudioWhisperSTTHandlerArguments,
     parakeet_tdt_stt_handler_kwargs: ParakeetTDTSTTHandlerArguments,
+    qwen3_asr_stt_handler_kwargs: Qwen3ASRSTTHandlerArguments,
 ) -> BaseHandler[STTIn, STTOut]:
     from speech_to_speech.STT.base_stt_handler import BaseSTTHandler
 
@@ -872,9 +888,21 @@ def get_stt_handler(
                 setup_kwargs=setup_kwargs,
             )
         )
+    elif module_kwargs.stt == "qwen3-asr":
+        from speech_to_speech.STT.qwen3_asr_handler import Qwen3ASRSTTHandler
+
+        return with_speculative_turns(
+            Qwen3ASRSTTHandler(
+                stop_event,
+                queue_in=spoken_prompt_queue,
+                queue_out=text_prompt_queue,
+                setup_kwargs=vars(qwen3_asr_stt_handler_kwargs),
+            )
+        )
     else:
         raise ValueError(
-            "The STT should be either whisper, whisper-mlx, mlx-audio-whisper, faster-whisper, parakeet-tdt, or paraformer."
+            "The STT should be either whisper, whisper-mlx, mlx-audio-whisper, faster-whisper, parakeet-tdt, "
+            "paraformer, or qwen3-asr."
         )
 
 
@@ -1027,6 +1055,7 @@ def main() -> None:
         args.faster_whisper_stt_handler_kwargs,
         args.mlx_audio_whisper_stt_handler_kwargs,
         args.parakeet_tdt_stt_handler_kwargs,
+        args.qwen3_asr_stt_handler_kwargs,
         args.language_model_handler_kwargs,
         args.responses_api_language_model_handler_kwargs,
         args.chat_tts_handler_kwargs,
@@ -1071,6 +1100,7 @@ def main() -> None:
         args.paraformer_stt_handler_kwargs,
         args.mlx_audio_whisper_stt_handler_kwargs,
         args.parakeet_tdt_stt_handler_kwargs,
+        args.qwen3_asr_stt_handler_kwargs,
         args.language_model_handler_kwargs,
         args.responses_api_language_model_handler_kwargs,
         args.chat_tts_handler_kwargs,

--- a/tests/test_cli_defaults.py
+++ b/tests/test_cli_defaults.py
@@ -11,6 +11,7 @@ from speech_to_speech.arguments_classes.module_arguments import ModuleArguments
 from speech_to_speech.arguments_classes.paraformer_stt_arguments import ParaformerSTTHandlerArguments
 from speech_to_speech.arguments_classes.parakeet_tdt_arguments import ParakeetTDTSTTHandlerArguments
 from speech_to_speech.arguments_classes.pocket_tts_arguments import PocketTTSHandlerArguments
+from speech_to_speech.arguments_classes.qwen3_asr_stt_arguments import Qwen3ASRSTTHandlerArguments
 from speech_to_speech.arguments_classes.qwen3_tts_arguments import Qwen3TTSHandlerArguments
 from speech_to_speech.arguments_classes.responses_api_language_model_arguments import (
     ResponsesApiLanguageModelHandlerArguments,
@@ -67,6 +68,7 @@ EXPECTED_FIELD_TYPES = {
     "faster_whisper_stt_handler_kwargs": FasterWhisperSTTHandlerArguments,
     "mlx_audio_whisper_stt_handler_kwargs": MLXAudioWhisperSTTHandlerArguments,
     "parakeet_tdt_stt_handler_kwargs": ParakeetTDTSTTHandlerArguments,
+    "qwen3_asr_stt_handler_kwargs": Qwen3ASRSTTHandlerArguments,
     "language_model_handler_kwargs": LanguageModelHandlerArguments,
     "responses_api_language_model_handler_kwargs": ResponsesApiLanguageModelHandlerArguments,
     "chat_tts_handler_kwargs": ChatTTSHandlerArguments,

--- a/tests/test_cli_defaults.py
+++ b/tests/test_cli_defaults.py
@@ -11,6 +11,7 @@ from speech_to_speech.arguments_classes.module_arguments import ModuleArguments
 from speech_to_speech.arguments_classes.paraformer_stt_arguments import ParaformerSTTHandlerArguments
 from speech_to_speech.arguments_classes.parakeet_tdt_arguments import ParakeetTDTSTTHandlerArguments
 from speech_to_speech.arguments_classes.pocket_tts_arguments import PocketTTSHandlerArguments
+from speech_to_speech.arguments_classes.qwen3_asr_http_stt_arguments import Qwen3ASRHTTPSTTHandlerArguments
 from speech_to_speech.arguments_classes.qwen3_asr_stt_arguments import Qwen3ASRSTTHandlerArguments
 from speech_to_speech.arguments_classes.qwen3_tts_arguments import Qwen3TTSHandlerArguments
 from speech_to_speech.arguments_classes.responses_api_language_model_arguments import (
@@ -69,6 +70,7 @@ EXPECTED_FIELD_TYPES = {
     "mlx_audio_whisper_stt_handler_kwargs": MLXAudioWhisperSTTHandlerArguments,
     "parakeet_tdt_stt_handler_kwargs": ParakeetTDTSTTHandlerArguments,
     "qwen3_asr_stt_handler_kwargs": Qwen3ASRSTTHandlerArguments,
+    "qwen3_asr_http_stt_handler_kwargs": Qwen3ASRHTTPSTTHandlerArguments,
     "language_model_handler_kwargs": LanguageModelHandlerArguments,
     "responses_api_language_model_handler_kwargs": ResponsesApiLanguageModelHandlerArguments,
     "chat_tts_handler_kwargs": ChatTTSHandlerArguments,

--- a/tests/test_qwen3_asr_http_transcription_events.py
+++ b/tests/test_qwen3_asr_http_transcription_events.py
@@ -88,3 +88,17 @@ def test_qwen3_asr_http_transcription_is_final(monkeypatch):
     sent = handler.client.last_json
     assert sent["messages"][0]["content"][0]["type"] == "audio_url"
     assert sent["messages"][0]["content"][0]["audio_url"]["url"].startswith("data:audio/wav;base64,")
+
+
+def test_qwen3_asr_http_progressive_mode_yields_nothing_and_skips_request(monkeypatch):
+    monkeypatch.setattr(qwen3_asr_http_handler.console, "print", lambda *args, **kwargs: None)
+
+    handler = _handler()
+    result = list(
+        handler.process(
+            VADAudio(audio=np.zeros(16000, dtype=np.float32), mode="progressive", turn_id="turn_2", turn_revision=1)
+        )
+    )
+
+    assert result == []
+    assert handler.client.last_json is None

--- a/tests/test_qwen3_asr_http_transcription_events.py
+++ b/tests/test_qwen3_asr_http_transcription_events.py
@@ -1,0 +1,90 @@
+import numpy as np
+
+from speech_to_speech.pipeline.messages import Transcription, VADAudio
+from speech_to_speech.STT import qwen3_asr_http_handler
+from speech_to_speech.STT.qwen3_asr_http_handler import (
+    Qwen3ASRHTTPSTTHandler,
+    _encode_wav_data_uri,
+    _parse_asr_output,
+)
+
+
+class _FakeResponse:
+    def __init__(self, content: str) -> None:
+        self._content = content
+
+    def raise_for_status(self) -> None:
+        pass
+
+    def json(self):
+        return {"choices": [{"message": {"content": self._content}}]}
+
+
+class _FakeHTTPClient:
+    def __init__(self, content: str = "language English<asr_text>hello there") -> None:
+        self.content = content
+        self.last_json = None
+
+    def post(self, url, json):
+        self.last_json = json
+        return _FakeResponse(self.content)
+
+
+def _handler(content: str = "language English<asr_text>hello there"):
+    handler = object.__new__(Qwen3ASRHTTPSTTHandler)
+    handler.base_url = "http://127.0.0.1:8000"
+    handler.client = _FakeHTTPClient(content)
+    return handler
+
+
+def test_parse_asr_output_with_tag():
+    language, text = _parse_asr_output("language Chinese<asr_text>你好")
+    assert language == "Chinese"
+    assert text == "你好"
+
+
+def test_parse_asr_output_without_tag_is_plain_text():
+    language, text = _parse_asr_output("just plain text, no tag")
+    assert language == ""
+    assert text == "just plain text, no tag"
+
+
+def test_parse_asr_output_empty_audio():
+    language, text = _parse_asr_output("language None<asr_text>")
+    assert language == ""
+    assert text == ""
+
+
+def test_encode_wav_data_uri_roundtrip_header():
+    audio = np.zeros(1600, dtype=np.float32)
+    uri = _encode_wav_data_uri(audio, sample_rate=16000)
+    assert uri.startswith("data:audio/wav;base64,")
+
+
+def test_qwen3_asr_http_transcription_is_final(monkeypatch):
+    monkeypatch.setattr(qwen3_asr_http_handler.console, "print", lambda *args, **kwargs: None)
+
+    handler = _handler()
+    result = list(
+        handler.process(
+            VADAudio(
+                audio=np.zeros(16000, dtype=np.float32),
+                mode="final",
+                turn_id="turn_1",
+                turn_revision=2,
+                created_at_s=123.0,
+            )
+        )
+    )
+
+    assert len(result) == 1
+    assert isinstance(result[0], Transcription)
+    assert result[0].text == "hello there"
+    assert result[0].language_code == "en"
+    assert result[0].turn_id == "turn_1"
+    assert result[0].turn_revision == 2
+    assert result[0].speech_stopped_at_s == 123.0
+
+    sent = handler.client.last_json
+    assert sent["messages"][0]["content"][0]["type"] == "audio_url"
+    assert sent["messages"][0]["content"][0]["audio_url"]["url"].startswith("data:audio/wav;base64,")

--- a/tests/test_qwen3_asr_transcription_events.py
+++ b/tests/test_qwen3_asr_transcription_events.py
@@ -62,3 +62,15 @@ def test_qwen3_asr_auto_language_appends_suffix(monkeypatch):
     )
 
     assert result[0].language_code == "zh-auto"
+
+
+def test_qwen3_asr_progressive_mode_yields_nothing(monkeypatch):
+    monkeypatch.setattr(qwen3_asr_handler.console, "print", lambda *args, **kwargs: None)
+
+    result = list(
+        _handler().process(
+            VADAudio(audio=np.zeros(16000, dtype=np.float32), mode="progressive", turn_id="turn_3", turn_revision=1)
+        )
+    )
+
+    assert result == []

--- a/tests/test_qwen3_asr_transcription_events.py
+++ b/tests/test_qwen3_asr_transcription_events.py
@@ -1,0 +1,64 @@
+import numpy as np
+
+from speech_to_speech.pipeline.messages import Transcription, VADAudio
+from speech_to_speech.STT import qwen3_asr_handler
+from speech_to_speech.STT.qwen3_asr_handler import Qwen3ASRSTTHandler
+
+
+class _FakeQwen3ASRResult:
+    def __init__(self, text: str, language: str) -> None:
+        self.text = text
+        self.language = language
+
+
+class _FakeQwen3ASRModel:
+    def __init__(self, language: str = "English") -> None:
+        self.language = language
+
+    def transcribe(self, audio, language=None):
+        return [_FakeQwen3ASRResult(text="hello there", language=self.language)]
+
+
+def _handler(start_language=None, model_language="English"):
+    handler = object.__new__(Qwen3ASRSTTHandler)
+    handler.model = _FakeQwen3ASRModel(language=model_language)
+    handler.start_language = start_language
+    handler.last_language_code = start_language if start_language != "auto" else None
+    handler.language_name = None
+    return handler
+
+
+def test_qwen3_asr_transcription_is_final(monkeypatch):
+    monkeypatch.setattr(qwen3_asr_handler.console, "print", lambda *args, **kwargs: None)
+
+    result = list(
+        _handler().process(
+            VADAudio(
+                audio=np.zeros(16000, dtype=np.float32),
+                mode="final",
+                turn_id="turn_1",
+                turn_revision=2,
+                created_at_s=123.0,
+            )
+        )
+    )
+
+    assert len(result) == 1
+    assert isinstance(result[0], Transcription)
+    assert result[0].text == "hello there"
+    assert result[0].language_code == "en"
+    assert result[0].turn_id == "turn_1"
+    assert result[0].turn_revision == 2
+    assert result[0].speech_stopped_at_s == 123.0
+
+
+def test_qwen3_asr_auto_language_appends_suffix(monkeypatch):
+    monkeypatch.setattr(qwen3_asr_handler.console, "print", lambda *args, **kwargs: None)
+
+    result = list(
+        _handler(start_language="auto", model_language="Chinese").process(
+            VADAudio(audio=np.zeros(16000, dtype=np.float32), mode="final", turn_id="turn_2", turn_revision=1)
+        )
+    )
+
+    assert result[0].language_code == "zh-auto"


### PR DESCRIPTION
## Summary
- Adds `--stt qwen3-asr`, wiring `Qwen/Qwen3-ASR-1.7B` (and `Qwen/Qwen3-ASR-0.6B`) in through the `qwen-asr` PyPI package, following the same handler/arguments-class pattern as the existing Whisper/Paraformer/Parakeet STT backends.
- Adds `--stt qwen3-asr-http`, a second backend that talks to a separately-running Qwen3-ASR HTTP server instead of loading the model in-process — see "Known limitation" below for why this exists and is the recommended path on macOS.
- New optional extra: `pip install speech-to-speech[qwen3-asr]` (only needed for the in-process backend; `qwen3-asr-http` has no extra dependency beyond the existing `httpx` base dependency).
- New flags:
  - in-process: `--qwen3_asr_model_name`, `--qwen3_asr_device`, `--qwen3_asr_torch_dtype`, `--qwen3_asr_language`, `--qwen3_asr_max_new_tokens`, `--qwen3_asr_max_inference_batch_size`
  - HTTP: `--qwen3_asr_http_base_url`, `--qwen3_asr_http_timeout_s`
- Supports the 30 languages (plus Cantonese) Qwen3-ASR covers, with `--qwen3_asr_language auto` for automatic language detection (in-process backend; the HTTP backend relies on Qwen3-ASR's own auto-detect tag, see limitations).
- Adds `scripts/qwen3_asr_server.py`, a small Flask server that the HTTP backend talks to (see below for why this exists instead of `qwen-asr`'s own `qwen-asr-serve`), plus `docker-compose.qwen3-asr.yml` / `Dockerfile.cpu` / `docker/qwen3-asr/Dockerfile` for a CPU-only, no-NVIDIA-toolkit-needed way to run both sides as containers.
- Documented in the top-level README and `src/speech_to_speech/STT/README.md`.

## ⚠️ Known limitation: `--stt qwen3-asr` (in-process) does not work on macOS as of `qwen-asr==0.0.6`

`qwen-asr==0.0.6` hard-pins `transformers==4.57.6`, which conflicts with this project's
`transformers==5.6.2` pin on macOS (needed by Qwen3-TTS/mlx-audio) — installing the extra requires
`pip install --no-deps qwen-asr==0.0.6` plus its non-`transformers` deps.

On top of `transformers==5.6.2`, `qwen_asr`'s vendored modeling/config code
(`qwen_asr/core/transformers_backend/`) hits **at least four** separate transformers 4→5 breaking
changes it hasn't adapted to upstream — root-caused interactively together with a user testing this
branch live on a real macOS install (Python 3.12, Apple Silicon):

1. `check_model_inputs()` called as an optional-arg decorator factory (4.57.x style); 5.x made `func`
   required — `TypeError: check_model_inputs() missing 1 required positional argument`.
2. `Qwen3ASRConfig.__init__` reads `self.thinker_config` from inside `super().__init__(**kwargs)`
   (5.x's config validation now calls `get_text_config()` eagerly there), before that attribute is
   assigned — `AttributeError: 'Qwen3ASRConfig' object has no attribute 'thinker_config'`.
3. The `"default"` key was removed from `ROPE_INIT_FUNCTIONS` in 5.x (replaced by a
   `rope_parameters`-based API) — `KeyError: 'default'`. Re-registering it with the 4.57.6
   implementation works, but the replacement API also drops `mrope_interleaved`/`mrope_section`,
   meaning this specific patch risks *silently wrong* positional encoding rather than a crash.
4. `Qwen3ASRThinkerConfig` similarly ends up missing `pad_token_id` at model-build time —
   `AttributeError: 'Qwen3ASRThinkerConfig' object has no attribute 'pad_token_id'`. Unresolved.

`qwen3_asr_handler.py` applies runtime shims for (1)–(3) (see `_apply_transformers_5x_compat`; each
checks current state first, so they no-op once `qwen-asr` fixes things upstream), but model
construction still fails on (4). **Do not rely on `--stt qwen3-asr` on macOS** until `qwen-asr` adds
transformers 5.x support upstream. On Linux/CUDA, the base `transformers>=4.57.0` requirement is a
*range*, so `transformers==4.57.6` may resolve and run there without any of this — untested, would
appreciate someone with a CUDA box confirming.

## ✅ `--stt qwen3-asr-http` is the confirmed-working path on macOS

Rather than keep patching an increasingly deep well of incompatibilities (with real correctness risk
on #3 above), `--stt qwen3-asr-http` runs Qwen3-ASR as its own process in a separate virtualenv pinned
to `transformers==4.57.6` — the version it actually needs, no patches required — and the pipeline talks
to it over plain HTTP (`localhost`, negligible added latency).

**Important correction from an earlier version of this PR:** that separate process is
`scripts/qwen3_asr_server.py` (added in this PR), *not* `qwen-asr`'s own `qwen-asr-serve` command.
`qwen-asr-serve` turns out to be a thin wrapper around `vllm serve` and hard-requires the `vllm`
package — confirmed live: it raises `ModuleNotFoundError: No module named 'vllm'` on macOS even when
the transformers backend is otherwise requested, because `vllm` has no wheels for macOS/Apple Silicon
at all. `scripts/qwen3_asr_server.py` is a ~50-line Flask server wrapping the exact
`Qwen3ASRModel.from_pretrained(...).transcribe(...)` call already confirmed working end-to-end on Apple
Silicon MPS (direct Python API, no server), exposing the same OpenAI-chat-completions-shaped
`/v1/chat/completions` contract `Qwen3ASRHTTPSTTHandler` expects. Verified inside the built Docker image
with a mocked model: import succeeds, a POST round-trips the exact `"language X<asr_text>Y"` format the
handler's `_parse_asr_output` parses, and `/health` responds.

```bash
# Terminal 1 — separate venv, only for Qwen3-ASR
uv venv --python 3.12 .venv-qwen3-asr && source .venv-qwen3-asr/bin/activate
uv pip install qwen-asr==0.0.6
python scripts/qwen3_asr_server.py --device mps --host 127.0.0.1 --port 8000
```
```bash
# Terminal 2 — the normal speech-to-speech venv
speech-to-speech --stt qwen3-asr-http --qwen3_asr_http_base_url http://127.0.0.1:8000
```

Or, entirely via Docker (CPU-only, no NVIDIA Container Toolkit needed — see `docker-compose.qwen3-asr.yml`):

```bash
export OPENAI_API_KEY=...
docker compose -f docker-compose.qwen3-asr.yml up
python scripts/listen_and_play.py --host 127.0.0.1   # native, for mic/speaker access
```

Known gaps:
- Per-request language forcing isn't wired up for this path — `scripts/qwen3_asr_server.py` always calls
  `.transcribe(language=None)`, relying on Qwen3-ASR's own auto-detected language tag. Easy to add later
  (thread a `language` field through the request JSON) if needed.
- On a CUDA host with `vllm` installed, the *real* `qwen-asr-serve` would likely outperform this via
  vLLM's batching. Since this handler's HTTP contract only assumes an OpenAI-chat-completions-shaped
  response, swapping the server side later doesn't require touching `qwen3_asr_http_handler.py`.

Given this, I'd treat `--stt qwen3-asr` as **not macOS-ready / blocked upstream** and `--stt
qwen3-asr-http` as the one to actually merge/use — happy to split these into separate PRs if
maintainers would rather land the working HTTP path now and hold the in-process one, or land both
together with the limitation clearly flagged (current state of this PR).

## Test plan
- [x] `ast.parse` syntax-checked all new/modified Python files (no Python 3.10+/uv environment was available in the sandbox to run the full `uv sync && pytest`).
- [x] Added `tests/test_qwen3_asr_transcription_events.py` (in-process handler) and `tests/test_qwen3_asr_http_transcription_events.py` (HTTP handler), mirroring `tests/test_paraformer_transcription_events.py`.
- [x] The HTTP handler's `_parse_asr_output`/`_fix_char_repeats` helpers were executed standalone in the sandbox (no numpy/torch needed) against the four cases documented in `qwen_asr.inference.utils.parse_asr_output`'s own docstring — all passed.
- [x] Updated `tests/test_cli_defaults.py`'s `EXPECTED_FIELD_TYPES` to include both new `*_stt_handler_kwargs` fields on `ParsedArguments`.
- [x] `docker/qwen3-asr/Dockerfile` built successfully in the sandbox (CPU-only, ARM64); `scripts/qwen3_asr_server.py` verified inside that built image — imports cleanly, and its Flask route was exercised end-to-end with a mocked model, producing byte-for-byte the format the client parses.
- [x] End-to-end tested live on macOS (Python 3.12, Apple Silicon): in-process backend confirmed blocked (limitation above); the underlying `Qwen3ASRModel.from_pretrained(...).transcribe(...)` call confirmed working with a real transcription. `scripts/qwen3_asr_server.py` itself (the actual HTTP server) was verified via the Docker build + mocked-model test above, not yet re-run live end-to-end on the user's Mac since it replaced `qwen-asr-serve` partway through testing — a live re-confirmation would still be good before merging.
- [ ] Not run: `pytest`, `ruff check` (no compatible local environment) — please run CI/maintainer review.
