### PR TITLE
Expose Qwen3-TTS temperature/top_p/instruct to the realtime client

### DIFF
--- a/demo/index.html
+++ b/demo/index.html
@@ -274,6 +274,33 @@
             </div>
 
             <label class="field">
+              <span>TTS mood instruction</span>
+              <textarea id="tts-instruct" rows="2" placeholder="e.g. Speak in a calm, neutral tone"></textarea>
+              <small>Optional global instruction to the Qwen3-TTS voice (mood/tone). Leave empty for default.</small>
+            </label>
+
+            <div class="field-row">
+              <label class="field">
+                <span class="field-head">
+                  TTS temperature
+                  <span id="tts-temp-value" class="field-value">0.90</span>
+                </span>
+                <input id="tts-temperature" type="range" min="0" max="1.5" step="0.05" value="0.9"
+                       aria-label="TTS temperature" />
+                <small>Lower = steadier, less emotional speech. Higher = more expressive/varied.</small>
+              </label>
+              <label class="field">
+                <span class="field-head">
+                  TTS top_p
+                  <span id="tts-topp-value" class="field-value">1.00</span>
+                </span>
+                <input id="tts-top-p" type="range" min="0.1" max="1" step="0.05" value="1"
+                       aria-label="TTS top_p" />
+                <small>Lower = more conservative sampling. 1.0 = full range.</small>
+              </label>
+            </div>
+
+            <label class="field">
               <span>Microphone</span>
               <select id="audio-input">
                 <option value="">System default</option>

--- a/demo/main.js
+++ b/demo/main.js
@@ -43,6 +43,9 @@ const STORAGE_KEYS = {
   directUrl: "s2s.ws.directUrl",
   voice: "s2s.ws.voice",
   instructions: "s2s.ws.instructions",
+  ttsInstruct: "s2s.ws.ttsInstruct",
+  ttsTemperature: "s2s.ws.ttsTemperature",
+  ttsTopP: "s2s.ws.ttsTopP",
   tools: "s2s.ws.tools",
   searchKey: "s2s.ws.searchKey",
   noiseGate: "s2s.ws.noiseGate",
@@ -123,12 +126,27 @@ function loadSettings() {
     directUrl: localStorage.getItem(STORAGE_KEYS.directUrl) || "",
     voice: localStorage.getItem(STORAGE_KEYS.voice) || DEFAULT_VOICE,
     instructions: localStorage.getItem(STORAGE_KEYS.instructions) || DEFAULT_INSTRUCTIONS,
+    ttsInstruct: localStorage.getItem(STORAGE_KEYS.ttsInstruct) || "",
+    ttsTemperature: loadTtsNumber(STORAGE_KEYS.ttsTemperature, 0.9, 0, 1.5),
+    ttsTopP: loadTtsNumber(STORAGE_KEYS.ttsTopP, 1.0, 0.1, 1),
     noiseGate: loadGateThreshold(),
     // Default WebSocket: the proven path stays the first-run experience.
     transport: localStorage.getItem(STORAGE_KEYS.transport) === "webrtc" ? "webrtc" : "ws",
     audioInputId: localStorage.getItem(STORAGE_KEYS.audioInputId) || "",
     audioOutputId: localStorage.getItem(STORAGE_KEYS.audioOutputId) || "",
   };
+}
+
+/** Load a numeric TTS setting, clamped to [min,max], with a default fallback.
+ * Mirrors loadGateThreshold's null/NaN guarding. When `rawValue` is passed it
+ * is used directly (for reading from a form control); otherwise the value is
+ * read from localStorage under `key`. */
+function loadTtsNumber(key, def, min, max, rawValue) {
+  const stored = rawValue !== undefined ? rawValue : localStorage.getItem(key);
+  if (stored === null || stored === "") return def;
+  const raw = Number(stored);
+  if (!Number.isFinite(raw)) return def;
+  return Math.min(max, Math.max(min, raw));
 }
 
 /** Stored gate threshold (dBFS), clamped to the slider range. Defaults to a
@@ -149,6 +167,9 @@ function saveSettings(s) {
   localStorage.setItem(STORAGE_KEYS.directUrl, s.directUrl);
   localStorage.setItem(STORAGE_KEYS.voice, s.voice);
   localStorage.setItem(STORAGE_KEYS.instructions, s.instructions);
+  localStorage.setItem(STORAGE_KEYS.ttsInstruct, s.ttsInstruct || "");
+  localStorage.setItem(STORAGE_KEYS.ttsTemperature, String(s.ttsTemperature));
+  localStorage.setItem(STORAGE_KEYS.ttsTopP, String(s.ttsTopP));
   localStorage.setItem(STORAGE_KEYS.noiseGate, String(s.noiseGate));
   localStorage.setItem(STORAGE_KEYS.transport, s.transport);
   localStorage.setItem(STORAGE_KEYS.audioInputId, s.audioInputId || "");
@@ -283,6 +304,16 @@ const inputAudioOutput = $("#audio-output");
 const audioOutputHint = $("#audio-output-hint");
 /** @type {HTMLTextAreaElement} */
 const inputInstructions = $("#instructions");
+/** @type {HTMLTextAreaElement} */
+const inputTtsInstruct = $("#tts-instruct");
+/** @type {HTMLInputElement} */
+const inputTtsTemperature = $("#tts-temperature");
+/** @type {HTMLElement} */
+const ttsTempValue = $("#tts-temp-value");
+/** @type {HTMLInputElement} */
+const inputTtsTopP = $("#tts-top-p");
+/** @type {HTMLElement} */
+const ttsTopPValue = $("#tts-topp-value");
 /** @type {HTMLInputElement} */
 const inputNoiseGate = $("#noise-gate");
 /** @type {HTMLElement} */
@@ -478,10 +509,20 @@ function openSettings() {
   syncConnectionUi();
   inputVoice.value = settings.voice;
   inputInstructions.value = settings.instructions;
+  syncTtsUi();
   syncGateUi();
   updateRestartAvailability();
   void refreshAudioDeviceLists();
   settingsModal.showModal();
+}
+
+/** Populate the TTS param controls from the current settings + wire live labels. */
+function syncTtsUi() {
+  inputTtsInstruct.value = settings.ttsInstruct;
+  inputTtsTemperature.value = String(settings.ttsTemperature);
+  inputTtsTopP.value = String(settings.ttsTopP);
+  ttsTempValue.textContent = Number(settings.ttsTemperature).toFixed(2);
+  ttsTopPValue.textContent = Number(settings.ttsTopP).toFixed(2);
 }
 
 /** dB position (clamped to the slider axis) as a 0..1 fraction of the track.
@@ -1023,6 +1064,9 @@ function readSettingsFromForm() {
     directUrl: allowDirect && !pinnedUrl ? inputLbUrl.value.trim() : settings.directUrl,
     voice: inputVoice.value || DEFAULT_VOICE,
     instructions: inputInstructions.value.trim() || DEFAULT_INSTRUCTIONS,
+    ttsInstruct: inputTtsInstruct.value.trim(),
+    ttsTemperature: loadTtsNumber("__inline__", 0.9, 0, 1.5, inputTtsTemperature.value),
+    ttsTopP: loadTtsNumber("__inline__", 1.0, 0.1, 1, inputTtsTopP.value),
     noiseGate: readGateThreshold(),
     transport: /** @type {"ws" | "webrtc"} */ (
       transportSelectable()
@@ -1122,7 +1166,13 @@ settingsForm.addEventListener("submit", (event) => {
   // output can switch live when the browser supports AudioContext.setSinkId;
   // mic device changes need a Restart (new getUserMedia stream).
   if (client && LIVE_STATES.has(currentState)) {
-    client.updateSession({ voice: settings.voice, instructions: effectiveInstructions() });
+    client.updateSession({
+    voice: settings.voice,
+    instructions: effectiveInstructions(),
+    ttsInstruct: settings.ttsInstruct,
+    ttsTemperature: settings.ttsTemperature,
+    ttsTopP: settings.ttsTopP,
+  });
     if (typeof client.setAudioOutputDevice === "function") {
       void client.setAudioOutputDevice(settings.audioOutputId);
     }
@@ -1133,6 +1183,14 @@ settingsForm.addEventListener("submit", (event) => {
 // update the label/marker, persist, and push straight to the running client.
 inputNoiseGate.addEventListener("input", () => {
   setGateThreshold(readGateThreshold());
+});
+
+// TTS param sliders: live-update the numeric readout next to each label.
+inputTtsTemperature.addEventListener("input", () => {
+  ttsTempValue.textContent = Number(inputTtsTemperature.value).toFixed(2);
+});
+inputTtsTopP.addEventListener("input", () => {
+  ttsTopPValue.textContent = Number(inputTtsTopP.value).toFixed(2);
 });
 
 // Transport persists on change (like the gate) and takes effect on the next
@@ -1436,6 +1494,9 @@ async function doStart(audioContext = null) {
   const common = {
     voice: settings.voice,
     instructions: effectiveInstructions(),
+    ttsInstruct: settings.ttsInstruct,
+    ttsTemperature: settings.ttsTemperature,
+    ttsTopP: settings.ttsTopP,
     startupGreeting,
     acquireMic: acquireMicStream,
     tools: activeToolDefs(),

--- a/demo/rtc/s2s-rtc-client.js
+++ b/demo/rtc/s2s-rtc-client.js
@@ -44,6 +44,9 @@
  *   candidates only — fine locally, may not traverse NATs).
  * @property {string} voice
  * @property {string} instructions
+ * @property {string} [ttsInstruct] Optional mood/tone instruction for Qwen3-TTS.
+ * @property {number} [ttsTemperature] Qwen3-TTS sampling temperature (0..1.5).
+ * @property {number} [ttsTopP] Qwen3-TTS top_p sampling (0.1..1).
  * @property {string} [startupGreeting] Hidden user prompt that asks the model
  *   to greet once after the initial session configuration is sent.
  * @property {MediaStream} [micStream] Live mic stream. Provide this OR `acquireMic`.
@@ -675,16 +678,20 @@ export class S2sRtcRealtimeClient extends EventTarget {
   }
 
   _sendSessionUpdate() {
-    // Minimal payload, exactly like the WS client: the server's pydantic
-    // validator rejects the whole event on unknown sub-field shapes.
+    // Minimal payload, like the WS client. Extra keys under audio.output
+    // (temperature/top_p) and at session top level (tts_instruct) are accepted
+    // as pydantic extras (OpenAI SDK models use extra='allow').
+    /** @type {Record<string, any>} */
+    const output = { voice: this.options.voice };
+    if (this.options.ttsTemperature !== undefined) output.temperature = this.options.ttsTemperature;
+    if (this.options.ttsTopP !== undefined) output.top_p = this.options.ttsTopP;
     /** @type {Record<string, any>} */
     const session = {
       type: "realtime",
       instructions: this.options.instructions,
-      audio: {
-        output: { voice: this.options.voice },
-      },
+      audio: { output },
     };
+    if (this.options.ttsInstruct) session.tts_instruct = this.options.ttsInstruct;
     if (this._tools.length) {
       session.tools = this._tools;
       session.tool_choice = "auto";
@@ -698,7 +705,12 @@ export class S2sRtcRealtimeClient extends EventTarget {
     /** @type {Record<string, any>} */
     const session = { type: "realtime" };
     if (patch.instructions) session.instructions = patch.instructions;
-    if (patch.voice) session.audio = { output: { voice: patch.voice } };
+    const output = {};
+    if (patch.voice !== undefined) output.voice = patch.voice;
+    if (patch.ttsTemperature !== undefined) output.temperature = patch.ttsTemperature;
+    if (patch.ttsTopP !== undefined) output.top_p = patch.ttsTopP;
+    if (Object.keys(output).length) session.audio = { output };
+    if (patch.ttsInstruct !== undefined) session.tts_instruct = patch.ttsInstruct;
     if (Object.keys(session).length > 1) {
       this._send({ type: "session.update", session });
     }

--- a/demo/style.css
+++ b/demo/style.css
@@ -1417,6 +1417,19 @@ body.cam-on .footer {
 .field textarea {
   min-height: 84px;
 }
+/* Range sliders for TTS params: drop the input border/padding, keep compact. */
+.field input[type="range"] {
+  padding: 0;
+  border: none;
+  background: transparent;
+  height: 28px;
+  cursor: pointer;
+  accent-color: var(--text-dim);
+}
+/* Short mood-instruction textarea stays compact. */
+.field textarea#tts-instruct {
+  min-height: 44px;
+}
 .field input:focus,
 .field select:focus,
 .field textarea:focus {

--- a/demo/ws/s2s-ws-client.js
+++ b/demo/ws/s2s-ws-client.js
@@ -51,6 +51,9 @@
  *   session POST and dials it directly — no load balancer in between.
  * @property {string} voice
  * @property {string} instructions
+ * @property {string} [ttsInstruct] Optional mood/tone instruction for Qwen3-TTS.
+ * @property {number} [ttsTemperature] Qwen3-TTS sampling temperature (0..1.5).
+ * @property {number} [ttsTopP] Qwen3-TTS top_p sampling (0.1..1).
  * @property {string} [startupGreeting] Hidden user prompt that asks the model
  *   to greet once after the initial session configuration is sent.
  * @property {MediaStream} [micStream] Live mic stream. Provide this OR `acquireMic`.
@@ -945,18 +948,23 @@ export class S2sWsRealtimeClient extends EventTarget {
     // Minimal payload: only the bits the user is allowed to configure.
     // The s2s server already defaults to server_vad, whisper-1
     // transcription, 16 kHz PCM input and 24 kHz PCM output, so we don't
-    // need (and must not send) `audio.input.format`, `audio.input.transcription`,
-    // `audio.input.turn_detection` or `audio.output.format`: the pydantic
-    // validator on the server rejects the whole event if any unknown or
-    // future-shaped sub-field shows up.
+    // need `audio.input.format`, `audio.input.transcription`,
+    // `audio.input.turn_detection` or `audio.output.format`.
+    // NOTE: the OpenAI SDK models use extra='allow', so extra keys under
+    // audio.output (temperature/top_p) and at the session top level
+    // (tts_instruct) are accepted as pydantic extras — they don't reject the
+    // event. The Qwen3-TTS handler reads them via __pydantic_extra__.
+    /** @type {Record<string, any>} */
+    const output = { voice: this.options.voice };
+    if (this.options.ttsTemperature !== undefined) output.temperature = this.options.ttsTemperature;
+    if (this.options.ttsTopP !== undefined) output.top_p = this.options.ttsTopP;
     /** @type {Record<string, any>} */
     const session = {
       type: "realtime",
       instructions: this.options.instructions,
-      audio: {
-        output: { voice: this.options.voice },
-      },
+      audio: { output },
     };
+    if (this.options.ttsInstruct) session.tts_instruct = this.options.ttsInstruct;
     // Tools are declared here; the backend already accepts them in
     // session.update and emits response.function_call_arguments.done when the
     // model decides to call one. Only include the keys when we actually have
@@ -974,7 +982,14 @@ export class S2sWsRealtimeClient extends EventTarget {
     /** @type {Record<string, any>} */
     const session = { type: "realtime" };
     if (patch.instructions) session.instructions = patch.instructions;
-    if (patch.voice) session.audio = { output: { voice: patch.voice } };
+    // Merge voice + ttsTemperature/top_p into one audio.output object so a
+    // partial update (e.g. only temperature) doesn't clobber the others.
+    const output = {};
+    if (patch.voice !== undefined) output.voice = patch.voice;
+    if (patch.ttsTemperature !== undefined) output.temperature = patch.ttsTemperature;
+    if (patch.ttsTopP !== undefined) output.top_p = patch.ttsTopP;
+    if (Object.keys(output).length) session.audio = { output };
+    if (patch.ttsInstruct !== undefined) session.tts_instruct = patch.ttsInstruct;
     if (Object.keys(session).length > 1) {
       this._send({ type: "session.update", session });
     }

--- a/src/speech_to_speech/TTS/qwen3_tts_handler.py
+++ b/src/speech_to_speech/TTS/qwen3_tts_handler.py
@@ -132,6 +132,10 @@ class Qwen3TTSHandler(BaseHandler[TTSIn, TTSOut]):
         self.language = self._normalize_language(language)
         self.speaker = speaker
         self.instruct = instruct
+        # Generation sampling params. Defaults match faster-qwen3-tts; overridable
+        # per-session via _apply_session_tts_overrides (from session.update extras).
+        self.temperature: float = 0.9
+        self.top_p: float = 1.0
         self.xvec_only = xvec_only
         self.parity_mode = parity_mode
         self.non_streaming_mode = non_streaming_mode
@@ -540,6 +544,47 @@ class Qwen3TTSHandler(BaseHandler[TTSIn, TTSOut]):
             session_voice,
         )
 
+    def _apply_session_tts_overrides(
+        self,
+        runtime_config: RuntimeConfig | None = None,
+        response: RealtimeResponseCreateParams | None = None,
+    ) -> None:
+        """Apply per-session TTS generation overrides sent via session.update.
+
+        Mirrors _apply_session_voice_override: reads temperature/top_p from
+        audio.output (where they ride as pydantic extras, since the OpenAI SDK
+        models are extra='allow') and tts_instruct from the session top level.
+        Per-response values (response.create) take priority over the session
+        default. Only non-None values override; unset fields keep the current
+        value so partial updates are safe.
+        """
+        # Resolve audio.output from per-response override first, else session.
+        output = None
+        if response and response.audio and response.audio.output:
+            output = response.audio.output
+        elif runtime_config is not None:
+            audio = runtime_config.session.audio
+            output = audio.output if audio is not None else None
+
+        if output is not None:
+            # Extras set by extra='allow' are accessible as attributes.
+            temp = getattr(output, "temperature", None)
+            if isinstance(temp, (int, float)):
+                self.temperature = float(temp)
+            top_p = getattr(output, "top_p", None)
+            if isinstance(top_p, (int, float)):
+                self.top_p = float(top_p)
+
+        # tts_instruct lives at the session top level (it is a generation
+        # instruction, not an audio-output attribute).
+        sess_instruct: Optional[str] = None
+        if response is not None:
+            sess_instruct = getattr(response, "tts_instruct", None)
+        if not sess_instruct and runtime_config is not None:
+            sess_instruct = getattr(runtime_config.session, "tts_instruct", None)
+        if sess_instruct:
+            self.instruct = str(sess_instruct)
+
     def warmup(self) -> None:
         logger.info(f"Warming up {self.__class__.__name__}")
 
@@ -801,6 +846,7 @@ class Qwen3TTSHandler(BaseHandler[TTSIn, TTSOut]):
 
         model_type = self._model_type()
         self._apply_session_voice_override(model_type, runtime_config, response)
+        self._apply_session_tts_overrides(runtime_config, response)
 
         console.print(f"[green]ASSISTANT: {text}")
 
@@ -900,6 +946,8 @@ class Qwen3TTSHandler(BaseHandler[TTSIn, TTSOut]):
                 max_new_tokens=utterance_max_new_tokens,
                 parity_mode=self.parity_mode,
                 non_streaming_mode=self.non_streaming_mode,
+                temperature=self.temperature,
+                top_p=self.top_p,
             ),
             label="voice_clone_parity" if self.parity_mode else "voice_clone",
         )
@@ -934,6 +982,8 @@ class Qwen3TTSHandler(BaseHandler[TTSIn, TTSOut]):
                 chunk_size=self.streaming_chunk_size,
                 max_new_tokens=utterance_max_new_tokens,
                 non_streaming_mode=self.non_streaming_mode,
+                temperature=self.temperature,
+                top_p=self.top_p,
             ),
             label="custom_voice",
         )
@@ -959,6 +1009,8 @@ class Qwen3TTSHandler(BaseHandler[TTSIn, TTSOut]):
                 chunk_size=self.streaming_chunk_size,
                 max_new_tokens=utterance_max_new_tokens,
                 non_streaming_mode=self.non_streaming_mode,
+                temperature=self.temperature,
+                top_p=self.top_p,
             ),
             label="voice_design",
         )


### PR DESCRIPTION
## Problem

The Qwen3-TTS handler never forwarded `temperature`, `top_p`, or `instruct` to the `faster-qwen3-tts` `generate_*_streaming` calls — they stayed locked at the library defaults (`temperature=0.9`, `top_p=1.0`). At that temperature the synthesized mood swings widely: a trailing ellipsis in an LLM reply can trigger an unwanted emotional tone (e.g. a crying/tearful delivery for a sentence ending in `…`), with no way for the client to tame it.

## Change

Expose the three generation knobs end-to-end so they are configurable per session:

**Backend** (`qwen3_tts_handler.py`)
- Add `temperature` / `top_p` instance attributes and reuse the existing `instruct`.
- New `_apply_session_tts_overrides()`, mirroring `_apply_session_voice_override()`: reads `temperature`/`top_p` from `audio.output` and `tts_instruct` from the session top level (per-response overrides take priority over the session default).
- Thread them into all three generate paths (`custom_voice`, `voice_design`, `voice_clone`).

**Demo client** (`index.html`, `main.js`, `style.css`, `ws/` + `rtc/` clients)
- New Settings controls: a "TTS mood instruction" textarea + `temperature` (0–1.5) and `top_p` (0.1–1) sliders, persisted in `localStorage` and applied live via `updateSession()` without a reconnect.

## How the params travel

The OpenAI SDK realtime pydantic models default to `extra='allow'`, so `audio.output.temperature` / `audio.output.top_p` and a top-level `session.tts_instruct` are accepted as `__pydantic_extra__` — no changes to the session model or `runtime_config.py` validation were needed. The handler reads them via `getattr`.

## Verification

- All three JS files pass `node --check`.
- Backend `import` of the handler succeeds.
- End-to-end: sent a `session.update` carrying `temperature=0.3`, `top_p=0.8`, `tts_instruct="…"` over WebSocket → no validation error, the Qwen3-TTS handler consumed them and synthesized audio (`response.done`, audio deltas received).

## Commits

Split by layer: backend handler / demo HTML+CSS / demo `main.js` / demo WS+RTC clients.