### PR TITLE
Avoid Silero default-branch probe during offline startup

### DIFF
--- a/src/speech_to_speech/VAD/vad_handler.py
+++ b/src/speech_to_speech/VAD/vad_handler.py
@@ -120,7 +120,7 @@ class VADHandler(BaseHandler[VADIn, VADOut]):
             self.smart_turn_max_wait_ms if smart_turn else 0,
         )
         self.model, _ = torch.hub.load(
-            "snakers4/silero-vad",
+            "snakers4/silero-vad:master",
             "silero_vad",
             trust_repo=True,
             skip_validation=True,

--- a/tests/test_smart_turn.py
+++ b/tests/test_smart_turn.py
@@ -69,6 +69,35 @@ def test_inference_failure_uses_default_speculative_grace() -> None:
     assert len(analyzer.calls) == 1
 
 
+def test_silero_load_pins_cached_master_ref(monkeypatch) -> None:
+    class FakeSileroModel:
+        def reset_states(self) -> None:
+            pass
+
+    load_calls = []
+
+    def fake_load(repo, model, **kwargs):
+        load_calls.append((repo, model, kwargs))
+        return FakeSileroModel(), None
+
+    monkeypatch.setattr(torch.hub, "load", fake_load)
+    handler = object.__new__(VADHandler)
+
+    handler.setup(
+        Event(),
+        speculative_turns=SpeculativeTurnTracker(),
+        smart_turn=False,
+    )
+
+    assert load_calls == [
+        (
+            "snakers4/silero-vad:master",
+            "silero_vad",
+            {"trust_repo": True, "skip_validation": True},
+        )
+    ]
+
+
 def test_unanswered_reopen_cap_covers_smart_turn_wait(monkeypatch) -> None:
     class FakeSileroModel:
         def reset_states(self) -> None:


### PR DESCRIPTION
## Summary

- pin the Silero VAD Torch Hub repository to its cached `master` ref
- add a focused regression test for the explicit ref and existing load options

## Root cause

Torch Hub probes GitHub to determine whether an unqualified repository uses `main` or `master` before consulting its cache. If GitHub closes that request, the resulting `RemoteDisconnected` is not handled by Torch Hub's offline cache fallback, so startup can fail even when `snakers4_silero-vad_master` is already cached.

## User impact

Machines with a primed Silero Torch Hub cache can start offline without making a GitHub default-branch discovery request.

## Validation

- `uv run pytest -q tests/test_smart_turn.py` — 10 passed
- `uv run ruff check src/speech_to_speech/VAD/vad_handler.py tests/test_smart_turn.py`
- `uv run ruff format --check src/speech_to_speech/VAD/vad_handler.py tests/test_smart_turn.py`
- `uv run mypy src/`
