### PR TITLE
fix: carry a split PCM16 sample across appends instead of raising

### DIFF
--- a/src/speech_to_speech/api/openai_realtime/handlers/audio.py
+++ b/src/speech_to_speech/api/openai_realtime/handlers/audio.py
@@ -72,9 +72,21 @@ class AudioHandler(RealtimeBaseHandler):
         one place regardless of how audio arrives.
         """
         st = self._state(conn_id)
-        pcm_bytes = resample(pcm_bytes, src_rate, PIPELINE_SAMPLE_RATE)
 
-        pcm_bytes = st.audio_remainder + pcm_bytes
+        # PCM16 is two bytes per sample, but nothing guarantees an append lands
+        # on a sample boundary: a client is free to split a sample across two
+        # ``input_audio_buffer.append`` events, and ``base64.b64decode`` happily
+        # returns an odd number of bytes. Carry the stray byte over to the next
+        # append so ``resample``'s ``np.frombuffer(..., np.int16)`` never sees an
+        # odd-length buffer — it raises ``ValueError`` there, outside
+        # ``handle_audio_append``'s try/except, which tears down the session.
+        raw = st.pcm_byte_remainder + pcm_bytes
+        if len(raw) % 2:
+            st.pcm_byte_remainder, raw = raw[-1:], raw[:-1]
+        else:
+            st.pcm_byte_remainder = b""
+
+        pcm_bytes = st.audio_remainder + resample(raw, src_rate, PIPELINE_SAMPLE_RATE)
 
         chunks = []
         for i in range(0, len(pcm_bytes), CHUNK_SIZE_BYTES):

--- a/src/speech_to_speech/api/openai_realtime/service.py
+++ b/src/speech_to_speech/api/openai_realtime/service.py
@@ -164,6 +164,9 @@ class ConnState(BaseModel):
     response_pending: bool = False
     audio_buffer_has_data: bool = False
     audio_remainder: bytes = b""
+    # Trailing byte of a PCM16 sample split across two appends, held at the
+    # client's sample rate until its other half arrives (see ``append_pcm``).
+    pcm_byte_remainder: bytes = b""
     current_response_id: Optional[str] = None
     current_item_id: Optional[str] = None
     content_index: int = 0

--- a/tests/openai_realtime/test_webrtc.py
+++ b/tests/openai_realtime/test_webrtc.py
@@ -123,6 +123,36 @@ class TestAppendPcm:
         unit.service.append_pcm(conn_id, b"\x01\x00" * 512, PIPELINE_SAMPLE_RATE)
         assert unit.service.handle_audio_commit(conn_id) is None
 
+    def test_odd_length_append_at_a_non_pipeline_rate_does_not_raise(self):
+        """A client may split a PCM16 sample across two appends.
+
+        ``resample`` does ``np.frombuffer(..., np.int16)``, which raises
+        ``ValueError`` on an odd-length buffer. That raise is outside
+        ``handle_audio_append``'s try/except and unwinds the websocket receive
+        loop, tearing down the whole session. 24 kHz is the OpenAI Realtime
+        default input rate, so a spec-following client reaches this path.
+        """
+        unit = _make_unit()
+        conn_id = unit.service.register()
+
+        # 1024 well-formed bytes plus the low half of one more sample.
+        unit.service.append_pcm(conn_id, b"\x01\x00" * 512 + b"\xff", 24000)
+        # The next append supplies its high half.
+        unit.service.append_pcm(conn_id, b"\x7f" + b"\x02\x00" * 512, 24000)
+
+    def test_split_sample_is_reassembled_across_appends(self):
+        """The byte held back from an odd-length append must be paired with the
+        byte that follows it, not dropped and not left to shift the stream."""
+        unit = _make_unit()
+        conn_id = unit.service.register()
+
+        unit.service.append_pcm(conn_id, b"\x01\x00" * 512 + b"\xff", PIPELINE_SAMPLE_RATE)
+        chunks = unit.service.append_pcm(conn_id, b"\x7f" + b"\x02\x00" * 512, PIPELINE_SAMPLE_RATE)
+
+        assert [len(c) for c in chunks] == [CHUNK_SIZE_BYTES]
+        assert chunks[0][:4] == b"\xff\x7f\x02\x00"
+        assert len(unit.service._state(conn_id).audio_remainder) % 2 == 0
+
 
 # ---------------------------------------------------------------------------
 # PcmResampler


### PR DESCRIPTION
## The bug

`append_pcm` (`src/speech_to_speech/api/openai_realtime/handlers/audio.py:65`) chunks the client's audio **by bytes**, but PCM16 is two bytes per sample and nothing makes an append land on a sample boundary. A client may legitimately split a sample across two `input_audio_buffer.append` events, and `base64.b64decode` returns whatever byte count it is handed:

```python
>>> len(base64.b64decode("AAAA"))
3
```

When the client's rate differs from the pipeline rate, that odd-length buffer reaches `resample` (`api/openai_realtime/utils.py:9`):

```python
samples = np.frombuffer(audio_int16, dtype=np.int16).astype(np.float32) / 32768.0
# ValueError: buffer size must be a multiple of element size
```

The raise is **outside** `handle_audio_append`'s `try/except` (which only guards `b64decode`). It propagates through `_dispatch_client_event` and out of the websocket receive loop, whose only recovery arm is `except asyncio.TimeoutError`; the route's blanket `except Exception` (`websocket_router.py:496`) then falls through to `_release_session`. **The client gets no `error` event, just a close, and the whole conversation — chat history and response state — is destroyed.**

**24 kHz is the OpenAI Realtime default input rate**, so a spec-following client is on this path. Only a client running at the pipeline's own 16 kHz escapes it, because `resample` returns early without touching numpy.

Repro against `main`:

```python
svc.append_pcm(conn_id, b"\x01\x00" * 512 + b"\xff", 24000)   # ValueError
```

## The fix

Hold a trailing odd byte back at the **client's** sample rate, before resampling, and pair it with the byte that follows it in the next append. One new `ConnState` field carries it; `ConnState` is constructed fresh per `register()`, so no reset hook is needed.

The 16 kHz path is unchanged — it already reassembled split samples correctly, since the carried `audio_remainder` is re-prefixed to the next append and numpy is never reached.

## Scope note

The guard is placed at `append_pcm`, the single point where untrusted bytes enter, rather than inside `resample`. `resample`'s only other caller is the outbound path (`audio.py:211`), which is fed by our own pipeline and is always sample-aligned.

## Tests

Added to `tests/openai_realtime/test_webrtc.py::TestAppendPcm`: the 24 kHz crash (fails on `main` with the `ValueError` above) and correct reassembly of a sample split across two appends.

`ruff check`, `ruff format --check`, `mypy src/` and the full `pytest tests/` suite are green (728 passed, 1 skipped — 726 before this change).