### PR TITLE
Stop whisper-mlx dropping turns in an unsupported language

### DIFF
--- a/src/speech_to_speech/STT/lightning_whisper_mlx_handler.py
+++ b/src/speech_to_speech/STT/lightning_whisper_mlx_handler.py
@@ -32,6 +32,8 @@ SUPPORTED_LANGUAGES = [
     "nl",
 ]
 
+DEFAULT_LANGUAGE = "en"
+
 
 class LightningWhisperSTTHandler(BaseSTTHandler):
     """
@@ -52,7 +54,9 @@ class LightningWhisperSTTHandler(BaseSTTHandler):
         self.device = device
         self.model = LightningWhisperMLX(model=model_name, batch_size=6, quant=None)
         self.start_language = language
-        self.last_language = language
+        # "auto" is a request to detect, not a language code, so it must never leak into
+        # last_language -- it would fail every SUPPORTED_LANGUAGES check downstream.
+        self.last_language = language if language != "auto" else None
 
         self.warmup()
 
@@ -67,29 +71,50 @@ class LightningWhisperSTTHandler(BaseSTTHandler):
             with MLXLockContext(handler_name=self.__class__.__name__):
                 _ = self.model.transcribe(dummy_input)["text"].strip()
 
+    def _forced_language(self) -> Optional[str]:
+        """The language explicitly requested by the user, if any."""
+        if self.start_language and self.start_language != "auto":
+            return self.start_language
+        return None
+
+    def _resolve_language(self, transcription_dict: dict[str, Any], forced_language: Optional[str]) -> str:
+        """Report the language that was actually transcribed.
+
+        A detected language outside ``SUPPORTED_LANGUAGES`` is still reported as-is: the
+        transcription is correct, and that list only decides what becomes the sticky
+        fallback. Re-transcribing in a different language, or dropping the turn, throws away
+        a good result because of a downstream allowlist.
+        """
+        if forced_language is not None:
+            # transcribe() ran with this language, so it is authoritative.
+            self.last_language = forced_language
+            return forced_language
+
+        detected = transcription_dict.get("language")
+        if isinstance(detected, str) and detected:
+            if detected in SUPPORTED_LANGUAGES:
+                self.last_language = detected
+            else:
+                logger.warning("Whisper detected unsupported language: %s", detected)
+            return detected
+
+        # Only when no language could be determined at all.
+        return self.last_language or DEFAULT_LANGUAGE
+
     def process(self, vad_audio: STTIn) -> Iterator[STTOut]:
         logger.debug("infering whisper...")
 
         audio = vad_audio.audio
-        if self.start_language != "auto":
-            with MLXLockContext(handler_name=self.__class__.__name__):
-                transcription_dict = self.model.transcribe(audio, language=self.start_language)
-        else:
-            with MLXLockContext(handler_name=self.__class__.__name__):
-                transcription_dict = self.model.transcribe(audio)
-            language_code = transcription_dict["language"]
-            if language_code not in SUPPORTED_LANGUAGES:
-                logger.warning(f"Whisper detected unsupported language: {language_code}")
-                if self.last_language in SUPPORTED_LANGUAGES:  # reprocess with the last language
-                    with MLXLockContext(handler_name=self.__class__.__name__):
-                        transcription_dict = self.model.transcribe(audio, language=self.last_language)
-                else:
-                    transcription_dict = {"text": "", "language": "en"}
-            else:
-                self.last_language = language_code
+        forced_language = self._forced_language()
 
-        pred_text = transcription_dict["text"].strip()
-        language_code = transcription_dict["language"]
+        with MLXLockContext(handler_name=self.__class__.__name__):
+            if forced_language is not None:
+                transcription_dict = self.model.transcribe(audio, language=forced_language)
+            else:
+                transcription_dict = self.model.transcribe(audio)
+
+        pred_text = (transcription_dict.get("text") or "").strip()
+        language_code = self._resolve_language(transcription_dict, forced_language)
         torch.mps.empty_cache()
 
         logger.debug("finished whisper inference")

--- a/tests/test_lightning_whisper_language_fallback.py
+++ b/tests/test_lightning_whisper_language_fallback.py
@@ -1,0 +1,240 @@
+"""Regression tests for the whisper-mlx STT handler's auto-language fallback.
+
+In auto mode the handler used to *discard the user's turn* when Whisper detected a language
+outside its 12-entry SUPPORTED_LANGUAGES list and no supported language had been seen yet:
+
+    if language_code not in SUPPORTED_LANGUAGES:
+        if self.last_language in SUPPORTED_LANGUAGES:
+            transcription_dict = self.model.transcribe(audio, language=self.last_language)
+        else:
+            transcription_dict = {"text": "", "language": "en"}   # <- transcription dropped
+
+`setup()` also stored `--language auto` verbatim in `last_language`, and "auto" is not in
+SUPPORTED_LANGUAGES, so the drop branch was the one taken on the first such utterance.
+
+Whisper transcribes those languages fine; only the pipeline threw the result away. The
+handler now reports the language actually transcribed and never drops the text, matching the
+behaviour agreed for the transformers-Whisper handler.
+
+`lightning_whisper_mlx` is a macOS-only optional dependency and `torch.mps.empty_cache()`
+raises off Apple Silicon, so both are stubbed and these tests run anywhere.
+"""
+
+from __future__ import annotations
+
+import importlib
+import sys
+import types
+
+import numpy as np
+import pytest
+
+from speech_to_speech.pipeline.messages import VADAudio
+
+
+class FakeLightningWhisperMLX:
+    """Stand-in for the real model: scripted results, records every transcribe() call."""
+
+    def __init__(self, *args, **kwargs):
+        self.calls: list[dict] = []
+        # Default warmup result; tests overwrite `results` afterwards.
+        self.results = [{"text": "", "language": "en"}]
+
+    def transcribe(self, audio, language=None):
+        self.calls.append({"language": language})
+        index = min(len(self.calls) - 1, len(self.results) - 1)
+        return self.results[index]
+
+
+@pytest.fixture
+def handler_module(monkeypatch):
+    """Import the handler with its macOS-only dependency stubbed out."""
+    fake_pkg = types.ModuleType("lightning_whisper_mlx")
+    fake_pkg.LightningWhisperMLX = FakeLightningWhisperMLX  # type: ignore[attr-defined]
+    monkeypatch.setitem(sys.modules, "lightning_whisper_mlx", fake_pkg)
+    monkeypatch.delitem(sys.modules, "speech_to_speech.STT.lightning_whisper_mlx_handler", raising=False)
+
+    module = importlib.import_module("speech_to_speech.STT.lightning_whisper_mlx_handler")
+    # torch.mps.empty_cache() raises RuntimeError without an MPS backend.
+    monkeypatch.setattr(module.torch.mps, "empty_cache", lambda: None)
+
+    yield module
+
+    # Don't leave a module built against the stub in sys.modules for other tests.
+    sys.modules.pop("speech_to_speech.STT.lightning_whisper_mlx_handler", None)
+
+
+def make_handler(handler_module, *, language, results, last_language=...):
+    handler = object.__new__(handler_module.LightningWhisperSTTHandler)
+    handler.device = "mps"
+    handler.start_language = language
+    handler.last_language = (language if language != "auto" else None) if last_language is ... else last_language
+    handler.model = FakeLightningWhisperMLX()
+    handler.model.results = results
+    return handler
+
+
+def vad_audio():
+    return VADAudio(audio=np.zeros(16000, dtype=np.float32), turn_id="turn_1", turn_revision=0)
+
+
+def run(handler):
+    outputs = list(handler.process(vad_audio()))
+    assert len(outputs) == 1
+    return outputs[0]
+
+
+# --- the dropped-turn bug -----------------------------------------------------------------
+
+
+def test_unsupported_detected_language_keeps_the_transcription(handler_module):
+    """The core bug: Russian speech came back as empty text and was silently dropped."""
+    handler = make_handler(
+        handler_module,
+        language="auto",
+        results=[{"text": "Privet, kak dela?", "language": "ru"}],
+    )
+
+    result = run(handler)
+
+    assert result.text == "Privet, kak dela?"
+    assert result.language_code == "ru-auto"
+    # One transcribe() call: no destructive re-transcription.
+    assert len(handler.model.calls) == 1
+
+
+def test_unsupported_detected_language_is_not_retranscribed_in_last_language(handler_module):
+    """With a previous supported language, the audio used to be re-transcribed as that."""
+    handler = make_handler(
+        handler_module,
+        language="auto",
+        results=[{"text": "Privet, kak dela?", "language": "ru"}],
+        last_language="de",
+    )
+
+    result = run(handler)
+
+    assert result.text == "Privet, kak dela?"
+    assert result.language_code == "ru-auto"
+    assert len(handler.model.calls) == 1
+    # An unsupported code must not become the sticky fallback.
+    assert handler.last_language == "de"
+
+
+def test_supported_detected_language_becomes_the_sticky_fallback(handler_module):
+    handler = make_handler(
+        handler_module,
+        language="auto",
+        results=[{"text": "Ich heisse Max.", "language": "de"}],
+    )
+
+    assert run(handler).language_code == "de-auto"
+    assert handler.last_language == "de"
+
+
+@pytest.mark.parametrize("detected", ["ru", "ar", "sv", "tr"])
+def test_no_language_ever_yields_empty_text(handler_module, detected):
+    """No detected language may cause the user's turn to be discarded."""
+    handler = make_handler(
+        handler_module,
+        language="auto",
+        results=[{"text": "some real transcription", "language": detected}],
+    )
+
+    result = run(handler)
+
+    assert result.text == "some real transcription"
+    assert result.language_code == f"{detected}-auto"
+
+
+# --- setup() must not store "auto" as a language code -------------------------------------
+
+
+@pytest.mark.parametrize(
+    ("language", "expected_last_language"),
+    [("auto", None), ("de", "de"), (None, None)],
+)
+def test_setup_does_not_store_auto_as_last_language(handler_module, language, expected_last_language):
+    handler = object.__new__(handler_module.LightningWhisperSTTHandler)
+    handler.setup(model_name="distil-large-v3", language=language)
+
+    assert handler.start_language == language
+    assert handler.last_language == expected_last_language
+
+
+def test_setup_strips_a_repo_prefix_from_the_model_name(handler_module):
+    """Pre-existing behaviour, pinned so the setup change doesn't regress it."""
+    handler = object.__new__(handler_module.LightningWhisperSTTHandler)
+    handler.setup(model_name="mlx-community/distil-large-v3", language="en")
+
+    assert handler.last_language == "en"
+
+
+# --- forced language ----------------------------------------------------------------------
+
+
+def test_forced_language_is_passed_through_and_reported(handler_module):
+    handler = make_handler(
+        handler_module,
+        language="de",
+        results=[{"text": "Ich heisse Max.", "language": "it"}],
+    )
+
+    result = run(handler)
+
+    assert handler.model.calls == [{"language": "de"}]
+    # No "-auto" suffix when the language was pinned.
+    assert result.language_code == "de"
+    assert result.text == "Ich heisse Max."
+
+
+def test_language_none_is_treated_as_auto_detect_without_suffix(handler_module):
+    """`language=None` means "don't force", but it is not the `auto` display mode."""
+    handler = make_handler(
+        handler_module,
+        language=None,
+        results=[{"text": "Hello.", "language": "en"}],
+    )
+
+    result = run(handler)
+
+    assert handler.model.calls == [{"language": None}]
+    assert result.language_code == "en"
+
+
+# --- degenerate model output --------------------------------------------------------------
+
+
+def test_missing_language_key_falls_back_without_crashing(handler_module):
+    handler = make_handler(
+        handler_module,
+        language="auto",
+        results=[{"text": "Hello."}],
+        last_language="de",
+    )
+
+    result = run(handler)
+
+    assert result.text == "Hello."
+    assert result.language_code == "de-auto"
+
+
+def test_missing_language_and_no_fallback_defaults_to_english(handler_module):
+    handler = make_handler(
+        handler_module,
+        language="auto",
+        results=[{"text": "Hello."}],
+        last_language=None,
+    )
+
+    assert run(handler).language_code == "en-auto"
+
+
+def test_missing_text_key_yields_empty_string_not_a_crash(handler_module):
+    handler = make_handler(
+        handler_module,
+        language="auto",
+        results=[{"language": "en"}],
+    )
+
+    assert run(handler).text == ""


### PR DESCRIPTION
Fixes #404

## Problem

With `--stt whisper-mlx --language auto`, the handler discards the transcription whenever Whisper detects a language outside its 12-entry `SUPPORTED_LANGUAGES`:

```python
if language_code not in SUPPORTED_LANGUAGES:
    if self.last_language in SUPPORTED_LANGUAGES:
        transcription_dict = self.model.transcribe(audio, language=self.last_language)
    else:
        transcription_dict = {"text": "", "language": "en"}   # <- transcription discarded
```

Two bad outcomes:

1. **The turn is dropped entirely.** `setup()` stores `--language auto` verbatim in `last_language`, and `"auto"` isn't in `SUPPORTED_LANGUAGES`, so the `else` branch is taken on the first such utterance. The user speaks and an empty transcription reaches the LLM. The only trace is a warning.
2. **The transcription is replaced by a wrong-language one.** Once a supported language has been seen, the audio is re-transcribed forcing that older language and the correct result is thrown away — Russian after German returns German.

Whisper transcribes these languages fine. `SUPPORTED_LANGUAGES` is a 12-entry list governing the sticky fallback, not a claim about model capability, so checking the detected language against it and then discarding good output is the defect. Affected: everything Whisper detects beyond `en fr es zh ja ko hi de pt pl it nl`.

## Fix

Same resolution already agreed for the transformers-Whisper handler in review on #378 — *"retain any actual detected language and reserve `last_language` fallback for cases where no language could be determined"* — applied here so the backends behave consistently:

- Report the language actually transcribed, even when outside `SUPPORTED_LANGUAGES`; never drop or re-transcribe. That list now only decides what becomes the sticky `last_language`.
- Reserve the `last_language` fallback for when no language could be determined at all, then `DEFAULT_LANGUAGE`.
- Normalize `--language auto` to `None` in `setup()` instead of storing it as a language code, matching `WhisperSTTHandler` and `MLXAudioWhisperSTTHandler`.
- Read `text`/`language` with `.get()` so degenerate model output can't raise `KeyError`.

There's no re-transcription path left, so the unsupported-language case now costs one inference instead of two. Behaviour for a pinned `--language` and for supported detected languages is unchanged.

## Tests

`tests/test_lightning_whisper_language_fallback.py` stubs the macOS-only `lightning_whisper_mlx` dependency and `torch.mps.empty_cache()` (which raises off Apple Silicon), so it runs on Linux CI with no optional extras. Coverage: the dropped turn, the destructive re-transcription, the sticky-fallback rules, `setup()` normalization, forced language, `language=None` vs `"auto"`, and degenerate model output.

11 of the 16 fail against the current code. The headline case fails with exactly the data loss:

```
assert result.text == "Privet, kak dela?"
E   AssertionError: assert '' == 'Privet, kak dela?'
```

The fixture pops the stub-built module from `sys.modules` afterwards, so it can't affect the `test_llm_utils.py` sweep that expects this handler to be unimportable without extras — verified by running both together.

Full suite: 742 passed, 1 skipped. `ruff check`, `ruff format --check`, `mypy src/` clean.

## Note

I deliberately left the unconditional `torch.mps.empty_cache()` in this handler alone — that's the subject of #145 / #370, and this handler is macOS-only so it isn't hit in practice.
