### PR TITLE
Document pull request history policy

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,6 +1,7 @@
 # Repository Instructions
 
 - Never include `codex` in branch names or pull request titles.
+- For existing/open pull requests, do not amend, squash, rebase-rewrite, or force-push follow-up changes. Make new commits and push normally unless explicitly asked to rewrite history.
 - Keep release pull requests focused on version metadata and release documentation.
 - Do not commit local build artifacts such as `dist/`, `build/`, or generated wheel/sdist files.
 


### PR DESCRIPTION
## Summary

- Add repository guidance for follow-up changes on existing or open pull requests.
- Require new commits and normal pushes unless history rewriting is explicitly requested.

## Why

`AGENTS.md` did not explicitly state how follow-up changes should be published to an existing pull request. This guidance preserves reviewable history and avoids unintended force pushes.

## Impact

Contributors and agents will use additive commits for normal pull request updates while retaining an explicit opt-in path for history rewrites.

## Validation

- `git diff --check`
