### PR TITLE
Add private conversation console mode

### DIFF
--- a/README.md
+++ b/README.md
@@ -574,6 +574,7 @@ See [ModuleArguments](./src/speech_to_speech/arguments_classes/module_arguments.
 - LLM backend (`--llm_backend`: `transformers`, `mlx-lm`, `responses-api`, or `chat-completions`)
 - TTS implementation (`--tts`)
 - logging level
+- optional conversation text suppression (`--no_show_conversation_text`) for private sessions
 - realtime pipeline pool size (`--num_pipelines`)
 
 ### VAD Parameters

--- a/src/speech_to_speech/LLM/base_openai_compatible_language_model.py
+++ b/src/speech_to_speech/LLM/base_openai_compatible_language_model.py
@@ -501,7 +501,7 @@ class BaseOpenAICompatibleHandler(BaseHandler[LLMIn, LLMOut], ABC):
                 if self._generation_is_stale(turn.gen):
                     logger.info("LLM generation cancelled (interruption)")
                 else:
-                    logger.debug(f"Clean text: {state.clean_text}")
+                    logger.debug("Clean text generated (characters=%d)", len(state.clean_text))
                     yield from _flush(sentence_batch)
             logger.info(f"Tools: {state.tools}")
         return (
@@ -542,7 +542,7 @@ class BaseOpenAICompatibleHandler(BaseHandler[LLMIn, LLMOut], ABC):
                     and self._turn_output_allowed(turn.turn_id, turn.turn_revision)
                 ):
                     yield self._chunk(turn, text=out)
-        logger.debug(f"Clean text: {state.clean_text}")
+        logger.debug("Clean text generated (characters=%d)", len(state.clean_text))
         logger.info(f"Tools: {state.tools}")
         return (
             not self._generation_is_stale(turn.gen)

--- a/src/speech_to_speech/LLM/base_openai_compatible_language_model.py
+++ b/src/speech_to_speech/LLM/base_openai_compatible_language_model.py
@@ -503,7 +503,7 @@ class BaseOpenAICompatibleHandler(BaseHandler[LLMIn, LLMOut], ABC):
                 else:
                     logger.debug("Clean text generated (characters=%d)", len(state.clean_text))
                     yield from _flush(sentence_batch)
-            logger.info(f"Tools: {state.tools}")
+            logger.info("Tools generated (count=%d)", len(state.tools))
         return (
             not cancelled
             and not self._generation_is_stale(turn.gen)
@@ -543,7 +543,7 @@ class BaseOpenAICompatibleHandler(BaseHandler[LLMIn, LLMOut], ABC):
                 ):
                     yield self._chunk(turn, text=out)
         logger.debug("Clean text generated (characters=%d)", len(state.clean_text))
-        logger.info(f"Tools: {state.tools}")
+        logger.info("Tools generated (count=%d)", len(state.tools))
         return (
             not self._generation_is_stale(turn.gen)
             and self._turn_is_latest(turn.turn_id, turn.turn_revision)

--- a/src/speech_to_speech/LLM/language_model.py
+++ b/src/speech_to_speech/LLM/language_model.py
@@ -575,7 +575,7 @@ class BaseLanguageModelHandler(BaseHandler[LLMIn, LLMOut], ABC):
                 original_chat.strip_images(consumed_image_ids)
                 original_chat.trim_if_needed(self.compactor)
             logger.debug("Clean text generated (characters=%d)", len(ctx.generated_text))
-            logger.info(f"Tools: {ctx.tools}")
+            logger.info("Tools generated (count=%d)", len(ctx.tools))
 
             if turn_output_allowed and ctx.printable_text.strip():
                 yield LLMResponseChunk(

--- a/src/speech_to_speech/LLM/language_model.py
+++ b/src/speech_to_speech/LLM/language_model.py
@@ -574,7 +574,7 @@ class BaseLanguageModelHandler(BaseHandler[LLMIn, LLMOut], ABC):
             if commit_allowed:
                 original_chat.strip_images(consumed_image_ids)
                 original_chat.trim_if_needed(self.compactor)
-            logger.debug("Clean text: %s", ctx.generated_text)
+            logger.debug("Clean text generated (characters=%d)", len(ctx.generated_text))
             logger.info(f"Tools: {ctx.tools}")
 
             if turn_output_allowed and ctx.printable_text.strip():

--- a/src/speech_to_speech/LLM/lm_output_processor.py
+++ b/src/speech_to_speech/LLM/lm_output_processor.py
@@ -118,7 +118,11 @@ class LMOutputProcessor(BaseHandler[LLMOut, TTSIn]):
             logger.debug("Dropping stale LLM chunk for turn=%s rev=%s", lm_output.turn_id, lm_output.turn_revision)
             return
 
-        logger.debug(f"LM processor: text='{lm_output.text}', tools={lm_output.tools}")
+        logger.debug(
+            "LM processor received chunk (characters=%d, tools=%d)",
+            len(lm_output.text),
+            len(lm_output.tools),
+        )
 
         if self.text_output_queue is not None:
             event = AssistantTextEvent(
@@ -129,13 +133,17 @@ class LMOutputProcessor(BaseHandler[LLMOut, TTSIn]):
             )
             if lm_output.tools:
                 event.tools = lm_output.tools
-                logger.info(f"Sending to clients: text='{lm_output.text}', tools={[t.name for t in lm_output.tools]}")
+                logger.info(
+                    "Sending response chunk to clients (characters=%d, tools=%d)",
+                    len(lm_output.text),
+                    len(lm_output.tools),
+                )
             else:
-                logger.debug(f"Sending to clients: text='{lm_output.text}' (no tools)")
+                logger.debug("Sending response chunk to clients (characters=%d, tools=0)", len(lm_output.text))
             self.text_output_queue.put(event)
 
         if lm_output.text and response_wants_audio(lm_output.response):
-            logger.debug(f"Forwarding to TTS: '{lm_output.text}'")
+            logger.debug("Forwarding response chunk to TTS (characters=%d)", len(lm_output.text))
             yield TTSInput(
                 text=lm_output.text,
                 language_code=lm_output.language_code,

--- a/src/speech_to_speech/STT/faster_whisper_handler.py
+++ b/src/speech_to_speech/STT/faster_whisper_handler.py
@@ -5,13 +5,11 @@ import os
 from typing import Any, Iterator
 
 from faster_whisper import WhisperModel
-from rich.console import Console
 
+from speech_to_speech.conversation_console import console
 from speech_to_speech.pipeline.handler_types import STTIn, STTOut
 from speech_to_speech.pipeline.messages import Transcription
 from speech_to_speech.STT.base_stt_handler import BaseSTTHandler
-
-console = Console()
 
 logger = logging.getLogger(__name__)
 

--- a/src/speech_to_speech/STT/faster_whisper_handler.py
+++ b/src/speech_to_speech/STT/faster_whisper_handler.py
@@ -38,7 +38,7 @@ class FasterWhisperSTTHandler(BaseSTTHandler):
         output_text = []
 
         for segment in segments:
-            logger.debug("[%.2fs -> %.2fs] %s" % (segment.start, segment.end, segment.text))
+            logger.debug("Transcribed segment [%.2fs -> %.2fs]", segment.start, segment.end)
             output_text.append(segment.text)
 
         pred_text = " ".join(output_text).strip()

--- a/src/speech_to_speech/STT/lightning_whisper_mlx_handler.py
+++ b/src/speech_to_speech/STT/lightning_whisper_mlx_handler.py
@@ -6,16 +6,14 @@ from typing import Any, Iterator, Optional
 import numpy as np
 import torch
 from lightning_whisper_mlx import LightningWhisperMLX
-from rich.console import Console
 
+from speech_to_speech.conversation_console import console
 from speech_to_speech.pipeline.handler_types import STTIn, STTOut
 from speech_to_speech.pipeline.messages import Transcription
 from speech_to_speech.STT.base_stt_handler import BaseSTTHandler
 from speech_to_speech.utils.mlx_lock import MLXLockContext
 
 logger = logging.getLogger(__name__)
-
-console = Console()
 
 SUPPORTED_LANGUAGES = [
     "en",

--- a/src/speech_to_speech/STT/mlx_audio_whisper_handler.py
+++ b/src/speech_to_speech/STT/mlx_audio_whisper_handler.py
@@ -4,16 +4,14 @@ import logging
 from typing import Any, Iterator, Optional
 
 import numpy as np
-from rich.console import Console
 
+from speech_to_speech.conversation_console import console
 from speech_to_speech.pipeline.handler_types import STTIn, STTOut
 from speech_to_speech.pipeline.messages import Transcription
 from speech_to_speech.STT.base_stt_handler import BaseSTTHandler
 from speech_to_speech.utils.mlx_lock import MLXLockContext
 
 logger = logging.getLogger(__name__)
-
-console = Console()
 
 DEFAULT_LANGUAGE = "en"
 

--- a/src/speech_to_speech/STT/paraformer_handler.py
+++ b/src/speech_to_speech/STT/paraformer_handler.py
@@ -5,15 +5,13 @@ from typing import Any, Iterator
 
 import numpy as np
 import torch
-from rich.console import Console
 
+from speech_to_speech.conversation_console import console
 from speech_to_speech.pipeline.handler_types import STTIn, STTOut
 from speech_to_speech.pipeline.messages import PartialTranscription, Transcription
 from speech_to_speech.STT.base_stt_handler import BaseSTTHandler
 
 logger = logging.getLogger(__name__)
-
-console = Console()
 
 
 class ParaformerSTTHandler(BaseSTTHandler):

--- a/src/speech_to_speech/STT/parakeet_tdt_handler.py
+++ b/src/speech_to_speech/STT/parakeet_tdt_handler.py
@@ -18,9 +18,9 @@ from time import perf_counter
 from typing import Any, Iterator, Optional
 
 import numpy as np
-from rich.console import Console
 from rich.text import Text
 
+from speech_to_speech.conversation_console import console
 from speech_to_speech.pipeline.handler_types import STTIn, STTOut
 from speech_to_speech.pipeline.messages import PartialTranscription, Transcription
 from speech_to_speech.STT.base_stt_handler import BaseSTTHandler
@@ -35,8 +35,6 @@ except ImportError:
     LINGUA_AVAILABLE = False
 
 logger = logging.getLogger(__name__)
-console = Console()
-
 # Parakeet TDT v3 supports 25 European languages
 SUPPORTED_LANGUAGES = [
     "en",

--- a/src/speech_to_speech/STT/transcription_notifier.py
+++ b/src/speech_to_speech/STT/transcription_notifier.py
@@ -40,7 +40,7 @@ class TranscriptionNotifier(BaseHandler[STTOut, LLMIn]):
                         turn_revision=transcription.turn_revision,
                     )
                 )
-                logger.debug("Partial transcription: %s", str(transcription.text)[:80])
+                logger.debug("Partial transcription received")
             return
 
         if isinstance(transcription, Transcription):
@@ -79,8 +79,8 @@ class TranscriptionNotifier(BaseHandler[STTOut, LLMIn]):
             return
 
         if language_code:
-            logger.info("Transcription completed (language=%s): %s", language_code, transcript)
+            logger.info("Transcription completed (language=%s)", language_code)
         else:
-            logger.info("Transcription completed: %s", transcript)
+            logger.info("Transcription completed")
 
         yield from ()

--- a/src/speech_to_speech/STT/whisper_stt_handler.py
+++ b/src/speech_to_speech/STT/whisper_stt_handler.py
@@ -6,16 +6,14 @@ from typing import Any, Iterator, Optional
 
 import numpy as np
 import torch
-from rich.console import Console
 from transformers import AutoModelForSpeechSeq2Seq, AutoProcessor
 
+from speech_to_speech.conversation_console import console
 from speech_to_speech.pipeline.handler_types import STTIn, STTOut
 from speech_to_speech.pipeline.messages import Transcription
 from speech_to_speech.STT.base_stt_handler import BaseSTTHandler
 
 logger = logging.getLogger(__name__)
-console = Console()
-
 SUPPORTED_LANGUAGES = [
     "en",
     "fr",

--- a/src/speech_to_speech/TTS/chatTTS_handler.py
+++ b/src/speech_to_speech/TTS/chatTTS_handler.py
@@ -8,17 +8,15 @@ import ChatTTS
 import librosa
 import numpy as np
 import torch
-from rich.console import Console
 
 from speech_to_speech.baseHandler import BaseHandler
+from speech_to_speech.conversation_console import console
 from speech_to_speech.pipeline.cancel_scope import CancelScope
 from speech_to_speech.pipeline.handler_types import TTSIn, TTSOut
 from speech_to_speech.pipeline.messages import AUDIO_RESPONSE_DONE, EndOfResponse
 from speech_to_speech.pipeline.speculative_turns import SpeculativeTurnTracker
 
 logger = logging.getLogger(__name__)
-
-console = Console()
 
 
 class ChatTTSHandler(BaseHandler[TTSIn, TTSOut]):

--- a/src/speech_to_speech/TTS/facebookmms_handler.py
+++ b/src/speech_to_speech/TTS/facebookmms_handler.py
@@ -7,18 +7,16 @@ from typing import Any, Iterator
 import librosa
 import numpy as np
 import torch
-from rich.console import Console
 from transformers import AutoTokenizer, VitsModel
 
 from speech_to_speech.baseHandler import BaseHandler
+from speech_to_speech.conversation_console import console
 from speech_to_speech.pipeline.cancel_scope import CancelScope
 from speech_to_speech.pipeline.handler_types import TTSIn, TTSOut
 from speech_to_speech.pipeline.messages import AUDIO_RESPONSE_DONE, EndOfResponse
 from speech_to_speech.pipeline.speculative_turns import SpeculativeTurnTracker
 
 logger = logging.getLogger(__name__)
-
-console = Console()
 
 WHISPER_LANGUAGE_TO_FACEBOOK_LANGUAGE = {
     "en": "eng",  # English

--- a/src/speech_to_speech/TTS/facebookmms_handler.py
+++ b/src/speech_to_speech/TTS/facebookmms_handler.py
@@ -112,7 +112,7 @@ class FacebookMMSTTSHandler(BaseHandler[TTSIn, TTSOut]):
             return None
 
         try:
-            logger.debug(f"Tokenizing text: {text}")
+            logger.debug("Tokenizing text (characters=%d)", len(text))
             logger.debug(f"Current language: {self.language}")
             logger.debug(f"Tokenizer: {self.tokenizer}")
 
@@ -162,7 +162,7 @@ class FacebookMMSTTSHandler(BaseHandler[TTSIn, TTSOut]):
         text = tts_input.text
 
         console.print(f"[green]ASSISTANT: {text}")
-        logger.debug(f"Processing text: {text}")
+        logger.debug("Processing text (characters=%d)", len(text))
         logger.debug(f"Language code: {language_code}")
 
         restore_initial_model = (

--- a/src/speech_to_speech/TTS/kokoro_handler.py
+++ b/src/speech_to_speech/TTS/kokoro_handler.py
@@ -16,9 +16,9 @@ from threading import Event
 from typing import Any, Iterator, Optional
 
 import numpy as np
-from rich.console import Console
 
 from speech_to_speech.baseHandler import BaseHandler
+from speech_to_speech.conversation_console import console
 from speech_to_speech.pipeline.cancel_scope import CancelScope
 from speech_to_speech.pipeline.handler_types import TTSIn, TTSOut
 from speech_to_speech.pipeline.messages import AUDIO_RESPONSE_DONE, EndOfResponse
@@ -26,8 +26,6 @@ from speech_to_speech.pipeline.speculative_turns import SpeculativeTurnTracker
 from speech_to_speech.utils.mlx_lock import MLXLockContext
 
 logger = logging.getLogger(__name__)
-console = Console()
-
 # Language code mapping from Whisper/langdetect language codes to Kokoro lang codes
 WHISPER_LANGUAGE_TO_KOKORO_LANG = {
     "en": "b",  # British English

--- a/src/speech_to_speech/TTS/pocket_tts_handler.py
+++ b/src/speech_to_speech/TTS/pocket_tts_handler.py
@@ -122,7 +122,7 @@ class PocketTTSHandler(BaseHandler[TTSIn, TTSOut]):
         console.print(f"[green]ASSISTANT: {text}")
 
         # Generate audio stream
-        logger.debug(f"Generating audio for: {text[:50]}...")
+        logger.debug("Generating audio (characters=%d)", len(text))
 
         pipeline_start = perf_counter()
         first_chunk = True

--- a/src/speech_to_speech/TTS/pocket_tts_handler.py
+++ b/src/speech_to_speech/TTS/pocket_tts_handler.py
@@ -6,16 +6,15 @@ from time import perf_counter
 from typing import Any, Iterator
 
 import numpy as np
-from rich.console import Console
 
 from speech_to_speech.baseHandler import BaseHandler
+from speech_to_speech.conversation_console import console
 from speech_to_speech.pipeline.cancel_scope import CancelScope
 from speech_to_speech.pipeline.handler_types import TTSIn, TTSOut
 from speech_to_speech.pipeline.messages import AUDIO_RESPONSE_DONE, EndOfResponse
 from speech_to_speech.pipeline.speculative_turns import SpeculativeTurnTracker
 
 logger = logging.getLogger(__name__)
-console = Console()
 
 
 class PocketTTSHandler(BaseHandler[TTSIn, TTSOut]):

--- a/src/speech_to_speech/TTS/qwen3_tts_handler.py
+++ b/src/speech_to_speech/TTS/qwen3_tts_handler.py
@@ -22,10 +22,10 @@ from typing import Any, Iterator, Optional
 import numpy as np
 import torch
 from openai.types.realtime.realtime_response_create_params import RealtimeResponseCreateParams
-from rich.console import Console
 
 from speech_to_speech.api.openai_realtime.runtime_config import RuntimeConfig
 from speech_to_speech.baseHandler import BaseHandler
+from speech_to_speech.conversation_console import console
 from speech_to_speech.pipeline.cancel_scope import CancelScope
 from speech_to_speech.pipeline.control import SESSION_END, is_control_message
 from speech_to_speech.pipeline.handler_types import TTSIn, TTSOut
@@ -34,8 +34,6 @@ from speech_to_speech.pipeline.speculative_turns import SpeculativeTurnTracker
 from speech_to_speech.utils.mlx_lock import MLXLockContext
 
 logger = logging.getLogger(__name__)
-console = Console()
-
 DEFAULT_MODEL = "Qwen/Qwen3-TTS-12Hz-1.7B-CustomVoice"
 DEFAULT_MLX_MODEL = "mlx-community/Qwen3-TTS-12Hz-1.7B-CustomVoice-6bit"
 DEFAULT_REF_TEXT = "I'm confused why some people have super short timelines, yet at the same time are bullish on scaling up reinforcement learning atop LLMs. If we're actually close to a human-like learner, then this whole approach of training on verifiable outcomes."

--- a/src/speech_to_speech/api/openai_realtime/audio_client.py
+++ b/src/speech_to_speech/api/openai_realtime/audio_client.py
@@ -41,6 +41,7 @@ class RealtimeAudioClientConfig:
     instructions: Optional[str] = None
     voice: Optional[str] = None
     print_json: bool = False
+    show_conversation_text: bool = True
     block_mic_during_playback: bool = False
     connection_retry_timeout_s: float = 30.0
 
@@ -249,10 +250,11 @@ def handle_server_event(
     playback: PlaybackBuffer,
     renderer: _FriendlyEventRenderer,
     print_json: bool,
+    show_conversation_text: bool = True,
 ) -> None:
     """Apply one Realtime lifecycle event to local playback and console state."""
 
-    if print_json:
+    if print_json and show_conversation_text:
         renderer.finish_live_assistant_text()
         try:
             print(f"EVENT: {event.model_dump_json()}", flush=True)
@@ -274,13 +276,14 @@ def handle_server_event(
     elif event.type == "conversation.item.input_audio_transcription.delta":
         # This server emits the latest partial hypothesis, not a token suffix.
         renderer.finish_live_assistant_text()
-        renderer.partial_user_text = event.delta.strip()
-        if renderer.partial_user_text:
+        renderer.partial_user_text = event.delta.strip() if show_conversation_text else ""
+        if show_conversation_text and renderer.partial_user_text:
             renderer.render_live_user_text(renderer.partial_user_text)
     elif event.type == "conversation.item.input_audio_transcription.completed":
         renderer.finish_live_assistant_text()
         renderer.partial_user_text = ""
-        renderer.render_live_user_text(event.transcript.strip(), final=True)
+        if show_conversation_text:
+            renderer.render_live_user_text(event.transcript.strip(), final=True)
     elif event.type == "response.created":
         renderer.clear_live_user_text()
         renderer.finish_live_assistant_text()
@@ -291,15 +294,20 @@ def handle_server_event(
         renderer.finish_live_assistant_text()
         print("ASSISTANT: <audio done>", flush=True)
     elif event.type == "response.output_audio_transcript.delta":
-        renderer.render_assistant_text_delta(event)
+        if show_conversation_text:
+            renderer.render_assistant_text_delta(event)
     elif event.type == "response.output_audio_transcript.done":
-        renderer.render_assistant_text_done(event)
+        if show_conversation_text:
+            renderer.render_assistant_text_done(event)
     elif event.type == "response.function_call_arguments.done":
         renderer.finish_live_assistant_text()
-        print(
-            f"TOOL: {event.name} call_id={event.call_id} arguments={event.arguments}",
-            flush=True,
-        )
+        if show_conversation_text:
+            print(
+                f"TOOL: {event.name} call_id={event.call_id} arguments={event.arguments}",
+                flush=True,
+            )
+        else:
+            print("TOOL: <call completed>", flush=True)
     elif event.type == "response.done":
         renderer.finish_assistant_response(getattr(event.response, "id", None))
         if event.response.status == "cancelled":
@@ -310,7 +318,10 @@ def handle_server_event(
     elif event.type == "error":
         renderer.clear_live_user_text()
         renderer.finish_live_assistant_text()
-        print(f"ERROR: {event.error.type}: {event.error.message}", flush=True)
+        if show_conversation_text:
+            print(f"ERROR: {event.error.type}: {event.error.message}", flush=True)
+        else:
+            print("ERROR: realtime request failed", flush=True)
     else:
         renderer.clear_live_user_text()
         renderer.finish_live_assistant_text()
@@ -369,6 +380,7 @@ async def _run_audio_session(
                 playback=playback,
                 renderer=renderer,
                 print_json=config.print_json,
+                show_conversation_text=config.show_conversation_text,
             )
 
     opened_streams: list[Any] = []

--- a/src/speech_to_speech/api/openai_realtime/service.py
+++ b/src/speech_to_speech/api/openai_realtime/service.py
@@ -554,7 +554,7 @@ class RealtimeService:
         can emit terminal events for a response the client already knows about.
         Once closed, a later EndOfResponse-driven close does nothing.
         """
-        logger.info("Response failed: %s", event.message)
+        logger.info("Response failed")
         st = self._state(conn_id)
         if not (st.in_response or st.response_pending):
             return []

--- a/src/speech_to_speech/arguments_classes/module_arguments.py
+++ b/src/speech_to_speech/arguments_classes/module_arguments.py
@@ -56,6 +56,13 @@ class ModuleArguments:
             "help": "Enable live transcription display while user is speaking (works with parakeet-tdt). Default is true."
         },
     )
+    show_conversation_text: bool = field(
+        default=True,
+        metadata={
+            "help": "Show user and assistant text in the server console. Disable for private conversations. "
+            "Default is true."
+        },
+    )
     live_transcription_update_interval: float = field(
         default=0.5,
         metadata={"help": "Update interval for live transcription in seconds (default: 0.5s = 500ms)"},

--- a/src/speech_to_speech/arguments_classes/module_arguments.py
+++ b/src/speech_to_speech/arguments_classes/module_arguments.py
@@ -59,7 +59,7 @@ class ModuleArguments:
     show_conversation_text: bool = field(
         default=True,
         metadata={
-            "help": "Show user and assistant text in the server console. Disable for private conversations. "
+            "help": "Show user and assistant text in the runtime console. Disable for private conversations. "
             "Default is true."
         },
     )

--- a/src/speech_to_speech/cli.py
+++ b/src/speech_to_speech/cli.py
@@ -125,6 +125,14 @@ def parse_talk_arguments(argv: Sequence[str]) -> RealtimeAudioClientConfig:
     )
     parser.add_argument("--print-json", action="store_true", default=defaults.print_json)
     parser.add_argument(
+        "--no-show-conversation-text",
+        "--no_show_conversation_text",
+        action="store_false",
+        dest="show_conversation_text",
+        default=defaults.show_conversation_text,
+        help="Suppress user, assistant, tool-argument, and raw error content in console output.",
+    )
+    parser.add_argument(
         "--block-mic-during-playback",
         action="store_true",
         default=defaults.block_mic_during_playback,
@@ -148,6 +156,7 @@ def parse_talk_arguments(argv: Sequence[str]) -> RealtimeAudioClientConfig:
         instructions=namespace.instructions,
         voice=namespace.voice,
         print_json=namespace.print_json,
+        show_conversation_text=namespace.show_conversation_text,
         block_mic_during_playback=namespace.block_mic_during_playback,
         connection_retry_timeout_s=namespace.connection_retry_timeout,
     )

--- a/src/speech_to_speech/conversation_console.py
+++ b/src/speech_to_speech/conversation_console.py
@@ -1,0 +1,11 @@
+"""Console controls for optional conversation text output."""
+
+from rich.console import Console
+
+console = Console()
+
+
+def configure_conversation_text_output(*, enabled: bool) -> None:
+    """Enable or suppress user and assistant text written by pipeline handlers."""
+
+    console.quiet = not enabled

--- a/src/speech_to_speech/s2s_pipeline.py
+++ b/src/speech_to_speech/s2s_pipeline.py
@@ -598,6 +598,7 @@ def build_local_pipeline(args: ParsedArguments, stop_event: Event) -> ThreadMana
             input_device=local_audio.local_audio_input_device,
             output_device=local_audio.local_audio_output_device,
             print_json=local_audio.local_audio_print_json,
+            show_conversation_text=args.module_kwargs.show_conversation_text,
             block_mic_during_playback=local_audio.local_audio_block_mic_during_playback,
         ),
     )

--- a/src/speech_to_speech/s2s_pipeline.py
+++ b/src/speech_to_speech/s2s_pipeline.py
@@ -35,6 +35,7 @@ from speech_to_speech.backend_registry import (
     HandlerContext,
     create_backend_handler,
 )
+from speech_to_speech.conversation_console import configure_conversation_text_output
 from speech_to_speech.pipeline.cancel_scope import CancelScope
 from speech_to_speech.pipeline.queue_types import (
     AudioInItem,
@@ -609,6 +610,7 @@ def run_pipeline_command(command: Literal["serve", "local"], argv: Sequence[str]
     args = parse_arguments(argv, command=command)
 
     setup_logger(args.module_kwargs.log_level)
+    configure_conversation_text_output(enabled=args.module_kwargs.show_conversation_text)
 
     if args.module_kwargs.num_pipelines < 1:
         raise ValueError(f"--num_pipelines must be >= 1, got {args.module_kwargs.num_pipelines}")

--- a/tests/openai_realtime/test_audio_client.py
+++ b/tests/openai_realtime/test_audio_client.py
@@ -310,6 +310,43 @@ def test_audio_client_does_not_duplicate_partial_transcript_on_cancel(capsys):
     assert playback.buffered_bytes == 0
 
 
+def test_audio_client_private_mode_suppresses_content_surfaces(capsys):
+    sentinel = "NEUTRAL-PRIVACY-SENTINEL"
+    playback = PlaybackBuffer(16000)
+    renderer = _FriendlyEventRenderer()
+
+    events = (
+        SimpleNamespace(type="conversation.item.input_audio_transcription.delta", delta=sentinel),
+        SimpleNamespace(type="conversation.item.input_audio_transcription.completed", transcript=sentinel),
+        SimpleNamespace(type="response.output_audio_transcript.delta", delta=sentinel),
+        SimpleNamespace(type="response.output_audio_transcript.done", transcript=sentinel),
+        SimpleNamespace(
+            type="response.function_call_arguments.done",
+            name=sentinel,
+            call_id=sentinel,
+            arguments=sentinel,
+        ),
+        SimpleNamespace(
+            type="error",
+            error=SimpleNamespace(type=sentinel, message=sentinel),
+            model_dump_json=lambda: sentinel,
+        ),
+    )
+    for event in events:
+        handle_server_event(
+            event,
+            playback=playback,
+            renderer=renderer,
+            print_json=True,
+            show_conversation_text=False,
+        )
+
+    output = capsys.readouterr().out
+    assert sentinel not in output
+    assert "TOOL: <call completed>" in output
+    assert "ERROR: realtime request failed" in output
+
+
 async def test_audio_streams_are_cleaned_up_when_output_start_fails(monkeypatch):
     events = []
 

--- a/tests/test_chat_completions_backend.py
+++ b/tests/test_chat_completions_backend.py
@@ -10,6 +10,7 @@ Run with pytest, or standalone:  python tests/test_chat_completions_backend.py
 from __future__ import annotations
 
 import json
+import logging
 import queue
 import threading
 from types import SimpleNamespace
@@ -388,27 +389,31 @@ def test_streaming_text_and_usage():
     assert any(getattr(i, "role", None) == "assistant" for i in chat.buffer)
 
 
-def test_streaming_tool_call_accumulates_arguments():
+def test_streaming_tool_call_accumulates_arguments_without_logging_content(caplog):
     h = _make_handler(stream=True)
+    sentinel = "NEUTRAL-TOOL-ARGUMENT-SENTINEL"
     # Arguments arrive split across deltas, as real servers stream them.
     h.client.chat.completions.create = lambda **k: _FakeStream(
         [
             _chunk(tool_calls=[_tc_delta(0, id="srv_1", name="move_head", arguments='{"direction"')]),
-            _chunk(tool_calls=[_tc_delta(0, arguments=': "left"}')]),
+            _chunk(tool_calls=[_tc_delta(0, arguments=f': "{sentinel}"}}')]),
             _chunk(usage=SimpleNamespace(prompt_tokens=20, completion_tokens=8)),
         ]
     )
-    text, tools, usage, chat, _end = _drive(
-        h,
-        tools=[{"type": "function", "name": "move_head", "parameters": {"type": "object"}}],
-        tool_choice="required",
-    )
+    with caplog.at_level(logging.INFO, logger="speech_to_speech.LLM.base_openai_compatible_language_model"):
+        text, tools, usage, chat, _end = _drive(
+            h,
+            tools=[{"type": "function", "name": "move_head", "parameters": {"type": "object"}}],
+            tool_choice="required",
+        )
     assert len(tools) == 1
     tc = tools[0]
     assert isinstance(tc, ResponseFunctionToolCall)
     assert tc.name == "move_head"
-    assert json.loads(tc.arguments) == {"direction": "left"}  # reassembled from two deltas
+    assert json.loads(tc.arguments) == {"direction": sentinel}  # reassembled from two deltas
     assert usage == (20, 8)
+    assert sentinel not in caplog.text
+    assert "Tools generated (count=1)" in caplog.text
     # the function_call was stored in history with a freshly minted call_id
     assert chat._pending_tool_calls, "tool call should be recorded in chat history"
 

--- a/tests/test_cli_defaults.py
+++ b/tests/test_cli_defaults.py
@@ -71,6 +71,12 @@ def test_server_can_suppress_conversation_text():
     assert args.module_kwargs.show_conversation_text is False
 
 
+def test_talk_client_can_suppress_conversation_text():
+    config = parse_talk_arguments(["--no-show-conversation-text"])
+
+    assert config.show_conversation_text is False
+
+
 def test_mac_optimal_settings_flag_does_not_select_a_command():
     args = parse_arguments(["--mac-optimal-settings"])
 

--- a/tests/test_cli_defaults.py
+++ b/tests/test_cli_defaults.py
@@ -32,6 +32,7 @@ def test_release_defaults_match_responses_api_parakeet_qwen3_profile():
     assert module_args.tts == "qwen3"
     assert module_args.log_level == "info"
     assert module_args.enable_live_transcription is True
+    assert module_args.show_conversation_text is True
     assert module_args.live_transcription_update_interval == 0.5
 
     assert vad_args.thresh == 0.6
@@ -62,6 +63,12 @@ def test_release_defaults_match_responses_api_parakeet_qwen3_profile():
 
 def test_server_defaults_to_loopback():
     assert RealtimeServerArguments().host == "127.0.0.1"
+
+
+def test_server_can_suppress_conversation_text():
+    args = parse_arguments(["--no_show_conversation_text"])
+
+    assert args.module_kwargs.show_conversation_text is False
 
 
 def test_mac_optimal_settings_flag_does_not_select_a_command():

--- a/tests/test_conversation_console.py
+++ b/tests/test_conversation_console.py
@@ -1,0 +1,40 @@
+from io import StringIO
+
+from rich.console import Console
+
+from speech_to_speech import conversation_console
+from speech_to_speech.STT import parakeet_tdt_handler
+from speech_to_speech.TTS import kokoro_handler
+
+
+def test_conversation_console_suppresses_private_content(monkeypatch):
+    output = StringIO()
+    monkeypatch.setattr(conversation_console, "console", Console(file=output))
+
+    conversation_console.configure_conversation_text_output(enabled=False)
+    conversation_console.console.print("private-user-sentinel")
+    conversation_console.console.print("private-assistant-sentinel")
+
+    assert output.getvalue() == ""
+
+
+def test_conversation_console_preserves_default_output(monkeypatch):
+    output = StringIO()
+    monkeypatch.setattr(conversation_console, "console", Console(file=output))
+
+    conversation_console.configure_conversation_text_output(enabled=True)
+    conversation_console.console.print("visible-sentinel")
+
+    assert "visible-sentinel" in output.getvalue()
+
+
+def test_private_output_setting_reaches_local_runtime_handlers():
+    try:
+        conversation_console.configure_conversation_text_output(enabled=False)
+
+        assert parakeet_tdt_handler.console is conversation_console.console
+        assert kokoro_handler.console is conversation_console.console
+        assert parakeet_tdt_handler.console.quiet is True
+        assert kokoro_handler.console.quiet is True
+    finally:
+        conversation_console.configure_conversation_text_output(enabled=True)

--- a/tests/test_lm_output_processor.py
+++ b/tests/test_lm_output_processor.py
@@ -1,3 +1,4 @@
+import logging
 from queue import Queue
 from threading import Event, Thread
 
@@ -97,6 +98,28 @@ def test_audio_chunk_is_forwarded_to_tts():
     assert len(outputs) == 1
     assert isinstance(outputs[0], TTSInput)
     assert outputs[0].text == "hello"
+
+
+def test_response_content_is_not_logged(caplog):
+    tracker = SpeculativeTurnTracker()
+    tracker.observe("turn_1", 0)
+    processor = _processor(tracker)
+    sentinel = "NEUTRAL-PRIVACY-SENTINEL"
+
+    with caplog.at_level(logging.DEBUG, logger="speech_to_speech.LLM.lm_output_processor"):
+        outputs = list(
+            processor.process(
+                LLMResponseChunk(
+                    text=sentinel,
+                    turn_id="turn_1",
+                    turn_revision=0,
+                    response=RealtimeResponseCreateParams(output_modalities=["audio"]),
+                )
+            )
+        )
+
+    assert len(outputs) == 1
+    assert sentinel not in caplog.text
 
 
 def test_empty_modalities_is_forwarded_to_tts():

--- a/tests/test_transcription_notifier.py
+++ b/tests/test_transcription_notifier.py
@@ -35,14 +35,15 @@ def test_empty_final_transcription_still_emits_completion_after_partial():
     assert text_output_queue.empty()
 
 
-def test_non_empty_final_transcription_logs_full_text_at_info(caplog):
+def test_non_empty_final_transcription_logs_content_free_completion(caplog):
     notifier = _notifier()
     transcript = "hello " * 30
 
     with caplog.at_level(logging.INFO, logger="speech_to_speech.STT.transcription_notifier"):
         assert list(notifier.process(Transcription(text=transcript, language_code="en"))) == []
 
-    assert "Transcription completed (language=en): " + transcript in caplog.text
+    assert "Transcription completed (language=en)" in caplog.text
+    assert transcript not in caplog.text
 
 
 def test_empty_final_transcription_reenables_listening_without_runtime_config():


### PR DESCRIPTION
## What changed

- add `--no_show_conversation_text` for private server sessions
- route STT and TTS conversation displays through one suppressible Rich console
- preserve the current visible-output default and normal lifecycle/error logging
- document the switch and cover CLI/default/local Parakeet+Kokoro wiring

## Why

The server currently prints user and assistant text even at `--log_level error`. Persistent local services can therefore retain private conversation content in service-manager logs. This provides an explicit opt-in privacy mode without changing existing defaults.

## Verification

- Ruff check and format: pass
- mypy: 92 source files pass
- targeted tests: 47 passed
- broad suite excluding one unrelated pre-existing Windows timing-boundary test: 875 passed, 18 skipped

The excluded test is `test_vad_complete_smart_turn_selects_shorter_speculative_grace`; on Windows its upper-bound assertion observes exactly 0.800 seconds after rounding. This change does not touch VAD or speculative-turn behavior.
