### PR TITLE
Backfill a placeholder user turn when generating with no user input yet

### DIFF
--- a/src/speech_to_speech/LLM/language_model.py
+++ b/src/speech_to_speech/LLM/language_model.py
@@ -79,6 +79,24 @@ except ImportError:
 
 logger = logging.getLogger(__name__)
 
+# Some chat templates (e.g. Qwen3.5's) hard-require at least one user-role
+# message and raise a jinja2 TemplateError otherwise. OpenAI's Realtime API
+# allows a response to be generated from system instructions alone (e.g. an
+# initial greeting before the caller has spoken), so we backfill a minimal
+# placeholder turn to keep locally-loaded models with that requirement working.
+_PLACEHOLDER_USER_TURN = "..."
+# Must match the role Chat.to_transformers_chat() emits for user messages
+# (TransformersUserMessage hardcodes "user"), not the configurable --user_role:
+# checking the latter would miss real turns and backfill on every call.
+_SERIALIZED_USER_ROLE = "user"
+
+
+def _ensure_user_turn(messages: list[dict[str, Any]]) -> list[dict[str, Any]]:
+    """Append a placeholder user turn if *messages* has no user-role message."""
+    if any(m.get("role") == _SERIALIZED_USER_ROLE for m in messages):
+        return messages
+    return messages + [{"role": _SERIALIZED_USER_ROLE, "content": _PLACEHOLDER_USER_TURN}]
+
 
 @runtime_checkable
 class _Tokenizer(Protocol):
@@ -680,7 +698,7 @@ class LanguageModelHandler(BaseLanguageModelHandler):
         runtime_config: RuntimeConfig | None = None,
         response: RealtimeResponseCreateParams | None = None,
     ) -> Iterator[LLMResponseChunk]:
-        chat_messages = chat.to_transformers_chat()
+        chat_messages = _ensure_user_turn(chat.to_transformers_chat())
         chat_input = self.tokenizer.apply_chat_template(chat_messages, tokenize=True)
         ctx.input_tokens += len(chat_input if isinstance(chat_input, list) else chat_input["input_ids"])  # type: ignore[index]
         logger.debug("Prompt token count: %d", ctx.input_tokens)
@@ -854,7 +872,7 @@ class VisionLanguageModelHandler(BaseLanguageModelHandler):
         runtime_config: RuntimeConfig | None = None,
         response: RealtimeResponseCreateParams | None = None,
     ) -> Iterator[LLMResponseChunk]:
-        prepared = chat.to_transformers_chat()
+        prepared = _ensure_user_turn(chat.to_transformers_chat())
         if self.backend == "mlx":
             images, formatted_prompt = self._prepare_mlx_vlm_inputs(prepared)
             ctx.input_tokens += len(self.tokenizer.encode(formatted_prompt))

--- a/tests/test_language_model_chat_template.py
+++ b/tests/test_language_model_chat_template.py
@@ -1,0 +1,62 @@
+"""Unit tests for language_model helpers that shape messages before
+apply_chat_template, independent of any loaded model/tokenizer.
+"""
+
+from speech_to_speech.LLM.chat import Chat, make_user_message
+from speech_to_speech.LLM.language_model import _ensure_user_turn
+
+
+class TestEnsureUserTurn:
+    def test_leaves_messages_with_a_user_turn_unchanged(self):
+        messages = [
+            {"role": "system", "content": "Be helpful."},
+            {"role": "user", "content": "Hi there."},
+        ]
+        assert _ensure_user_turn(messages) == messages
+
+    def test_appends_placeholder_user_turn_when_none_present(self):
+        messages = [{"role": "system", "content": "Be helpful."}]
+        result = _ensure_user_turn(messages)
+        assert result[:-1] == messages
+        assert result[-1]["role"] == "user"
+        assert result[-1]["content"]
+
+    def test_appends_when_messages_only_contain_assistant_turns(self):
+        messages = [
+            {"role": "system", "content": "Be helpful."},
+            {"role": "assistant", "content": "Hello!"},
+        ]
+        result = _ensure_user_turn(messages)
+        assert result[-1]["role"] == "user"
+
+    def test_appends_when_only_tool_turns_follow_the_system_message(self):
+        """A tool result alone is not a user turn, so the template still needs one."""
+        messages = [
+            {"role": "system", "content": "Be helpful."},
+            {"role": "tool", "tool_call_id": "call_1", "name": "f", "content": "42"},
+        ]
+        result = _ensure_user_turn(messages)
+        assert result[-1]["role"] == "user"
+
+    def test_does_not_mutate_the_input_list(self):
+        messages = [{"role": "system", "content": "Be helpful."}]
+        _ensure_user_turn(messages)
+        assert messages == [{"role": "system", "content": "Be helpful."}]
+
+    def test_real_serialized_user_turn_is_recognised(self):
+        """Guards the coupling to Chat.to_transformers_chat(): the role checked
+        here has to be the one the serializer actually emits, or a real user
+        turn goes unnoticed and a placeholder is appended on every call.
+        """
+        chat = Chat(size=10)
+        chat.add_item(make_user_message("Hi there."))
+        serialized = chat.to_transformers_chat()
+
+        assert _ensure_user_turn(serialized) == serialized
+
+    def test_empty_serialized_chat_gets_a_placeholder(self):
+        chat = Chat(size=10)
+        serialized = chat.to_transformers_chat()
+
+        result = _ensure_user_turn(serialized)
+        assert [m["role"] for m in result] == ["user"]


### PR DESCRIPTION
## Summary

- backfill a placeholder user turn when a generation request carries no user message yet
- apply it in both the text/mlx-lm and vision-language paths, immediately before `apply_chat_template`
- match the role `Chat.to_transformers_chat()` emits (`"user"`) rather than the configurable `--user_role`

## Why

Some chat templates require at least one plain user-role message. Qwen3.5's scans the history backwards and raises `TemplateError: No user query found in messages.` when it finds none. Qwen3-4B-Instruct's template has no such requirement, so this only appeared after switching models.

Nothing in the protocol makes a user turn a precondition for generating. `response.create` accepts an empty `input` array specifically to "remove existing context" ([Realtime conversations guide](https://developers.openai.com/api/docs/guides/realtime-conversations)), so an empty context is a valid state to generate from. The constraint is the model's template rather than the API, and it rejects a legitimate request: a bare `response.create` used to have the assistant open a conversation from its system instructions, before the user has spoken.

## User impact

Assistant-opens-the-conversation flows work against models whose templates demand a user turn. Histories that already contain one serialize unchanged, and the placeholder exists only in the per-turn copy handed to the template, never in stored conversation state.

## Validation

- `pytest -q tests/` — 733 passed, 1 skipped
- `ruff check .` — passed
- `ruff format --check` on the changed files — passed
- over a WebSocket: `response.create` on an empty conversation returns a greeting instead of failing
