### PR TITLE
Rename raw PCM mode to raw-websocket

### DIFF
--- a/README.md
+++ b/README.md
@@ -176,9 +176,9 @@ Select implementations with `--stt`, `--llm_backend`, and `--tts`. Run `speech-t
 
 | Mode | Transport | Use it when |
 |---|---|---|
-| `realtime` (default) | WebSocket, OpenAI Realtime protocol at `/v1/realtime` | You are building an app or device against a standard voice API. |
+| `realtime` (default) | OpenAI Realtime protocol over WebSocket or WebRTC | You are building an app or device against a standard voice API. |
 | `local` | Your machine's microphone and speakers | You want to talk to the pipeline directly, no client needed. |
-| `websocket` | Raw PCM over WebSocket | You want a minimal custom client without the Realtime protocol. |
+| `raw-websocket` | Raw PCM over WebSocket | You want a minimal custom client without the Realtime protocol. |
 | `socket` | Raw PCM over TCP | Models run on a remote server, with a simple microphone/playback client. |
 
 ### Realtime Server
@@ -244,15 +244,17 @@ python scripts/benchmark_tts.py \
     --qwen3_mlx_quantizations bf16 4bit 6bit 8bit
 ```
 
-### WebSocket
+### Raw WebSocket
 
-1. Run the pipeline in WebSocket mode:
+1. Run the pipeline in raw WebSocket mode:
 
    ```bash
-   speech-to-speech --mode websocket --ws_host 0.0.0.0 --ws_port 8765
+   speech-to-speech --mode raw-websocket --ws_host 0.0.0.0 --ws_port 8765
    ```
 
 2. Connect from your client at `ws://<server-ip>:8765`. Send raw audio bytes as 16 kHz, int16, mono PCM and receive generated audio bytes back.
+
+The previous `--mode websocket` value remains available as a deprecated alias for backward compatibility.
 
 ### TCP Socket
 
@@ -282,7 +284,7 @@ The compose file starts a llama.cpp server with Gemma 4, starts the TCP socket s
 
 ## Realtime API
 
-Realtime mode streams audio over a WebSocket using the OpenAI Realtime protocol, with live transcription and low-latency turn-taking. The server exposes `/v1/realtime`, and any OpenAI Realtime-compatible client can connect:
+Realtime mode supports the OpenAI Realtime protocol over WebSocket and WebRTC, with live transcription and low-latency turn-taking. WebSocket clients connect at `/v1/realtime`:
 
 ```python
 from openai import OpenAI
@@ -533,7 +535,7 @@ References for all CLI arguments live in the [arguments classes](./src/speech_to
 See [ModuleArguments](./src/speech_to_speech/arguments_classes/module_arguments.py). It allows setting:
 
 - a common `--device`, if every part should run on the same device
-- `--mode`: `realtime` (default), `local`, `socket`, or `websocket`
+- `--mode`: `realtime` (default), `local`, `socket`, or `raw-websocket`
 - STT implementation (`--stt`)
 - LLM backend (`--llm_backend`: `transformers`, `mlx-lm`, `responses-api`, or `chat-completions`)
 - TTS implementation (`--tts`)

--- a/README.md
+++ b/README.md
@@ -254,8 +254,6 @@ python scripts/benchmark_tts.py \
 
 2. Connect from your client at `ws://<server-ip>:8765`. Send raw audio bytes as 16 kHz, int16, mono PCM and receive generated audio bytes back.
 
-The previous `--mode websocket` value remains available as a deprecated alias for backward compatibility.
-
 ### TCP Socket
 
 TCP socket mode is intentionally minimal. It streams raw PCM audio, but does not provide the full Realtime API feature set, including interruption handling, live transcript events, or tool-call events.

--- a/src/speech_to_speech/STT/transcription_notifier.py
+++ b/src/speech_to_speech/STT/transcription_notifier.py
@@ -23,7 +23,7 @@ class TranscriptionNotifier(BaseHandler[STTOut, Union[STTOut, LLMIn]]):
     on ``text_output_queue`` for protocol translation but yields nothing -- the
     ``RealtimeService`` builds ``GenerateResponseRequest`` directly.
 
-    For **legacy mode** (``runtime_config`` provided): appends the user
+    For **non-Realtime pipeline modes** (``runtime_config`` provided): appends the user
     message to ``runtime_config.chat`` and yields a
     ``GenerateResponseRequest`` so the LLM handler receives a uniform input
     type regardless of pipeline mode.

--- a/src/speech_to_speech/arguments_classes/module_arguments.py
+++ b/src/speech_to_speech/arguments_classes/module_arguments.py
@@ -8,12 +8,11 @@ class ModuleArguments:
         default=None,
         metadata={"help": "If specified, overrides the device for all handlers."},
     )
-    mode: Optional[Literal["local", "socket", "raw-websocket", "websocket", "realtime"]] = field(
+    mode: Optional[Literal["local", "socket", "raw-websocket", "realtime"]] = field(
         default="realtime",
         metadata={
             "help": "The mode to run the pipeline in. Either 'local', 'socket', 'raw-websocket', or "
-            "'realtime'. The old 'websocket' value is a deprecated alias for 'raw-websocket'. Default is "
-            "'realtime'."
+            "'realtime'. Default is 'realtime'."
         },
     )
     local_mac_optimal_settings: bool = field(

--- a/src/speech_to_speech/arguments_classes/module_arguments.py
+++ b/src/speech_to_speech/arguments_classes/module_arguments.py
@@ -8,10 +8,12 @@ class ModuleArguments:
         default=None,
         metadata={"help": "If specified, overrides the device for all handlers."},
     )
-    mode: Optional[Literal["local", "socket", "websocket", "realtime"]] = field(
+    mode: Optional[Literal["local", "socket", "raw-websocket", "websocket", "realtime"]] = field(
         default="realtime",
         metadata={
-            "help": "The mode to run the pipeline in. Either 'local', 'socket', 'websocket', or 'realtime'. Default is 'realtime'."
+            "help": "The mode to run the pipeline in. Either 'local', 'socket', 'raw-websocket', or "
+            "'realtime'. The old 'websocket' value is a deprecated alias for 'raw-websocket'. Default is "
+            "'realtime'."
         },
     )
     local_mac_optimal_settings: bool = field(
@@ -81,8 +83,8 @@ class ModuleArguments:
         default=1,
         metadata={
             "help": "Number of isolated realtime pipelines in the pool. One uvicorn server listens on "
-            "--ws_port and routes each incoming websocket to the next free pipeline (each has its own "
-            "VAD/STT/LM/TTS handlers and conversation state). Max concurrent websocket sessions equals "
+            "--ws_port and routes each incoming WebSocket or WebRTC session to the next free pipeline (each "
+            "has its own VAD/STT/LM/TTS handlers and conversation state). Max concurrent Realtime sessions equals "
             "num_pipelines; further connections are rejected. Only valid for --mode realtime. Default is 1."
         },
     )

--- a/src/speech_to_speech/s2s_pipeline.py
+++ b/src/speech_to_speech/s2s_pipeline.py
@@ -307,6 +307,9 @@ def overwrite_device_argument(common_device: Optional[str], *handler_kwargs: Any
 
 def prepare_module_args(module_kwargs: ModuleArguments, *handler_kwargs: Any) -> None:
     optimal_mac_settings(module_kwargs.local_mac_optimal_settings, module_kwargs, *handler_kwargs)
+    if module_kwargs.mode == "websocket":
+        logger.warning("--mode websocket is deprecated; use --mode raw-websocket")
+        module_kwargs.mode = "raw-websocket"
     if module_kwargs.tts is None:
         module_kwargs.tts = "qwen3"
     if platform == "darwin":
@@ -636,7 +639,7 @@ def build_pipeline(
     lm_response_queue = queues_and_events["lm_response_queue"]
     lm_processed_queue = queues_and_events["lm_processed_queue"]
     text_output_queue = (
-        None  # Only set for websocket/realtime modes; kept None otherwise to avoid unbounded queue growth
+        None  # Only set for raw WebSocket and Realtime modes; kept None otherwise to avoid unbounded queue growth
     )
 
     comms_handlers: list[Any] = []
@@ -650,7 +653,7 @@ def build_pipeline(
         )
         comms_handlers = [local_audio_streamer]
         should_listen.set()
-    elif module_kwargs.mode == "websocket":
+    elif module_kwargs.mode in ("raw-websocket", "websocket"):
         from speech_to_speech.connections.websocket_streamer import WebSocketStreamer
 
         text_output_queue = queues_and_events["text_output_queue"]

--- a/src/speech_to_speech/s2s_pipeline.py
+++ b/src/speech_to_speech/s2s_pipeline.py
@@ -307,9 +307,6 @@ def overwrite_device_argument(common_device: Optional[str], *handler_kwargs: Any
 
 def prepare_module_args(module_kwargs: ModuleArguments, *handler_kwargs: Any) -> None:
     optimal_mac_settings(module_kwargs.local_mac_optimal_settings, module_kwargs, *handler_kwargs)
-    if module_kwargs.mode == "websocket":
-        logger.warning("--mode websocket is deprecated; use --mode raw-websocket")
-        module_kwargs.mode = "raw-websocket"
     if module_kwargs.tts is None:
         module_kwargs.tts = "qwen3"
     if platform == "darwin":
@@ -653,7 +650,7 @@ def build_pipeline(
         )
         comms_handlers = [local_audio_streamer]
         should_listen.set()
-    elif module_kwargs.mode in ("raw-websocket", "websocket"):
+    elif module_kwargs.mode == "raw-websocket":
         from speech_to_speech.connections.websocket_streamer import WebSocketStreamer
 
         text_output_queue = queues_and_events["text_output_queue"]

--- a/tests/test_cli_defaults.py
+++ b/tests/test_cli_defaults.py
@@ -1,6 +1,8 @@
 import sys
 from dataclasses import fields
 
+import pytest
+
 from speech_to_speech.arguments_classes.chat_tts_arguments import ChatTTSHandlerArguments
 from speech_to_speech.arguments_classes.facebookmms_tts_arguments import FacebookMMSTTSHandlerArguments
 from speech_to_speech.arguments_classes.faster_whisper_stt_arguments import FasterWhisperSTTHandlerArguments
@@ -20,7 +22,7 @@ from speech_to_speech.arguments_classes.socket_sender_arguments import SocketSen
 from speech_to_speech.arguments_classes.vad_arguments import VADHandlerArguments
 from speech_to_speech.arguments_classes.websocket_streamer_arguments import WebSocketStreamerArguments
 from speech_to_speech.arguments_classes.whisper_stt_arguments import WhisperSTTHandlerArguments
-from speech_to_speech.s2s_pipeline import ParsedArguments, parse_arguments, prepare_module_args
+from speech_to_speech.s2s_pipeline import ParsedArguments, parse_arguments
 
 
 def test_release_defaults_match_responses_api_parakeet_qwen3_realtime_profile():
@@ -127,14 +129,14 @@ def test_parse_arguments_accepts_raw_websocket_mode():
     assert args.module_kwargs.mode == "raw-websocket"
 
 
-def test_prepare_module_args_normalizes_deprecated_websocket_alias(caplog):
-    module_args = ModuleArguments(mode="websocket")
-
-    with caplog.at_level("WARNING"):
-        prepare_module_args(module_args)
-
-    assert module_args.mode == "raw-websocket"
-    assert "--mode websocket is deprecated; use --mode raw-websocket" in caplog.text
+def test_parse_arguments_rejects_removed_websocket_mode():
+    original_argv = sys.argv[:]
+    try:
+        sys.argv = ["speech-to-speech", "--mode", "websocket"]
+        with pytest.raises(SystemExit):
+            parse_arguments()
+    finally:
+        sys.argv = original_argv
 
 
 def test_parse_arguments_transformers_backend():

--- a/tests/test_cli_defaults.py
+++ b/tests/test_cli_defaults.py
@@ -20,7 +20,7 @@ from speech_to_speech.arguments_classes.socket_sender_arguments import SocketSen
 from speech_to_speech.arguments_classes.vad_arguments import VADHandlerArguments
 from speech_to_speech.arguments_classes.websocket_streamer_arguments import WebSocketStreamerArguments
 from speech_to_speech.arguments_classes.whisper_stt_arguments import WhisperSTTHandlerArguments
-from speech_to_speech.s2s_pipeline import ParsedArguments, parse_arguments
+from speech_to_speech.s2s_pipeline import ParsedArguments, parse_arguments, prepare_module_args
 
 
 def test_release_defaults_match_responses_api_parakeet_qwen3_realtime_profile():
@@ -114,6 +114,27 @@ def test_parse_arguments_accepts_qwen3_tts_backend_override():
         sys.argv = original_argv
 
     assert args.qwen3_tts_handler_kwargs.qwen3_tts_backend == "torch"
+
+
+def test_parse_arguments_accepts_raw_websocket_mode():
+    original_argv = sys.argv[:]
+    try:
+        sys.argv = ["speech-to-speech", "--mode", "raw-websocket"]
+        args = parse_arguments()
+    finally:
+        sys.argv = original_argv
+
+    assert args.module_kwargs.mode == "raw-websocket"
+
+
+def test_prepare_module_args_normalizes_deprecated_websocket_alias(caplog):
+    module_args = ModuleArguments(mode="websocket")
+
+    with caplog.at_level("WARNING"):
+        prepare_module_args(module_args)
+
+    assert module_args.mode == "raw-websocket"
+    assert "--mode websocket is deprecated; use --mode raw-websocket" in caplog.text
 
 
 def test_parse_arguments_transformers_backend():


### PR DESCRIPTION
## Summary

- rename the raw PCM CLI mode from `websocket` to `raw-websocket`
- remove the old `websocket` mode value entirely
- clarify that Realtime is a protocol mode transported over either WebSocket or WebRTC
- replace the ambiguous internal "legacy mode" wording with "non-Realtime pipeline modes"

## Why

`websocket` was overloaded: it named the raw PCM mode while also describing one of the transports supported by Realtime mode. Calling the raw mode `raw-websocket` makes the protocol/transport distinction explicit and avoids preserving a confusing name in the interface.

## User impact

This is an intentional breaking CLI change. Commands using `--mode websocket` must switch to `--mode raw-websocket`; the removed value is rejected during argument parsing.

Realtime mode is unchanged and continues to support both WebSocket and WebRTC transports.

## Validation

- `pytest -q tests/` — 712 passed
- `ruff check .`
- `mypy src/`
- `ruff format --check` on all changed Python files
