### PR TITLE
Remove stale dependency extras

### DIFF
--- a/README.md
+++ b/README.md
@@ -121,19 +121,18 @@ pip install speech-to-speech
 
 To use the previous CUDA-graphs implementation instead of GGML, pass `--qwen3_tts_backend torch`.
 
-### Optional Backends
+### Optional Components
 
-Extra backends are installed with pip extras:
+Optional components are installed with pip extras:
 
 ```bash
 pip install "speech-to-speech[kokoro]"          # Kokoro-82M TTS on non-macOS
 pip install "speech-to-speech[pocket]"          # Pocket TTS
 pip install "speech-to-speech[chattts]"         # ChatTTS
-pip install "speech-to-speech[facebook-mms]"    # MMS TTS
 pip install "speech-to-speech[faster-whisper]"  # Faster Whisper STT
 pip install "speech-to-speech[whisper-mlx]"     # Lightning Whisper MLX STT on macOS
 pip install "speech-to-speech[paraformer]"      # Paraformer STT through FunASR
-pip install "speech-to-speech[mlx-lm]"          # mlx-vlm support for vision models on macOS
+pip install "speech-to-speech[mlx-vlm]"         # mlx-vlm support for vision models on macOS
 ```
 
 Deprecated implementations, including MeloTTS, live in [`archive/`](./archive) and are no longer wired into the CLI.
@@ -168,7 +167,7 @@ This installs the package in editable mode and makes the `speech-to-speech` CLI 
 | TTS | [Kokoro-82M](https://huggingface.co/hexgrad/Kokoro-82M) | CUDA / CPU, Apple Silicon | `kokoro` on non-macOS; built-in on macOS |
 | TTS | [Pocket TTS](https://github.com/kyutai-labs/pocket-tts) | CPU / CUDA | `pocket` |
 | TTS | [ChatTTS](https://github.com/2noise/ChatTTS) | CUDA / CPU | `chattts` |
-| TTS | [MMS TTS](https://huggingface.co/docs/transformers/model_doc/mms) | CUDA / CPU | `facebook-mms` |
+| TTS | [MMS TTS](https://huggingface.co/docs/transformers/model_doc/mms) | CUDA / CPU | built-in |
 
 Select implementations with `--stt`, `--llm_backend`, and `--tts`. Run `speech-to-speech -h` for exact values and backend-specific flags.
 

--- a/README.md
+++ b/README.md
@@ -132,7 +132,7 @@ pip install "speech-to-speech[chattts]"         # ChatTTS
 pip install "speech-to-speech[faster-whisper]"  # Faster Whisper STT
 pip install "speech-to-speech[whisper-mlx]"     # Lightning Whisper MLX STT on macOS
 pip install "speech-to-speech[paraformer]"      # Paraformer STT through FunASR
-pip install "speech-to-speech[mlx-vlm]"         # mlx-vlm support for vision models on macOS
+pip install "speech-to-speech[mlx-lm]"          # mlx-vlm support for vision models on macOS
 ```
 
 Deprecated implementations, including MeloTTS, live in [`archive/`](./archive) and are no longer wired into the CLI.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -67,20 +67,13 @@ dependencies = [
 chattts = [
     "ChatTTS>=0.1.1",
 ]
-facebook-mms = [
-    "transformers>=4.57.0",
-]
 faster-whisper = [
     "faster-whisper>=1.0.3",
 ]
 kokoro = [
     "kokoro>=0.9.2; platform_system != 'Darwin'",
 ]
-language-detection = [
-    "lingua-language-detector>=2.0.2",
-]
-mlx-lm = [
-    "mlx-lm==0.31.1; platform_system == 'Darwin'",
+mlx-vlm = [
     "mlx-vlm==0.4.1; platform_system == 'Darwin'",
 ]
 paraformer = [
@@ -93,9 +86,6 @@ pocket = [
 ]
 webrtc = [
     "aiortc>=1.9.0",
-]
-websocket = [
-    "websockets>=12.0",
 ]
 whisper-mlx = [
     "lightning-whisper-mlx>=0.0.10; platform_system == 'Darwin'",
@@ -115,7 +105,6 @@ dev = [
     "mypy",
     "pytest",
     "pytest-asyncio",
-    "websockets>=12.0",
     "aiortc>=1.9.0",
 ]
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -73,7 +73,8 @@ faster-whisper = [
 kokoro = [
     "kokoro>=0.9.2; platform_system != 'Darwin'",
 ]
-mlx-vlm = [
+mlx-lm = [
+    "mlx-lm==0.31.1; platform_system == 'Darwin'",
     "mlx-vlm==0.4.1; platform_system == 'Darwin'",
 ]
 paraformer = [

--- a/src/speech_to_speech/LLM/language_model.py
+++ b/src/speech_to_speech/LLM/language_model.py
@@ -826,7 +826,7 @@ class VisionLanguageModelHandler(BaseLanguageModelHandler):
         if self.backend == "mlx":
             if not HAS_MLX_VLM:
                 raise ImportError(
-                    'mlx-vlm is required for MLX VLM models. Install with: pip install "speech-to-speech[mlx-vlm]"'
+                    'mlx-vlm is required for MLX VLM models. Install with: pip install "speech-to-speech[mlx-lm]"'
                 )
             self.model, self.processor = mlx_vlm_load(model_name)  # type: ignore[assignment]
             self.tokenizer = self.processor.tokenizer  # type: ignore[assignment]

--- a/src/speech_to_speech/LLM/language_model.py
+++ b/src/speech_to_speech/LLM/language_model.py
@@ -825,7 +825,9 @@ class VisionLanguageModelHandler(BaseLanguageModelHandler):
 
         if self.backend == "mlx":
             if not HAS_MLX_VLM:
-                raise ImportError("mlx-vlm is required for MLX VLM models. Install with: pip install mlx-vlm")
+                raise ImportError(
+                    'mlx-vlm is required for MLX VLM models. Install with: pip install "speech-to-speech[mlx-vlm]"'
+                )
             self.model, self.processor = mlx_vlm_load(model_name)  # type: ignore[assignment]
             self.tokenizer = self.processor.tokenizer  # type: ignore[assignment]
             self.gen_kwargs = gen_kwargs


### PR DESCRIPTION
## Summary

- remove the no-op `facebook-mms`, `language-detection`, and `websocket` extras now that their packages are installed by default
- remove the duplicate `websockets` development dependency
- preserve the existing `mlx-lm` extra name and requirements for compatibility

## Why

Several backends moved into the default installation over time, but their old extras remained in `pyproject.toml`. Installing those extras no longer changed the environment, and `websockets` was declared a third time in the development group.

## Impact

The default installation is unchanged. MMS TTS, language detection, and WebSocket support remain built in. The existing `speech-to-speech[mlx-lm]` interface remains available with the same requirements.

## Validation

- `ruff check src/ tests/`
- `ruff format --check src/ tests/`
- `mypy src/`
- `pytest tests/ -x -q` (787 passed)
- offline wheel and sdist build
- `twine check --strict` on both distributions
- inspected wheel metadata to confirm only the intended extras are published
