### PR TITLE
fix(qwen3-tts): preserve CJK punctuation and budget CJK utterances correctly

### DIFF
--- a/src/speech_to_speech/LLM/utils.py
+++ b/src/speech_to_speech/LLM/utils.py
@@ -16,7 +16,7 @@ SMART_PUNCT_TRANSLATION = str.maketrans(
 )
 
 SPEECHABLE_PATTERN = re.compile(
-    r"[^\w\s.,!?;:'\"\-()\/\\@#%&*+=$€£¥₹₽¢\[\]{}<>~`^|…—–\n\r\t]",
+    r"[^\w\s.,!?;:'\"\-()\/\\@#%&*+=$€£¥₹₽¢\[\]{}<>~`^|…—–，。！？；：、\n\r\t]",
     flags=re.UNICODE,
 )
 

--- a/src/speech_to_speech/TTS/qwen3_tts_handler.py
+++ b/src/speech_to_speech/TTS/qwen3_tts_handler.py
@@ -622,9 +622,7 @@ class Qwen3TTSHandler(BaseHandler[TTSIn, TTSOut]):
         punctuation_count = sum(unicodedata.category(ch).startswith("P") for ch in text)
         punctuation_seconds = punctuation_count * QWEN3_PUNCTUATION_PAUSE_SECONDS
         estimated_seconds = (
-            max(word_seconds, char_seconds, cjk_seconds)
-            + punctuation_seconds
-            + QWEN3_BASE_PROMPT_SECONDS
+            max(word_seconds, char_seconds, cjk_seconds) + punctuation_seconds + QWEN3_BASE_PROMPT_SECONDS
         )
         estimated_tokens = math.ceil(estimated_seconds * MLX_STREAMING_TOKENS_PER_SECOND * QWEN3_TOKEN_SAFETY_MARGIN)
         aligned_tokens = max(

--- a/src/speech_to_speech/TTS/qwen3_tts_handler.py
+++ b/src/speech_to_speech/TTS/qwen3_tts_handler.py
@@ -50,9 +50,14 @@ MLX_STREAMING_TOKENS_PER_SECOND = 12.5
 PIPELINE_SR = 16000
 ESTIMATED_QWEN3_WORDS_PER_SECOND = 2.6
 ESTIMATED_QWEN3_CHARS_PER_SECOND = 14.0
+ESTIMATED_QWEN3_CJK_CHARS_PER_SECOND = 5.5
 QWEN3_TOKEN_SAFETY_MARGIN = 1.35
 QWEN3_BASE_PROMPT_SECONDS = 1.0
 QWEN3_PUNCTUATION_PAUSE_SECONDS = 0.5
+CJK_CHARACTER_PATTERN = re.compile(
+    r"[\u3040-\u30ff\u3400-\u4dbf\u4e00-\u9fff\uac00-\ud7af\uf900-\ufaff"
+    r"\U00020000-\U0002fa1f]"
+)
 QWEN3_LANGUAGE_ALIASES = {
     "zh": "chinese",
     "zh-cn": "chinese",
@@ -610,11 +615,17 @@ class Qwen3TTSHandler(BaseHandler[TTSIn, TTSOut]):
 
         word_count = len(re.findall(r"\w+", text, flags=re.UNICODE))
         char_count = len(re.sub(r"\s+", "", text))
+        cjk_char_count = len(CJK_CHARACTER_PATTERN.findall(text))
         word_seconds = word_count / ESTIMATED_QWEN3_WORDS_PER_SECOND if word_count else 0.0
         char_seconds = char_count / ESTIMATED_QWEN3_CHARS_PER_SECOND if char_count else 0.0
+        cjk_seconds = cjk_char_count / ESTIMATED_QWEN3_CJK_CHARS_PER_SECOND if cjk_char_count else 0.0
         punctuation_count = sum(unicodedata.category(ch).startswith("P") for ch in text)
         punctuation_seconds = punctuation_count * QWEN3_PUNCTUATION_PAUSE_SECONDS
-        estimated_seconds = max(word_seconds, char_seconds) + punctuation_seconds + QWEN3_BASE_PROMPT_SECONDS
+        estimated_seconds = (
+            max(word_seconds, char_seconds, cjk_seconds)
+            + punctuation_seconds
+            + QWEN3_BASE_PROMPT_SECONDS
+        )
         estimated_tokens = math.ceil(estimated_seconds * MLX_STREAMING_TOKENS_PER_SECOND * QWEN3_TOKEN_SAFETY_MARGIN)
         aligned_tokens = max(
             chunk_size,
@@ -633,10 +644,11 @@ class Qwen3TTSHandler(BaseHandler[TTSIn, TTSOut]):
             )
 
         logger.debug(
-            "Qwen3-TTS using max_new_tokens=%d for utterance with %d words and %d chars",
+            "Qwen3-TTS using max_new_tokens=%d for utterance with %d words, %d chars, and %d CJK chars",
             resolved_tokens,
             word_count,
             char_count,
+            cjk_char_count,
         )
         return resolved_tokens
 

--- a/tests/test_llm_utils.py
+++ b/tests/test_llm_utils.py
@@ -17,6 +17,11 @@ def test_remove_unspeechable_keeps_text_and_drops_emoji() -> None:
     assert remove_unspeechable("Hello 👋 lobster 🦞") == "Hello  lobster "
 
 
+def test_remove_unspeechable_keeps_chinese_punctuation() -> None:
+    text = "你好，今天怎么样？很好！停顿；说明：一、二。"
+    assert remove_unspeechable(text) == text
+
+
 # --- language name coverage ---------------------------------------------------------------
 #
 # A language code with no entry in WHISPER_LANGUAGE_TO_LLM_LANGUAGE resolves to a `None`

--- a/tests/test_qwen3_tts_handler_backend.py
+++ b/tests/test_qwen3_tts_handler_backend.py
@@ -903,6 +903,23 @@ def test_estimate_max_new_tokens_scales_with_utterance_length():
     assert long_budget <= handler.max_new_tokens
 
 
+def test_estimate_max_new_tokens_uses_cjk_speaking_rate():
+    handler = object.__new__(Qwen3TTSHandler)
+    handler.streaming_chunk_size = 8
+    handler.max_new_tokens = 1536
+
+    short_text = "我懂，心情不好时会让人特别疲惫。"
+    long_text = (
+        "上海是一座充满活力的现代化大都市，既有繁华的金融中心和摩天大楼，也有老城厢的弄堂风情"
+        "和江南水乡的韵味。这里交通便利，餐饮选择丰富，从精致西餐到地道小馆应有尽有。同时，上海"
+        "还是文化与创新的交汇点，艺术展览、科技展会和国际活动频繁。如果你喜欢快节奏的生活和多元"
+        "的氛围，上海会是个很吸引人的地方。你想了解哪方面的具体信息呢？"
+    )
+
+    assert handler._estimate_max_new_tokens(short_text) == 360
+    assert handler._estimate_max_new_tokens(long_text) == 576
+
+
 def test_estimate_max_new_tokens_respects_configured_cap():
     handler = object.__new__(Qwen3TTSHandler)
     handler.streaming_chunk_size = 8


### PR DESCRIPTION
## Summary

- preserve common CJK punctuation before text reaches TTS
- account for CJK speaking rate in Qwen3-TTS codec-token budgeting
- add regression coverage for punctuation preservation and Chinese utterance budgets

## Problem

Common Chinese punctuation was removed by remove_unspeechable, which degraded prosody and removed pause information before synthesis.

The Qwen3-TTS budget estimator also treated CJK text using the generic 14-characters-per-second rate. A tested 159-character Chinese utterance therefore remained at 360 codec tokens and stopped at the generation boundary before completing.

## Fix

The speechable-character filter now preserves common CJK punctuation.

The Qwen3-TTS estimator detects CJK characters and includes a conservative CJK speaking-rate estimate while preserving the existing minimum budget, configured cap, chunk alignment, sampling behavior, and natural EOS.

For the 159-character regression sample, the resolved budget changes from 360 to 576 tokens and the model completes naturally.

## Validation

- 73 passed, 1 skipped in focused tests
- 769 passed, 2 skipped in the full test suite
- Ruff and git diff --check pass
- realtime model regression completed with exact 159/159-character output, 0.017s trailing silence, and no token-boundary truncation