### PR TITLE
Send session.updated after session.update

### DIFF
--- a/src/speech_to_speech/api/openai_realtime/handlers/session.py
+++ b/src/speech_to_speech/api/openai_realtime/handlers/session.py
@@ -6,6 +6,7 @@ from typing import Optional
 from openai.types.realtime import (
     RealtimeErrorEvent,
     SessionCreatedEvent,
+    SessionUpdatedEvent,
     SessionUpdateEvent,
 )
 from openai.types.realtime.realtime_transcription_session_create_request import (
@@ -60,6 +61,20 @@ class SessionHandler(RealtimeBaseHandler):
         session = cfg.session.model_copy(update={"id": conn_id})
         return SessionCreatedEvent(
             type="session.created",
+            event_id=self._next_event_id(),
+            session=session,
+        )
+
+    def build_session_updated(self, conn_id: str) -> SessionUpdatedEvent:
+        """Build a SessionUpdatedEvent populated with the current config.
+
+        Sent after a successful session.update, per the OpenAI Realtime
+        protocol: https://platform.openai.com/docs/api-reference/realtime-server-events/session/updated
+        """
+        cfg = self._state(conn_id).runtime_config
+        session = cfg.session.model_copy(update={"id": conn_id})
+        return SessionUpdatedEvent(
+            type="session.updated",
             event_id=self._next_event_id(),
             session=session,
         )

--- a/src/speech_to_speech/api/openai_realtime/service.py
+++ b/src/speech_to_speech/api/openai_realtime/service.py
@@ -28,6 +28,7 @@ from openai.types.realtime import (
     ResponseTextDeltaEvent,
     ResponseTextDoneEvent,
     SessionCreatedEvent,
+    SessionUpdatedEvent,
     SessionUpdateEvent,
 )
 from openai.types.realtime.realtime_response_create_params import RealtimeResponseCreateParams
@@ -284,6 +285,9 @@ class RealtimeService:
 
     def build_session_created(self, conn_id: str) -> SessionCreatedEvent:
         return self.session.build_session_created(conn_id)
+
+    def build_session_updated(self, conn_id: str) -> SessionUpdatedEvent:
+        return self.session.build_session_updated(conn_id)
 
     def handle_session_update(self, conn_id: str, event: SessionUpdateEvent) -> Optional[RealtimeErrorEvent]:
         return self.session.handle_session_update(conn_id, event)

--- a/src/speech_to_speech/api/openai_realtime/websocket_router.py
+++ b/src/speech_to_speech/api/openai_realtime/websocket_router.py
@@ -378,6 +378,8 @@ async def _dispatch_client_event(
         err = service.handle_session_update(session_id, event)
         if err:
             await transport.send_events([err])
+        else:
+            await transport.send_events([service.build_session_updated(session_id)])
 
     elif isinstance(event, ConversationItemCreateEvent):
         events = service.handle_conversation_item_create(session_id, event)

--- a/tests/openai_realtime/test_realtime_service.py
+++ b/tests/openai_realtime/test_realtime_service.py
@@ -31,6 +31,7 @@ from openai.types.realtime import (
     ResponseTextDeltaEvent,
     ResponseTextDoneEvent,
     SessionCreatedEvent,
+    SessionUpdatedEvent,
     SessionUpdateEvent,
 )
 
@@ -116,6 +117,21 @@ class TestConnectionLifecycle:
         assert evt.session.tool_choice == "auto"
         assert evt.session.audio.output.voice == "echo"
         assert evt.session.audio.input.turn_detection.type == "server_vad"
+
+    def test_build_session_updated(self, service, conn_id, runtime_config):
+        service.handle_session_update(
+            conn_id,
+            SessionUpdateEvent(
+                type="session.update",
+                session={"type": "realtime", "instructions": "Be concise"},
+            ),
+        )
+
+        evt = service.build_session_updated(conn_id)
+        assert isinstance(evt, SessionUpdatedEvent)
+        assert evt.event_id.startswith("event_")
+        assert evt.session is not None
+        assert evt.session.instructions == "Be concise"
 
 
 # ===================================================================

--- a/tests/openai_realtime/test_websocket_router.py
+++ b/tests/openai_realtime/test_websocket_router.py
@@ -197,6 +197,29 @@ class TestClientEventDispatch:
                 cid = service.connection_ids[0]
                 assert service._state(cid).runtime_config.session.audio.output.voice == "coral"
 
+    def test_session_update_receives_session_updated_confirmation(self, setup):
+        """The OpenAI Realtime protocol requires a session.updated reply to
+        every successful session.update, unless there is an error:
+        https://platform.openai.com/docs/api-reference/realtime-server-events/session/updated
+        """
+        app, *_ = setup
+        with TestClient(app) as client:
+            with client.websocket_connect("/v1/realtime") as ws:
+                ws.receive_json()  # session.created
+                ws.send_json(
+                    {
+                        "type": "session.update",
+                        "session": {
+                            "type": "realtime",
+                            "audio": {"output": {"voice": "coral"}},
+                        },
+                    }
+                )
+                msg = ws.receive_json()
+                assert msg["type"] == "session.updated"
+                assert msg["event_id"].startswith("event_")
+                assert msg["session"]["audio"]["output"]["voice"] == "coral"
+
     def test_conversation_item_create_returns_events(self, setup):
         app, *_ = setup
         with TestClient(app) as client:


### PR DESCRIPTION
## Summary

- reply with `session.updated` after a successful `session.update`
- add `SessionHandler.build_session_updated`, mirroring the existing `build_session_created`

## Why

The protocol acknowledges an accepted `session.update`. From the [Realtime conversations guide](https://developers.openai.com/api/docs/guides/realtime-conversations):

> When the session has been updated, the server will emit a `session.updated` event with the new state of the session.

The server applied the incoming update but never sent that acknowledgement, so a client that waits for it before streaming audio had nothing to wait on and sat idle until it gave up and closed the connection.

## User impact

Clients that treat `session.updated` as the go-ahead for audio now proceed instead of stalling. Clients that ignore the event are unaffected, since nothing else in the exchange changed.

## Validation

- `pytest -q tests/` — 728 passed, 1 skipped
- `ruff check .` — passed
- `ruff format --check` on the changed files — passed
- over a WebSocket with the `openai` SDK: `session.created`, then `session.updated` echoing the requested voice back
