### PR TITLE
fix: keep non-ASCII punctuation and combining marks in remove_unspeechable

### DIFF
--- a/src/speech_to_speech/LLM/utils.py
+++ b/src/speech_to_speech/LLM/utils.py
@@ -1,6 +1,7 @@
 import base64
 import io
 import re
+import unicodedata
 from typing import Optional
 
 import requests  # type: ignore[import-untyped]
@@ -20,13 +21,35 @@ SPEECHABLE_PATTERN = re.compile(
     flags=re.UNICODE,
 )
 
+# Unicode general categories kept in addition to the ASCII allow-list above:
+#   P*  every punctuation class (connector, dash, open/close, quotes, other)
+#   M*  combining marks, which are part of the preceding letter
+#   Sc  currency symbols
+# The allow-list only enumerates ASCII marks, so without this ``。、？「」``
+# (CJK), ``।`` (Devanagari), ``¿¡`` (Spanish), ``«»`` (French/German) and
+# ``،؟`` (Arabic) would be deleted. Marks matter even more: ``\w`` does not
+# match them, so Devanagari matras and the virama were being stripped out of
+# the middle of words (``नमस्ते`` -> ``नमसत``), as were Arabic/Hebrew
+# diacritics and any NFD-decomposed accent. Emoji and other symbols are
+# category ``So``/``Sm``/``Sk`` and stay excluded.
+SPEECHABLE_UNICODE_CATEGORIES = frozenset({"Pc", "Pd", "Pe", "Pf", "Pi", "Po", "Ps", "Mc", "Me", "Mn", "Sc"})
+
+
+def _strip_unspeechable(match: "re.Match[str]") -> str:
+    char = match.group()
+    return char if unicodedata.category(char) in SPEECHABLE_UNICODE_CATEGORIES else ""
+
 
 def remove_unspeechable(text: str) -> str:
     """Keep only speechable characters: letters, digits, punctuation, whitespace.
     support unicode characters (english, arabic, chinese, japanese, korean, etc.)
     """
     text = text.translate(SMART_PUNCT_TRANSLATION)
-    return SPEECHABLE_PATTERN.sub("", text)
+    # The regex is a fast pre-filter: ASCII-only text matches nothing and pays
+    # no per-character cost. Anything it does match is kept only when Unicode
+    # says it is punctuation or currency, so non-ASCII sentence marks survive
+    # while emoji and other symbols are still dropped.
+    return SPEECHABLE_PATTERN.sub(_strip_unspeechable, text)
 
 
 # Maps an STT language code to the language name used in the "Please reply ... in {name}"

--- a/tests/test_llm_utils.py
+++ b/tests/test_llm_utils.py
@@ -1,4 +1,5 @@
 import importlib
+import unicodedata
 
 import pytest
 
@@ -15,6 +16,37 @@ def test_remove_unspeechable_normalizes_smart_apostrophes() -> None:
 
 def test_remove_unspeechable_keeps_text_and_drops_emoji() -> None:
     assert remove_unspeechable("Hello 👋 lobster 🦞") == "Hello  lobster "
+
+
+@pytest.mark.parametrize(
+    "text",
+    [
+        "你好。今天天气怎么样？",  # zh — ideographic full stop / fullwidth question mark
+        "こんにちは。元気ですか？",  # ja
+        "안녕하세요。「반갑습니다」",  # ko — corner brackets
+        "नमस्ते। आप कैसे हैं?",  # hi — devanagari danda
+        "¿Cómo estás? ¡Bien!",  # es — inverted marks
+        "Er sagte: «Guten Tag»",  # de/fr — guillemets
+        "مرحبا، كيف حالك؟",  # ar — arabic comma / question mark
+    ],
+)
+def test_remove_unspeechable_keeps_non_ascii_sentence_punctuation(text: str) -> None:
+    """Sentence punctuation outside ASCII must survive: it reaches the TTS, the
+    client transcript and the chat history, so dropping it flattens prosody and
+    corrupts the conversation for every non-English language we support."""
+    assert remove_unspeechable(text) == text
+
+
+def test_remove_unspeechable_keeps_combining_marks() -> None:
+    """``\\w`` does not match combining marks, so they were stripped from the
+    middle of words: Devanagari matras/virama, Arabic and Hebrew diacritics, and
+    NFD-decomposed Latin accents."""
+    assert remove_unspeechable("नमस्ते") == "नमस्ते"
+    assert remove_unspeechable(unicodedata.normalize("NFD", "café")) == unicodedata.normalize("NFD", "café")
+
+
+def test_remove_unspeechable_drops_symbols_but_keeps_punctuation() -> None:
+    assert remove_unspeechable("100 % ✅ done。") == "100 %  done。"
 
 
 # --- language name coverage ---------------------------------------------------------------


### PR DESCRIPTION
## The bug

`SPEECHABLE_PATTERN` (`src/speech_to_speech/LLM/utils.py:18`) is an allow-list, but it enumerates only **ASCII** punctuation. Everything else falls into the negated class and is deleted — despite the docstring promising support for *"english, arabic, chinese, japanese, korean, etc."*.

`remove_unspeechable` runs on every audio turn (`base_openai_compatible_language_model.py:382,428`, `language_model.py:457`), and the cleaned string is what reaches the **TTS**, the **client transcript** (`lm_output_processor.py:124-135` builds `AssistantTextEvent` from it) and — on the local backends — the **committed chat history** (`language_model.py:561`). So the loss is user-visible and, for local backends, permanent across turns.

### 1. Sentence punctuation is dropped for most supported languages

```
'你好。今天天气怎么样？'  -> '你好今天天气怎么样'
'こんにちは。元気ですか？' -> 'こんにちは元気ですか'
'¿Cómo estás? ¡Bien!'     -> 'Cómo estás? Bien!'
'مرحبا، كيف حالك؟'        -> 'مرحبا كيف حالك'
```

ASCII `.` `,` `!` `?` are explicitly *kept*, so preserving sentence punctuation is clearly the intent — the non-ASCII forms just fall through. Losing them flattens TTS prosody and degrades downstream sentence splitting.

### 2. Combining marks are stripped from the middle of words

`\w` does not match combining marks, so they match the negated class too. Hindi is a supported language (`hi` in `WHISPER_LANGUAGE_TO_LLM_LANGUAGE`, and `parakeet-tdt`, the default STT, reports it):

```
'नमस्ते' -> 'नमसत'
```

The matras and the virama are gone — the word is mangled, not merely unpunctuated. The same applies to Arabic/Hebrew diacritics and to any NFD-decomposed Latin accent (`café` in NFD → `cafe`).

Repro against `main`:

```python
from speech_to_speech.LLM.utils import remove_unspeechable
assert remove_unspeechable("नमस्ते।") == "नमस्ते।"   # fails: 'नमसत'
```

## The fix

Keep the regex as a **fast pre-filter** — ASCII-only text still matches nothing and pays no per-character cost — and decide each matched character by its Unicode general category, keeping punctuation (`P*`), combining marks (`M*`) and currency (`Sc`).

Emoji and other symbols are `So`/`Sm`/`Sk` and are still dropped. Because the regex only *matches* characters that are removed today, the callback can only ever keep **more** — this is strictly a superset of the previous behaviour, so no character that used to be kept is now removed.

## Tests

Added to `tests/test_llm_utils.py`: zh/ja/ko/hi/es/de/ar sentence punctuation, combining marks (Devanagari + NFD Latin), and a guard that emoji and other symbols are still removed. All 8 new assertions fail on `main` and pass here.

`ruff check`, `ruff format --check`, `mypy src/` and the full `pytest tests/` suite are green (735 passed, 1 skipped — 726 before this change).