### PR TITLE
Add GitHub Trending achievement badge

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,6 +7,7 @@
 [![PyPI](https://img.shields.io/pypi/v/speech-to-speech)](https://pypi.org/project/speech-to-speech/)
 [![Python](https://img.shields.io/pypi/pyversions/speech-to-speech)](https://pypi.org/project/speech-to-speech/)
 [![License](https://img.shields.io/badge/license-Apache%202.0-blue)](./LICENSE)
+[![#1 Repository of the Day on GitHub Trending](https://trendshift.io/api/badge/repositories/20645)](https://trendshift.io/repositories/20645)
 
 </div>
 


### PR DESCRIPTION
## Summary

- Add Trendshift's official GitHub Trending achievement badge to the README header.
- Link the badge to the repository's public Trendshift ranking record.

## Why

`speech-to-speech` first reached #1 on GitHub Trending on July 29, 2026. This preserves that milestone in the project README with an independently verifiable badge.

## Impact

Documentation only. There are no runtime, dependency, packaging, or release changes.

## Validation

- `git diff --check`
- Verified the badge endpoint returns HTTP 200 with `image/svg+xml`.
- Verified the linked ranking record returns HTTP 200.
