### PR TITLE
fix(stt): stop Whisper handlers finalizing turns on progressive audio

### DIFF
--- a/src/speech_to_speech/STT/faster_whisper_handler.py
+++ b/src/speech_to_speech/STT/faster_whisper_handler.py
@@ -8,7 +8,7 @@ from faster_whisper import WhisperModel
 from rich.console import Console
 
 from speech_to_speech.pipeline.handler_types import STTIn, STTOut
-from speech_to_speech.pipeline.messages import Transcription
+from speech_to_speech.pipeline.messages import PartialTranscription, Transcription
 from speech_to_speech.STT.base_stt_handler import BaseSTTHandler
 
 console = Console()
@@ -48,6 +48,14 @@ class FasterWhisperSTTHandler(BaseSTTHandler):
         logger.debug("finished whisper inference")
         if pred_text:
             console.print(f"[yellow]USER: {pred_text}")
+
+            if vad_audio.mode == "progressive":
+                yield PartialTranscription(
+                    text=pred_text,
+                    turn_id=vad_audio.turn_id,
+                    turn_revision=vad_audio.turn_revision,
+                )
+                return
 
             yield Transcription(
                 text=pred_text,

--- a/src/speech_to_speech/STT/lightning_whisper_mlx_handler.py
+++ b/src/speech_to_speech/STT/lightning_whisper_mlx_handler.py
@@ -9,7 +9,7 @@ from lightning_whisper_mlx import LightningWhisperMLX
 from rich.console import Console
 
 from speech_to_speech.pipeline.handler_types import STTIn, STTOut
-from speech_to_speech.pipeline.messages import Transcription
+from speech_to_speech.pipeline.messages import PartialTranscription, Transcription
 from speech_to_speech.STT.base_stt_handler import BaseSTTHandler
 from speech_to_speech.utils.mlx_lock import MLXLockContext
 
@@ -98,6 +98,14 @@ class LightningWhisperSTTHandler(BaseSTTHandler):
 
         if self.start_language == "auto":
             language_code += "-auto"
+
+        if vad_audio.mode == "progressive":
+            yield PartialTranscription(
+                text=pred_text,
+                turn_id=vad_audio.turn_id,
+                turn_revision=vad_audio.turn_revision,
+            )
+            return
 
         yield Transcription(
             text=pred_text,

--- a/src/speech_to_speech/STT/mlx_audio_whisper_handler.py
+++ b/src/speech_to_speech/STT/mlx_audio_whisper_handler.py
@@ -7,7 +7,7 @@ import numpy as np
 from rich.console import Console
 
 from speech_to_speech.pipeline.handler_types import STTIn, STTOut
-from speech_to_speech.pipeline.messages import Transcription
+from speech_to_speech.pipeline.messages import PartialTranscription, Transcription
 from speech_to_speech.STT.base_stt_handler import BaseSTTHandler
 from speech_to_speech.utils.mlx_lock import MLXLockContext
 
@@ -164,6 +164,14 @@ class MLXAudioWhisperSTTHandler(BaseSTTHandler):
 
         if self.start_language == "auto":
             language_code += "-auto"
+
+        if vad_audio.mode == "progressive":
+            yield PartialTranscription(
+                text=pred_text,
+                turn_id=vad_audio.turn_id,
+                turn_revision=vad_audio.turn_revision,
+            )
+            return
 
         yield Transcription(
             text=pred_text,

--- a/src/speech_to_speech/STT/whisper_stt_handler.py
+++ b/src/speech_to_speech/STT/whisper_stt_handler.py
@@ -10,7 +10,7 @@ from rich.console import Console
 from transformers import AutoModelForSpeechSeq2Seq, AutoProcessor
 
 from speech_to_speech.pipeline.handler_types import STTIn, STTOut
-from speech_to_speech.pipeline.messages import Transcription
+from speech_to_speech.pipeline.messages import PartialTranscription, Transcription
 from speech_to_speech.STT.base_stt_handler import BaseSTTHandler
 
 logger = logging.getLogger(__name__)
@@ -137,6 +137,14 @@ class WhisperSTTHandler(BaseSTTHandler):
 
         if self.start_language == "auto":
             language_code += "-auto"
+
+        if vad_audio.mode == "progressive":
+            yield PartialTranscription(
+                text=pred_text,
+                turn_id=vad_audio.turn_id,
+                turn_revision=vad_audio.turn_revision,
+            )
+            return
 
         yield Transcription(
             text=pred_text,

--- a/tests/test_whisper_progressive_transcription.py
+++ b/tests/test_whisper_progressive_transcription.py
@@ -1,0 +1,224 @@
+"""Whisper-family STT handlers must tag progressive audio as PartialTranscription.
+
+`BaseSTTHandler.before_emit_output` marks a turn revision complete as soon as it sees a
+`Transcription`, and `should_process_input` then rejects every later chunk of that
+revision as "input-after-final". A handler that emits `Transcription` for a progressive
+chunk therefore closes the turn while the user is still speaking, and the full utterance
+is discarded: the LLM only ever receives the first fragment.
+
+`ParakeetTDTSTTHandler` branches on `vad_audio.mode` and yields `PartialTranscription`
+for progressive audio. The four Whisper-family handlers did not, so they truncated every
+turn in `--mode realtime` for any language Parakeet does not cover.
+
+Only VAD emits progressive chunks, and only when live transcription is enabled
+(`s2s_pipeline` sets `enable_realtime_transcription` from `--enable_live_transcription`,
+and `vad_handler` gates the progressive yield on it), so branching on `mode` alone is
+sufficient here -- the handlers need no flag of their own.
+
+No Whisper, faster-whisper, MLX, or model download is needed: every model is faked, and
+the Darwin-only / extra-only backends are stubbed so all four handlers are covered on
+Linux CI as well as macOS.
+"""
+
+from __future__ import annotations
+
+import importlib
+import sys
+import types
+from queue import Queue
+from types import SimpleNamespace
+
+import numpy as np
+import pytest
+
+from speech_to_speech.pipeline.messages import PartialTranscription, Transcription, VADAudio
+
+SAMPLE_RATE = 16000
+
+# (mode, seconds of speech captured so far, what the model returns for it)
+CHUNKS = [
+    ("progressive", 1, "one"),
+    ("progressive", 2, "one two"),
+    ("final", 3, "one two three"),
+]
+FULL_UTTERANCE = CHUNKS[-1][2]
+
+TRANSCRIPTS = {int(SAMPLE_RATE * seconds): text for _, seconds, text in CHUNKS}
+
+
+def _ensure_module(name: str, **attrs: object) -> None:
+    """Make `name` importable, faking it when the optional backend is not installed."""
+    if name in sys.modules:
+        return
+    try:
+        importlib.import_module(name)
+    except ImportError:
+        module = types.ModuleType(name)
+        for attr, value in attrs.items():
+            setattr(module, attr, value)
+        sys.modules[name] = module
+
+
+def _prepare(handler):
+    handler.queue_in = Queue()
+    return handler
+
+
+def build_whisper(monkeypatch):
+    from speech_to_speech.STT import whisper_stt_handler
+    from speech_to_speech.STT.whisper_stt_handler import WhisperSTTHandler
+
+    monkeypatch.setattr(whisper_stt_handler.console, "print", lambda *a, **k: None)
+
+    # Row 0 is [number of audio samples, language token]: the handler reads index 1 for
+    # the language code and the fake decoder reads index 0 to pick the transcript.
+    handler = object.__new__(WhisperSTTHandler)
+    handler.gen_kwargs = {}
+    handler.start_language = "en"
+    handler.last_language = "en"
+    handler.prepare_model_inputs = lambda audio: audio
+    handler.model = SimpleNamespace(generate=lambda features, **kw: np.array([[len(features), 0]]))
+    handler.processor = SimpleNamespace(
+        tokenizer=SimpleNamespace(decode=lambda token: "<|en|>"),
+        batch_decode=lambda ids, **kw: [TRANSCRIPTS[int(ids[0][0])]],
+    )
+    return _prepare(handler)
+
+
+def build_faster_whisper(monkeypatch):
+    _ensure_module("faster_whisper", WhisperModel=object)
+    from speech_to_speech.STT import faster_whisper_handler
+    from speech_to_speech.STT.faster_whisper_handler import FasterWhisperSTTHandler
+
+    monkeypatch.setattr(faster_whisper_handler.console, "print", lambda *a, **k: None)
+
+    def transcribe(audio, **kw):
+        segment = SimpleNamespace(start=0.0, end=1.0, text=TRANSCRIPTS[len(audio)])
+        return [segment], None
+
+    handler = object.__new__(FasterWhisperSTTHandler)
+    handler.gen_kwargs = {}
+    handler.model = SimpleNamespace(transcribe=transcribe)
+    return _prepare(handler)
+
+
+def build_lightning_whisper_mlx(monkeypatch):
+    _ensure_module("lightning_whisper_mlx", LightningWhisperMLX=object)
+    from speech_to_speech.STT import lightning_whisper_mlx_handler
+    from speech_to_speech.STT.lightning_whisper_mlx_handler import LightningWhisperSTTHandler
+
+    monkeypatch.setattr(lightning_whisper_mlx_handler.console, "print", lambda *a, **k: None)
+    # torch.mps.empty_cache() is unguarded and is a no-op only where Metal exists.
+    monkeypatch.setattr(lightning_whisper_mlx_handler.torch.mps, "empty_cache", lambda: None)
+
+    handler = object.__new__(LightningWhisperSTTHandler)
+    handler.start_language = "en"
+    handler.last_language = "en"
+    handler.model = SimpleNamespace(transcribe=lambda audio, **kw: {"text": TRANSCRIPTS[len(audio)], "language": "en"})
+    return _prepare(handler)
+
+
+def build_mlx_audio_whisper(monkeypatch):
+    from speech_to_speech.STT import mlx_audio_whisper_handler
+    from speech_to_speech.STT.mlx_audio_whisper_handler import MLXAudioWhisperSTTHandler
+
+    monkeypatch.setattr(mlx_audio_whisper_handler.console, "print", lambda *a, **k: None)
+
+    handler = object.__new__(MLXAudioWhisperSTTHandler)
+    handler.model_name = "mlx-community/whisper-large-v3-turbo"
+    handler.start_language = "en"
+    handler.last_language = "en"
+    handler.gen_kwargs = {}
+    handler.model = SimpleNamespace(
+        generate=lambda audio, verbose=False, **kw: SimpleNamespace(text=TRANSCRIPTS[len(audio)])
+    )
+    return _prepare(handler)
+
+
+BUILDERS = {
+    "whisper": build_whisper,
+    "faster-whisper": build_faster_whisper,
+    "whisper-mlx": build_lightning_whisper_mlx,
+    "mlx-audio-whisper": build_mlx_audio_whisper,
+}
+
+
+def vad_chunk(mode: str, seconds: int) -> VADAudio:
+    return VADAudio(
+        audio=np.zeros(SAMPLE_RATE * seconds, dtype=np.float32),
+        mode=mode,
+        turn_id="turn_1",
+        turn_revision=0,
+    )
+
+
+def drive_turn(handler) -> list:
+    """Feed one utterance through the handler using BaseHandler.run()'s hook order.
+
+    The input queue is left empty between chunks, which is what the pipeline looks like
+    while the user is still speaking: the final chunk does not exist yet, so the
+    `progressive-before-final` guard in `should_process_input` cannot mask the defect.
+    """
+    emitted = []
+    for mode, seconds, _ in CHUNKS:
+        item = vad_chunk(mode, seconds)
+        if not handler.should_process_input(item):
+            continue
+        for output in handler.process(item):
+            if not handler.should_emit_output(output):
+                continue
+            handler.before_emit_output(output)
+            emitted.append(output)
+    return emitted
+
+
+@pytest.mark.parametrize("backend", sorted(BUILDERS))
+def test_progressive_audio_yields_partial_transcription(backend, monkeypatch):
+    handler = BUILDERS[backend](monkeypatch)
+
+    outputs = list(handler.process(vad_chunk("progressive", 1)))
+
+    assert len(outputs) == 1
+    assert isinstance(outputs[0], PartialTranscription)
+    assert outputs[0].text == "one"
+    assert outputs[0].turn_id == "turn_1"
+    assert outputs[0].turn_revision == 0
+
+
+@pytest.mark.parametrize("backend", sorted(BUILDERS))
+def test_final_audio_yields_transcription(backend, monkeypatch):
+    handler = BUILDERS[backend](monkeypatch)
+
+    outputs = list(handler.process(vad_chunk("final", 3)))
+
+    assert len(outputs) == 1
+    assert isinstance(outputs[0], Transcription)
+    assert outputs[0].text == FULL_UTTERANCE
+
+
+@pytest.mark.parametrize("backend", sorted(BUILDERS))
+def test_progressive_chunks_do_not_finalize_the_turn(backend, monkeypatch):
+    """The regression: the whole utterance must survive, not just the first fragment."""
+    handler = BUILDERS[backend](monkeypatch)
+
+    emitted = drive_turn(handler)
+
+    finals = [item for item in emitted if isinstance(item, Transcription)]
+    partials = [item for item in emitted if isinstance(item, PartialTranscription)]
+
+    assert [item.text for item in partials] == ["one", "one two"]
+    assert len(finals) == 1
+    assert finals[0].text == FULL_UTTERANCE
+
+
+@pytest.mark.parametrize("backend", sorted(BUILDERS))
+def test_absent_mode_still_yields_transcription(backend, monkeypatch):
+    """Non-realtime pipelines send VADAudio with mode=None and must be unaffected."""
+    handler = BUILDERS[backend](monkeypatch)
+
+    item = VADAudio(audio=np.zeros(SAMPLE_RATE * 3, dtype=np.float32), turn_id="turn_1", turn_revision=0)
+    outputs = list(handler.process(item))
+
+    assert len(outputs) == 1
+    assert isinstance(outputs[0], Transcription)
+    assert outputs[0].text == FULL_UTTERANCE


### PR DESCRIPTION
Fixes #412

## Summary

- branch on `vad_audio.mode` in the four Whisper-family STT handlers so progressive
  audio yields `PartialTranscription` rather than `Transcription`
- add `tests/test_whisper_progressive_transcription.py`, covering all four backends

The diagnosis and the shape of the fix are from @whitepepper355 in #412, including the
follow-up comment identifying `mlx_audio_whisper_handler.py` as a fourth affected file.

## Problem

In `--mode realtime` the VAD emits a progressive chunk while the user is still speaking,
then a final chunk once speech ends. `BaseSTTHandler` closes a turn on the first
`Transcription` it observes:

```python
def before_emit_output(self, output: STTOut) -> None:
    if isinstance(output, Transcription):
        self._mark_completed_final_revision(output)
```

`should_process_input` subsequently rejects every later chunk carrying that
`(turn_id, turn_revision)` as `input-after-final`.

`ParakeetTDTSTTHandler` avoids this by inspecting the mode at
`parakeet_tdt_handler.py:244`. The four Whisper-family handlers never read
`vad_audio.mode` and yielded `Transcription` unconditionally, so the progressive chunk
closed the turn and the remainder of the utterance was discarded:

- `STT/whisper_stt_handler.py`
- `STT/faster_whisper_handler.py`
- `STT/lightning_whisper_mlx_handler.py`
- `STT/mlx_audio_whisper_handler.py`

Parakeet is the default STT and covers roughly 25 languages. The defect is therefore
reached only after switching to a Whisper backend, which any language outside that set
requires.

## Why the mode check alone is sufficient

`ParakeetTDTSTTHandler` gates its progressive path behind `enable_live_transcription`.
An equivalent flag is not required in these handlers. `s2s_pipeline.py:500` sets
`vad_kw.enable_realtime_transcription` from `--enable_live_transcription`, and
`vad_handler.py:623` gates the progressive yield on that value. Progressive chunks
therefore exist only when live transcription is enabled, and a handler that receives one
is already operating in that mode.

## Verification

Each backend was exercised with real model weights, driven by the real `VADHandler`
rather than synthetic chunk boundaries. The VAD emitted `['progressive', 'final']` in
every case.

Reference transcription of the complete utterance:

```
I think the weather today is really quite nice and I would like to go outside.
```

| Backend | Model | Delivered to the LLM before | After |
| --- | --- | --- | --- |
| `whisper` | `openai/whisper-small` | `I think` | matches reference |
| `faster-whisper` | `small.en`, int8 | `I think.` | matches reference |
| `whisper-mlx` | `small` | `I think` | matches reference |
| `mlx-audio-whisper` | `whisper-small-mlx` | `I think` | matches reference |

Before, on each backend:

```
[progressive] -> LLM Transcription 'I think'
dropping stale STT input-after-final for turn=turn_1 rev=0
[final] REJECTED by should_process_input
```

After:

```
[progressive]  draft PartialTranscription 'I think'
[final] -> LLM Transcription 'I think the weather today is really quite nice and I would like to go outside.'
```

The `dropping stale` line falls from one occurrence per turn to zero, which is the
signal #412 predicted.

On this branch: 923 passed, 1 skipped. `ruff check`, `ruff format --check` and
`mypy src/` report no issues.

## Test design

The regression test drives the `BaseSTTHandler` hooks in `run()` order and leaves the
input queue empty between chunks. Enqueuing the whole utterance up front instead trips
the separate `progressive-before-final` guard in `should_process_input`, which discards
the progressive chunks and allows the test to pass against unfixed code. Reverting
`src/` while retaining the test produces 8 failures and 8 passes.

The optional backends are stubbed at import time so all four are covered on Linux CI,
where `faster-whisper` and `lightning-whisper-mlx` are not installed.

## Out of scope

Exercising the transformers handler against real weights also surfaces an `IndexError`
at `whisper_stt_handler.py:120`, where `pred_ids[0, 1]` reads a text token rather than a
language tag under transformers 5.6.2. That behaviour is #375 and is already addressed
by #378, so it is left untouched here.

This change does not attempt to quantify the added latency of running STT twice per
utterance, which #412 raises. Measuring it requires the full LLM and TTS chain.
