### PR TITLE
Refine GitHub Trending badge

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@
 [![PyPI](https://img.shields.io/pypi/v/speech-to-speech)](https://pypi.org/project/speech-to-speech/)
 [![Python](https://img.shields.io/pypi/pyversions/speech-to-speech)](https://pypi.org/project/speech-to-speech/)
 [![License](https://img.shields.io/badge/license-Apache%202.0-blue)](./LICENSE)
-[![#1 Repository of the Day on GitHub Trending](https://trendshift.io/api/badge/repositories/20645)](https://trendshift.io/repositories/20645)
+[![GitHub Trending: #1 Repository of the Day](https://img.shields.io/badge/GitHub%20Trending-%231%20Repository%20of%20the%20Day-7B2CBF?logo=github&logoColor=white)](https://trendshift.io/repositories/20645)
 
 </div>
 


### PR DESCRIPTION
## Summary

- Replace the oversized Trendshift card with a standard-height Shields badge.
- Keep the badge linked to the public Trendshift ranking record.

## Why

The original 250×55 badge visually dominated the existing 20px PyPI, Python, and license badges. The replacement uses the same 20px height and flat visual style as the rest of the README badge row.

## Impact

Documentation only. There are no runtime, dependency, packaging, or release changes.

## Validation

- `git diff --check`
- Verified GitHub's Markdown renderer accepts the badge markup.
- Verified the badge and evidence URLs return HTTP 200.
- Rendered the complete badge row locally on a GitHub-style dark background.
