### PR TITLE
Fix(TTS ): Align Facebook MMS language keys with Whisper codes

### DIFF
--- a/src/speech_to_speech/TTS/facebookmms_handler.py
+++ b/src/speech_to_speech/TTS/facebookmms_handler.py
@@ -31,7 +31,7 @@ WHISPER_LANGUAGE_TO_FACEBOOK_LANGUAGE = {
     "ar": "ara",  # Arabic
     "hy": "hyw",  # Armenian
     "az": "azb",  # Azerbaijani
-    "bu": "bul",  # Bulgarian
+    "bg": "bul",  # Bulgarian
     "ca": "cat",  # Catalan
     "nl": "nld",  # Dutch
     "fi": "fin",  # Finnish
@@ -41,22 +41,22 @@ WHISPER_LANGUAGE_TO_FACEBOOK_LANGUAGE = {
     "hu": "hun",  # Hungarian
     "is": "isl",  # Icelandic
     "id": "ind",  # Indonesian
-    "ka": "kan",  # Kannada
+    "kn": "kan",  # Kannada (Whisper uses "kn"; "ka" is Georgian)
     "kk": "kaz",  # Kazakh
     "lv": "lav",  # Latvian
-    "zl": "zlm",  # Malay
-    "ma": "mar",  # Marathi
+    "ms": "zlm",  # Malay
+    "mr": "mar",  # Marathi
     "fa": "fas",  # Persian
-    "po": "pol",  # Polish
+    "pl": "pol",  # Polish
     "pt": "por",  # Portuguese
     "ro": "ron",  # Romanian
     "ru": "rus",  # Russian
     "sw": "swh",  # Swahili
     "sv": "swe",  # Swedish
-    "tg": "tgl",  # Tagalog
+    "tl": "tgl",  # Tagalog (Whisper uses "tl"; "tg" is Tajik)
     "ta": "tam",  # Tamil
     "th": "tha",  # Thai
-    "tu": "tur",  # Turkish
+    "tr": "tur",  # Turkish
     "uk": "ukr",  # Ukrainian
     "ur": "urd",  # Urdu
     "vi": "vie",  # Vietnamese

--- a/tests/test_facebookmms_language_map.py
+++ b/tests/test_facebookmms_language_map.py
@@ -1,0 +1,66 @@
+"""Facebook MMS must key its model map by Whisper language codes.
+
+STT backends emit Whisper-style codes (e.g. ``pl``). Wrong keys silently fall
+back to English in ``FacebookMMSTTSHandler.load_model``.
+"""
+
+from speech_to_speech.TTS.facebookmms_handler import WHISPER_LANGUAGE_TO_FACEBOOK_LANGUAGE
+
+# Whisper-style ISO 639-1 codes expected as keys of this map. Keep the set
+# explicit so a typo like "po" instead of "pl" fails CI.
+_KNOWN_WHISPER_CODES = {
+    "en",
+    "fr",
+    "es",
+    "ko",
+    "hi",
+    "ar",
+    "hy",
+    "az",
+    "bg",
+    "ca",
+    "nl",
+    "fi",
+    "de",
+    "el",
+    "he",
+    "hu",
+    "is",
+    "id",
+    "kn",
+    "kk",
+    "lv",
+    "ms",
+    "mr",
+    "fa",
+    "pl",
+    "pt",
+    "ro",
+    "ru",
+    "sw",
+    "sv",
+    "tl",
+    "ta",
+    "th",
+    "tr",
+    "uk",
+    "ur",
+    "vi",
+    "cy",
+}
+
+
+def test_facebookmms_map_keys_are_whisper_codes() -> None:
+    unknown = sorted(set(WHISPER_LANGUAGE_TO_FACEBOOK_LANGUAGE) - _KNOWN_WHISPER_CODES)
+    assert unknown == [], f"Non-Whisper keys in MMS map (would never match STT): {unknown}"
+
+
+def test_common_stt_languages_resolve_to_mms_models() -> None:
+    # Failure mode: STT emits "pl" / "bg" / … and the map must hit the MMS model.
+    assert WHISPER_LANGUAGE_TO_FACEBOOK_LANGUAGE["pl"] == "pol"
+    assert WHISPER_LANGUAGE_TO_FACEBOOK_LANGUAGE["bg"] == "bul"
+    assert WHISPER_LANGUAGE_TO_FACEBOOK_LANGUAGE["tr"] == "tur"
+    assert WHISPER_LANGUAGE_TO_FACEBOOK_LANGUAGE["tl"] == "tgl"
+    assert WHISPER_LANGUAGE_TO_FACEBOOK_LANGUAGE["mr"] == "mar"
+    assert WHISPER_LANGUAGE_TO_FACEBOOK_LANGUAGE["ms"] == "zlm"
+    assert WHISPER_LANGUAGE_TO_FACEBOOK_LANGUAGE["kn"] == "kan"


### PR DESCRIPTION
hi,

This is a small hygiene fix in an older optional TTS path: a few Whisper→MMS language keys were mistyped, so STT language codes never matched and voices fell back to English (:

## Summary
- Fix mistyped Whisper-style keys in `WHISPER_LANGUAGE_TO_FACEBOOK_LANGUAGE` (`bu`→`bg`, `po`→`pl`, `tu`→`tr`, `tg`→`tl`, `ma`→`mr`, `zl`→`ms`, `ka`→`kn`).
- Keep Facebook MMS model suffixes unchanged; only the STT-facing lookup keys are corrected.
- Add regression tests so non-Whisper keys cannot land in the map again.

## Why / example use case
STT backends emit Whisper codes (e.g. `pl`). Facebook MMS looks them up to load `facebook/mms-tts-*`.

Keys follow [openai/whisper `tokenizer.py`](https://github.com/openai/whisper/blob/main/whisper/tokenizer.py) (e.g. `kn` = Kannada, `ka` = Georgian).

When STT detects Polish (`pl`), the map used to look for the non-Whisper key `po`, hit a `KeyError`, and fall back to English. It now resolves `pl` → `pol` → `facebook/mms-tts-pol`.

## Test plan
- [x] `uv run pytest tests/test_facebookmms_language_map.py -v`
- [ ] Confirm `WHISPER_LANGUAGE_TO_FACEBOOK_LANGUAGE["pl"] == "pol"` (and `bg` / `tr` / `tl` / `mr` / `ms` / `kn`)
- [ ] Optional: with `--tts facebook-mms`, a Polish turn no longer falls back to English solely because of a map miss