### PR TITLE
Upgrade NLTK to 3.10.0

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -27,7 +27,7 @@ classifiers = [
 dependencies = [
     "fastapi>=0.115.0",
     "httpx>=0.28.0",
-    "nltk==3.9.4",
+    "nltk==3.10.0",
     "numpy>=1.26.0,<2.4.4; platform_system == 'Darwin'",
     "numpy>=1.26.0; platform_system != 'Darwin'",
     "openai==2.28.0",


### PR DESCRIPTION
## Summary

- Upgrade the pinned NLTK dependency from 3.9.4 to 3.10.0.
- Resolve the two Dependabot findings for GHSA-p4gq-832x-fm9v / CVE-2026-54293.

## Why

NLTK 3.9.4 is affected by a URL-encoded path traversal flaw in `nltk.data.load()` that can allow arbitrary local file reads. NLTK 3.10.0 is the first patched release.

## Impact

Installations will use the patched NLTK release without changing the package API used by speech-to-speech.

## Validation

- `710 passed` with NLTK 3.10.0
- Confirmed sentence tokenization remains functional
- Confirmed the encoded traversal payload is rejected
- `git diff --check`
