### PR TITLE
Fix session.updated event contract

### DIFF
--- a/src/speech_to_speech/api/openai_realtime/README.md
+++ b/src/speech_to_speech/api/openai_realtime/README.md
@@ -68,6 +68,7 @@ flowchart LR
 | Event | Description |
 |---|---|
 | `session.created` | Sent on connection with current session config. |
+| `session.updated` | Confirms a successful `session.update` with the effective session config. |
 | `error` | Protocol errors (`session_limit_reached`, `unknown_or_invalid_event`, `invalid_session_type`, `conversation_already_has_active_response`, etc.) |
 | `input_audio_buffer.speech_started` | VAD detected user speech. |
 | `input_audio_buffer.speech_stopped` | End of user speech segment. |

--- a/src/speech_to_speech/api/openai_realtime/handlers/session.py
+++ b/src/speech_to_speech/api/openai_realtime/handlers/session.py
@@ -19,7 +19,7 @@ logger = logging.getLogger(__name__)
 
 
 class SessionHandler(RealtimeBaseHandler):
-    """Owns session lifecycle: config updates and session.created events."""
+    """Owns session lifecycle: config updates and lifecycle events."""
 
     def handle_session_update(self, conn_id: str, event: SessionUpdateEvent) -> Optional[RealtimeErrorEvent]:
         """Apply session config changes.

--- a/src/speech_to_speech/api/openai_realtime/service.py
+++ b/src/speech_to_speech/api/openai_realtime/service.py
@@ -89,6 +89,7 @@ ClientEvent = Union[
 
 ServerEvent = Union[
     SessionCreatedEvent,
+    SessionUpdatedEvent,
     RealtimeErrorEvent,
     InputAudioBufferSpeechStartedEvent,
     InputAudioBufferSpeechStoppedEvent,


### PR DESCRIPTION
## Summary

- include `SessionUpdatedEvent` in the `ServerEvent` transport contract
- document `session.updated` in the supported server-event table
- update the session handler description to cover both lifecycle events

## Why

PR #413 emits `SessionUpdatedEvent`, but the event was missing from the `ServerEvent` union. That made the new dispatch fail the repository mypy check.

## Validation

- `mypy src/` — 92 source files passed
- focused Realtime tests — 174 passed
- `ruff check` and `ruff format --check` on the affected Realtime files — passed