### PR TITLE
Add reversible pre-confirmation audio ducking

### DIFF
--- a/README.md
+++ b/README.md
@@ -281,7 +281,7 @@ The compose file starts a llama.cpp server with Gemma 4, starts the TCP socket s
 
 ## Realtime API
 
-Realtime mode supports the OpenAI Realtime protocol over WebSocket and WebRTC, with live transcription and low-latency turn-taking. WebSocket clients connect at `/v1/realtime`:
+Realtime mode supports the OpenAI Realtime protocol over WebSocket and WebRTC, with live transcription and low-latency turn-taking. The bundled browser clients also use reversible barge-in: after 96 ms of active speech they temporarily duck assistant playback, but model cancellation and audio-buffer clearing still wait for the normal 384 ms speech confirmation. If the candidate was only a short noise, playback fades back in without restarting the response. WebSocket clients connect at `/v1/realtime`:
 
 ```python
 from openai import OpenAI
@@ -315,7 +315,7 @@ with client.realtime.connect(model="local") as conn:
         print(event.type)
 ```
 
-The server implements the core Realtime event set: `input_audio_buffer.append`, `session.update`, `conversation.item.create`, `response.create`, and `response.cancel` inbound; speech start/stop, streaming transcription, audio deltas, tool calls, and `response.done` outbound. The full event reference, architecture, and design details live in the [Realtime Engine README](./src/speech_to_speech/api/openai_realtime/README.md).
+The server implements the core Realtime event set: `input_audio_buffer.append`, `session.update`, `conversation.item.create`, `response.create`, and `response.cancel` inbound; speech start/stop, streaming transcription, audio deltas, tool calls, and `response.done` outbound. It additionally emits optional `input_audio_buffer.speech_candidate_started` and `input_audio_buffer.speech_candidate_rejected` extension events for reversible playback ducking; clients that do not implement them can safely ignore them. The full event reference, architecture, and design details live in the [Realtime Engine README](./src/speech_to_speech/api/openai_realtime/README.md).
 
 ### LLM Proxy
 
@@ -577,6 +577,7 @@ See [VADHandlerArguments](./src/speech_to_speech/arguments_classes/vad_arguments
 
 - `--thresh`: threshold value to trigger voice activity detection.
 - `--min_speech_ms`: minimum duration of detected voice activity to be considered speech.
+- `--speech_candidate_ms`: active-speech duration before realtime clients receive a reversible playback-duck hint. Default is 96 ms; this does not create a turn or cancel model work, and `0` disables it.
 - `--min_speech_continuation_ms`: sustain-bar hysteresis threshold for speech that continues a reopenable soft-ended, uncommitted turn within the reopen window. The default and recommended pairing is `--min_speech_ms 384 --min_speech_continuation_ms 192`.
 - `--min_silence_ms`: minimum length of silence intervals for segmenting speech. Default is 64 ms.
 - `--short_segment_merge_ms`: optional merge window for stitching adjacent VAD segments that are each shorter than `--min_speech_ms`.

--- a/demo/README.md
+++ b/demo/README.md
@@ -246,6 +246,7 @@ transport pick, and `s2s.audio.inputId` / `s2s.audio.outputId` for devices).
 | `limiter.py` | SQLite per-day talk-time budget (chunked server-clock reservation) |
 | `ws/s2s-ws-client.js` | WebSocket handshake + OpenAI Realtime GA protocol |
 | `rtc/s2s-rtc-client.js` | WebRTC sibling: SDP handshake via `/api/calls`, events over the data channel, track audio |
+| `audio-ducker.js` | Candidate-scoped output gain controller shared by WebSocket and WebRTC clients |
 | `ws/codec.js` | base64 <-> PCM helpers + transcript extraction (pure) |
 | `ws/user-audio-recorder.js` | Bounded sent-PCM buffer + VAD slicing + browser-playable WAV wrapping |
 | `ws/orb-visualizer.js` | `OrbVisualiser`: FFT bands -> orb CSS custom properties |
@@ -267,10 +268,12 @@ transport pick, and `s2s.audio.inputId` / `s2s.audio.outputId` for devices).
   and is posted to the `audio-playback` worklet. The worklet maintains a
   per-context ring buffer, linearly interpolates 24 -> 48, and applies
   short 32-frame fades on entry/exit to suppress clicks.
-- **Barge-in**: when the server VAD detects user speech mid-response
-  (`input_audio_buffer.speech_started` while `ai-speaking`), the client
-  posts `{ kind: "clear" }` to the playback worklet to wipe the queue
-  immediately. The server itself cancels the in-flight response.
+- **Barge-in**: after 96 ms of active speech, the optional
+  `input_audio_buffer.speech_candidate_started` event ramps output gain to
+  `0.12` over 15 ms. A matching reject restores it over 80 ms without
+  cancelling model work. Only confirmed speech (384 ms by default) clears the
+  WebSocket playback queue or server-side WebRTC track buffer and cancels the
+  response; `speech_stopped` restores full gain.
 
 ## Credits
 

--- a/demo/audio-ducker.js
+++ b/demo/audio-ducker.js
@@ -1,0 +1,65 @@
+// @ts-check
+
+const DUCK_GAIN = 0.12;
+const ATTACK_SECONDS = 0.015;
+const RELEASE_SECONDS = 0.08;
+
+/**
+ * Reversible output-gain state machine for pre-confirmation barge-in.
+ *
+ * A speech candidate only attenuates playback. The standard confirmed
+ * speech_started event may hard-mute it, and speech_stopped restores normal
+ * gain. Candidate ids keep a late reject from releasing a newer candidate.
+ */
+export class ReversibleAudioDucker {
+  /** @param {GainNode} gainNode @param {AudioContext} audioContext */
+  constructor(gainNode, audioContext) {
+    this._gainNode = gainNode;
+    this._ctx = audioContext;
+    this._candidateId = "";
+    this._confirmed = false;
+  }
+
+  /** @param {string} candidateId @param {boolean} [interruptResponse] */
+  candidateStarted(candidateId, interruptResponse = true) {
+    if (!candidateId || !interruptResponse) return;
+    this._candidateId = candidateId;
+    this._confirmed = false;
+    this._ramp(DUCK_GAIN, ATTACK_SECONDS);
+  }
+
+  /** @param {string} candidateId */
+  candidateRejected(candidateId) {
+    if (!candidateId || candidateId !== this._candidateId || this._confirmed) return;
+    this._candidateId = "";
+    this._ramp(1, RELEASE_SECONDS);
+  }
+
+  /** @param {boolean} [interruptResponse] */
+  speechStarted(interruptResponse = true) {
+    this._candidateId = "";
+    this._confirmed = interruptResponse;
+    this._ramp(interruptResponse ? 0 : 1, interruptResponse ? ATTACK_SECONDS : RELEASE_SECONDS);
+  }
+
+  speechStopped() {
+    this._candidateId = "";
+    this._confirmed = false;
+    this._ramp(1, RELEASE_SECONDS);
+  }
+
+  reset() {
+    this._candidateId = "";
+    this._confirmed = false;
+    this._ramp(1, 0);
+  }
+
+  /** @param {number} target @param {number} durationSeconds */
+  _ramp(target, durationSeconds) {
+    const param = this._gainNode.gain;
+    const now = this._ctx.currentTime;
+    param.cancelScheduledValues(now);
+    param.setValueAtTime(param.value, now);
+    param.linearRampToValueAtTime(target, now + durationSeconds);
+  }
+}

--- a/demo/rtc/s2s-rtc-client.js
+++ b/demo/rtc/s2s-rtc-client.js
@@ -57,6 +57,7 @@
  *   (AudioContext.setSinkId when supported).
  */
 
+import { ReversibleAudioDucker } from "../audio-ducker.js";
 import { extractResponseTranscript } from "../ws/codec.js";
 import { OrbVisualiser, VIS_FFT_SIZE } from "../ws/orb-visualizer.js";
 
@@ -113,6 +114,10 @@ export class S2sRtcRealtimeClient extends EventTarget {
     this._micAnalyser = null;
     /** @type {AnalyserNode | null} */
     this._outAnalyser = null;
+    /** @type {GainNode | null} */
+    this._outputGain = null;
+    /** @type {ReversibleAudioDucker | null} */
+    this._audioDucker = null;
     /** @type {OrbVisualiser | null} */
     this._visualiser = null;
     /** @type {number} Level/status poll timer (setInterval id). */
@@ -341,8 +346,12 @@ export class S2sRtcRealtimeClient extends EventTarget {
     const outAnalyser = ctx.createAnalyser();
     outAnalyser.fftSize = VIS_FFT_SIZE;
     outAnalyser.smoothingTimeConstant = 0.3;
-    outAnalyser.connect(ctx.destination);
+    const outputGain = ctx.createGain();
+    outAnalyser.connect(outputGain);
+    outputGain.connect(ctx.destination);
     this._outAnalyser = outAnalyser;
+    this._outputGain = outputGain;
+    this._audioDucker = new ReversibleAudioDucker(outputGain, ctx);
 
     void this.setAudioOutputDevice(this.options.audioOutputId || "");
 
@@ -465,20 +474,40 @@ export class S2sRtcRealtimeClient extends EventTarget {
       case "session.updated":
         break;
 
+      case "input_audio_buffer.speech_candidate_started":
+        this._audioDucker?.candidateStarted(
+          typeof event.candidate_id === "string" ? event.candidate_id : "",
+          event.interrupt_response !== false,
+        );
+        break;
+
+      case "input_audio_buffer.speech_candidate_rejected":
+        this._audioDucker?.candidateRejected(
+          typeof event.candidate_id === "string" ? event.candidate_id : "",
+        );
+        break;
+
       case "input_audio_buffer.speech_started":
-        // Barge-in: unlike WS there is no client playback buffer to clear —
-        // the server flushes its track buffer — so this is UI state only.
-        this._aiSpeaking = false;
-        this._lastAudibleAt = 0;
-        this.dispatchEvent(new CustomEvent("user-turn-started", {
-          detail: {
-            itemId: typeof event.item_id === "string" ? event.item_id : "",
-          },
-        }));
-        this._setStatus("user-speaking");
+        {
+          const interruptResponse = event.interrupt_response !== false;
+          this._audioDucker?.speechStarted(interruptResponse);
+          // Barge-in: unlike WS there is no client playback buffer to clear —
+          // the server flushes its track buffer — so this is UI state only.
+          if (interruptResponse) {
+            this._aiSpeaking = false;
+            this._lastAudibleAt = 0;
+          }
+          this.dispatchEvent(new CustomEvent("user-turn-started", {
+            detail: {
+              itemId: typeof event.item_id === "string" ? event.item_id : "",
+            },
+          }));
+          this._setStatus("user-speaking");
+        }
         break;
 
       case "input_audio_buffer.speech_stopped":
+        this._audioDucker?.speechStopped();
         this.dispatchEvent(new CustomEvent("user-turn-stopped", {
           detail: {
             itemId: typeof event.item_id === "string" ? event.item_id : "",
@@ -871,6 +900,13 @@ export class S2sRtcRealtimeClient extends EventTarget {
     } catch {
       // ignored
     }
+    this._audioDucker?.reset();
+    this._audioDucker = null;
+    try {
+      this._outputGain?.disconnect();
+    } catch {
+      // ignored
+    }
     try {
       await this._ctx?.close();
     } catch {
@@ -881,6 +917,7 @@ export class S2sRtcRealtimeClient extends EventTarget {
     this._micSrc = null;
     this._micAnalyser = null;
     this._outAnalyser = null;
+    this._outputGain = null;
     this._setStatus("closed");
   }
 }

--- a/demo/ws/s2s-ws-client.js
+++ b/demo/ws/s2s-ws-client.js
@@ -92,6 +92,7 @@ import {
   extractResponseTranscript,
   trimTrailingSlash,
 } from "./codec.js";
+import { ReversibleAudioDucker } from "../audio-ducker.js";
 import { OrbVisualiser, VIS_FFT_SIZE } from "./orb-visualizer.js";
 import { SentAudioRecorder } from "./user-audio-recorder.js";
 
@@ -168,6 +169,10 @@ export class S2sWsRealtimeClient extends EventTarget {
     this._micAnalyser = null;
     /** @type {AnalyserNode | null} */
     this._outAnalyser = null;
+    /** @type {GainNode | null} */
+    this._outputGain = null;
+    /** @type {ReversibleAudioDucker | null} */
+    this._audioDucker = null;
     /** @type {OrbVisualiser | null} */
     this._visualiser = null;
     /** @type {WsStatus} */
@@ -527,13 +532,18 @@ export class S2sWsRealtimeClient extends EventTarget {
     playbackNode.port.postMessage({ kind: "config", inputRate: OUTPUT_SAMPLE_RATE });
     playbackNode.port.onmessage = (e) => this._onPlaybackMessage(e.data);
 
-    // Output analyser sits between the playback worklet and the speakers.
+    // Keep the analyser before the gain so UI/audibility detection observes
+    // the source signal even while a reversible barge-in candidate ducks it.
     const outAnalyser = ctx.createAnalyser();
     outAnalyser.fftSize = VIS_FFT_SIZE;
     outAnalyser.smoothingTimeConstant = 0.3;
+    const outputGain = ctx.createGain();
     playbackNode.connect(outAnalyser);
-    outAnalyser.connect(ctx.destination);
+    outAnalyser.connect(outputGain);
+    outputGain.connect(ctx.destination);
     this._outAnalyser = outAnalyser;
+    this._outputGain = outputGain;
+    this._audioDucker = new ReversibleAudioDucker(outputGain, ctx);
     this._playbackNode = playbackNode;
 
     await this.setAudioOutputDevice(this.options.audioOutputId || "");
@@ -670,28 +680,47 @@ export class S2sWsRealtimeClient extends EventTarget {
         // already queued from session.created and is guarded against repeats.
         break;
 
+      case "input_audio_buffer.speech_candidate_started":
+        this._audioDucker?.candidateStarted(
+          typeof event.candidate_id === "string" ? event.candidate_id : "",
+          event.interrupt_response !== false,
+        );
+        break;
+
+      case "input_audio_buffer.speech_candidate_rejected":
+        this._audioDucker?.candidateRejected(
+          typeof event.candidate_id === "string" ? event.candidate_id : "",
+        );
+        break;
+
       case "input_audio_buffer.speech_started":
-        // User started speaking — stop any audio still playing OR queued, every
-        // time. We clear unconditionally (not just when `_aiSpeaking`): after a
-        // reply or a tool result the worklet's ring buffer can still be draining
-        // even though we already flipped `_aiSpeaking` off, and that tail would
-        // otherwise keep playing over the user's barge-in.
-        this._playbackNode?.port.postMessage({ kind: "clear" });
-        this._aiSpeaking = false;
-        this._userAudioRecorder.speechStarted({
-          itemId: typeof event.item_id === "string" ? event.item_id : "",
-          audioStartMs: Number(event.audio_start_ms),
-        });
-        this.dispatchEvent(new CustomEvent("user-turn-started", {
-          detail: {
+        {
+          const interruptResponse = event.interrupt_response !== false;
+          this._audioDucker?.speechStarted(interruptResponse);
+          // Clear every interrupting turn, even if `_aiSpeaking` is already
+          // false: the worklet can still be draining a response tail. When the
+          // session disables interruption, transcription continues while the
+          // existing playback buffer remains intact.
+          if (interruptResponse) {
+            this._playbackNode?.port.postMessage({ kind: "clear" });
+            this._aiSpeaking = false;
+          }
+          this._userAudioRecorder.speechStarted({
             itemId: typeof event.item_id === "string" ? event.item_id : "",
-          },
-        }));
-        this._setStatus("user-speaking");
+            audioStartMs: Number(event.audio_start_ms),
+          });
+          this.dispatchEvent(new CustomEvent("user-turn-started", {
+            detail: {
+              itemId: typeof event.item_id === "string" ? event.item_id : "",
+            },
+          }));
+          this._setStatus("user-speaking");
+        }
         break;
 
       case "input_audio_buffer.speech_stopped":
         {
+          this._audioDucker?.speechStopped();
           const itemId = typeof event.item_id === "string" ? event.item_id : "";
           const recording = this._userAudioRecorder.speechStopped({
             itemId,
@@ -1168,6 +1197,13 @@ export class S2sWsRealtimeClient extends EventTarget {
     } catch {
       // ignored
     }
+    this._audioDucker?.reset();
+    this._audioDucker = null;
+    try {
+      this._outputGain?.disconnect();
+    } catch {
+      // ignored
+    }
     try {
       this._playbackNode?.disconnect();
     } catch {
@@ -1184,6 +1220,7 @@ export class S2sWsRealtimeClient extends EventTarget {
     this._micSrc = null;
     this._micAnalyser = null;
     this._outAnalyser = null;
+    this._outputGain = null;
     this._setStatus("closed");
   }
 }

--- a/src/speech_to_speech/VAD/vad_handler.py
+++ b/src/speech_to_speech/VAD/vad_handler.py
@@ -13,7 +13,12 @@ import torch
 
 from speech_to_speech.api.openai_realtime.runtime_config import RuntimeConfig
 from speech_to_speech.baseHandler import BaseHandler
-from speech_to_speech.pipeline.events import SpeechStartedEvent, SpeechStoppedEvent
+from speech_to_speech.pipeline.events import (
+    SpeechCandidateRejectedEvent,
+    SpeechCandidateStartedEvent,
+    SpeechStartedEvent,
+    SpeechStoppedEvent,
+)
 from speech_to_speech.pipeline.handler_types import VADIn, VADOut
 from speech_to_speech.pipeline.messages import VADAudio
 from speech_to_speech.pipeline.queue_types import TextEventItem
@@ -63,6 +68,7 @@ class VADHandler(BaseHandler[VADIn, VADOut]):
         sample_rate: int = 16000,
         min_silence_ms: int = 64,
         min_speech_ms: int = 384,
+        speech_candidate_ms: int = 96,
         min_speech_continuation_ms: int = 192,
         max_speech_ms: float = float("inf"),
         speech_pad_ms: int = 30,
@@ -85,6 +91,9 @@ class VADHandler(BaseHandler[VADIn, VADOut]):
         self.sample_rate = sample_rate
         self.min_silence_ms = min_silence_ms
         self.min_speech_ms = min_speech_ms
+        if speech_candidate_ms < 0:
+            raise ValueError(f"speech_candidate_ms must be at least 0, got {speech_candidate_ms}")
+        self.speech_candidate_ms = speech_candidate_ms
         self.min_speech_continuation_ms = self._resolve_min_speech_continuation_ms(
             self.min_speech_ms,
             min_speech_continuation_ms,
@@ -157,6 +166,8 @@ class VADHandler(BaseHandler[VADIn, VADOut]):
         self._log_speech_ends = 0
         self._log_progressive_yields = 0
         self._speech_started_emitted = False
+        self._speech_candidate_counter = 0
+        self._speech_candidate_id: str | None = None
         self._turn_counter = 0
         self._current_turn_id: str | None = None
         self._current_turn_revision: int | None = None
@@ -225,6 +236,51 @@ class VADHandler(BaseHandler[VADIn, VADOut]):
     def _current_active_speech_duration_ms(self) -> float:
         active_speech_samples = getattr(self.iterator, "active_speech_samples", 0)
         return active_speech_samples / self.sample_rate * 1000
+
+    def _maybe_emit_speech_candidate(self, active_speech_ms: float, audio_start_ms: int) -> None:
+        """Emit a reversible early signal without allocating a turn.
+
+        Candidates are a realtime UX hint only.  The ordinary
+        ``SpeechStartedEvent`` remains the sole confirmation boundary for
+        response cancellation and conversation state.
+        """
+        if (
+            self._speech_candidate_id is not None
+            or self.speech_candidate_ms <= 0
+            or not self._uses_realtime_turn_handling()
+            or self.text_output_queue is None
+            or active_speech_ms < self.speech_candidate_ms
+        ):
+            return
+        self._speech_candidate_counter += 1
+        candidate_id = f"candidate_{self._speech_candidate_counter}"
+        self._speech_candidate_id = candidate_id
+        self.text_output_queue.put(
+            SpeechCandidateStartedEvent(
+                candidate_id=candidate_id,
+                audio_start_ms=audio_start_ms,
+            )
+        )
+        logger.debug(
+            "Speech candidate started (active=%.0fms, threshold=%dms, id=%s)",
+            active_speech_ms,
+            self.speech_candidate_ms,
+            candidate_id,
+        )
+
+    def _reject_speech_candidate(self) -> None:
+        candidate_id = self._speech_candidate_id
+        self._speech_candidate_id = None
+        if candidate_id is None or self.text_output_queue is None:
+            return
+        self.text_output_queue.put(SpeechCandidateRejectedEvent(candidate_id=candidate_id))
+        logger.debug("Speech candidate rejected (id=%s)", candidate_id)
+
+    def _confirm_speech_candidate(self) -> None:
+        # Confirmation is represented on the wire by the standard
+        # input_audio_buffer.speech_started event, so no second custom event is
+        # necessary. Clearing the id also makes a late reject impossible.
+        self._speech_candidate_id = None
 
     def _last_utterance_active_speech_duration_ms(self) -> float:
         active_speech_samples = getattr(self.iterator, "last_utterance_active_speech_samples", 0)
@@ -590,9 +646,12 @@ class VADHandler(BaseHandler[VADIn, VADOut]):
             )
             self._begin_pending_reopen_if_needed(effective_start_ms)
             active_speech_min_ms = self._active_speech_min_ms(effective_start_ms)
+            if self.speech_candidate_ms < active_speech_min_ms:
+                self._maybe_emit_speech_candidate(effective_active_speech_duration_ms, effective_start_ms)
             if effective_active_speech_duration_ms >= active_speech_min_ms:
                 turn_id, turn_revision, reopened = self._ensure_turn_for_speech_start(effective_start_ms)
                 self._speech_started_emitted = True
+                self._confirm_speech_candidate()
                 self._log_speech_starts += 1
                 logger.info(
                     "Speech started (confirmed, active=%.0fms, min=%.0fms, segment=%.0fms, turn=%s rev=%s)",
@@ -687,6 +746,7 @@ class VADHandler(BaseHandler[VADIn, VADOut]):
                         )
                     )
                 if not self._speech_started_emitted:
+                    self._reject_speech_candidate()
                     self._cancel_pending_reopen()
                 self._speech_started_emitted = False
                 self._discard_expired_pending_short_segment()
@@ -737,6 +797,7 @@ class VADHandler(BaseHandler[VADIn, VADOut]):
                         )
                     )
                 if not self._speech_started_emitted:
+                    self._reject_speech_candidate()
                     self._cancel_pending_reopen()
                 self._speech_started_emitted = False
             else:
@@ -747,6 +808,7 @@ class VADHandler(BaseHandler[VADIn, VADOut]):
                         active_speech_duration_ms,
                     )
                 if not self._speech_started_emitted:
+                    self._confirm_speech_candidate()
                     turn_id, turn_revision, reopened = self._ensure_turn_for_speech_start(start_ms)
                     if self.text_output_queue:
                         self.text_output_queue.put(
@@ -929,6 +991,8 @@ class VADHandler(BaseHandler[VADIn, VADOut]):
         self.last_process_time = 0.0
         self._total_samples = 0
         self._speech_started_emitted = False
+        self._speech_candidate_counter = 0
+        self._speech_candidate_id = None
         self._turn_counter = 0
         self._current_turn_id = None
         self._current_turn_revision = None

--- a/src/speech_to_speech/api/openai_realtime/README.md
+++ b/src/speech_to_speech/api/openai_realtime/README.md
@@ -82,6 +82,18 @@ flowchart LR
 | `response.function_call_arguments.done` | Tool call with `call_id`, `name`, and JSON `arguments`. |
 | `response.done` | Response finished (`completed`, `cancelled` with reason `turn_detected` or `client_cancelled`). |
 
+### Project-specific optional extensions
+
+The bundled browser clients understand two additional outbound events. `input_audio_buffer.speech_candidate_started`
+is an early, reversible speech hint that ducks playback without creating a conversation item or cancelling the response.
+`input_audio_buffer.speech_candidate_rejected` restores playback only when its `candidate_id` matches the active hint.
+Other Realtime clients can safely ignore both events and continue to rely on the standard confirmed
+`input_audio_buffer.speech_started` boundary.
+
+Confirmed `input_audio_buffer.speech_started` events also carry an extra `interrupt_response` boolean. The bundled
+clients use it to avoid clearing or muting playback when session interruption is disabled; clients that do not need
+that distinction can ignore the extra field.
+
 ---
 
 ## WebRTC Transport
@@ -173,6 +185,9 @@ sequenceDiagram
 
     Note over TTS,Client: Response active or pending (in_response / response_pending)
     User->>VAD: speaks
+    VAD->>Client: speech_candidate_started after 96 ms
+    Client->>Client: duck playback (reversible)
+    Note over VAD,Client: A short noise emits speech_candidate_rejected and restores playback
     VAD->>SendLoop: speech_started on text_output_queue
     SendLoop->>Client: input_audio_buffer.speech_started
     SendLoop->>Client: response.done (status=cancelled, reason=turn_detected)
@@ -188,8 +203,8 @@ sequenceDiagram
 
 **Step by step:**
 
-1. **VAD detects speech**: puts a `SpeechStartedEvent` on `text_output_queue`.
-2. **`_send_loop` processes text events first** (priority over audio): translates `speech_started` into protocol events. If an active response was in progress, `RealtimeService.dispatch_pipeline_event` emits `response.output_audio.done` + `response.done` with `status="cancelled"` and `reason="turn_detected"`.
+1. **VAD proposes speech**: after `--speech_candidate_ms` of active speech (96 ms by default), it emits a candidate event. Bundled clients lower output gain, but the server does not create a conversation turn, cancel work, flush audio, or increment the cancellation generation. If speech ends below the confirmation threshold, a candidate-scoped reject restores playback. Set the threshold to `0` to disable this extension.
+2. **VAD confirms speech**: once active speech reaches `--min_speech_ms` (384 ms by default), it puts the ordinary `SpeechStartedEvent` on `text_output_queue`. `_send_loop` processes text events first and translates it into protocol events. If an active response was in progress, `RealtimeService.dispatch_pipeline_event` emits `response.output_audio.done` + `response.done` with `status="cancelled"` and `reason="turn_detected"`.
 3. **Cancel + queue flush**: if a response is active (`in_response`) *or* pending (`response_pending` -- a model request is queued, but no output has started), and interrupts are enabled (see step 4), the send loop calls `cancel_scope.cancel()` (increments generation, enables discard), clears `response_pending`, drains `output_queue` (preserving `__RESPONSE_DONE__` sentinels) and `text_output_queue` (preserving user-side events: `speech_stopped`, direct-audio completions, partial/completed transcriptions, token usage), then clears `response_playing`.
 4. **Interrupt gating**: the cancel only fires if the `SpeechStartedEvent.interrupt_response` flag is set *and* the session config allows it (`turn_detection.interrupt_response`, read via `RuntimeConfig.interrupt_response_enabled`, default true). When disabled, user speech during a response is transcribed but the response keeps playing.
 5. **LLM/TTS cancellation**: handlers capture `gen = cancel_scope.generation` at the start of each response and check `cancel_scope.is_stale(gen)` on every streaming token, aborting early when stale.

--- a/src/speech_to_speech/api/openai_realtime/extension_events.py
+++ b/src/speech_to_speech/api/openai_realtime/extension_events.py
@@ -1,0 +1,32 @@
+"""Project-specific Realtime server events.
+
+These optional events improve the bundled demo without changing the OpenAI
+Realtime compatibility contract. Unknown clients can ignore them; confirmed
+turns and cancellation still use the standard
+``input_audio_buffer.speech_started`` event.
+"""
+
+from typing import Literal
+
+from openai.types.realtime import InputAudioBufferSpeechStartedEvent
+from pydantic import BaseModel
+
+
+class InputAudioBufferSpeechCandidateStartedEvent(BaseModel):
+    type: Literal["input_audio_buffer.speech_candidate_started"] = "input_audio_buffer.speech_candidate_started"
+    event_id: str
+    candidate_id: str
+    audio_start_ms: int
+    interrupt_response: bool = True
+
+
+class InputAudioBufferSpeechCandidateRejectedEvent(BaseModel):
+    type: Literal["input_audio_buffer.speech_candidate_rejected"] = "input_audio_buffer.speech_candidate_rejected"
+    event_id: str
+    candidate_id: str
+
+
+class ExtendedInputAudioBufferSpeechStartedEvent(InputAudioBufferSpeechStartedEvent):
+    """Standard speech-start event with the project's interrupt decision."""
+
+    interrupt_response: bool = True

--- a/src/speech_to_speech/api/openai_realtime/handlers/audio.py
+++ b/src/speech_to_speech/api/openai_realtime/handlers/audio.py
@@ -6,16 +6,25 @@ from typing import TYPE_CHECKING
 
 from openai.types.realtime import (
     InputAudioBufferAppendEvent,
-    InputAudioBufferSpeechStartedEvent,
     InputAudioBufferSpeechStoppedEvent,
     RealtimeErrorEvent,
     ResponseAudioDeltaEvent,
     ResponseCreatedEvent,
 )
 
+from speech_to_speech.api.openai_realtime.extension_events import (
+    ExtendedInputAudioBufferSpeechStartedEvent,
+    InputAudioBufferSpeechCandidateRejectedEvent,
+    InputAudioBufferSpeechCandidateStartedEvent,
+)
 from speech_to_speech.api.openai_realtime.handlers.base import RealtimeBaseHandler
 from speech_to_speech.api.openai_realtime.utils import resample
-from speech_to_speech.pipeline.events import SpeechStartedEvent, SpeechStoppedEvent
+from speech_to_speech.pipeline.events import (
+    SpeechCandidateRejectedEvent,
+    SpeechCandidateStartedEvent,
+    SpeechStartedEvent,
+    SpeechStoppedEvent,
+)
 
 if TYPE_CHECKING:
     from speech_to_speech.api.openai_realtime.service import ServerEvent
@@ -105,12 +114,51 @@ class AudioHandler(RealtimeBaseHandler):
 
     # ── Pipeline event handlers ────────────────────
 
+    def on_speech_candidate_started(
+        self,
+        conn_id: str,
+        event: SpeechCandidateStartedEvent,
+    ) -> list[ServerEvent]:
+        """Expose reversible playback ducking without touching turn state."""
+        st = self._state(conn_id)
+        interrupt_response = event.interrupt_response and st.runtime_config.interrupt_response_enabled
+        if not interrupt_response or st.speech_candidate_id == event.candidate_id:
+            return []
+        st.speech_candidate_id = event.candidate_id
+        return [
+            InputAudioBufferSpeechCandidateStartedEvent(
+                event_id=self._next_event_id(),
+                candidate_id=event.candidate_id,
+                audio_start_ms=event.audio_start_ms,
+                interrupt_response=True,
+            )
+        ]
+
+    def on_speech_candidate_rejected(
+        self,
+        conn_id: str,
+        event: SpeechCandidateRejectedEvent,
+    ) -> list[ServerEvent]:
+        """Release only the matching candidate so stale rejects are harmless."""
+        st = self._state(conn_id)
+        if st.speech_candidate_id != event.candidate_id:
+            return []
+        st.speech_candidate_id = None
+        return [
+            InputAudioBufferSpeechCandidateRejectedEvent(
+                event_id=self._next_event_id(),
+                candidate_id=event.candidate_id,
+            )
+        ]
+
     def on_speech_started(self, conn_id: str, event: SpeechStartedEvent) -> list[ServerEvent]:
         """Handle VAD speech_started: cancel active response if interrupts enabled, start new input item."""
         response = self._service.response
         events: list[ServerEvent] = []
         st = self._state(conn_id)
-        if st.in_response and event.interrupt_response and st.runtime_config.interrupt_response_enabled:
+        interrupt_response = event.interrupt_response and st.runtime_config.interrupt_response_enabled
+        st.speech_candidate_id = None
+        if st.in_response and interrupt_response:
             events.extend(response.finish_response(conn_id, status="cancelled", reason="turn_detected"))
         is_reopen = bool(event.reopened and event.turn_id is not None and event.turn_id == st.speculative_turn_id)
         preserve_active_response = st.in_response
@@ -138,11 +186,12 @@ class AudioHandler(RealtimeBaseHandler):
         st.speculative_turn_revision = event.turn_revision
         st.last_item_id = input_item_id
         events.append(
-            InputAudioBufferSpeechStartedEvent(
+            ExtendedInputAudioBufferSpeechStartedEvent(
                 type="input_audio_buffer.speech_started",
                 event_id=self._next_event_id(),
                 audio_start_ms=event.audio_start_ms,
                 item_id=input_item_id,
+                interrupt_response=interrupt_response,
             )
         )
         return events

--- a/src/speech_to_speech/api/openai_realtime/service.py
+++ b/src/speech_to_speech/api/openai_realtime/service.py
@@ -12,7 +12,6 @@ from openai.types.realtime import (
     ConversationItemInputAudioTranscriptionDeltaEvent,
     InputAudioBufferAppendEvent,
     InputAudioBufferCommitEvent,
-    InputAudioBufferSpeechStartedEvent,
     InputAudioBufferSpeechStoppedEvent,
     OutputAudioBufferClearEvent,
     RealtimeError,
@@ -34,6 +33,11 @@ from openai.types.realtime import (
 from openai.types.realtime.realtime_response_create_params import RealtimeResponseCreateParams
 from pydantic import BaseModel, ConfigDict, Field, ValidationError
 
+from speech_to_speech.api.openai_realtime.extension_events import (
+    ExtendedInputAudioBufferSpeechStartedEvent,
+    InputAudioBufferSpeechCandidateRejectedEvent,
+    InputAudioBufferSpeechCandidateStartedEvent,
+)
 from speech_to_speech.api.openai_realtime.handlers import (
     AudioHandler,
     ConversationHandler,
@@ -48,6 +52,8 @@ from speech_to_speech.pipeline.events import (
     PartialTranscriptionEvent,
     PipelineEvent,
     ResponseFailedEvent,
+    SpeechCandidateRejectedEvent,
+    SpeechCandidateStartedEvent,
     SpeechStartedEvent,
     SpeechStoppedEvent,
     TokenUsageEvent,
@@ -92,7 +98,9 @@ ServerEvent = Union[
     SessionCreatedEvent,
     SessionUpdatedEvent,
     RealtimeErrorEvent,
-    InputAudioBufferSpeechStartedEvent,
+    InputAudioBufferSpeechCandidateStartedEvent,
+    InputAudioBufferSpeechCandidateRejectedEvent,
+    ExtendedInputAudioBufferSpeechStartedEvent,
     InputAudioBufferSpeechStoppedEvent,
     ConversationItemCreatedEvent,
     ConversationItemInputAudioTranscriptionDeltaEvent,
@@ -184,6 +192,7 @@ class ConnState(BaseModel):
     speculative_user_item_id: Optional[str] = None
     speculative_input_item_id: Optional[str] = None
     speculative_audio_duration_s: float = 0.0
+    speech_candidate_id: Optional[str] = None
     # Client conversation.item.create items that arrived while a response was
     # generating. Applying them mid-generation races the LLM handler's chat
     # write-back (cross-thread), so they are buffered here and flushed in order
@@ -219,6 +228,8 @@ class RealtimeService:
         self.conversation = ConversationHandler(self)
 
         self._pipeline_dispatch: dict[type[PipelineEvent], Callable[..., list[ServerEvent]]] = {
+            SpeechCandidateStartedEvent: self.audio.on_speech_candidate_started,
+            SpeechCandidateRejectedEvent: self.audio.on_speech_candidate_rejected,
             SpeechStartedEvent: self.audio.on_speech_started,
             SpeechStoppedEvent: self.audio.on_speech_stopped,
             TokenUsageEvent: self._on_token_usage,

--- a/src/speech_to_speech/api/openai_realtime/websocket_router.py
+++ b/src/speech_to_speech/api/openai_realtime/websocket_router.py
@@ -36,6 +36,8 @@ from speech_to_speech.pipeline.events import (
     AudioInputCompletedEvent,
     PartialTranscriptionEvent,
     PipelineEvent,
+    SpeechCandidateRejectedEvent,
+    SpeechCandidateStartedEvent,
     SpeechStartedEvent,
     SpeechStoppedEvent,
     TokenUsageEvent,
@@ -91,6 +93,8 @@ def _keep_user_text_event(item: Any) -> bool:
         item,
         (
             SpeechStoppedEvent,
+            SpeechCandidateStartedEvent,
+            SpeechCandidateRejectedEvent,
             PartialTranscriptionEvent,
             TranscriptionCompletedEvent,
             AudioInputCompletedEvent,

--- a/src/speech_to_speech/arguments_classes/vad_arguments.py
+++ b/src/speech_to_speech/arguments_classes/vad_arguments.py
@@ -27,6 +27,14 @@ class VADHandlerArguments:
             "help": "Minimum length of speech segments to be considered valid speech. Measured in milliseconds. Default is 384 ms."
         },
     )
+    speech_candidate_ms: int = field(
+        default=96,
+        metadata={
+            "help": "Active-speech duration before emitting a reversible playback-duck candidate in realtime mode. "
+            "The normal min_speech_ms threshold still controls conversation turns and cancellation. Set to 0 to disable. "
+            "Default is 96 ms."
+        },
+    )
     min_speech_continuation_ms: int = field(
         default=192,
         metadata={

--- a/src/speech_to_speech/pipeline/events.py
+++ b/src/speech_to_speech/pipeline/events.py
@@ -28,6 +28,28 @@ class PipelineEvent(BaseModel):
 # ── VAD events ────────────────────────────────────────────────────────
 
 
+class SpeechCandidateStartedEvent(PipelineEvent):
+    """Reversible early speech signal used to duck assistant playback.
+
+    Unlike :class:`SpeechStartedEvent`, this event must not create a
+    conversation item or cancel in-flight model work.  A short candidate is
+    either confirmed by the ordinary ``speech_started`` event or paired with a
+    :class:`SpeechCandidateRejectedEvent`.
+    """
+
+    type: Literal["speech_candidate_started"] = "speech_candidate_started"
+    candidate_id: str
+    audio_start_ms: int = 0
+    interrupt_response: bool = Field(default=True, exclude=True)
+
+
+class SpeechCandidateRejectedEvent(PipelineEvent):
+    """A pre-confirmation speech candidate ended below the speech threshold."""
+
+    type: Literal["speech_candidate_rejected"] = "speech_candidate_rejected"
+    candidate_id: str
+
+
 class SpeechStartedEvent(PipelineEvent):
     type: Literal["speech_started"] = "speech_started"
     audio_start_ms: int = 0

--- a/tests/install_smoke.py
+++ b/tests/install_smoke.py
@@ -25,7 +25,7 @@ def _run_installed_cli_help() -> None:
         stderr=subprocess.STDOUT,
         text=True,
     )
-    expected_flags = ("--mode", "--stt", "--llm_backend", "--tts")
+    expected_flags = ("--mode", "--stt", "--llm_backend", "--tts", "--speech_candidate_ms")
     missing_flags = [flag for flag in expected_flags if flag not in result.stdout]
     if missing_flags:
         raise RuntimeError(f"Installed CLI help is missing expected flags: {', '.join(missing_flags)}")
@@ -70,6 +70,7 @@ def _validate_package_defaults() -> None:
     assert vad_args.thresh == 0.6
     assert vad_args.min_silence_ms == 64
     assert vad_args.min_speech_ms == 384
+    assert vad_args.speech_candidate_ms == 96
     assert vad_args.min_speech_continuation_ms == 192
     assert vad_args.realtime_processing_pause == 0.5
     assert vad_args.smart_turn is True

--- a/tests/openai_realtime/test_openai_client.py
+++ b/tests/openai_realtime/test_openai_client.py
@@ -34,6 +34,8 @@ from speech_to_speech.pipeline.cancel_scope import CancelScope
 from speech_to_speech.pipeline.events import (
     AssistantTextEvent,
     PartialTranscriptionEvent,
+    SpeechCandidateRejectedEvent,
+    SpeechCandidateStartedEvent,
     SpeechStartedEvent,
     SpeechStoppedEvent,
     TranscriptionCompletedEvent,
@@ -139,6 +141,8 @@ async def _recv(conn, timeout: float = 3.0):
 # event.type using both GA and legacy names for compatibility.  These
 # constants match the Literal values from openai.types.realtime.
 SESSION_CREATED = "session.created"
+SPEECH_CANDIDATE_STARTED = "input_audio_buffer.speech_candidate_started"
+SPEECH_CANDIDATE_REJECTED = "input_audio_buffer.speech_candidate_rejected"
 SPEECH_STARTED = "input_audio_buffer.speech_started"
 SPEECH_STOPPED = "input_audio_buffer.speech_stopped"
 TRANSCRIPTION_DELTA = "conversation.item.input_audio_transcription.delta"
@@ -293,6 +297,24 @@ class TestSDKVoiceTurn:
 
 
 class TestSDKBargeIn:
+    @pytest.mark.asyncio
+    async def test_candidate_extensions_are_consumable_by_openai_sdk(self, server_env):
+        """Unknown optional events remain iterable through the stock SDK."""
+        client = server_env.make_client()
+        async with client.realtime.connect(model="test") as conn:
+            await _recv(conn)  # session.created
+
+            server_env.text_output_queue.put(SpeechCandidateStartedEvent(candidate_id="candidate_1", audio_start_ms=96))
+            started = await _recv(conn)
+            assert started.type == SPEECH_CANDIDATE_STARTED
+            assert started.candidate_id == "candidate_1"
+            assert started.audio_start_ms == 96
+
+            server_env.text_output_queue.put(SpeechCandidateRejectedEvent(candidate_id="candidate_1"))
+            rejected = await _recv(conn)
+            assert rejected.type == SPEECH_CANDIDATE_REJECTED
+            assert rejected.candidate_id == "candidate_1"
+
     @pytest.mark.asyncio
     async def test_speech_interrupts_active_response(self, server_env):
         """User speech during audio streaming cancels with turn_detected."""

--- a/tests/openai_realtime/test_realtime_service.py
+++ b/tests/openai_realtime/test_realtime_service.py
@@ -36,6 +36,10 @@ from openai.types.realtime import (
     SessionUpdateEvent,
 )
 
+from speech_to_speech.api.openai_realtime.extension_events import (
+    InputAudioBufferSpeechCandidateRejectedEvent,
+    InputAudioBufferSpeechCandidateStartedEvent,
+)
 from speech_to_speech.api.openai_realtime.service import (
     CHUNK_SIZE_BYTES,
     RealtimeService,
@@ -45,6 +49,8 @@ from speech_to_speech.pipeline.events import (
     AudioInputCompletedEvent,
     PartialTranscriptionEvent,
     ResponseFailedEvent,
+    SpeechCandidateRejectedEvent,
+    SpeechCandidateStartedEvent,
     SpeechStartedEvent,
     SpeechStoppedEvent,
     TokenUsageEvent,
@@ -814,6 +820,65 @@ class TestFinishAudioResponse:
 
 
 class TestDispatchPipelineEvent:
+    # -- reversible speech candidate --
+
+    def test_speech_candidate_ducks_without_cancelling_response(self, service, conn_id):
+        service.response._ensure_response(conn_id)
+
+        events = service.dispatch_pipeline_event(
+            conn_id,
+            SpeechCandidateStartedEvent(candidate_id="candidate_1", audio_start_ms=32),
+        )
+
+        assert len(events) == 1
+        assert isinstance(events[0], InputAudioBufferSpeechCandidateStartedEvent)
+        assert events[0].candidate_id == "candidate_1"
+        assert events[0].audio_start_ms == 32
+        assert service._state(conn_id).in_response is True
+
+        rejected = service.dispatch_pipeline_event(
+            conn_id,
+            SpeechCandidateRejectedEvent(candidate_id="candidate_1"),
+        )
+        assert len(rejected) == 1
+        assert isinstance(rejected[0], InputAudioBufferSpeechCandidateRejectedEvent)
+        assert service._state(conn_id).in_response is True
+
+    def test_stale_candidate_reject_does_not_release_new_candidate(self, service, conn_id):
+        service.dispatch_pipeline_event(
+            conn_id,
+            SpeechCandidateStartedEvent(candidate_id="candidate_1"),
+        )
+        service.dispatch_pipeline_event(
+            conn_id,
+            SpeechCandidateStartedEvent(candidate_id="candidate_2"),
+        )
+
+        assert (
+            service.dispatch_pipeline_event(
+                conn_id,
+                SpeechCandidateRejectedEvent(candidate_id="candidate_1"),
+            )
+            == []
+        )
+        assert service._state(conn_id).speech_candidate_id == "candidate_2"
+
+    def test_speech_candidate_is_suppressed_when_interrupt_disabled(self, service, conn_id):
+        from openai.types.realtime.realtime_audio_input_turn_detection import ServerVad
+
+        service._state(conn_id).runtime_config.session.audio.input.turn_detection = ServerVad(
+            type="server_vad",
+            interrupt_response=False,
+        )
+
+        events = service.dispatch_pipeline_event(
+            conn_id,
+            SpeechCandidateStartedEvent(candidate_id="candidate_1"),
+        )
+
+        assert events == []
+        assert service._state(conn_id).speech_candidate_id is None
+
     # -- speech_started --
 
     def test_speech_started_emits_event(self, service, conn_id):
@@ -849,6 +914,7 @@ class TestDispatchPipelineEvent:
         )
         assert len(events) == 1
         assert isinstance(events[0], InputAudioBufferSpeechStartedEvent)
+        assert events[0].interrupt_response is True
 
     def test_speech_started_does_not_cancel_when_interrupt_disabled(self, service, conn_id):
         """With interrupt_response=False, speech_started emits the started event but does NOT cancel the active response."""
@@ -865,6 +931,7 @@ class TestDispatchPipelineEvent:
         )
         assert len(events) == 1
         assert isinstance(events[0], InputAudioBufferSpeechStartedEvent)
+        assert events[0].interrupt_response is False
         assert service._state(conn_id).in_response is True
         assert service._state(conn_id).current_item_id == response_item_id
 
@@ -877,10 +944,29 @@ class TestDispatchPipelineEvent:
 
         assert len(events) == 1
         assert isinstance(events[0], InputAudioBufferSpeechStartedEvent)
+        assert events[0].interrupt_response is False
         assert service._state(conn_id).in_response is True
         assert service._state(conn_id).current_item_id == response_item_id
         done_events = service.finish_response(conn_id)
         assert done_events[0].item_id == response_item_id
+
+    def test_speech_started_confirms_and_clears_active_candidate(self, service, conn_id):
+        service.dispatch_pipeline_event(
+            conn_id,
+            SpeechCandidateStartedEvent(candidate_id="candidate_1"),
+        )
+
+        events = service.dispatch_pipeline_event(conn_id, SpeechStartedEvent())
+
+        assert any(isinstance(event, InputAudioBufferSpeechStartedEvent) for event in events)
+        assert service._state(conn_id).speech_candidate_id is None
+        assert (
+            service.dispatch_pipeline_event(
+                conn_id,
+                SpeechCandidateRejectedEvent(candidate_id="candidate_1"),
+            )
+            == []
+        )
 
     def test_consecutive_speech_cycles_get_distinct_item_ids(self, service, conn_id):
         """Each speech_started/stopped cycle generates a new unique item_id."""

--- a/tests/openai_realtime/test_websocket_router.py
+++ b/tests/openai_realtime/test_websocket_router.py
@@ -27,6 +27,8 @@ from speech_to_speech.pipeline.control import SESSION_END, PipelineControlMessag
 from speech_to_speech.pipeline.events import (
     AssistantTextEvent,
     AudioInputCompletedEvent,
+    SpeechCandidateRejectedEvent,
+    SpeechCandidateStartedEvent,
     SpeechStartedEvent,
     TokenUsageEvent,
 )
@@ -415,6 +417,31 @@ class TestSendLoop:
                 assert msg["type"] == "input_audio_buffer.speech_started"
                 assert msg["audio_start_ms"] == 0
 
+    def test_candidate_events_do_not_cancel_pending_response(self, setup):
+        app, service, _, _, text_output_queue, _, _, response_playing, cancel_scope = setup
+        with TestClient(app) as client:
+            with client.websocket_connect("/v1/realtime") as ws:
+                ws.receive_json()  # session.created
+                conn_id = service.connection_ids[0]
+                service._state(conn_id).response_pending = True
+                response_playing.set()
+                generation = cancel_scope.generation
+
+                text_output_queue.put(SpeechCandidateStartedEvent(candidate_id="candidate_1", audio_start_ms=32))
+                started = ws.receive_json()
+                assert started["type"] == "input_audio_buffer.speech_candidate_started"
+                assert started["candidate_id"] == "candidate_1"
+
+                text_output_queue.put(SpeechCandidateRejectedEvent(candidate_id="candidate_1"))
+                rejected = ws.receive_json()
+                assert rejected["type"] == "input_audio_buffer.speech_candidate_rejected"
+
+                time.sleep(0.1)
+                assert cancel_scope.generation == generation
+                assert not cancel_scope.discarding
+                assert service._state(conn_id).response_pending is True
+                assert response_playing.is_set()
+
     def test_barge_in_discard_clears_after_response_done(self, setup):
         """After barge-in sets discarding=True, __RESPONSE_DONE__ must clear it back to False."""
         app, service, _, output_queue, text_output_queue, _, _, response_playing, cancel_scope = setup
@@ -756,12 +783,18 @@ class TestDrainRelease:
     def test_barge_in_flush_preserves_completed_audio_input(self):
         q: Queue = Queue()
         audio_event = AudioInputCompletedEvent(audio=np.zeros(1600, dtype=np.float32), audio_duration_s=0.1)
+        candidate_started = SpeechCandidateStartedEvent(candidate_id="candidate_1")
+        candidate_rejected = SpeechCandidateRejectedEvent(candidate_id="candidate_1")
         q.put(AssistantTextEvent(text="stale"))
         q.put(audio_event)
+        q.put(candidate_started)
+        q.put(candidate_rejected)
 
         router_module._flush_queue(q, preserve=router_module._keep_user_text_event)
 
         assert q.get_nowait() is audio_event
+        assert q.get_nowait() is candidate_started
+        assert q.get_nowait() is candidate_rejected
         assert q.empty()
 
     def test_barge_in_flush_preserves_session_end(self):

--- a/tests/test_cli_defaults.py
+++ b/tests/test_cli_defaults.py
@@ -45,6 +45,7 @@ def test_release_defaults_match_responses_api_parakeet_qwen3_realtime_profile():
     assert vad_args.thresh == 0.6
     assert vad_args.min_silence_ms == 64
     assert vad_args.min_speech_ms == 384
+    assert vad_args.speech_candidate_ms == 96
     assert vad_args.min_speech_continuation_ms == 192
     assert vad_args.realtime_processing_pause == 0.5
     assert vad_args.smart_turn is True
@@ -118,6 +119,7 @@ def test_parse_arguments_default_backend_returns_openai_api():
     assert args.responses_api_language_model_handler_kwargs.model_name == "gpt-5.4-mini"
     assert args.module_kwargs.llm_backend == "responses-api"
     assert args.vad_handler_kwargs.smart_turn is True
+    assert args.vad_handler_kwargs.speech_candidate_ms == 96
     assert args.vad_handler_kwargs.smart_turn_model_path is None
     assert args.vad_handler_kwargs.smart_turn_threshold == 0.5
     assert args.vad_handler_kwargs.smart_turn_max_wait_ms == 2000
@@ -153,6 +155,17 @@ def test_parse_arguments_accepts_smart_turn_options():
     assert vad_args.smart_turn_max_wait_ms == 2500
     assert vad_args.smart_turn_incomplete_delay_ms == 700
     assert vad_args.smart_turn_cpu_count == 2
+
+
+def test_parse_arguments_accepts_speech_candidate_override():
+    original_argv = sys.argv[:]
+    try:
+        sys.argv = ["speech-to-speech", "--speech_candidate_ms", "128"]
+        args = parse_arguments()
+    finally:
+        sys.argv = original_argv
+
+    assert args.vad_handler_kwargs.speech_candidate_ms == 128
 
 
 def test_parse_arguments_can_disable_smart_turn():

--- a/tests/test_demo_audio_ducker.py
+++ b/tests/test_demo_audio_ducker.py
@@ -1,0 +1,169 @@
+import shutil
+import subprocess
+from pathlib import Path
+
+import pytest
+
+REPO_ROOT = Path(__file__).resolve().parents[1]
+
+
+def _run_node(script: str) -> None:
+    node = shutil.which("node")
+    if node is None:
+        pytest.skip("Node.js is required for demo client tests")
+    subprocess.run(
+        [node, "--input-type=module", "-e", script],
+        cwd=REPO_ROOT,
+        check=True,
+        capture_output=True,
+        text=True,
+    )
+
+
+def test_ducker_reject_is_reversible_and_candidate_scoped():
+    _run_node(
+        """
+const { ReversibleAudioDucker } = await import("./demo/audio-ducker.js");
+const targets = [];
+const gain = {
+  value: 1,
+  cancelScheduledValues() {},
+  setValueAtTime(value) { this.value = value; },
+  linearRampToValueAtTime(value) { this.value = value; targets.push(value); },
+};
+const ducker = new ReversibleAudioDucker({ gain }, { currentTime: 1 });
+
+ducker.candidateStarted("candidate_1");
+ducker.candidateStarted("candidate_2");
+ducker.candidateRejected("candidate_1");
+if (targets.at(-1) !== 0.12) throw new Error("stale reject released newer candidate");
+ducker.candidateRejected("candidate_2");
+if (targets.at(-1) !== 1) throw new Error("matching reject did not restore output");
+
+ducker.candidateStarted("candidate_3");
+ducker.speechStarted(true);
+ducker.candidateRejected("candidate_3");
+if (targets.at(-1) !== 0) throw new Error("confirmed speech was released by stale reject");
+ducker.speechStopped();
+if (targets.at(-1) !== 1) throw new Error("speech stop did not restore output");
+
+ducker.candidateStarted("candidate_4");
+ducker.speechStarted(false);
+if (targets.at(-1) !== 1) throw new Error("non-interrupting speech should not mute output");
+
+const beforeDisabledCandidate = targets.length;
+ducker.candidateStarted("candidate_5", false);
+if (targets.length !== beforeDisabledCandidate) throw new Error("disabled candidate changed output gain");
+
+ducker.candidateStarted("candidate_6");
+ducker.reset();
+if (targets.at(-1) !== 1) throw new Error("reset did not restore output");
+"""
+    )
+
+
+def test_websocket_client_maps_candidate_and_confirmation_events():
+    _run_node(
+        """
+globalThis.localStorage = { getItem() { return null; } };
+globalThis.WebSocket = { OPEN: 1 };
+globalThis.CustomEvent = class CustomEvent extends Event {
+  constructor(type, init = {}) { super(type); this.detail = init.detail; }
+};
+const { S2sWsRealtimeClient } = await import("./demo/ws/s2s-ws-client.js");
+const client = new S2sWsRealtimeClient({ voice: "Aiden", instructions: "Be helpful." });
+const calls = [];
+client._audioDucker = {
+  candidateStarted(id, interrupt) { calls.push(["candidate", id, interrupt]); },
+  candidateRejected(id) { calls.push(["reject", id]); },
+  speechStarted(interrupt) { calls.push(["start", interrupt]); },
+  speechStopped() { calls.push(["stop"]); },
+};
+const playback = [];
+client._playbackNode = { port: { postMessage(msg) { playback.push(msg.kind); } } };
+
+await client._onWsMessage(JSON.stringify({
+  type: "input_audio_buffer.speech_candidate_started",
+  candidate_id: "candidate_1",
+  interrupt_response: true,
+}));
+await client._onWsMessage(JSON.stringify({
+  type: "input_audio_buffer.speech_candidate_rejected",
+  candidate_id: "candidate_1",
+}));
+await client._onWsMessage(JSON.stringify({
+  type: "input_audio_buffer.speech_started",
+  item_id: "item_1",
+  audio_start_ms: 0,
+  interrupt_response: false,
+}));
+
+if (JSON.stringify(calls) !== JSON.stringify([
+  ["candidate", "candidate_1", true],
+  ["reject", "candidate_1"],
+  ["start", false],
+])) throw new Error(`unexpected ducker calls: ${JSON.stringify(calls)}`);
+if (playback.includes("clear")) throw new Error("non-interrupting speech cleared playback");
+
+await client._onWsMessage(JSON.stringify({
+  type: "input_audio_buffer.speech_started",
+  item_id: "item_2",
+  audio_start_ms: 0,
+  interrupt_response: true,
+}));
+if (playback.at(-1) !== "clear") throw new Error("confirmed interruption did not clear playback");
+
+await client._onWsMessage(JSON.stringify({
+  type: "response.done",
+  response: { id: "response_1", status: "cancelled", output: [] },
+}));
+if (JSON.stringify(calls.at(-1)) !== JSON.stringify(["start", true])) {
+  throw new Error("response.done released confirmed speech before speech_stopped");
+}
+"""
+    )
+
+
+def test_webrtc_client_maps_candidate_confirm_and_stop_events():
+    _run_node(
+        """
+globalThis.localStorage = { getItem() { return null; } };
+globalThis.CustomEvent = class CustomEvent extends Event {
+  constructor(type, init = {}) { super(type); this.detail = init.detail; }
+};
+const { S2sRtcRealtimeClient } = await import("./demo/rtc/s2s-rtc-client.js");
+const client = new S2sRtcRealtimeClient({
+  callsUrl: "/api/calls",
+  voice: "Aiden",
+  instructions: "Be helpful.",
+});
+const calls = [];
+client._audioDucker = {
+  candidateStarted(id, interrupt) { calls.push(["candidate", id, interrupt]); },
+  candidateRejected(id) { calls.push(["reject", id]); },
+  speechStarted(interrupt) { calls.push(["start", interrupt]); },
+  speechStopped() { calls.push(["stop"]); },
+};
+
+client._onDcMessage(JSON.stringify({
+  type: "input_audio_buffer.speech_candidate_started",
+  candidate_id: "candidate_1",
+  interrupt_response: true,
+}));
+client._onDcMessage(JSON.stringify({
+  type: "input_audio_buffer.speech_started",
+  item_id: "item_1",
+  interrupt_response: true,
+}));
+client._onDcMessage(JSON.stringify({
+  type: "input_audio_buffer.speech_stopped",
+  item_id: "item_1",
+}));
+
+if (JSON.stringify(calls) !== JSON.stringify([
+  ["candidate", "candidate_1", true],
+  ["start", true],
+  ["stop"],
+])) throw new Error(`unexpected ducker calls: ${JSON.stringify(calls)}`);
+"""
+    )

--- a/tests/test_speculative_turns.py
+++ b/tests/test_speculative_turns.py
@@ -7,7 +7,12 @@ import numpy as np
 import pytest
 import torch
 
-from speech_to_speech.pipeline.events import SpeechStartedEvent, SpeechStoppedEvent
+from speech_to_speech.pipeline.events import (
+    SpeechCandidateRejectedEvent,
+    SpeechCandidateStartedEvent,
+    SpeechStartedEvent,
+    SpeechStoppedEvent,
+)
 from speech_to_speech.pipeline.messages import VADAudio
 from speech_to_speech.pipeline.speculative_turns import SpeculativeTurnTracker
 from speech_to_speech.VAD.smart_turn import SmartTurnResult
@@ -347,6 +352,10 @@ class _StaticVADIterator:
     def speech_buffer(self) -> list[torch.Tensor]:
         return self._speech_chunks
 
+    def reset_states(self) -> None:
+        self.triggered = False
+        self.buffer = []
+
 
 class _StaticSmartTurnAnalyzer:
     def __init__(self, *results: SmartTurnResult) -> None:
@@ -366,6 +375,7 @@ def _vad_handler_for_iterator(iterator: _StaticVADIterator) -> VADHandler:
     handler.sample_rate = 16000
     handler.min_silence_ms = 300
     handler.min_speech_ms = 384
+    handler.speech_candidate_ms = 0
     handler.min_speech_continuation_ms = handler.min_speech_ms
     handler.max_speech_ms = float("inf")
     handler.enable_realtime_transcription = False
@@ -388,6 +398,8 @@ def _vad_handler_for_iterator(iterator: _StaticVADIterator) -> VADHandler:
     handler._log_speech_ends = 0
     handler._log_progressive_yields = 0
     handler._speech_started_emitted = False
+    handler._speech_candidate_counter = 0
+    handler._speech_candidate_id = None
     handler._turn_counter = 0
     handler._current_turn_id = None
     handler._current_turn_revision = None
@@ -470,6 +482,117 @@ def test_vad_interruption_emits_after_active_speech_threshold():
     assert isinstance(event, SpeechStartedEvent)
     assert event.interrupt_response is True
     assert handler._speech_started_emitted is True
+
+
+def test_vad_emits_reversible_candidate_before_confirmed_speech():
+    chunks = [torch.zeros(512) for _ in range(3)]
+    iterator = _StaticVADIterator(
+        triggered=True,
+        vad_output=None,
+        buffer_chunks=chunks,
+        speech_chunks=chunks,
+        active_speech_samples=3 * 512,
+    )
+    handler = _vad_handler_for_iterator(iterator)
+    handler.speech_candidate_ms = 96
+
+    assert list(handler.process(_audio_bytes())) == []
+
+    event = handler.text_output_queue.get_nowait()
+    assert isinstance(event, SpeechCandidateStartedEvent)
+    assert event.candidate_id == "candidate_1"
+    assert handler._speech_started_emitted is False
+    assert handler._current_turn_id is None
+
+
+def test_vad_candidate_threshold_zero_disables_early_signal():
+    chunks = [torch.zeros(512) for _ in range(3)]
+    iterator = _StaticVADIterator(
+        triggered=True,
+        vad_output=None,
+        buffer_chunks=chunks,
+        speech_chunks=chunks,
+        active_speech_samples=3 * 512,
+    )
+    handler = _vad_handler_for_iterator(iterator)
+    handler.speech_candidate_ms = 0
+
+    assert list(handler.process(_audio_bytes())) == []
+    assert handler.text_output_queue.empty()
+    assert handler._current_turn_id is None
+
+
+def test_vad_rejects_short_candidate_without_creating_turn():
+    chunks = [torch.zeros(512) for _ in range(3)]
+    iterator = _StaticVADIterator(
+        triggered=True,
+        vad_output=None,
+        buffer_chunks=chunks,
+        speech_chunks=chunks,
+        active_speech_samples=3 * 512,
+    )
+    handler = _vad_handler_for_iterator(iterator)
+    handler.speech_candidate_ms = 96
+
+    assert list(handler.process(_audio_bytes())) == []
+    started = handler.text_output_queue.get_nowait()
+    assert isinstance(started, SpeechCandidateStartedEvent)
+
+    iterator.triggered = False
+    iterator._vad_output = [torch.zeros(512) for _ in range(4)]
+    iterator.last_utterance_active_speech_samples = 3 * 512
+    assert list(handler.process(_audio_bytes())) == []
+
+    rejected = handler.text_output_queue.get_nowait()
+    assert isinstance(rejected, SpeechCandidateRejectedEvent)
+    assert rejected.candidate_id == started.candidate_id
+    assert handler._current_turn_id is None
+    assert handler._speech_candidate_id is None
+
+
+def test_vad_confirmation_supersedes_candidate_without_reject():
+    chunks = [torch.zeros(512) for _ in range(12)]
+    iterator = _StaticVADIterator(
+        triggered=True,
+        vad_output=None,
+        buffer_chunks=chunks,
+        speech_chunks=chunks,
+        active_speech_samples=3 * 512,
+    )
+    handler = _vad_handler_for_iterator(iterator)
+    handler.speech_candidate_ms = 96
+
+    assert list(handler.process(_audio_bytes())) == []
+    assert isinstance(handler.text_output_queue.get_nowait(), SpeechCandidateStartedEvent)
+
+    iterator.active_speech_samples = 12 * 512
+    assert list(handler.process(_audio_bytes())) == []
+
+    confirmed = handler.text_output_queue.get_nowait()
+    assert isinstance(confirmed, SpeechStartedEvent)
+    assert handler._speech_candidate_id is None
+    assert handler.text_output_queue.empty()
+
+
+def test_vad_session_reset_clears_candidate_state():
+    chunks = [torch.zeros(512) for _ in range(3)]
+    iterator = _StaticVADIterator(
+        triggered=True,
+        vad_output=None,
+        buffer_chunks=chunks,
+        speech_chunks=chunks,
+        active_speech_samples=3 * 512,
+    )
+    handler = _vad_handler_for_iterator(iterator)
+    handler.speech_candidate_ms = 96
+
+    assert list(handler.process(_audio_bytes())) == []
+    assert handler._speech_candidate_id == "candidate_1"
+
+    handler.on_session_end()
+
+    assert handler._speech_candidate_id is None
+    assert handler._speech_candidate_counter == 0
 
 
 def test_vad_live_transcription_without_speculative_turns_stops_listening_on_final():


### PR DESCRIPTION
## Summary

- emit a configurable VAD speech candidate after 96 ms of active speech without creating a turn, cancelling LLM/TTS work, or flushing audio
- share a candidate-scoped Web Audio gain state machine across the WebSocket and WebRTC demos, restoring playback for rejected noise and hard-muting only after confirmed speech
- preserve playback when `interrupt_response` is disabled and expose the decision on confirmed speech events
- document the optional Realtime extensions and cover them with VAD, service, router, official OpenAI SDK, and browser-client tests

## Compatibility

Clients that ignore `input_audio_buffer.speech_candidate_started` and `input_audio_buffer.speech_candidate_rejected` keep the existing confirmed interruption behavior. The stock OpenAI Python SDK path is covered by an integration test.

## Tests

- `pytest tests/ -x -q`: 803 passed, 1 skipped
- `mypy src/`: passed
- `ruff check src/ tests/`: passed
- `ruff format --check src/ tests/`: passed
- demo JavaScript syntax checks: passed
- installed-package smoke test: passed

Closes #433
