### PR TITLE
Fix demo status after empty STT transcription

### DIFF
--- a/demo/rtc/s2s-rtc-client.js
+++ b/demo/rtc/s2s-rtc-client.js
@@ -578,6 +578,10 @@ export class S2sRtcRealtimeClient extends EventTarget {
               },
             }),
           );
+        } else if (this._status === "processing" && !this._responsePending()) {
+          // Empty STT results intentionally do not create a response, so there
+          // will be no response.done event to return the UI to listening.
+          this._setStatus("connected");
         }
         break;
       }
@@ -776,6 +780,11 @@ export class S2sRtcRealtimeClient extends EventTarget {
 
   _responseActive() {
     return this._openResponses > 0 || this._createInFlight;
+  }
+
+  /** True while a response is active, awaiting confirmation, or queued. */
+  _responsePending() {
+    return this._responseActive() || this._createQueue.length > 0;
   }
 
   /** @param {{ image?: string }} [opts] */

--- a/demo/ws/s2s-ws-client.js
+++ b/demo/ws/s2s-ws-client.js
@@ -845,6 +845,10 @@ export class S2sWsRealtimeClient extends EventTarget {
               },
             }),
           );
+        } else if (this._status === "processing" && !this._responsePending()) {
+          // Empty STT results intentionally do not create a response, so there
+          // will be no response.done event to return the UI to listening.
+          this._setStatus("connected");
         }
         break;
       }
@@ -1083,6 +1087,11 @@ export class S2sWsRealtimeClient extends EventTarget {
   /** True while a response occupies the single backend slot. */
   _responseActive() {
     return this._openResponses > 0 || this._createInFlight;
+  }
+
+  /** True while a response is active, awaiting confirmation, or queued. */
+  _responsePending() {
+    return this._responseActive() || this._createQueue.length > 0;
   }
 
   /** Send a response.create immediately and arm the in-flight guard. Any image

--- a/tests/test_demo_startup_greeting.py
+++ b/tests/test_demo_startup_greeting.py
@@ -170,6 +170,125 @@ if (client._asstTranscriptByResp.size !== 0 || client._asstFullByResp.size !== 0
     )
 
 
+@pytest.mark.parametrize(
+    "module_path,class_name,message_handler",
+    [
+        ("./demo/ws/s2s-ws-client.js", "S2sWsRealtimeClient", "_onWsMessage"),
+        ("./demo/rtc/s2s-rtc-client.js", "S2sRtcRealtimeClient", "_onDcMessage"),
+    ],
+)
+def test_demo_clients_leave_processing_after_empty_transcript(module_path, class_name, message_handler):
+    node = shutil.which("node")
+    if node is None:
+        pytest.skip("Node.js is required for demo client tests")
+
+    script = f"""
+globalThis.localStorage = {{ getItem() {{ return null; }} }};
+globalThis.CustomEvent = class CustomEvent extends Event {{
+  constructor(type, init = {{}}) {{
+    super(type);
+    this.detail = init.detail;
+  }}
+}};
+const {{ {class_name} }} = await import({json.dumps(module_path)});
+const client = new {class_name}({{
+  voice: "Aiden",
+  instructions: "Be helpful.",
+  directUrl: "ws://unused",
+  callsUrl: "api/calls",
+}});
+client._status = "connected";
+const statuses = [];
+const transcripts = [];
+client.addEventListener("status", (event) => statuses.push(event.detail.status));
+client.addEventListener("transcript", (event) => transcripts.push(event.detail));
+const deliver = async (event) => {{
+  await client[{json.dumps(message_handler)}](JSON.stringify(event));
+}};
+
+await deliver({{ type: "input_audio_buffer.speech_started", item_id: "item_empty" }});
+await deliver({{ type: "input_audio_buffer.speech_stopped", item_id: "item_empty" }});
+if (client.status !== "processing") throw new Error(`expected processing, got ${{client.status}}`);
+
+await deliver({{
+  type: "conversation.item.input_audio_transcription.completed",
+  item_id: "item_empty",
+  transcript: "",
+}});
+
+const expectedStatuses = ["user-speaking", "processing", "connected"];
+if (JSON.stringify(statuses) !== JSON.stringify(expectedStatuses)) {{
+  throw new Error(`unexpected statuses: ${{JSON.stringify(statuses)}}`);
+}}
+if (transcripts.length !== 0) {{
+  throw new Error(`empty final transcript was emitted: ${{JSON.stringify(transcripts)}}`);
+}}
+"""
+    subprocess.run(
+        [node, "--input-type=module", "-e", script],
+        cwd=REPO_ROOT,
+        check=True,
+        capture_output=True,
+        text=True,
+    )
+
+
+@pytest.mark.parametrize(
+    "module_path,class_name,message_handler",
+    [
+        ("./demo/ws/s2s-ws-client.js", "S2sWsRealtimeClient", "_onWsMessage"),
+        ("./demo/rtc/s2s-rtc-client.js", "S2sRtcRealtimeClient", "_onDcMessage"),
+    ],
+)
+def test_empty_transcript_preserves_processing_for_pending_response(module_path, class_name, message_handler):
+    node = shutil.which("node")
+    if node is None:
+        pytest.skip("Node.js is required for demo client tests")
+
+    script = f"""
+globalThis.localStorage = {{ getItem() {{ return null; }} }};
+globalThis.CustomEvent = class CustomEvent extends Event {{
+  constructor(type, init = {{}}) {{
+    super(type);
+    this.detail = init.detail;
+  }}
+}};
+const {{ {class_name} }} = await import({json.dumps(module_path)});
+const client = new {class_name}({{
+  voice: "Aiden",
+  instructions: "Be helpful.",
+  directUrl: "ws://unused",
+  callsUrl: "api/calls",
+}});
+const deliverEmptyTranscript = async () => {{
+  client._status = "processing";
+  await client[{json.dumps(message_handler)}](JSON.stringify({{
+    type: "conversation.item.input_audio_transcription.completed",
+    transcript: "",
+  }}));
+  if (client.status !== "processing") {{
+    throw new Error(`pending response status was overwritten: ${{client.status}}`);
+  }}
+}};
+
+client._openResponses = 1;
+await deliverEmptyTranscript();
+client._openResponses = 0;
+client._createInFlight = true;
+await deliverEmptyTranscript();
+client._createInFlight = false;
+client._createQueue.push({{}});
+await deliverEmptyTranscript();
+"""
+    subprocess.run(
+        [node, "--input-type=module", "-e", script],
+        cwd=REPO_ROOT,
+        check=True,
+        capture_output=True,
+        text=True,
+    )
+
+
 def test_rtc_microphone_opens_after_startup_events_are_queued():
     node = shutil.which("node")
     if node is None:


### PR DESCRIPTION
## Summary

- return the WebSocket and WebRTC demo clients to the connected/listening state after an empty final STT transcript
- keep the processing state when a response is active, awaiting confirmation, or queued
- cover the empty-transcript lifecycle and pending-response guards for both transports

## Root cause

The clients entered `processing` on `input_audio_buffer.speech_stopped` and normally relied on `response.done` to leave it. Empty STT results intentionally do not trigger a model response, so that terminal event never arrived.

## Validation

- `uv run pytest tests/ -q` (911 passed, 1 skipped)
- `uv run ruff check src/ tests/`
- `uv run ruff format --check src/ tests/`
- `node --check demo/ws/s2s-ws-client.js`
- `node --check demo/rtc/s2s-rtc-client.js`

Closes #458
