### PR TITLE
Require confirmation before merging pull requests

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,6 +1,7 @@
 # Repository Instructions
 
 - Never include `codex` in branch names or pull request titles.
+- Never merge a pull request into `main` unless the user explicitly asks the agent to perform the merge and then confirms when asked immediately before the merge. Requests to review, fix, prepare, finish, or get a pull request ready do not count as merge authorization. Once the pull request is ready, report its status and ask for confirmation; merge only after a clear follow-up confirmation.
 - For existing/open pull requests, do not amend, squash, rebase-rewrite, or force-push follow-up changes. Make new commits and push normally unless explicitly asked to rewrite history.
 - Keep release pull requests focused on version metadata and release documentation.
 - Do not commit local build artifacts such as `dist/`, `build/`, or generated wheel/sdist files.


### PR DESCRIPTION
## Summary

- require users to explicitly ask the agent to perform a merge into `main`
- require a separate, immediate follow-up confirmation before the merge
- clarify that reviewing, fixing, preparing, finishing, or getting a pull request ready is not merge authorization

## Why

This keeps the final merge decision with the user unless they unmistakably delegate that action to the agent and confirm it at the point of execution.

## Impact

Agents will stop once a pull request is ready, report its status, and ask the user to confirm before merging it into `main`.

## Validation

- `git diff --check`
