### PR TITLE
Preserve ordered assistant output across text and tool calls

### DIFF
--- a/src/speech_to_speech/LLM/language_model.py
+++ b/src/speech_to_speech/LLM/language_model.py
@@ -49,6 +49,7 @@ from speech_to_speech.LLM.voice_prompt import build_voice_system_prompt
 from speech_to_speech.pipeline.cancel_scope import CancelScope
 from speech_to_speech.pipeline.handler_types import LLMIn, LLMOut
 from speech_to_speech.pipeline.messages import (
+    AssistantToolCallPart,
     EndOfResponse,
     GenerateResponseRequest,
     LLMResponseChunk,
@@ -308,7 +309,7 @@ class BaseLanguageModelHandler(BaseHandler[LLMIn, LLMOut], ABC):
         """
         chunks: list[LLMResponseChunk] = []
 
-        if ctx.enter_code and ctx.enter_code in printable_text:
+        while ctx.enter_code and ctx.enter_code in printable_text:
             idx = printable_text.index(ctx.enter_code)
             before = printable_text[:idx]
             code_and_after = printable_text[idx:]
@@ -329,44 +330,36 @@ class BaseLanguageModelHandler(BaseHandler[LLMIn, LLMOut], ABC):
                     )
                 )
                 ctx.sentence_batch = []
-            if ctx.block_regex and ctx.end_code and ctx.end_code in code_and_after:
-                stripped, func_calls = extract_function_calls_from_text(
-                    code_and_after,
-                    ctx.block_regex,
-                )
-                parsed_tools: list[ResponseFunctionToolCall] = []
-                for fc in func_calls:
-                    if tools:
-                        logger.warning(
-                            "Skipping extra tool call '%s'; only one tool call is allowed per response",
-                            fc.function_name,
-                        )
-                        continue
-                    try:
-                        tool_call = fc.to_realtime_function_tool_call(ctx.function_tools)
-                    except ValueError as e:
-                        logger.warning("Skipping invalid tool call: %s", e)
-                        continue
-                    tools.append(tool_call)
-                    parsed_tools.append(tool_call)
-                if parsed_tools:
-                    chunks.append(
-                        LLMResponseChunk(
-                            text="",
-                            language_code=language_code,
-                            tools=parsed_tools,
-                            runtime_config=runtime_config,
-                            response=response,
-                            turn_id=ctx.turn_id,
-                            turn_revision=ctx.turn_revision,
-                            speech_stopped_at_s=ctx.speech_stopped_at_s,
-                            cancel_generation=ctx.cancel_generation,
-                        )
+            if not ctx.block_regex or not ctx.end_code or ctx.end_code not in code_and_after:
+                # Preserve the incomplete block until more streamed text arrives.
+                return chunks, tools, code_and_after
+
+            block_end = code_and_after.index(ctx.end_code) + len(ctx.end_code)
+            complete_block = code_and_after[:block_end]
+            printable_text = code_and_after[block_end:]
+            _, func_calls = extract_function_calls_from_text(complete_block, ctx.block_regex)
+            parsed_tools: list[ResponseFunctionToolCall] = []
+            for fc in func_calls:
+                try:
+                    tool_call = fc.to_realtime_function_tool_call(ctx.function_tools)
+                except ValueError as e:
+                    logger.warning("Skipping invalid tool call: %s", e)
+                    continue
+                tools.append(tool_call)
+                parsed_tools.append(tool_call)
+            if parsed_tools:
+                chunks.append(
+                    LLMResponseChunk(
+                        parts=[AssistantToolCallPart(tool=tool_call) for tool_call in parsed_tools],
+                        language_code=language_code,
+                        runtime_config=runtime_config,
+                        response=response,
+                        turn_id=ctx.turn_id,
+                        turn_revision=ctx.turn_revision,
+                        speech_stopped_at_s=ctx.speech_stopped_at_s,
+                        cancel_generation=ctx.cancel_generation,
                     )
-                printable_text = stripped
-            else:
-                printable_text = code_and_after
-            return chunks, tools, printable_text
+                )
 
         if printable_text and not response_wants_audio(response) and ctx.enter_code is None:
             # Text-only with no tool block: stream the raw text immediately. No TTS

--- a/src/speech_to_speech/LLM/lm_output_processor.py
+++ b/src/speech_to_speech/LLM/lm_output_processor.py
@@ -15,7 +15,7 @@ from queue import Queue
 from speech_to_speech.baseHandler import BaseHandler
 from speech_to_speech.pipeline.events import AssistantTextEvent, ResponseFailedEvent, TokenUsageEvent
 from speech_to_speech.pipeline.handler_types import LLMOut, TTSIn
-from speech_to_speech.pipeline.messages import EndOfResponse, LLMResponseChunk, TokenUsage, TTSInput
+from speech_to_speech.pipeline.messages import AssistantTextPart, EndOfResponse, LLMResponseChunk, TokenUsage, TTSInput
 from speech_to_speech.pipeline.queue_types import TextEventItem
 from speech_to_speech.pipeline.speculative_turns import SpeculativeTurnTracker
 from speech_to_speech.utils.utils import response_wants_audio
@@ -118,11 +118,11 @@ class LMOutputProcessor(BaseHandler[LLMOut, TTSIn]):
             logger.debug("Dropping stale LLM chunk for turn=%s rev=%s", lm_output.turn_id, lm_output.turn_revision)
             return
 
-        logger.debug(f"LM processor: text='{lm_output.text}', tools={lm_output.tools}")
+        logger.debug("LM processor: parts=%s", lm_output.parts)
 
         if self.text_output_queue is not None:
             event = AssistantTextEvent(
-                text=lm_output.text,
+                parts=lm_output.parts,
                 turn_id=lm_output.turn_id,
                 turn_revision=lm_output.turn_revision,
                 cancel_generation=lm_output.cancel_generation,
@@ -134,15 +134,18 @@ class LMOutputProcessor(BaseHandler[LLMOut, TTSIn]):
                 logger.debug(f"Sending to clients: text='{lm_output.text}' (no tools)")
             self.text_output_queue.put(event)
 
-        if lm_output.text and response_wants_audio(lm_output.response):
-            logger.debug(f"Forwarding to TTS: '{lm_output.text}'")
-            yield TTSInput(
-                text=lm_output.text,
-                language_code=lm_output.language_code,
-                runtime_config=lm_output.runtime_config,
-                response=lm_output.response,
-                turn_id=lm_output.turn_id,
-                turn_revision=lm_output.turn_revision,
-                speech_stopped_at_s=lm_output.speech_stopped_at_s,
-                cancel_generation=lm_output.cancel_generation,
-            )
+        if response_wants_audio(lm_output.response):
+            for part in lm_output.parts:
+                if not isinstance(part, AssistantTextPart) or not part.text:
+                    continue
+                logger.debug("Forwarding to TTS: '%s'", part.text)
+                yield TTSInput(
+                    text=part.text,
+                    language_code=lm_output.language_code,
+                    runtime_config=lm_output.runtime_config,
+                    response=lm_output.response,
+                    turn_id=lm_output.turn_id,
+                    turn_revision=lm_output.turn_revision,
+                    speech_stopped_at_s=lm_output.speech_stopped_at_s,
+                    cancel_generation=lm_output.cancel_generation,
+                )

--- a/src/speech_to_speech/LLM/tool_call/tool_prompt.py
+++ b/src/speech_to_speech/LLM/tool_call/tool_prompt.py
@@ -34,7 +34,7 @@ Available tools:
 {{ tool.to_code_prompt() }}
 
 {% endfor %}
-To call a tool, put exactly one named-argument function call inside {{ enter_code }}...{{ end_code }}:
+To call tools, put each named-argument function call inside its own {{ enter_code }}...{{ end_code }} block:
 {{ enter_code }}function_name(required_arg='value'){{ end_code }}
 
 Rules:
@@ -42,7 +42,7 @@ Rules:
 - For expression/background tools, always speak first. For requested expressions, use a short pattern like "Sure, here's my best <emotion>."; otherwise use a fitting empathetic sentence.
 - Do not mention tags, functions, or tools. Keep prose outside tags brief, and do not claim tool results before a tool result is available.
 - Use named arguments only; quote strings. Omit optional args instead of placeholder values like "random", "none", "", or null.
-- Only one tool call may appear in a response.\
+- Keep every tool call in a separate block and preserve the intended text/tool order.\
 """,
     keep_trailing_newline=True,
 )
@@ -57,14 +57,14 @@ Available tools:
 {{ tool.to_code_prompt() }}
 
 {% endfor %}
-To call a tool, put exactly one named-argument function call inside {{ enter_code }}...{{ end_code }}:
+To call tools, put each named-argument function call inside its own {{ enter_code }}...{{ end_code }} block:
 {{ enter_code }}function_name(required_arg='value'){{ end_code }}
 
 Rules:
 - Call a tool directly when it helps fulfill the request; no preamble sentence is required.
 - Do not mention tags, functions, or tools in your prose, and do not claim tool results before a tool result is available.
 - Use named arguments only; quote strings. Omit optional args instead of placeholder values like "random", "none", "", or null.
-- Only one tool call may appear in a response.\
+- Keep every tool call in a separate block and preserve the intended text/tool order.\
 """,
     keep_trailing_newline=True,
 )

--- a/src/speech_to_speech/LLM/voice_prompt.py
+++ b/src/speech_to_speech/LLM/voice_prompt.py
@@ -10,7 +10,7 @@ VOICE_SYSTEM_PROMPT_TAIL = """\
 - Keep replies brief by default: usually one spoken sentence, two if needed. Go longer only when asked.
 - Speak naturally. No markdown, bullets, headings, visual formatting, or action/emote text like *laughs*.
 - Treat transcripts as noisy. Correct likely mishearings only if asked or meaning depends on it.
-- Speech is the default. Use at most one tool when it helps fulfill the request or clearly fits the moment.
+- Speech is the default. Use tools when they help fulfill the request or clearly fit the moment.
 - Before a tool call, use a brief natural utterance unless the user asked for silence or tool-only output. For slow information tools, briefly say that you will check.
 - For expression/background tools, speak first. If asked to show an expression, use a short pattern like "Sure, here's my best <emotion>." Otherwise use a fitting empathetic sentence. Never mention tools.
 - After completed expression/background/physical-action tools, do not add a second spoken comment unless the result has user-facing information.

--- a/src/speech_to_speech/api/openai_realtime/handlers/response.py
+++ b/src/speech_to_speech/api/openai_realtime/handlers/response.py
@@ -21,7 +21,7 @@ from openai.types.realtime.realtime_response_usage import RealtimeResponseUsage
 from speech_to_speech.api.openai_realtime.handlers.base import RealtimeBaseHandler
 from speech_to_speech.LLM.chat import ChatItemError
 from speech_to_speech.pipeline.events import AssistantTextEvent
-from speech_to_speech.pipeline.messages import GenerateResponseRequest
+from speech_to_speech.pipeline.messages import AssistantTextPart, AssistantToolCallPart, GenerateResponseRequest
 from speech_to_speech.utils.utils import _generate_id, is_out_of_band, response_wants_audio
 
 if TYPE_CHECKING:
@@ -70,7 +70,12 @@ class ResponseHandler(RealtimeBaseHandler):
         st.in_response = False
         st.response_pending = False
         st.current_response_params = None
-        st.pending_output_text_parts = []
+        st.next_output_index = 0
+        st.current_output_index = None
+        st.current_output_kind = None
+        st.last_text_item_id = None
+        st.last_text_output_index = None
+        st.pending_text_outputs = []
 
     def _start_item(self, conn_id: str) -> str:
         """Generate a new item ID, reset content index, and store it."""
@@ -90,6 +95,29 @@ class ResponseHandler(RealtimeBaseHandler):
         idx = st.content_index
         st.content_index += 1
         return idx
+
+    def _output_part_context(self, conn_id: str, kind: str) -> tuple[int, str]:
+        """Return a stable output index and item id for an ordered part.
+
+        Consecutive text chunks share one assistant output item. Every tool
+        call starts a new item, and text after a tool starts a new assistant
+        item, preserving order even when parts arrive in separate events.
+        """
+        st = self._state(conn_id)
+        if (
+            kind == "text"
+            and st.current_output_kind == "text"
+            and st.current_output_index is not None
+            and st.current_item_id is not None
+        ):
+            return st.current_output_index, st.current_item_id
+
+        item_id = self._current_item_id(conn_id) if st.next_output_index == 0 else self._start_item(conn_id)
+        output_index = st.next_output_index
+        st.next_output_index += 1
+        st.current_output_index = output_index
+        st.current_output_kind = "text" if kind == "text" else "tool_call"
+        return output_index, item_id
 
     def _build_response(
         self,
@@ -227,23 +255,24 @@ class ResponseHandler(RealtimeBaseHandler):
                         type="response.output_audio.done",
                         event_id=self._next_event_id(),
                         content_index=0,
-                        item_id=item_id,
-                        output_index=0,
+                        item_id=st.last_text_item_id or item_id,
+                        output_index=st.last_text_output_index or 0,
                         response_id=resp_id,
                     )
                 )
-            elif status == "completed" and st.pending_output_text_parts:
-                events.append(
-                    ResponseTextDoneEvent(
-                        type="response.output_text.done",
-                        event_id=self._next_event_id(),
-                        content_index=0,
-                        item_id=item_id,
-                        output_index=0,
-                        response_id=resp_id,
-                        text="".join(st.pending_output_text_parts),
+            elif status == "completed":
+                for pending in st.pending_text_outputs:
+                    events.append(
+                        ResponseTextDoneEvent(
+                            type="response.output_text.done",
+                            event_id=self._next_event_id(),
+                            content_index=0,
+                            item_id=str(pending["item_id"]),
+                            output_index=int(pending["output_index"]),
+                            response_id=resp_id,
+                            text="".join(pending["parts"]),
+                        )
                     )
-                )
             events.append(
                 ResponseDoneEvent(
                     type="response.done",
@@ -287,42 +316,47 @@ class ResponseHandler(RealtimeBaseHandler):
                 return []
         st = self._state(conn_id)
         events: list[ServerEvent] = []
-        resp_id, item_id = self._ensure_response(conn_id)
-        st.last_item_id = item_id
-        output_idx = 0
-        if event.text:
-            if response_wants_audio(st.current_response_params):
-                events.append(
-                    ResponseAudioTranscriptDoneEvent(
-                        type="response.output_audio_transcript.done",
-                        event_id=self._next_event_id(),
-                        content_index=0,
-                        item_id=item_id,
-                        output_index=output_idx,
-                        response_id=resp_id,
-                        transcript=event.text,
+        resp_id, _ = self._ensure_response(conn_id)
+        for part in event.parts:
+            if isinstance(part, AssistantTextPart):
+                if not part.text:
+                    continue
+                output_idx, item_id = self._output_part_context(conn_id, "text")
+                st.last_text_item_id = item_id
+                st.last_text_output_index = output_idx
+                if response_wants_audio(st.current_response_params):
+                    events.append(
+                        ResponseAudioTranscriptDoneEvent(
+                            type="response.output_audio_transcript.done",
+                            event_id=self._next_event_id(),
+                            content_index=0,
+                            item_id=item_id,
+                            output_index=output_idx,
+                            response_id=resp_id,
+                            transcript=part.text,
+                        )
                     )
-                )
-            else:
-                # Stream the delta now; the matching response.output_text.done is
-                # emitted once at close in finish_response, carrying the per-chunk
-                # parts collected here, space-joined ("" when there were none).
-                st.pending_output_text_parts.append(event.text)
-                events.append(
-                    ResponseTextDeltaEvent(
-                        type="response.output_text.delta",
-                        event_id=self._next_event_id(),
-                        content_index=0,
-                        item_id=item_id,
-                        output_index=output_idx,
-                        response_id=resp_id,
-                        delta=event.text,
+                else:
+                    # Stream the delta now; finish_response emits one matching
+                    # done event for each contiguous text output item.
+                    if not st.pending_text_outputs or st.pending_text_outputs[-1]["output_index"] != output_idx:
+                        st.pending_text_outputs.append({"item_id": item_id, "output_index": output_idx, "parts": []})
+                    st.pending_text_outputs[-1]["parts"].append(part.text)
+                    events.append(
+                        ResponseTextDeltaEvent(
+                            type="response.output_text.delta",
+                            event_id=self._next_event_id(),
+                            content_index=0,
+                            item_id=item_id,
+                            output_index=output_idx,
+                            response_id=resp_id,
+                            delta=part.text,
+                        )
                     )
-                )
-            output_idx += 1
-        if event.tools:
-            st.response_usage.tool_calls += len(event.tools)
-            for tool in event.tools:
+            elif isinstance(part, AssistantToolCallPart):
+                tool = part.tool
+                output_idx, item_id = self._output_part_context(conn_id, "tool_call")
+                st.response_usage.tool_calls += 1
                 events.append(
                     ResponseFunctionCallArgumentsDoneEvent(
                         type="response.function_call_arguments.done",
@@ -335,5 +369,5 @@ class ResponseHandler(RealtimeBaseHandler):
                         response_id=resp_id,
                     )
                 )
-                output_idx += 1
+            st.last_item_id = item_id
         return events

--- a/src/speech_to_speech/api/openai_realtime/service.py
+++ b/src/speech_to_speech/api/openai_realtime/service.py
@@ -171,7 +171,15 @@ class ConnState(BaseModel):
     input_audio_duration_s: float = 0.0
     last_item_id: Optional[str] = None
     current_response_params: RealtimeResponseCreateParams | None = None
-    pending_output_text_parts: list[str] = Field(default_factory=list)
+    next_output_index: int = 0
+    current_output_index: int | None = None
+    current_output_kind: Literal["text", "tool_call"] | None = None
+    last_text_item_id: str | None = None
+    last_text_output_index: int | None = None
+    # Each entry contains item_id, output_index, and the contiguous text parts
+    # for one assistant message. Kept as plain internal data to avoid coupling
+    # connection state to protocol event models.
+    pending_text_outputs: list[dict[str, Any]] = Field(default_factory=list)
     response_usage: UsageMetrics = Field(default_factory=UsageMetrics)
     speculative_turn_id: Optional[str] = None
     speculative_turn_revision: Optional[int] = None

--- a/src/speech_to_speech/pipeline/events.py
+++ b/src/speech_to_speech/pipeline/events.py
@@ -11,7 +11,13 @@ from __future__ import annotations
 from typing import Literal, Optional
 
 from openai.types.responses.response_function_tool_call import ResponseFunctionToolCall
-from pydantic import BaseModel, Field
+from pydantic import BaseModel, Field, model_validator
+
+from speech_to_speech.pipeline.messages import (
+    AssistantOutputPart,
+    AssistantTextPart,
+    AssistantToolCallPart,
+)
 
 
 class PipelineEvent(BaseModel):
@@ -68,7 +74,8 @@ class TranscriptionCompletedEvent(PipelineEvent):
 
 class AssistantTextEvent(PipelineEvent):
     type: Literal["assistant_text"] = "assistant_text"
-    text: str
+    parts: list[AssistantOutputPart] = Field(default_factory=list)
+    text: str = ""
     tools: list[ResponseFunctionToolCall] = Field(default_factory=list)
     turn_id: str | None = None
     turn_revision: int | None = None
@@ -76,6 +83,17 @@ class AssistantTextEvent(PipelineEvent):
     # send loop discard stale assistant text by the same generation-aware rule as
     # audio, instead of blanket-dropping while cancel_scope.discarding is set.
     cancel_generation: int | None = None
+
+    @model_validator(mode="after")
+    def _normalize_ordered_parts(self) -> "AssistantTextEvent":
+        if self.parts:
+            self.text = "".join(part.text for part in self.parts if isinstance(part, AssistantTextPart))
+            self.tools = [part.tool for part in self.parts if isinstance(part, AssistantToolCallPart)]
+        else:
+            if self.text:
+                self.parts.append(AssistantTextPart(text=self.text))
+            self.parts.extend(AssistantToolCallPart(tool=tool) for tool in self.tools)
+        return self
 
 
 class TokenUsageEvent(PipelineEvent):

--- a/src/speech_to_speech/pipeline/messages.py
+++ b/src/speech_to_speech/pipeline/messages.py
@@ -9,12 +9,12 @@ constants.
 from __future__ import annotations
 
 from time import perf_counter
-from typing import Final, Literal, Optional, TypeAlias
+from typing import Annotated, Final, Literal, Optional, TypeAlias
 
 import numpy as np
 from openai.types.realtime.realtime_response_create_params import RealtimeResponseCreateParams
 from openai.types.responses.response_function_tool_call import ResponseFunctionToolCall
-from pydantic import BaseModel, ConfigDict, Field
+from pydantic import BaseModel, ConfigDict, Field, model_validator
 
 from speech_to_speech.api.openai_realtime.runtime_config import RuntimeConfig
 
@@ -73,11 +73,37 @@ class Transcription(PipelineMessage):
 # ── LLM → LMOutputProcessor ──────────────────────────────────────────
 
 
+class AssistantTextPart(BaseModel):
+    """One ordered assistant text part."""
+
+    type: Literal["text"] = "text"
+    text: str
+
+
+class AssistantToolCallPart(BaseModel):
+    """One ordered assistant function-call part."""
+
+    type: Literal["tool_call"] = "tool_call"
+    tool: ResponseFunctionToolCall
+
+
+AssistantOutputPart: TypeAlias = Annotated[
+    AssistantTextPart | AssistantToolCallPart,
+    Field(discriminator="type"),
+]
+
+
 class LLMResponseChunk(PipelineMessage):
-    """One sentence/chunk of the LLM response."""
+    """One ordered group of assistant output parts.
+
+    ``text`` and ``tools`` remain as compatibility views for callers that
+    still construct the legacy shape. New code can populate ``parts`` to
+    represent arbitrary text/tool interleaving without losing order.
+    """
 
     tag: Literal["llm_response_chunk"] = "llm_response_chunk"
-    text: str
+    parts: list[AssistantOutputPart] = Field(default_factory=list)
+    text: str = ""
     language_code: Optional[str] = None
     tools: list[ResponseFunctionToolCall] = Field(default_factory=list)
     runtime_config: RuntimeConfig | None = None
@@ -86,6 +112,17 @@ class LLMResponseChunk(PipelineMessage):
     turn_revision: int | None = None
     speech_stopped_at_s: float | None = None
     cancel_generation: int | None = None
+
+    @model_validator(mode="after")
+    def _normalize_ordered_parts(self) -> "LLMResponseChunk":
+        if self.parts:
+            self.text = "".join(part.text for part in self.parts if isinstance(part, AssistantTextPart))
+            self.tools = [part.tool for part in self.parts if isinstance(part, AssistantToolCallPart)]
+        else:
+            if self.text:
+                self.parts.append(AssistantTextPart(text=self.text))
+            self.parts.extend(AssistantToolCallPart(tool=tool) for tool in self.tools)
+        return self
 
 
 class TokenUsage(PipelineMessage):

--- a/tests/openai_realtime/test_realtime_service.py
+++ b/tests/openai_realtime/test_realtime_service.py
@@ -47,7 +47,7 @@ from speech_to_speech.pipeline.events import (
     TokenUsageEvent,
     TranscriptionCompletedEvent,
 )
-from speech_to_speech.pipeline.messages import GenerateResponseRequest
+from speech_to_speech.pipeline.messages import AssistantTextPart, AssistantToolCallPart, GenerateResponseRequest
 from speech_to_speech.pipeline.speculative_turns import SpeculativeTurnTracker
 
 # ---------------------------------------------------------------------------
@@ -968,6 +968,74 @@ class TestDispatchPipelineEvent:
         assert len(events) == 1
         assert isinstance(events[0], ResponseFunctionCallArgumentsDoneEvent)
         assert events[0].output_index == 0
+
+    def test_assistant_parts_preserve_tool_text_tool_text_order(self, service, conn_id):
+        events = service.dispatch_pipeline_event(
+            conn_id,
+            AssistantTextEvent(
+                parts=[
+                    AssistantToolCallPart(
+                        tool={"type": "function_call", "call_id": "c1", "name": "first", "arguments": "{}"}
+                    ),
+                    AssistantTextPart(text="between"),
+                    AssistantToolCallPart(
+                        tool={"type": "function_call", "call_id": "c2", "name": "second", "arguments": "{}"}
+                    ),
+                    AssistantTextPart(text="after"),
+                ]
+            ),
+        )
+
+        assert [event.type for event in events] == [
+            "response.function_call_arguments.done",
+            "response.output_audio_transcript.done",
+            "response.function_call_arguments.done",
+            "response.output_audio_transcript.done",
+        ]
+        assert [event.output_index for event in events] == [0, 1, 2, 3]
+        assert len({event.item_id for event in events}) == 4
+
+    def test_assistant_part_indices_continue_across_pipeline_events(self, service, conn_id):
+        first = service.dispatch_pipeline_event(conn_id, AssistantTextEvent(text="before"))
+        second = service.dispatch_pipeline_event(
+            conn_id,
+            AssistantTextEvent(tools=[{"type": "function_call", "call_id": "c1", "name": "tool", "arguments": "{}"}]),
+        )
+        third = service.dispatch_pipeline_event(conn_id, AssistantTextEvent(text="after"))
+
+        assert [first[0].output_index, second[0].output_index, third[0].output_index] == [0, 1, 2]
+        assert len({first[0].item_id, second[0].item_id, third[0].item_id}) == 3
+
+    def test_text_only_interleaving_closes_each_text_item_before_response_done(self, service, conn_id):
+        from openai.types.realtime.realtime_response_create_params import RealtimeResponseCreateParams
+
+        service._state(conn_id).current_response_params = RealtimeResponseCreateParams(
+            output_modalities=["text"],
+        )
+        events = service.dispatch_pipeline_event(
+            conn_id,
+            AssistantTextEvent(
+                parts=[
+                    AssistantTextPart(text="before"),
+                    AssistantToolCallPart(
+                        tool={"type": "function_call", "call_id": "c1", "name": "tool", "arguments": "{}"}
+                    ),
+                    AssistantTextPart(text="after"),
+                ]
+            ),
+        )
+
+        assert [event.type for event in events] == [
+            "response.output_text.delta",
+            "response.function_call_arguments.done",
+            "response.output_text.delta",
+        ]
+        assert [event.output_index for event in events] == [0, 1, 2]
+
+        done_events = service.finish_response(conn_id)
+        text_done = [event for event in done_events if isinstance(event, ResponseTextDoneEvent)]
+        assert [(event.output_index, event.text) for event in text_done] == [(0, "before"), (2, "after")]
+        assert isinstance(done_events[-1], ResponseDoneEvent)
 
     def test_assistant_text_text_only_emits_text_events(self, service, conn_id):
         from openai.types.realtime.realtime_response_create_params import RealtimeResponseCreateParams

--- a/tests/test_lm_output_processor.py
+++ b/tests/test_lm_output_processor.py
@@ -2,9 +2,16 @@ from queue import Queue
 from threading import Event, Thread
 
 from openai.types.realtime.realtime_response_create_params import RealtimeResponseCreateParams
+from openai.types.responses import ResponseFunctionToolCall
 
 from speech_to_speech.LLM.lm_output_processor import LMOutputProcessor
-from speech_to_speech.pipeline.messages import EndOfResponse, LLMResponseChunk, TTSInput
+from speech_to_speech.pipeline.messages import (
+    AssistantTextPart,
+    AssistantToolCallPart,
+    EndOfResponse,
+    LLMResponseChunk,
+    TTSInput,
+)
 from speech_to_speech.pipeline.speculative_turns import SpeculativeTurnTracker
 
 
@@ -97,6 +104,35 @@ def test_audio_chunk_is_forwarded_to_tts():
     assert len(outputs) == 1
     assert isinstance(outputs[0], TTSInput)
     assert outputs[0].text == "hello"
+
+
+def test_ordered_parts_reach_clients_and_only_text_reaches_tts():
+    tracker = SpeculativeTurnTracker()
+    tracker.observe("turn_1", 0)
+    processor = _processor(tracker)
+    first_tool = ResponseFunctionToolCall(type="function_call", call_id="call_1", name="first", arguments="{}")
+    second_tool = ResponseFunctionToolCall(type="function_call", call_id="call_2", name="second", arguments="{}")
+
+    outputs = list(
+        processor.process(
+            LLMResponseChunk(
+                parts=[
+                    AssistantToolCallPart(tool=first_tool),
+                    AssistantTextPart(text="between"),
+                    AssistantToolCallPart(tool=second_tool),
+                    AssistantTextPart(text="after"),
+                ],
+                turn_id="turn_1",
+                turn_revision=0,
+            )
+        )
+    )
+
+    assert [output.text for output in outputs] == ["between", "after"]
+    event = processor.text_output_queue.get_nowait()
+    assert [part.type for part in event.parts] == ["tool_call", "text", "tool_call", "text"]
+    assert event.text == "betweenafter"
+    assert [tool.name for tool in event.tools] == ["first", "second"]
 
 
 def test_empty_modalities_is_forwarded_to_tts():

--- a/tests/test_text_prompt.py
+++ b/tests/test_text_prompt.py
@@ -36,7 +36,9 @@ def test_text_tool_prompt_drops_speak_first_but_keeps_structural_rules():
     prompt = build_tool_system_prompt([_dance_tool()], text_only=True)
 
     assert "no preamble sentence is required" in prompt
-    assert "Only one tool call may appear in a response." in prompt
+    assert "each named-argument function call inside its own" in prompt
+    assert "preserve the intended text/tool order" in prompt
+    assert "Only one tool call may appear in a response." not in prompt
     assert "Omit optional args instead of placeholder values" in prompt
     assert "do not claim tool results before a tool result is available" in prompt
     # Voice choreography must not appear in the text variant.

--- a/tests/test_voice_prompt.py
+++ b/tests/test_voice_prompt.py
@@ -17,7 +17,8 @@ def test_voice_prompt_makes_speech_the_default_and_handles_noisy_stt():
     prompt = build_voice_system_prompt("Be concise.")
 
     assert "Speech is the default." in prompt
-    assert "Use at most one tool" in prompt
+    assert "Use tools when they help" in prompt
+    assert "Use at most one tool" not in prompt
     assert "Treat transcripts as noisy." in prompt
     assert "Correct likely mishearings only if asked or meaning depends on it" in prompt
     assert "Reachy/Richie/Richy" not in prompt
@@ -37,7 +38,7 @@ def test_voice_prompt_requests_spoken_lead_in_and_sparing_expression_tools():
     assert "Use motion, dance, emotion, and similar tools sparingly" in prompt
 
 
-def test_local_tool_prompt_forbids_multiple_tool_calls():
+def test_local_tool_prompt_preserves_multiple_tool_call_order():
     prompt = build_tool_system_prompt(
         [
             FunctionTool(
@@ -49,8 +50,9 @@ def test_local_tool_prompt_forbids_multiple_tool_calls():
         ]
     )
 
-    assert "Only one tool call may appear in a response." in prompt
-    assert "Multiple tool calls can live" not in prompt
+    assert "each named-argument function call inside its own" in prompt
+    assert "preserve the intended text/tool order" in prompt
+    assert "Only one tool call may appear in a response." not in prompt
 
 
 def test_local_tool_prompt_allows_spoken_lead_in_before_code_block():
@@ -127,7 +129,11 @@ def test_local_tool_parser_flushes_pending_batch_before_tool_with_empty_before_t
     assert remaining == ""
 
 
-def test_local_tool_parser_skips_duplicate_tool_blocks_and_preserves_trailing_text():
+def test_local_tool_parser_preserves_repeated_tool_blocks(monkeypatch):
+    monkeypatch.setattr(
+        "speech_to_speech.LLM.language_model.sent_tokenize",
+        lambda value: [value.strip()] if value.strip() else [],
+    )
     handler = object.__new__(LanguageModelHandler)
     ctx = StreamContext(
         function_tools=[
@@ -146,7 +152,47 @@ def test_local_tool_parser_skips_duplicate_tool_blocks_and_preserves_trailing_te
 
     chunks, tools, remaining = handler._process_printable_text(text, None, [], ctx)
 
-    assert [chunk.text for chunk in chunks] == ["Watch this.", ""]
+    assert [chunk.text for chunk in chunks] == ["Watch this.", "", "Watch this.", ""]
     assert [tool.name for tool in chunks[1].tools] == ["dance"]
-    assert [tool.name for tool in tools] == ["dance"]
-    assert remaining.strip() == "Watch this."
+    assert [tool.name for tool in chunks[3].tools] == ["dance"]
+    assert [tool.name for tool in tools] == ["dance", "dance"]
+    assert remaining == ""
+
+
+def test_local_tool_parser_preserves_interleaved_text_and_tool_calls(monkeypatch):
+    monkeypatch.setattr(
+        "speech_to_speech.LLM.language_model.sent_tokenize",
+        lambda value: [value.strip()] if value.strip() else [],
+    )
+    handler = object.__new__(LanguageModelHandler)
+    ctx = StreamContext(
+        function_tools=[
+            FunctionTool(
+                type="function",
+                name="dance",
+                description="Dance once.",
+                parameters={"type": "object", "properties": {}},
+            ),
+            FunctionTool(
+                type="function",
+                name="camera",
+                description="Look through the camera.",
+                parameters={"type": "object", "properties": {}},
+            ),
+        ],
+        block_regex=build_block_regex(),
+        enter_code=ENTER_CODE,
+        end_code=END_CODE,
+    )
+    text = f"First. {ENTER_CODE}dance(){END_CODE} Middle. {ENTER_CODE}camera(){END_CODE} Last."
+
+    chunks, tools, remaining = handler._process_printable_text(text, None, [], ctx)
+
+    assert [(chunk.text, [tool.name for tool in chunk.tools]) for chunk in chunks] == [
+        ("First.", []),
+        ("", ["dance"]),
+        ("Middle.", []),
+        ("", ["camera"]),
+    ]
+    assert [tool.name for tool in tools] == ["dance", "camera"]
+    assert remaining.strip() == "Last."


### PR DESCRIPTION
Fixes #309

## Summary

- add an explicit ordered assistant-part model for text and function calls while retaining compatibility with the existing `text`/`tools` fields
- preserve interleaved local-model output such as `text -> tool_call -> text -> tool_call -> text` instead of dropping calls after the first
- keep realtime output indices and item IDs stable across separate chunks, including text-only completion events
- update voice and text tool prompts to permit multiple ordered tool calls
- add regression coverage for parser, LM-to-TTS routing, realtime audio events, text-only events, and cross-chunk ordering

## Root cause

`LLMResponseChunk` and `AssistantTextEvent` represented output as one text field plus a tool list, which imposed text-before-tools ordering. The local parser also explicitly skipped every tool call after the first, and realtime output indices restarted for each event.

## User impact

Assistant output now retains the model's intended text/tool sequence without dropping later calls, reordering client events, or closing text-only output items under the wrong response index.

## Validation

- `uv run --python /usr/bin/python3.12 pytest tests -q` — 731 passed, 1 skipped
- `.venv/bin/ruff check src tests`
- `.venv/bin/ruff format --check src tests`
- `.venv/bin/mypy src/`
- `git diff --check`