### PR TITLE
Add missing Qwen3 TTS GGML features

### DIFF
--- a/src/speech_to_speech/TTS/README.md
+++ b/src/speech_to_speech/TTS/README.md
@@ -88,6 +88,10 @@ python s2s_pipeline.py \
 
 Behavior:
 - Uses `faster-qwen3-tts` on non-macOS platforms, defaulting to the GGML backend. Pass `--qwen3_tts_backend torch` to use the CUDA-graphs backend instead.
+- Supports GGML quantization selection via `--qwen3_tts_ggml_quantization BF16|Q8_0|Q4_K_M|F32`.
+- Accepts a local talker/codec GGUF pair via `--qwen3_tts_gguf_talker_path` and `--qwen3_tts_gguf_codec_path`.
+- Automatically caches `.spk` and `.rvq` voice references when GGML voice cloning uses raw reference audio. Set `--qwen3_tts_ref_cache_dir` to override the default `~/.cache/faster-qwen3-tts/qwentts_refs` location.
+- Reuses precomputed GGML references via `--qwen3_tts_ref_spk` and the optional `--qwen3_tts_ref_rvq`.
 - Uses `mlx-audio` on Apple Silicon and auto-maps `Qwen/...` model IDs to `mlx-community/...`, defaulting to the `6bit` MLX variant unless the model name already pins a suffix.
 - Supports MLX quantization overrides on Apple Silicon via `--qwen3_tts_mlx_quantization bf16|4bit|6bit|8bit`.
 - Keeps the existing voice-clone/custom-voice/voice-design handler flow intact.
@@ -104,6 +108,55 @@ pip install speech-to-speech
 ```
 
 Available wheelhouse directories include `cu124`, `cu128`, `cu130`, and `cpu`.
+
+Select a quantized GGUF from the public model resolver:
+
+```bash
+python s2s_pipeline.py \
+  --tts qwen3 \
+  --qwen3_tts_backend ggml \
+  --qwen3_tts_model_name Qwen/Qwen3-TTS-12Hz-1.7B-CustomVoice \
+  --qwen3_tts_ggml_quantization Q4_K_M \
+  --qwen3_tts_speaker Aiden
+```
+
+Load local GGUF files by providing both the talker and codec paths. Keep the model name aligned with the local talker's model type so the handler selects the correct generation mode:
+
+```bash
+python s2s_pipeline.py \
+  --tts qwen3 \
+  --qwen3_tts_backend ggml \
+  --qwen3_tts_model_name Qwen/Qwen3-TTS-12Hz-1.7B-VoiceDesign \
+  --qwen3_tts_gguf_talker_path /models/qwen-talker-1.7b-voicedesign-Q4_K_M.gguf \
+  --qwen3_tts_gguf_codec_path /models/qwen-tokenizer-12hz-BF16.gguf \
+  --qwen3_tts_instruct "Warm, confident narrator"
+```
+
+For GGML voice cloning, a raw reference is cached on its first use:
+
+```bash
+python s2s_pipeline.py \
+  --tts qwen3 \
+  --qwen3_tts_backend ggml \
+  --qwen3_tts_model_name Qwen/Qwen3-TTS-12Hz-1.7B-Base \
+  --qwen3_tts_ref_audio /voices/freeman.wav \
+  --qwen3_tts_ref_text "The transcript for the reference audio." \
+  --qwen3_tts_ref_cache_dir /voices/cache
+```
+
+You can then pass a cached `.spk` by itself for speaker-only conditioning, or pair it with `.rvq` codes and the matching transcript for ICL conditioning:
+
+```bash
+python s2s_pipeline.py \
+  --tts qwen3 \
+  --qwen3_tts_backend ggml \
+  --qwen3_tts_model_name Qwen/Qwen3-TTS-12Hz-1.7B-Base \
+  --qwen3_tts_ref_spk /voices/cache/freeman.spk \
+  --qwen3_tts_ref_rvq /voices/cache/freeman.rvq \
+  --qwen3_tts_ref_text "The transcript for the reference audio."
+```
+
+Raw `--qwen3_tts_ref_audio` and cached `--qwen3_tts_ref_spk`/`--qwen3_tts_ref_rvq` inputs are mutually exclusive. `.rvq` input requires both `.spk` and reference text.
 
 Example for Apple Silicon using the default 6-bit MLX variant:
 

--- a/src/speech_to_speech/TTS/README.md
+++ b/src/speech_to_speech/TTS/README.md
@@ -144,15 +144,15 @@ python s2s_pipeline.py \
   --qwen3_tts_ref_cache_dir /voices/cache
 ```
 
-You can then pass a cached `.spk` by itself for speaker-only conditioning, or pair it with `.rvq` codes and the matching transcript for ICL conditioning:
+Automatic cache entries use the same SHA-256 cache key for their `.spk`, `.rvq`, and `.json` filenames. Inspect the cache directory for the matching key and replace `CACHE_KEY` below with that filename stem. You can then pass its `.spk` by itself for speaker-only conditioning, or pair it with the corresponding `.rvq` codes and transcript for ICL conditioning:
 
 ```bash
 python s2s_pipeline.py \
   --tts qwen3 \
   --qwen3_tts_backend ggml \
   --qwen3_tts_model_name Qwen/Qwen3-TTS-12Hz-1.7B-Base \
-  --qwen3_tts_ref_spk /voices/cache/freeman.spk \
-  --qwen3_tts_ref_rvq /voices/cache/freeman.rvq \
+  --qwen3_tts_ref_spk /voices/cache/CACHE_KEY.spk \
+  --qwen3_tts_ref_rvq /voices/cache/CACHE_KEY.rvq \
   --qwen3_tts_ref_text "The transcript for the reference audio."
 ```
 

--- a/src/speech_to_speech/TTS/qwen3_tts_handler.py
+++ b/src/speech_to_speech/TTS/qwen3_tts_handler.py
@@ -388,7 +388,9 @@ class Qwen3TTSHandler(BaseHandler[TTSIn, TTSOut]):
         return QWEN3_LANGUAGE_ALIASES.get(normalized, normalized)
 
     def _infer_model_type_from_name(self) -> str:
-        names = [getattr(self, "gguf_talker_path", None), self.model_name]
+        gguf_talker_path = getattr(self, "gguf_talker_path", None)
+        gguf_talker_name = Path(gguf_talker_path).name if gguf_talker_path is not None else None
+        names = [gguf_talker_name, self.model_name]
         for value in names:
             name = str(value or "").lower()
             if "voicedesign" in name:

--- a/src/speech_to_speech/TTS/qwen3_tts_handler.py
+++ b/src/speech_to_speech/TTS/qwen3_tts_handler.py
@@ -44,6 +44,7 @@ DEFAULT_MLX_STREAMING_CHUNK_SIZE = 4
 DEFAULT_QWEN3_TTS_MAX_NEW_TOKENS = 1536
 MIN_QWEN3_TTS_UTTERANCE_TOKENS = 360
 VALID_MLX_QUANTIZATION_SUFFIXES = ("bf16", "4bit", "6bit", "8bit")
+VALID_GGML_QUANTIZATIONS = ("BF16", "Q8_0", "Q4_K_M", "F32")
 VALID_FASTER_BACKENDS = ("ggml", "torch")
 MLX_STREAMING_TOKENS_PER_SECOND = 12.5
 PIPELINE_SR = 16000
@@ -85,7 +86,7 @@ class Qwen3TTSHandler(BaseHandler[TTSIn, TTSOut]):
       - Other platforms: faster-qwen3-tts
 
     Supports three generation modes depending on the loaded model:
-      - Voice cloning (ref_audio + ref_text)
+      - Voice cloning (raw ref_audio or cached GGML ref_spk/ref_rvq)
       - Custom voice (preset speakers)
       - Voice design (instruct prompt)
     """
@@ -98,7 +99,13 @@ class Qwen3TTSHandler(BaseHandler[TTSIn, TTSOut]):
         dtype: str | torch.dtype = "auto",
         attn_implementation: str = "eager",
         backend: str = "ggml",
+        ggml_quantization: str = "BF16",
+        gguf_talker_path: str | Path | None = None,
+        gguf_codec_path: str | Path | None = None,
+        ref_cache_dir: str | Path | None = None,
         ref_audio: str | Path | None = None,
+        ref_spk: str | Path | None = None,
+        ref_rvq: str | Path | None = None,
         ref_text: str = DEFAULT_REF_TEXT,
         language: str = "auto",
         speaker: Optional[str] = "Aiden",
@@ -119,6 +126,8 @@ class Qwen3TTSHandler(BaseHandler[TTSIn, TTSOut]):
         self.should_listen = should_listen
         self.requested_device = device
         self.ref_audio = ref_audio
+        self.ref_spk = self._normalize_optional_path(ref_spk)
+        self.ref_rvq = self._normalize_optional_path(ref_rvq)
         self.ref_text = ref_text
         self.language = self._normalize_language(language)
         self.speaker = speaker
@@ -127,6 +136,10 @@ class Qwen3TTSHandler(BaseHandler[TTSIn, TTSOut]):
         self.parity_mode = parity_mode
         self.non_streaming_mode = non_streaming_mode
         self.faster_backend = self._normalize_faster_backend(backend)
+        self.ggml_quantization = self._normalize_ggml_quantization(ggml_quantization)
+        self.gguf_talker_path = self._normalize_optional_path(gguf_talker_path)
+        self.gguf_codec_path = self._normalize_optional_path(gguf_codec_path)
+        self.ref_cache_dir = self._normalize_optional_path(ref_cache_dir)
         self.mlx_quantization = self._normalize_mlx_quantization(mlx_quantization)
         self.max_new_tokens = max_new_tokens
         self.blocksize = blocksize
@@ -137,6 +150,7 @@ class Qwen3TTSHandler(BaseHandler[TTSIn, TTSOut]):
 
         self.backend = "mlx" if platform == "darwin" else "faster_qwen3_tts"
         self.streaming_chunk_size = self._resolve_streaming_chunk_size(streaming_chunk_size)
+        self._validate_ggml_options()
 
         if self.backend == "mlx":
             self.device = "mps"
@@ -179,6 +193,8 @@ class Qwen3TTSHandler(BaseHandler[TTSIn, TTSOut]):
 
         self._initial_speaker = self.speaker
         self._initial_ref_audio = self.ref_audio
+        self._initial_ref_spk = self.ref_spk
+        self._initial_ref_rvq = self.ref_rvq
 
         self.warmup()
 
@@ -203,13 +219,21 @@ class Qwen3TTSHandler(BaseHandler[TTSIn, TTSOut]):
                 "Install with: pip install 'faster-qwen3-tts[ggml]'"
             ) from e
 
-        self.model = FasterQwen3TTS.from_pretrained(
-            model_name,
-            device=self.device,
-            dtype=self.dtype,
-            attn_implementation=attn_implementation,
-            backend=backend,
-        )
+        load_kwargs: dict[str, Any] = {
+            "device": self.device,
+            "dtype": self.dtype,
+            "attn_implementation": attn_implementation,
+            "backend": backend,
+        }
+        if backend == "ggml":
+            load_kwargs.update(
+                quant=self.ggml_quantization,
+                gguf_talker_path=self.gguf_talker_path,
+                gguf_codec_path=self.gguf_codec_path,
+                qwentts_ref_cache_dir=self.ref_cache_dir,
+            )
+
+        self.model = FasterQwen3TTS.from_pretrained(model_name, **load_kwargs)
         logger.info("Qwen3-TTS model loaded")
 
     def _setup_mlx(self, model_name: str) -> None:
@@ -246,6 +270,60 @@ class Qwen3TTSHandler(BaseHandler[TTSIn, TTSOut]):
                 f"Unsupported qwen3_tts_backend value {backend!r}. Supported values: {', '.join(VALID_FASTER_BACKENDS)}"
             )
         return value
+
+    def _normalize_ggml_quantization(self, quantization: Any) -> str:
+        value = str(quantization or "BF16").strip().upper()
+        if value not in VALID_GGML_QUANTIZATIONS:
+            raise ValueError(
+                "Unsupported qwen3_tts_ggml_quantization value "
+                f"{quantization!r}. Supported values: {', '.join(VALID_GGML_QUANTIZATIONS)}"
+            )
+        return value
+
+    def _normalize_optional_path(self, value: Any) -> Path | None:
+        if value is None or not str(value).strip():
+            return None
+        return Path(value).expanduser().resolve()
+
+    def _validate_ggml_options(self) -> None:
+        has_talker = self.gguf_talker_path is not None
+        has_codec = self.gguf_codec_path is not None
+        if has_talker != has_codec:
+            raise ValueError(
+                "qwen3_tts_gguf_talker_path and qwen3_tts_gguf_codec_path must be provided together."
+            )
+
+        has_cached_reference = self.ref_spk is not None or self.ref_rvq is not None
+        if self.ref_audio is not None and has_cached_reference:
+            raise ValueError(
+                "qwen3_tts_ref_audio is mutually exclusive with cached qwen3_tts_ref_spk/qwen3_tts_ref_rvq references."
+            )
+        if self.ref_rvq is not None and self.ref_spk is None:
+            raise ValueError("qwen3_tts_ref_rvq requires qwen3_tts_ref_spk.")
+        if self.ref_rvq is not None and not self.ref_text:
+            raise ValueError("qwen3_tts_ref_text is required when qwen3_tts_ref_rvq is provided.")
+        if self.ref_rvq is not None and self.xvec_only:
+            raise ValueError("qwen3_tts_ref_rvq requires qwen3_tts_xvec_only=False.")
+
+        explicit_ggml_loading_option = (
+            has_talker
+            or self.ref_cache_dir is not None
+            or has_cached_reference
+            or self.ggml_quantization != "BF16"
+        )
+        if self.backend == "mlx" and explicit_ggml_loading_option:
+            raise ValueError("GGML model and cached-reference options are unavailable with the mlx-audio backend.")
+        if self.backend == "faster_qwen3_tts" and self.faster_backend != "ggml" and explicit_ggml_loading_option:
+            raise ValueError("GGML model and cached qwentts.cpp references require backend='ggml'.")
+
+        for label, path in (
+            ("qwen3_tts_gguf_talker_path", self.gguf_talker_path),
+            ("qwen3_tts_gguf_codec_path", self.gguf_codec_path),
+            ("qwen3_tts_ref_spk", self.ref_spk),
+            ("qwen3_tts_ref_rvq", self.ref_rvq),
+        ):
+            if path is not None and not path.is_file():
+                raise FileNotFoundError(f"{label} does not point to a readable file: {path}")
 
     def _normalize_mlx_quantization(self, mlx_quantization: Any) -> Optional[str]:
         if mlx_quantization is None:
@@ -315,11 +393,15 @@ class Qwen3TTSHandler(BaseHandler[TTSIn, TTSOut]):
         return QWEN3_LANGUAGE_ALIASES.get(normalized, normalized)
 
     def _infer_model_type_from_name(self) -> str:
-        name = (self.model_name or "").lower()
-        if "voicedesign" in name:
-            return "voice_design"
-        if "customvoice" in name:
-            return "custom_voice"
+        names = [getattr(self, "gguf_talker_path", None), self.model_name]
+        for value in names:
+            name = str(value or "").lower()
+            if "voicedesign" in name:
+                return "voice_design"
+            if "customvoice" in name:
+                return "custom_voice"
+            if "base" in name:
+                return "base"
         return "base"
 
     def _resolve_audio_path(self, audio: Any) -> Path | None:
@@ -346,6 +428,13 @@ class Qwen3TTSHandler(BaseHandler[TTSIn, TTSOut]):
                 return path.resolve()
 
         return None
+
+    def _has_voice_clone_reference(self) -> bool:
+        return bool(self.ref_audio or getattr(self, "ref_spk", None))
+
+    def _clear_cached_voice_reference(self) -> None:
+        self.ref_spk = None
+        self.ref_rvq = None
 
     def _prepare_mlx_ref_audio(self, ref_audio: Any) -> Any:
         if self.backend != "mlx" or ref_audio is None:
@@ -441,10 +530,12 @@ class Qwen3TTSHandler(BaseHandler[TTSIn, TTSOut]):
 
             self.speaker = session_voice
             self.ref_audio = None
+            self._clear_cached_voice_reference()
             return
 
         if self._resolve_audio_path(session_voice) is not None:
             self.ref_audio = session_voice
+            self._clear_cached_voice_reference()
             return
 
         logger.warning(
@@ -554,7 +645,7 @@ class Qwen3TTSHandler(BaseHandler[TTSIn, TTSOut]):
 
     def _warmup_process(self, llm_sentence: str) -> Iterator[bytes | np.ndarray]:
         model_type = self._model_type()
-        if self.ref_audio:
+        if self._has_voice_clone_reference():
             yield from self._process_voice_clone(llm_sentence)
         elif model_type == "custom_voice":
             yield from self._process_custom_voice(llm_sentence)
@@ -562,8 +653,8 @@ class Qwen3TTSHandler(BaseHandler[TTSIn, TTSOut]):
             yield from self._process_voice_design(llm_sentence)
         else:
             raise ValueError(
-                "Qwen3-TTS Base model requires ref_audio for voice cloning. "
-                "Provide qwen3_tts_ref_audio or use a CustomVoice/VoiceDesign model."
+                "Qwen3-TTS Base model requires a voice-clone reference. "
+                "Provide qwen3_tts_ref_audio or qwen3_tts_ref_spk, or use a CustomVoice/VoiceDesign model."
             )
 
     def _resample_to_pipeline_sr(self, audio: np.ndarray, sr: int) -> np.ndarray:
@@ -717,7 +808,7 @@ class Qwen3TTSHandler(BaseHandler[TTSIn, TTSOut]):
         console.print(f"[green]ASSISTANT: {text}")
 
         try:
-            if self.ref_audio:
+            if self._has_voice_clone_reference():
                 audio_iter = self._process_voice_clone(text)
             elif model_type == "custom_voice":
                 audio_iter = self._process_custom_voice(text)
@@ -725,8 +816,8 @@ class Qwen3TTSHandler(BaseHandler[TTSIn, TTSOut]):
                 audio_iter = self._process_voice_design(text)
             else:
                 raise ValueError(
-                    "Qwen3-TTS Base model requires ref_audio for voice cloning. "
-                    "Provide qwen3_tts_ref_audio or use a CustomVoice/VoiceDesign model."
+                    "Qwen3-TTS Base model requires a voice-clone reference. "
+                    "Provide qwen3_tts_ref_audio or qwen3_tts_ref_spk, or use a CustomVoice/VoiceDesign model."
                 )
             first_audio = True
             for audio_chunk in audio_iter:
@@ -804,6 +895,8 @@ class Qwen3TTSHandler(BaseHandler[TTSIn, TTSOut]):
                 text=text,
                 language=self.language,
                 ref_audio=self.ref_audio,
+                ref_spk=getattr(self, "ref_spk", None),
+                ref_rvq=getattr(self, "ref_rvq", None),
                 ref_text=self.ref_text,
                 xvec_only=self.xvec_only,
                 chunk_size=self.streaming_chunk_size,
@@ -876,6 +969,8 @@ class Qwen3TTSHandler(BaseHandler[TTSIn, TTSOut]):
     def on_session_end(self) -> None:
         self.speaker = self._initial_speaker
         self.ref_audio = self._initial_ref_audio
+        self.ref_spk = self._initial_ref_spk
+        self.ref_rvq = self._initial_ref_rvq
         logger.debug("Qwen3-TTS session state reset")
 
     def cleanup(self) -> None:

--- a/src/speech_to_speech/TTS/qwen3_tts_handler.py
+++ b/src/speech_to_speech/TTS/qwen3_tts_handler.py
@@ -289,9 +289,7 @@ class Qwen3TTSHandler(BaseHandler[TTSIn, TTSOut]):
         has_talker = self.gguf_talker_path is not None
         has_codec = self.gguf_codec_path is not None
         if has_talker != has_codec:
-            raise ValueError(
-                "qwen3_tts_gguf_talker_path and qwen3_tts_gguf_codec_path must be provided together."
-            )
+            raise ValueError("qwen3_tts_gguf_talker_path and qwen3_tts_gguf_codec_path must be provided together.")
 
         has_cached_reference = self.ref_spk is not None or self.ref_rvq is not None
         if self.ref_audio is not None and has_cached_reference:
@@ -306,10 +304,7 @@ class Qwen3TTSHandler(BaseHandler[TTSIn, TTSOut]):
             raise ValueError("qwen3_tts_ref_rvq requires qwen3_tts_xvec_only=False.")
 
         explicit_ggml_loading_option = (
-            has_talker
-            or self.ref_cache_dir is not None
-            or has_cached_reference
-            or self.ggml_quantization != "BF16"
+            has_talker or self.ref_cache_dir is not None or has_cached_reference or self.ggml_quantization != "BF16"
         )
         if self.backend == "mlx" and explicit_ggml_loading_option:
             raise ValueError("GGML model and cached-reference options are unavailable with the mlx-audio backend.")

--- a/src/speech_to_speech/arguments_classes/qwen3_tts_arguments.py
+++ b/src/speech_to_speech/arguments_classes/qwen3_tts_arguments.py
@@ -34,10 +34,46 @@ class Qwen3TTSHandlerArguments:
             "help": "faster-qwen3-tts backend on non-macOS platforms. Options: 'ggml' or 'torch'. Default is 'ggml'. On Apple Silicon, mlx-audio is selected automatically and this option is ignored."
         },
     )
+    qwen3_tts_ggml_quantization: str = field(
+        default="BF16",
+        metadata={
+            "help": "GGUF quantization for the faster-qwen3-tts GGML backend. Supported values: 'BF16', 'Q8_0', 'Q4_K_M', 'F32'. Default is 'BF16'."
+        },
+    )
+    qwen3_tts_gguf_talker_path: Optional[str] = field(
+        default=None,
+        metadata={
+            "help": "Optional local qwentts.cpp talker GGUF path. Must be provided together with qwen3_tts_gguf_codec_path and requires the GGML backend."
+        },
+    )
+    qwen3_tts_gguf_codec_path: Optional[str] = field(
+        default=None,
+        metadata={
+            "help": "Optional local qwentts.cpp codec GGUF path. Must be provided together with qwen3_tts_gguf_talker_path and requires the GGML backend."
+        },
+    )
+    qwen3_tts_ref_cache_dir: Optional[str] = field(
+        default=None,
+        metadata={
+            "help": "Optional directory for automatically cached GGML voice references (.spk/.rvq). The faster-qwen3-tts default cache is used when unset."
+        },
+    )
     qwen3_tts_ref_audio: Optional[str] = field(
         default=None,
         metadata={
             "help": "Optional path to reference audio file for voice cloning. Leave unset when using a CustomVoice model."
+        },
+    )
+    qwen3_tts_ref_spk: Optional[str] = field(
+        default=None,
+        metadata={
+            "help": "Optional precomputed qwentts.cpp .spk speaker embedding for GGML voice cloning. Mutually exclusive with qwen3_tts_ref_audio."
+        },
+    )
+    qwen3_tts_ref_rvq: Optional[str] = field(
+        default=None,
+        metadata={
+            "help": "Optional precomputed qwentts.cpp .rvq acoustic codes for GGML ICL voice cloning. Requires qwen3_tts_ref_spk and qwen3_tts_ref_text."
         },
     )
     qwen3_tts_ref_text: str = field(

--- a/tests/install_smoke.py
+++ b/tests/install_smoke.py
@@ -60,6 +60,12 @@ def _validate_package_defaults() -> None:
     assert qwen3_args.qwen3_tts_backend == "ggml"
     assert qwen3_args.qwen3_tts_non_streaming_mode is True
     assert qwen3_args.qwen3_tts_ref_audio is None
+    assert qwen3_args.qwen3_tts_ref_spk is None
+    assert qwen3_args.qwen3_tts_ref_rvq is None
+    assert qwen3_args.qwen3_tts_ggml_quantization == "BF16"
+    assert qwen3_args.qwen3_tts_gguf_talker_path is None
+    assert qwen3_args.qwen3_tts_gguf_codec_path is None
+    assert qwen3_args.qwen3_tts_ref_cache_dir is None
     assert qwen3_args.qwen3_tts_mlx_quantization == "6bit"
     assert vad_args.thresh == 0.6
     assert vad_args.min_silence_ms == 64

--- a/tests/test_cli_defaults.py
+++ b/tests/test_cli_defaults.py
@@ -51,6 +51,12 @@ def test_release_defaults_match_responses_api_parakeet_qwen3_realtime_profile():
     assert qwen3_args.qwen3_tts_backend == "ggml"
     assert qwen3_args.qwen3_tts_non_streaming_mode is True
     assert qwen3_args.qwen3_tts_ref_audio is None
+    assert qwen3_args.qwen3_tts_ref_spk is None
+    assert qwen3_args.qwen3_tts_ref_rvq is None
+    assert qwen3_args.qwen3_tts_ggml_quantization == "BF16"
+    assert qwen3_args.qwen3_tts_gguf_talker_path is None
+    assert qwen3_args.qwen3_tts_gguf_codec_path is None
+    assert qwen3_args.qwen3_tts_ref_cache_dir is None
     assert qwen3_args.qwen3_tts_mlx_quantization == "6bit"
 
 
@@ -114,6 +120,37 @@ def test_parse_arguments_accepts_qwen3_tts_backend_override():
         sys.argv = original_argv
 
     assert args.qwen3_tts_handler_kwargs.qwen3_tts_backend == "torch"
+
+
+def test_parse_arguments_accepts_qwen3_tts_ggml_options():
+    original_argv = sys.argv[:]
+    try:
+        sys.argv = [
+            "speech-to-speech",
+            "--qwen3_tts_ggml_quantization",
+            "Q4_K_M",
+            "--qwen3_tts_gguf_talker_path",
+            "/models/talker.gguf",
+            "--qwen3_tts_gguf_codec_path",
+            "/models/codec.gguf",
+            "--qwen3_tts_ref_cache_dir",
+            "/voices/cache",
+            "--qwen3_tts_ref_spk",
+            "/voices/ref.spk",
+            "--qwen3_tts_ref_rvq",
+            "/voices/ref.rvq",
+        ]
+        args = parse_arguments()
+    finally:
+        sys.argv = original_argv
+
+    qwen3_args = args.qwen3_tts_handler_kwargs
+    assert qwen3_args.qwen3_tts_ggml_quantization == "Q4_K_M"
+    assert qwen3_args.qwen3_tts_gguf_talker_path == "/models/talker.gguf"
+    assert qwen3_args.qwen3_tts_gguf_codec_path == "/models/codec.gguf"
+    assert qwen3_args.qwen3_tts_ref_cache_dir == "/voices/cache"
+    assert qwen3_args.qwen3_tts_ref_spk == "/voices/ref.spk"
+    assert qwen3_args.qwen3_tts_ref_rvq == "/voices/ref.rvq"
 
 
 def test_parse_arguments_transformers_backend():

--- a/tests/test_qwen3_tts_handler_backend.py
+++ b/tests/test_qwen3_tts_handler_backend.py
@@ -150,6 +150,86 @@ def test_setup_passes_torch_backend_override_off_darwin(monkeypatch):
     assert recorded["backend"] == "torch"
 
 
+def test_setup_passes_ggml_model_and_cache_options_to_faster_backend(monkeypatch, tmp_path):
+    recorded = {}
+    talker_path = tmp_path / "talker-Q4_K_M.gguf"
+    codec_path = tmp_path / "codec-BF16.gguf"
+    talker_path.touch()
+    codec_path.touch()
+
+    class _FakeFasterQwen3TTS:
+        @classmethod
+        def from_pretrained(cls, model_name, **kwargs):
+            recorded["model_name"] = model_name
+            recorded.update(kwargs)
+            return SimpleNamespace()
+
+    monkeypatch.setattr(qwen3_tts_module, "platform", "linux")
+    monkeypatch.setitem(sys.modules, "faster_qwen3_tts", SimpleNamespace(FasterQwen3TTS=_FakeFasterQwen3TTS))
+    monkeypatch.setattr(Qwen3TTSHandler, "warmup", lambda self: None)
+
+    handler = object.__new__(Qwen3TTSHandler)
+    handler.setup(
+        Event(),
+        model_name="Qwen/Qwen3-TTS-12Hz-1.7B-Base",
+        backend="ggml",
+        ggml_quantization="q4_k_m",
+        gguf_talker_path=talker_path,
+        gguf_codec_path=codec_path,
+        ref_cache_dir=tmp_path / "voice-cache",
+    )
+
+    assert handler.ggml_quantization == "Q4_K_M"
+    assert recorded["model_name"] == "Qwen/Qwen3-TTS-12Hz-1.7B-Base"
+    assert recorded["backend"] == "ggml"
+    assert recorded["quant"] == "Q4_K_M"
+    assert recorded["gguf_talker_path"] == talker_path.resolve()
+    assert recorded["gguf_codec_path"] == codec_path.resolve()
+    assert recorded["qwentts_ref_cache_dir"] == (tmp_path / "voice-cache").resolve()
+
+
+def test_setup_passes_ggml_quantization_for_hub_model(monkeypatch):
+    recorded = {}
+
+    class _FakeFasterQwen3TTS:
+        @classmethod
+        def from_pretrained(cls, model_name, **kwargs):
+            recorded["model_name"] = model_name
+            recorded.update(kwargs)
+            return SimpleNamespace()
+
+    monkeypatch.setattr(qwen3_tts_module, "platform", "linux")
+    monkeypatch.setitem(sys.modules, "faster_qwen3_tts", SimpleNamespace(FasterQwen3TTS=_FakeFasterQwen3TTS))
+    monkeypatch.setattr(Qwen3TTSHandler, "warmup", lambda self: None)
+
+    handler = object.__new__(Qwen3TTSHandler)
+    handler.setup(Event(), ggml_quantization="q8_0")
+
+    assert recorded["quant"] == "Q8_0"
+    assert recorded["gguf_talker_path"] is None
+    assert recorded["gguf_codec_path"] is None
+
+
+def test_setup_rejects_incomplete_local_gguf_pair(monkeypatch, tmp_path):
+    monkeypatch.setattr(qwen3_tts_module, "platform", "linux")
+    monkeypatch.setattr(Qwen3TTSHandler, "warmup", lambda self: None)
+
+    handler = object.__new__(Qwen3TTSHandler)
+
+    with pytest.raises(ValueError, match="gguf_talker_path.*gguf_codec_path"):
+        handler.setup(Event(), gguf_talker_path=tmp_path / "talker.gguf")
+
+
+def test_setup_rejects_cached_ggml_references_with_torch_backend(monkeypatch):
+    monkeypatch.setattr(qwen3_tts_module, "platform", "linux")
+    monkeypatch.setattr(Qwen3TTSHandler, "warmup", lambda self: None)
+
+    handler = object.__new__(Qwen3TTSHandler)
+
+    with pytest.raises(ValueError, match="cached .* references require backend='ggml'"):
+        handler.setup(Event(), backend="torch", ref_spk="voice.spk")
+
+
 def test_setup_defaults_to_custom_voice_profile_off_darwin(monkeypatch):
     recorded = {}
 
@@ -329,6 +409,14 @@ def test_mlx_helper_methods_use_model_config_and_streaming_conversion():
     assert handler._model_type() == "custom_voice"
     assert handler._resolve_speaker() == "Vivian"
     assert handler._mlx_streaming_interval() == pytest.approx(0.64)
+
+
+def test_local_gguf_filename_takes_precedence_when_inferring_model_type():
+    handler = object.__new__(Qwen3TTSHandler)
+    handler.model_name = "Qwen/Qwen3-TTS-12Hz-1.7B-CustomVoice"
+    handler.gguf_talker_path = Path("qwen-talker-1.7b-base-Q4_K_M.gguf")
+
+    assert handler._infer_model_type_from_name() == "base"
 
 
 def test_prepare_mlx_ref_audio_normalizes_file_and_caches_result(monkeypatch, tmp_path):
@@ -681,6 +769,45 @@ def test_process_voice_clone_passes_none_non_streaming_mode_when_unset(monkeypat
 
     assert len(outputs) == 1
     assert captured["non_streaming_mode"] is None
+
+
+def test_process_voice_clone_uses_precomputed_ggml_references_without_audio(monkeypatch):
+    captured = {}
+    handler = object.__new__(Qwen3TTSHandler)
+    handler.should_listen = Event()
+    handler.cancel_scope = None
+    handler.ref_audio = None
+    handler.ref_spk = Path("voice.spk")
+    handler.ref_rvq = Path("voice.rvq")
+    handler.ref_text = "Reference text."
+    handler.speaker = None
+    handler.instruct = None
+    handler.language = "English"
+    handler.xvec_only = False
+    handler.parity_mode = False
+    handler.non_streaming_mode = True
+    handler.streaming_chunk_size = 8
+    handler.max_new_tokens = 360
+    handler.blocksize = 512
+    handler.backend = "faster_qwen3_tts"
+    handler.faster_backend = "ggml"
+    handler.queue_in = Queue()
+    handler.model = SimpleNamespace(
+        model=SimpleNamespace(model=SimpleNamespace(tts_model_type="base")),
+        generate_voice_clone_streaming=lambda **kwargs: (
+            captured.update(kwargs),
+            iter([(_audible_stream_chunk(), 16000, {})]),
+        )[1],
+    )
+
+    monkeypatch.setattr(qwen3_tts_module.console, "print", lambda *args, **kwargs: None)
+
+    outputs = list(handler.process(TTSInput(text="Hello there.")))
+
+    assert len(outputs) == 1
+    assert captured["ref_audio"] is None
+    assert captured["ref_spk"] == Path("voice.spk")
+    assert captured["ref_rvq"] == Path("voice.rvq")
 
 
 @pytest.mark.parametrize("override", [None, False, True])

--- a/tests/test_qwen3_tts_handler_backend.py
+++ b/tests/test_qwen3_tts_handler_backend.py
@@ -419,6 +419,14 @@ def test_local_gguf_filename_takes_precedence_when_inferring_model_type():
     assert handler._infer_model_type_from_name() == "base"
 
 
+def test_local_gguf_parent_directory_does_not_affect_model_type_inference():
+    handler = object.__new__(Qwen3TTSHandler)
+    handler.model_name = "Qwen/Qwen3-TTS-12Hz-1.7B-CustomVoice"
+    handler.gguf_talker_path = Path("/srv/database/qwen-talker-1.7b-Q4_K_M.gguf")
+
+    assert handler._infer_model_type_from_name() == "custom_voice"
+
+
 def test_prepare_mlx_ref_audio_normalizes_file_and_caches_result(monkeypatch, tmp_path):
     source = tmp_path / "source.wav"
     source.write_bytes(b"fake")


### PR DESCRIPTION
## Summary

- expose GGML quantization selection and local talker/codec GGUF paths through the Qwen3-TTS handler and CLI
- expose the automatic voice-reference cache directory plus precomputed `.spk`/`.rvq` inputs
- validate incompatible backend, file, and reference combinations
- document quantized, local-GGUF, and cached voice-cloning workflows

## Why

`faster-qwen3-tts` already supports these GGML capabilities, but the speech-to-speech Qwen3 handler did not forward the corresponding loading and generation options. Users therefore could not select lower-memory GGUF quantizations, load local GGUF pairs, or reuse cached voice references through this project.

## User impact

Linux GGML users can now choose `BF16`, `Q8_0`, `Q4_K_M`, or `F32`, load local model files, configure automatic `.spk`/`.rvq` caching, and synthesize from precomputed cached references.

## Validation

- `python -m pytest tests/test_qwen3_tts_handler_backend.py tests/test_cli_defaults.py -q` — 62 passed
- full test suite — 640 passed
- installed-package smoke test — passed
- Ruff and `git diff --check` — passed

Closes #334
