### PR TITLE
Handle expired OAuth sessions in the demo

### DIFF
--- a/demo/README.md
+++ b/demo/README.md
@@ -8,6 +8,7 @@ app_port: 7860
 pinned: false
 short_description: Voice chat over WebSocket against a HF speech-to-speech
 hf_oauth: true
+hf_oauth_expiration_minutes: 10080
 ---
 
 # Realtime Voice Demo

--- a/demo/auth.py
+++ b/demo/auth.py
@@ -16,6 +16,7 @@ Identity:
 import logging
 import os
 import secrets
+from datetime import datetime, timedelta, timezone
 
 import limiter
 
@@ -29,6 +30,7 @@ OAUTH_LOGOUT_PATH = "/oauth/huggingface/logout"
 
 ANON_COOKIE = "s2s_anon"
 _COOKIE_MAX_AGE = 60 * 60 * 24 * 30  # 30 days
+_OAUTH_EXPIRY_SKEW = timedelta(seconds=30)
 
 
 # Members of these orgs get unlimited usage (like PRO) out of the box. The
@@ -101,9 +103,49 @@ def current_oauth(request):
         return None
 
 
+def _oauth_token_expired(info, *, now=None) -> bool:
+    """Whether the OAuth access token is expired (including clock skew)."""
+    expires_at = _field(info, "access_token_expires_at")
+    if expires_at is None:
+        # Older huggingface_hub versions did not expose this field. Preserve
+        # compatibility and let the upstream service validate those tokens.
+        return False
+    if not isinstance(expires_at, datetime):
+        logger.warning("Unexpected OAuth expiry value; requiring a fresh login.")
+        return True
+    if expires_at.tzinfo is None:
+        expires_at = expires_at.replace(tzinfo=timezone.utc)
+    current = now or datetime.now(timezone.utc)
+    if current.tzinfo is None:
+        current = current.replace(tzinfo=timezone.utc)
+    return expires_at <= current + _OAUTH_EXPIRY_SKEW
+
+
+def _oauth_token(info) -> "str | None":
+    token = _field(info, "access_token")
+    if token is None:
+        return None
+    return str(token).strip() or None
+
+
+def oauth_login_required_reason(request) -> "str | None":
+    """Why a cached signed-in session cannot authenticate, if applicable."""
+    info = current_oauth(request)
+    if not _field(info, "user_info"):
+        return None
+    if _oauth_token_expired(info):
+        return "token_expired"
+    if not _oauth_token(info):
+        return "token_invalid"
+    return None
+
+
 def current_user(request):
     """The signed-in HF user-info, or None."""
-    return _field(current_oauth(request), "user_info")
+    info = current_oauth(request)
+    if _oauth_token_expired(info) or not _oauth_token(info):
+        return None
+    return _field(info, "user_info")
 
 
 def current_access_token(request) -> "str | None":
@@ -112,10 +154,10 @@ def current_access_token(request) -> "str | None":
     Keep this server-side: the demo uses it to attribute load-balancer session
     requests to the signed-in HF account, but never returns it to the browser.
     """
-    token = _field(current_oauth(request), "access_token")
-    if token is None:
+    info = current_oauth(request)
+    if _oauth_token_expired(info):
         return None
-    return str(token).strip() or None
+    return _oauth_token(info)
 
 
 def _user_org_names(user) -> "set[str]":
@@ -186,7 +228,11 @@ def user_view(request) -> dict:
     user = _field(info, "user_info")
     if not user:
         return {"loggedIn": False, "tier": "anon"}
-    token = _field(info, "access_token")
+    if _oauth_token_expired(info):
+        return {"loggedIn": False, "tier": "anon", "reason": "token_expired"}
+    token = _oauth_token(info)
+    if not token:
+        return {"loggedIn": False, "tier": "anon", "reason": "token_invalid"}
     out = {
         "loggedIn": True,
         "username": _field(user, "preferred_username") or _field(user, "name") or "you",
@@ -216,9 +262,9 @@ def resolve_identity(request):
     """
     info = current_oauth(request)
     user = _field(info, "user_info")
-    if user:
+    token = _oauth_token(info)
+    if user and token and not _oauth_token_expired(info):
         sub = _field(user, "sub") or _field(user, "preferred_username")
-        token = _field(info, "access_token")
         return resolve_tier(user, token), [limiter.hash_key(f"sub:{sub}")], None
 
     # Anonymous: key by IP and a signed cookie id, minting the cookie if absent.

--- a/demo/auth.py
+++ b/demo/auth.py
@@ -114,10 +114,10 @@ def _oauth_token_expired(info, *, now=None) -> bool:
         logger.warning("Unexpected OAuth expiry value; requiring a fresh login.")
         return True
     if expires_at.tzinfo is None:
-        expires_at = expires_at.replace(tzinfo=timezone.utc)
+        expires_at = expires_at.astimezone(timezone.utc)
     current = now or datetime.now(timezone.utc)
     if current.tzinfo is None:
-        current = current.replace(tzinfo=timezone.utc)
+        current = current.astimezone(timezone.utc)
     return expires_at <= current + _OAUTH_EXPIRY_SKEW
 
 

--- a/demo/main.js
+++ b/demo/main.js
@@ -1176,6 +1176,13 @@ circleBtn.addEventListener("click", async () => {
  *  a real fault (surface it). doStart already closed any orphan AudioContext.
  *  @param {any} err */
 async function handleStartError(err) {
+  if (err && err.code === "login-required") {
+    await teardown();
+    setState("error");
+    setCaption("Sign in again to continue.", "error");
+    account.showLoginRequired(err.loginUrl);
+    return;
+  }
   if (err && err.code === "limit") {
     await teardown();
     account.showLimit(err.tier);
@@ -1203,7 +1210,7 @@ async function handleStartError(err) {
     );
     return;
   }
-  onFatalError(err);
+  await onFatalError(err);
 }
 
 micBtn.addEventListener("click", () => {
@@ -1513,7 +1520,7 @@ async function doStart(audioContext = null) {
   });
   c.addEventListener("error", (e) => {
     const detail = /** @type {CustomEvent<{ error: unknown }>} */ (e).detail;
-    onFatalError(detail.error);
+    void onFatalError(detail.error);
   });
   c.addEventListener("server-error", (e) => {
     // Non-fatal: the backend reported an error mid-session. Log it, keep the
@@ -1692,15 +1699,17 @@ async function teardown() {
 }
 
 /** @param {unknown} err */
-function onFatalError(err) {
+async function onFatalError(err) {
   console.error("[main] fatal:", err);
-  setState("error");
   const message = err instanceof Error ? err.message : String(err);
-  setCaption(truncateError(message), "error");
-  void teardown().catch(() => {
+  try {
+    await teardown();
+  } catch (teardownError) {
+    console.warn("[main] error during fatal teardown:", teardownError);
+  } finally {
     setState("error");
     setCaption(truncateError(message), "error");
-  });
+  }
 }
 
 setState("idle");

--- a/demo/server.py
+++ b/demo/server.py
@@ -373,8 +373,13 @@ async def session(request: Request):
 
     if lb.status_code == 401:
         body = _safe_json(lb)
-        logger.info("Session authentication rejected: %s", body.get("reason", "unauthorized"))
-        return _login_required_response(body.get("reason", "login_required"), set_cookie)
+        reason = body.get("reason", "login_required")
+        if reason == "token_invalid":
+            session = getattr(request, "scope", {}).get("session")
+            if isinstance(session, dict):
+                session.pop("oauth_info", None)
+        logger.info("Session authentication rejected: %s", reason)
+        return _login_required_response(reason, set_cookie)
 
     if lb.status_code != 200:
         # The LB's error body may name the reason (e.g. capacity); it carries no

--- a/demo/server.py
+++ b/demo/server.py
@@ -328,6 +328,10 @@ async def session(request: Request):
         # never call this. 404 so it's indistinguishable from a missing route.
         raise HTTPException(status_code=404, detail="Not found.")
 
+    login_reason = auth.oauth_login_required_reason(request)
+    if login_reason:
+        return _login_required_response(login_reason)
+
     tier, keys, set_cookie = auth.resolve_identity(request)
     # Metering runs only on the deployed Space; off-Space the LB still proxies but
     # nothing is tracked. Within metering, unlimited tiers (pro, org) aren't either.
@@ -367,6 +371,11 @@ async def session(request: Request):
                 auth.set_anon_cookie(resp, set_cookie)
             return resp
 
+    if lb.status_code == 401:
+        body = _safe_json(lb)
+        logger.info("Session authentication rejected: %s", body.get("reason", "unauthorized"))
+        return _login_required_response(body.get("reason", "login_required"), set_cookie)
+
     if lb.status_code != 200:
         # The LB's error body may name the reason (e.g. capacity); it carries no
         # secret, so relay a trimmed copy.
@@ -386,6 +395,20 @@ async def session(request: Request):
 
     # A slot was free: reserve the first chunk now and return the grant.
     return await _finalize_grant(data, keys, tier, tracked, set_cookie)
+
+
+def _login_required_response(reason: str, set_cookie=None) -> JSONResponse:
+    """Actionable 401 understood by the browser's login-required flow."""
+    resp = JSONResponse(
+        {
+            "reason": reason,
+            "loginUrl": auth.OAUTH_LOGIN_PATH if AUTH_ENABLED else None,
+        },
+        status_code=401,
+    )
+    if set_cookie:
+        auth.set_anon_cookie(resp, set_cookie)
+    return resp
 
 
 def _load_balancer_headers(request: Request) -> dict[str, str]:

--- a/demo/server.py
+++ b/demo/server.py
@@ -436,6 +436,10 @@ async def queue_status(queue_id: str, request: Request):
     if not LOAD_BALANCER_URL:
         raise HTTPException(status_code=404, detail="Not found.")
 
+    login_reason = auth.oauth_login_required_reason(request)
+    if login_reason:
+        return _login_required_response(login_reason)
+
     tier, keys, set_cookie = auth.resolve_identity(request)
     tracked = LIMITER_ENABLED and limiter.budget_for(tier) is not None
 

--- a/demo/ui/account.js
+++ b/demo/ui/account.js
@@ -38,6 +38,7 @@ export class Account {
 
     /** @type {{enabled:boolean, auth?:boolean, loggedIn?:boolean, username?:string, avatar?:string, tier?:string, remainingSec?:number|null, limitSec?:number|null, loginUrl?:string|null, logoutUrl?:string|null}} */
     this._me = { enabled: false };
+    this._refreshId = 0;
     this._popoverOpen = false;
 
     $("#limit-close").addEventListener("click", () => this._modal.close());
@@ -59,12 +60,16 @@ export class Account {
   /** Fetch `/api/me` and (re)render the chip. Safe to call repeatedly (load,
    *  after the OAuth redirect, after a conversation ends). */
   async refresh() {
+    const refreshId = ++this._refreshId;
+    let me;
     try {
       const res = await fetch("api/me");
-      this._me = res.ok ? await res.json() : { enabled: false };
+      me = res.ok ? await res.json() : { enabled: false };
     } catch {
-      this._me = { enabled: false };
+      me = { enabled: false };
     }
+    if (refreshId !== this._refreshId) return;
+    this._me = me;
     this._render();
   }
 
@@ -179,6 +184,10 @@ export class Account {
   /** Replace a stale signed-in chip and ask the user to authenticate again.
    *  @param {string | null | undefined} loginUrl */
   showLoginRequired(loginUrl) {
+    // Teardown starts an account refresh before this runs. Invalidate that
+    // request so a revoked-but-not-yet-expired token cannot restore the stale
+    // signed-in chip when `/api/me` eventually responds.
+    this._refreshId += 1;
     const url = loginUrl || this._me.loginUrl;
     this._me = {
       ...this._me,

--- a/demo/ui/account.js
+++ b/demo/ui/account.js
@@ -176,6 +176,33 @@ export class Account {
     if (!this._modal.open) this._modal.showModal();
   }
 
+  /** Replace a stale signed-in chip and ask the user to authenticate again.
+   *  @param {string | null | undefined} loginUrl */
+  showLoginRequired(loginUrl) {
+    const url = loginUrl || this._me.loginUrl;
+    this._me = {
+      ...this._me,
+      enabled: true,
+      auth: !!url,
+      loggedIn: false,
+      tier: "anon",
+      loginUrl: url,
+    };
+    this._render();
+    this._modalTitle.textContent = "Sign in again";
+    this._modalMsg.textContent =
+      "Your Hugging Face session expired or was revoked. Sign in again to start a conversation.";
+    this._modalNote.textContent = "This keeps your account and conversation time secure.";
+    if (url) {
+      this._modalCta.innerHTML = `${HF_MARK}<span>Sign in with Hugging Face</span>`;
+      this._modalCta.href = url;
+      this._modalCta.hidden = false;
+    } else {
+      this._modalCta.hidden = true;
+    }
+    if (!this._modal.open) this._modal.showModal();
+  }
+
   /** Show a warm "we're at capacity" message when even the waiting line is full.
    *  Reuses the limit modal shell; no call-to-action, just reassurance. */
   showBusy() {

--- a/demo/ws/s2s-ws-client.js
+++ b/demo/ws/s2s-ws-client.js
@@ -96,7 +96,8 @@ import { OrbVisualiser, VIS_FFT_SIZE } from "./orb-visualizer.js";
 import { SentAudioRecorder } from "./user-audio-recorder.js";
 
 /** Build an Error carrying a `code` (and optional extra fields) so callers can
- *  branch on the failure kind: "limit" | "queue-full" | "queue-expired" | "aborted".
+ *  branch on the failure kind: "login-required" | "limit" | "queue-full" |
+ *  "queue-expired" | "aborted".
  *  @param {string} message @param {string} code @param {object} [extra] */
 function _codedError(message, code, extra) {
   const err = /** @type {Error & { code?: string }} */ (new Error(message));
@@ -362,6 +363,12 @@ export class S2sWsRealtimeClient extends EventTarget {
       const body = await response.json().catch(() => ({}));
       throw _codedError("Daily conversation limit reached", "limit", { tier: body?.tier });
     }
+    if (response.status === 401) {
+      const body = await response.json().catch(() => ({}));
+      throw _codedError("Sign in again to continue", "login-required", {
+        loginUrl: body?.loginUrl,
+      });
+    }
     if (response.status === 503) {
       const body = await response.json().catch(() => ({}));
       if (body?.state === "at_capacity") {
@@ -413,6 +420,12 @@ export class S2sWsRealtimeClient extends EventTarget {
       if (response.status === 402) {
         const body = await response.json().catch(() => ({}));
         throw _codedError("Daily conversation limit reached", "limit", { tier: body?.tier });
+      }
+      if (response.status === 401) {
+        const body = await response.json().catch(() => ({}));
+        throw _codedError("Sign in again to continue", "login-required", {
+          loginUrl: body?.loginUrl,
+        });
       }
       if (response.status === 404) {
         throw _codedError("Queue timed out", "queue-expired");

--- a/tests/test_demo_server.py
+++ b/tests/test_demo_server.py
@@ -3,8 +3,9 @@ import json
 import shutil
 import subprocess
 import sys
-from datetime import datetime, timedelta, timezone
+from datetime import datetime, timedelta
 from pathlib import Path
+from types import SimpleNamespace
 
 import httpx
 import pytest
@@ -39,7 +40,7 @@ def test_expiring_oauth_token_requires_fresh_login(monkeypatch):
         "current_oauth",
         lambda request: {
             "access_token": "hf_user_token",
-            "access_token_expires_at": datetime.now(timezone.utc) + timedelta(seconds=15),
+            "access_token_expires_at": datetime.now() + timedelta(seconds=15),
             "user_info": {"sub": "123", "preferred_username": "alice"},
         },
     )
@@ -100,13 +101,15 @@ async def test_session_preserves_load_balancer_authentication_failure(monkeypatc
     monkeypatch.setattr(demo_server.auth, "resolve_identity", lambda request: ("free", ["key"], None))
     monkeypatch.setattr(demo_server.auth, "current_access_token", lambda request: "hf_user_token")
 
-    response = await demo_server.session(object())
+    request = SimpleNamespace(scope={"session": {"oauth_info": {"access_token": "hf_user_token"}}})
+    response = await demo_server.session(request)
 
     assert response.status_code == 401
     assert json.loads(response.body) == {
         "reason": "token_invalid",
         "loginUrl": demo_auth.OAUTH_LOGIN_PATH,
     }
+    assert "oauth_info" not in request.scope["session"]
 
 
 async def test_session_rejects_locally_expired_oauth_before_proxying(monkeypatch):

--- a/tests/test_demo_server.py
+++ b/tests/test_demo_server.py
@@ -127,6 +127,29 @@ async def test_session_rejects_locally_expired_oauth_before_proxying(monkeypatch
     }
 
 
+async def test_queue_rejects_locally_expired_oauth_before_polling(monkeypatch):
+    monkeypatch.setattr(demo_server, "LOAD_BALANCER_URL", "https://load-balancer.example")
+    monkeypatch.setattr(demo_server, "AUTH_ENABLED", True)
+    monkeypatch.setattr(
+        demo_server.auth,
+        "oauth_login_required_reason",
+        lambda request: "token_expired",
+    )
+    monkeypatch.setattr(
+        demo_server.auth,
+        "resolve_identity",
+        lambda request: pytest.fail("expired OAuth must not resolve as anonymous"),
+    )
+
+    response = await demo_server.queue_status("ticket", object())
+
+    assert response.status_code == 401
+    assert json.loads(response.body) == {
+        "reason": "token_expired",
+        "loginUrl": demo_auth.OAUTH_LOGIN_PATH,
+    }
+
+
 def test_websocket_client_classifies_session_401_as_login_required():
     node = shutil.which("node")
     if node is None:
@@ -155,6 +178,74 @@ try {
   if (error.loginUrl !== "/oauth/huggingface/login") {
     throw new Error(`unexpected login URL: ${error.loginUrl}`);
   }
+}
+"""
+    subprocess.run(
+        [node, "--input-type=module", "-e", script],
+        cwd=Path(__file__).resolve().parents[1],
+        check=True,
+        capture_output=True,
+        text=True,
+    )
+
+
+def test_login_required_state_wins_over_inflight_account_refresh():
+    node = shutil.which("node")
+    if node is None:
+        pytest.skip("Node.js is required for demo client tests")
+
+    script = """
+globalThis.localStorage = { getItem() { return null; } };
+const elements = new Map();
+function element() {
+  return {
+    hidden: false,
+    innerHTML: "",
+    textContent: "",
+    href: "",
+    open: false,
+    addEventListener() {},
+    contains() { return false; },
+    setAttribute() {},
+    showModal() { this.open = true; },
+    close() { this.open = false; },
+  };
+}
+globalThis.document = {
+  querySelector(selector) {
+    if (!elements.has(selector)) elements.set(selector, element());
+    return elements.get(selector);
+  },
+  addEventListener() {},
+  getElementById(id) { return this.querySelector(`#${id}`); },
+};
+
+let resolveFetch;
+globalThis.fetch = () => new Promise((resolve) => { resolveFetch = resolve; });
+
+const { Account } = await import("./demo/ui/account.js");
+const account = new Account();
+const refresh = account.refresh();
+account.showLoginRequired("/oauth/huggingface/login");
+resolveFetch({
+  ok: true,
+  async json() {
+    return {
+      enabled: true,
+      auth: true,
+      loggedIn: true,
+      username: "alice",
+      tier: "free",
+      loginUrl: "/oauth/huggingface/login",
+    };
+  },
+});
+await refresh;
+
+if (account.tier !== "anon") throw new Error(`unexpected tier: ${account.tier}`);
+const root = elements.get("#account");
+if (!root.innerHTML.includes("signin-pill")) {
+  throw new Error(`stale account refresh won: ${root.innerHTML}`);
 }
 """
     subprocess.run(

--- a/tests/test_demo_server.py
+++ b/tests/test_demo_server.py
@@ -1,6 +1,13 @@
 import importlib
+import json
+import shutil
+import subprocess
 import sys
+from datetime import datetime, timedelta, timezone
 from pathlib import Path
+
+import httpx
+import pytest
 
 DEMO_DIR = Path(__file__).resolve().parents[1] / "demo"
 sys.path.insert(0, str(DEMO_DIR))
@@ -26,6 +33,26 @@ def test_current_access_token_rejects_missing_or_empty_token(monkeypatch):
     assert demo_auth.current_access_token(object()) is None
 
 
+def test_expiring_oauth_token_requires_fresh_login(monkeypatch):
+    monkeypatch.setattr(
+        demo_auth,
+        "current_oauth",
+        lambda request: {
+            "access_token": "hf_user_token",
+            "access_token_expires_at": datetime.now(timezone.utc) + timedelta(seconds=15),
+            "user_info": {"sub": "123", "preferred_username": "alice"},
+        },
+    )
+
+    assert demo_auth.current_access_token(object()) is None
+    assert demo_auth.oauth_login_required_reason(object()) == "token_expired"
+    assert demo_auth.user_view(object()) == {
+        "loggedIn": False,
+        "tier": "anon",
+        "reason": "token_expired",
+    }
+
+
 def test_load_balancer_headers_forward_signed_in_user_token(monkeypatch):
     monkeypatch.setattr(
         demo_server.auth,
@@ -49,3 +76,91 @@ def test_load_balancer_headers_keep_anonymous_requests_credential_free(monkeypat
         "Content-Type": "application/json",
         "User-Agent": "speech-to-speech-demo",
     }
+
+
+async def test_session_preserves_load_balancer_authentication_failure(monkeypatch):
+    class FakeAsyncClient:
+        def __init__(self, **kwargs):
+            pass
+
+        async def __aenter__(self):
+            return self
+
+        async def __aexit__(self, *args):
+            pass
+
+        async def post(self, *args, **kwargs):
+            return httpx.Response(401, json={"reason": "token_invalid"})
+
+    monkeypatch.setattr(demo_server, "LOAD_BALANCER_URL", "https://load-balancer.example")
+    monkeypatch.setattr(demo_server, "AUTH_ENABLED", True)
+    monkeypatch.setattr(demo_server, "LIMITER_ENABLED", False)
+    monkeypatch.setattr(demo_server.httpx, "AsyncClient", FakeAsyncClient)
+    monkeypatch.setattr(demo_server.auth, "oauth_login_required_reason", lambda request: None)
+    monkeypatch.setattr(demo_server.auth, "resolve_identity", lambda request: ("free", ["key"], None))
+    monkeypatch.setattr(demo_server.auth, "current_access_token", lambda request: "hf_user_token")
+
+    response = await demo_server.session(object())
+
+    assert response.status_code == 401
+    assert json.loads(response.body) == {
+        "reason": "token_invalid",
+        "loginUrl": demo_auth.OAUTH_LOGIN_PATH,
+    }
+
+
+async def test_session_rejects_locally_expired_oauth_before_proxying(monkeypatch):
+    monkeypatch.setattr(demo_server, "LOAD_BALANCER_URL", "https://load-balancer.example")
+    monkeypatch.setattr(demo_server, "AUTH_ENABLED", True)
+    monkeypatch.setattr(
+        demo_server.auth,
+        "oauth_login_required_reason",
+        lambda request: "token_expired",
+    )
+
+    response = await demo_server.session(object())
+
+    assert response.status_code == 401
+    assert json.loads(response.body) == {
+        "reason": "token_expired",
+        "loginUrl": demo_auth.OAUTH_LOGIN_PATH,
+    }
+
+
+def test_websocket_client_classifies_session_401_as_login_required():
+    node = shutil.which("node")
+    if node is None:
+        pytest.skip("Node.js is required for demo client tests")
+
+    script = """
+globalThis.localStorage = { getItem() { return null; } };
+globalThis.fetch = async () => ({
+  status: 401,
+  ok: false,
+  async json() {
+    return { reason: "token_invalid", loginUrl: "/oauth/huggingface/login" };
+  },
+});
+const { S2sWsRealtimeClient } = await import("./demo/ws/s2s-ws-client.js");
+const client = new S2sWsRealtimeClient({
+  voice: "Aiden",
+  instructions: "Be helpful.",
+  sessionUrl: "api/session",
+});
+try {
+  await client._postSession();
+  throw new Error("expected the session request to fail");
+} catch (error) {
+  if (error.code !== "login-required") throw error;
+  if (error.loginUrl !== "/oauth/huggingface/login") {
+    throw new Error(`unexpected login URL: ${error.loginUrl}`);
+  }
+}
+"""
+    subprocess.run(
+        [node, "--input-type=module", "-e", script],
+        cwd=Path(__file__).resolve().parents[1],
+        check=True,
+        capture_output=True,
+        text=True,
+    )


### PR DESCRIPTION
## Summary

- reject locally expired Hugging Face OAuth tokens with a 30-second clock-skew allowance
- report expired cached sessions as signed out from `/api/me`
- preserve load-balancer authentication failures as actionable `401` responses
- keep the sign-in/error UI visible after conversation teardown
- configure demo OAuth tokens for seven days (`10080` minutes)
- add regressions for expired OAuth timestamps, upstream `token_invalid`, and client-side `401` classification

## Root cause

The demo trusted cached OAuth user information after its access token expired, converted load-balancer authentication failures into generic `502` responses, and reset the fatal-error UI to idle during teardown.

## User impact

Users whose Space OAuth token expires or is revoked are now prompted to sign in again instead of seeing the orb silently return to idle. Newly issued demo OAuth tokens remain valid for seven days unless revoked.

## Validation

- `ruff check demo/auth.py demo/server.py tests/test_demo_server.py`
- JavaScript syntax checks for the modified client files
- OAuth metadata parsed and verified as `10080` minutes
- focused demo suite: 20 passed
- full test suite: 790 passed, 1 skipped

Closes #431
