### PR TITLE
Preserve queued provider token usage on session disconnect

### DIFF
--- a/src/speech_to_speech/api/openai_realtime/websocket_router.py
+++ b/src/speech_to_speech/api/openai_realtime/websocket_router.py
@@ -181,6 +181,52 @@ def _flush_queue(q: Queue[QItem], *, preserve: Callable[[QItem], bool] | None = 
             q.not_empty.notify(len(preserved))
 
 
+def _drain_token_usage(q: Queue[Any]) -> list[TokenUsageEvent]:
+    """Remove and return queued ``TokenUsageEvent``s, leaving every other item in place.
+
+    Non-matching items are re-inserted at the front in their original order (atomically
+    under the queue's mutex), mirroring :func:`_flush_queue`, so this is safe to call
+    independently of a flush.
+    """
+    usage: list[TokenUsageEvent] = []
+    remaining: list[Any] = []
+    while True:
+        try:
+            item = q.get_nowait()
+        except Empty:
+            break
+        if isinstance(item, TokenUsageEvent):
+            usage.append(item)
+        else:
+            remaining.append(item)
+    if remaining:
+        with q.mutex:
+            for item in reversed(remaining):
+                q.queue.appendleft(item)
+            q.not_empty.notify(len(remaining))
+    return usage
+
+
+def _account_queued_token_usage(unit: PipelineUnit, session_id: str) -> None:
+    """Fold queued provider usage into session accounting before release discards it.
+
+    Releasing a session calls :func:`_clean_unit`, which drains the output queues, and by
+    then the send loop is gone — so a ``TokenUsageEvent`` that reached a queue but was
+    never dispatched would be dropped before ``unregister()`` rolls this session's usage
+    into the global totals. Billable usage the provider already reported must survive a
+    client disconnect, so account it directly here.
+
+    The returned server events are discarded: the client is gone, and only the accounting
+    side effect matters.
+    """
+    for q in (unit.output_queue, unit.text_output_queue):
+        for event in _drain_token_usage(q):
+            try:
+                unit.service.dispatch_pipeline_event(session_id, event)
+            except Exception:  # noqa: BLE001 - release must not fail on accounting
+                logger.exception("Failed to account queued token usage for session %s", session_id)
+
+
 def _clean_unit(unit: PipelineUnit, preserve: Callable[[Any], bool] | None = None) -> None:
     """Cancel in-flight work and flush queues for a single pipeline unit.
 
@@ -315,6 +361,9 @@ def _release_session(unit: PipelineUnit, session_id: str) -> None:
         # Already released (e.g. duplicate close callbacks racing).
         return
     old_session.released_at = time.monotonic()
+    # Before the flush: queued usage is billable and the session is still registered,
+    # so it can still be folded into this connection's totals.
+    _account_queued_token_usage(unit, session_id)
     _clean_unit(unit)
     # Tag SESSION_END with this session's id so that, after a force
     # release, a late arrival can't satisfy the next session's drain.

--- a/tests/openai_realtime/test_release_token_usage.py
+++ b/tests/openai_realtime/test_release_token_usage.py
@@ -1,0 +1,203 @@
+"""Queued provider token usage must survive a client disconnect.
+
+`LMOutputProcessor` routes `TokenUsageEvent` through the router's output queues. Releasing a
+session calls `_clean_unit()`, which drains those queues, and by then the send loop is gone —
+so a usage event that reached a queue but was never dispatched was discarded before
+`RealtimeService.unregister()` rolled the connection's usage into the global totals. The
+provider had already billed those tokens.
+
+`_release_session()` now accounts queued usage directly, before the flush and while the
+session is still registered.
+"""
+
+from __future__ import annotations
+
+from queue import Queue
+from threading import Event as ThreadingEvent
+
+import pytest
+
+from speech_to_speech.api.openai_realtime import websocket_router as router
+from speech_to_speech.api.openai_realtime.pipeline_unit import PipelineUnit, SessionState
+from speech_to_speech.api.openai_realtime.service import RealtimeService
+from speech_to_speech.pipeline.cancel_scope import CancelScope
+from speech_to_speech.pipeline.events import TokenUsageEvent
+
+
+@pytest.fixture
+def unit():
+    text_prompt_queue: Queue = Queue()
+    should_listen = ThreadingEvent()
+    should_listen.set()
+    service = RealtimeService(text_prompt_queue=text_prompt_queue, should_listen=should_listen)
+    return PipelineUnit(
+        index=0,
+        service=service,
+        cancel_scope=CancelScope(),
+        should_listen=should_listen,
+        response_playing=ThreadingEvent(),
+        input_queue=Queue(),
+        output_queue=Queue(),
+        text_output_queue=Queue(),
+        text_prompt_queue=text_prompt_queue,
+        handlers=[],
+    )
+
+
+def usage(input_tokens: int, output_tokens: int) -> TokenUsageEvent:
+    return TokenUsageEvent(input_tokens=input_tokens, output_tokens=output_tokens)
+
+
+def totals(service: RealtimeService) -> tuple[int, int]:
+    return service.total_usage.input_tokens, service.total_usage.output_tokens
+
+
+# --- the dropped usage --------------------------------------------------------------------
+
+
+@pytest.mark.parametrize("queue_name", ["text_output_queue", "output_queue"])
+def test_queued_usage_survives_disconnect(unit, queue_name):
+    """The core bug: usage on a router queue was flushed away by release."""
+    session_id = unit.service.register()
+    getattr(unit, queue_name).put(usage(120, 45))
+
+    router._account_queued_token_usage(unit, session_id)
+    router._clean_unit(unit)
+    unit.service.unregister(session_id)
+
+    assert totals(unit.service) == (120, 45)
+
+
+def test_usage_on_both_queues_is_accounted_once_each(unit):
+    session_id = unit.service.register()
+    unit.output_queue.put(usage(10, 1))
+    unit.text_output_queue.put(usage(20, 2))
+
+    router._account_queued_token_usage(unit, session_id)
+    router._clean_unit(unit)
+    unit.service.unregister(session_id)
+
+    assert totals(unit.service) == (30, 3)
+
+
+def test_multiple_queued_usage_events_all_count(unit):
+    session_id = unit.service.register()
+    for _ in range(3):
+        unit.text_output_queue.put(usage(5, 2))
+
+    router._account_queued_token_usage(unit, session_id)
+    router._clean_unit(unit)
+    unit.service.unregister(session_id)
+
+    assert totals(unit.service) == (15, 6)
+
+
+def test_no_queued_usage_leaves_totals_untouched(unit):
+    session_id = unit.service.register()
+
+    router._account_queued_token_usage(unit, session_id)
+    router._clean_unit(unit)
+    unit.service.unregister(session_id)
+
+    assert totals(unit.service) == (0, 0)
+
+
+def test_accounting_failure_does_not_break_release(unit, monkeypatch):
+    """Release must not be blocked by an accounting error."""
+    session_id = unit.service.register()
+    unit.text_output_queue.put(usage(7, 7))
+
+    def boom(*args, **kwargs):
+        raise RuntimeError("accounting exploded")
+
+    monkeypatch.setattr(unit.service, "dispatch_pipeline_event", boom)
+
+    router._account_queued_token_usage(unit, session_id)  # must not raise
+    router._clean_unit(unit)
+    unit.service.unregister(session_id)
+
+
+def test_unknown_session_does_not_raise(unit):
+    """A duplicate/late release path must not explode on an already-gone session."""
+    unit.text_output_queue.put(usage(1, 1))
+
+    router._account_queued_token_usage(unit, "no-such-session")  # must not raise
+
+
+# --- end to end through the real release path ---------------------------------------------
+
+
+async def test_release_session_preserves_queued_usage(unit, monkeypatch):
+    """Drives `_release_session` itself, so this fails against the pre-fix router."""
+    session_id = unit.service.register()
+    unit.session = SessionState(session_id=session_id)
+    unit.text_output_queue.put(usage(64, 32))
+
+    # The drain-and-release task needs a live loop but nothing here depends on it
+    # completing, so stub it out to keep the test deterministic.
+    async def noop(*args, **kwargs):
+        return None
+
+    monkeypatch.setattr(router, "_release_unit_after_drain", noop)
+
+    router._release_session(unit, session_id)
+    unit.service.unregister(session_id)
+
+    assert totals(unit.service) == (64, 32)
+
+
+# --- _drain_token_usage must not disturb anything else ------------------------------------
+
+
+def test_drain_removes_only_usage_events():
+    q: Queue = Queue()
+    a, b = object(), object()
+    u = usage(3, 4)
+    for item in (a, u, b):
+        q.put(item)
+
+    drained = router._drain_token_usage(q)
+
+    assert drained == [u]
+    assert [q.get_nowait(), q.get_nowait()] == [a, b]
+    assert q.empty()
+
+
+def test_drain_preserves_order_of_remaining_items():
+    q: Queue = Queue()
+    items = [object() for _ in range(5)]
+    q.put(items[0])
+    q.put(usage(1, 1))
+    for item in items[1:]:
+        q.put(item)
+
+    router._drain_token_usage(q)
+
+    assert [q.get_nowait() for _ in range(5)] == items
+
+
+def test_drain_on_empty_queue_returns_nothing():
+    q: Queue = Queue()
+
+    assert router._drain_token_usage(q) == []
+    assert q.empty()
+
+
+# --- stale output must still be discarded (acceptance criterion) --------------------------
+
+
+def test_release_still_discards_stale_assistant_output(unit):
+    """Accounting usage must not start preserving assistant text/audio across sessions."""
+    session_id = unit.service.register()
+    unit.output_queue.put(b"stale-audio")
+    unit.text_output_queue.put(object())
+    unit.text_output_queue.put(usage(9, 9))
+
+    router._account_queued_token_usage(unit, session_id)
+    router._clean_unit(unit)
+
+    assert unit.output_queue.empty()
+    assert unit.text_output_queue.empty()
+
+    unit.service.unregister(session_id)
+    assert totals(unit.service) == (9, 9)


### PR DESCRIPTION
Fixes #456

## Problem

`LMOutputProcessor` routes `TokenUsageEvent` through the router's output queues. Releasing a session calls `_clean_unit()`, which drains those queues — and by then the send loop is gone, so a usage event that reached a queue but was never dispatched was discarded before `RealtimeService.unregister()` rolled the connection's usage into the global totals.

The provider had already billed those tokens, so a client disconnecting at the wrong moment silently under-reported usage. `_dispatch_pipeline_event()` already treats usage as billable accounting that cancellation must not make stale — the release path was the remaining hole.

## Fix

`_release_session()` now accounts queued usage directly, before the flush and while the session is still registered:

- **`_drain_token_usage()`** removes only `TokenUsageEvent`s from a queue and re-inserts every other item at the front in its original order, under the queue mutex, mirroring `_flush_queue()`. That makes it correct independently of a flush, rather than only valid when called immediately before one.
- **`_account_queued_token_usage()`** feeds each drained event through `service.dispatch_pipeline_event()` — the same entry point the send loop uses, so accounting goes through one path rather than a parallel one. Returned server events are discarded, since the client is gone and only the accounting side effect matters. Both `output_queue` and `text_output_queue` are covered.
- Accounting failures are logged, never raised, so release can't be blocked by them.

## Acceptance criteria

- **Queued usage accounted before unregistering** — done, directly rather than by preserving, since after release nothing remains to consume the queue.
- **Stale text/tools/audio still discarded** — unchanged. Only `TokenUsageEvent` is removed ahead of the flush; `_clean_unit()` itself is untouched. There's an explicit test asserting both queues end up empty and no assistant output survives.
- **WebSocket and WebRTC consistent** — both share `_release_session()`, so they get this identically.
- **Regression test for queued usage then immediate disconnect** — `test_release_session_preserves_queued_usage` drives the real `_release_session()`.

## Tests

`tests/openai_realtime/test_release_token_usage.py` — 12 cases: usage queued on either queue and on both at once, multiple events, the no-usage case, an accounting failure, an unknown session, `_drain_token_usage` ordering/isolation, and stale assistant output still being dropped.

The end-to-end case fails against current `main` with exactly the reported symptom:

```
assert totals(unit.service) == (64, 32)
E   assert (0, 0) == (64, 32)
```

I deliberately routed that test through `_release_session()` rather than the new helper, so it exercises the real disconnect path instead of just the code I added.

Full suite: **1023 passed, 1 skipped**. `ruff check`, `ruff format --check`, `mypy src/` clean.
