### PR TITLE
Fix WebRTC clear for stashed audio

### DIFF
--- a/src/speech_to_speech/api/openai_realtime/websocket_router.py
+++ b/src/speech_to_speech/api/openai_realtime/websocket_router.py
@@ -181,6 +181,16 @@ def _flush_queue(q: Queue[QItem], *, preserve: Callable[[QItem], bool] | None = 
             q.not_empty.notify(len(preserved))
 
 
+def _clear_stashed_audio(unit: PipelineUnit, session_id: str) -> None:
+    """Drop audio stashed by the send loop for the current session only."""
+    session = unit.session
+    if session is None or session.session_id != session_id:
+        return
+    pending = session.pending_output_item
+    if pending is not None and not _keep_non_audio_output(pending):
+        session.pending_output_item = None
+
+
 def _clean_unit(unit: PipelineUnit, preserve: Callable[[Any], bool] | None = None) -> None:
     """Cancel in-flight work and flush queues for a single pipeline unit.
 
@@ -380,6 +390,7 @@ async def _dispatch_client_event(
                 ]
             )
             return
+        _clear_stashed_audio(unit, session_id)
         _flush_queue(unit.output_queue, preserve=_keep_non_audio_output)
         transport.discard_pending_audio()
 

--- a/tests/openai_realtime/test_webrtc.py
+++ b/tests/openai_realtime/test_webrtc.py
@@ -33,7 +33,7 @@ from aiortc.mediastreams import AudioStreamTrack, MediaStreamError  # noqa: E402
 from starlette.testclient import TestClient  # noqa: E402
 
 import speech_to_speech.api.openai_realtime.websocket_router as router_module  # noqa: E402
-from speech_to_speech.api.openai_realtime.pipeline_unit import PipelineUnit  # noqa: E402
+from speech_to_speech.api.openai_realtime.pipeline_unit import PipelineUnit, SessionState  # noqa: E402
 from speech_to_speech.api.openai_realtime.service import CHUNK_SIZE_BYTES, RealtimeService  # noqa: E402
 from speech_to_speech.api.openai_realtime.transports import SessionTransport  # noqa: E402
 from speech_to_speech.api.openai_realtime.webrtc_session import (  # noqa: E402
@@ -261,6 +261,11 @@ class TestWebRTCDispatch:
         unit = _make_unit()
         conn_id = unit.service.register()
         transport = _FakeTransport()
+        unit.session = SessionState(
+            transport=transport,
+            session_id=conn_id,
+            pending_output_item=b"\x02\x00",
+        )
 
         text_event = AssistantOutputEvent(text="before audio", response_key="response_1")
         tool_event = AssistantOutputEvent(
@@ -288,6 +293,7 @@ class TestWebRTCDispatch:
 
         assert transport.sent == []  # no error
         assert transport.discards == 1
+        assert unit.session.pending_output_item is None
         # Only audio is flushed; ordered response state and the terminal survive.
         assert [unit.output_queue.get_nowait() for _ in range(6)] == [
             text_event,
@@ -299,6 +305,54 @@ class TestWebRTCDispatch:
         ]
         with pytest.raises(Empty):
             unit.output_queue.get_nowait()
+
+    @pytest.mark.parametrize(
+        "pending_output_item",
+        [
+            AssistantResponseDoneEvent(response_key="response_1"),
+            AUDIO_RESPONSE_DONE,
+        ],
+    )
+    async def test_output_audio_buffer_clear_preserves_stashed_lifecycle(self, pending_output_item):
+        unit = _make_unit()
+        conn_id = unit.service.register()
+        transport = _FakeTransport()
+        unit.session = SessionState(
+            transport=transport,
+            session_id=conn_id,
+            pending_output_item=pending_output_item,
+        )
+
+        await router_module._dispatch_client_event(
+            unit,
+            conn_id,
+            {"type": "output_audio_buffer.clear"},
+            transport,
+            transport_kind="webrtc",
+        )
+
+        assert unit.session.pending_output_item is pending_output_item
+
+    async def test_output_audio_buffer_clear_does_not_touch_replacement_session(self):
+        unit = _make_unit()
+        conn_id = unit.service.register()
+        transport = _FakeTransport()
+        replacement_audio = b"\x03\x00"
+        unit.session = SessionState(
+            transport=transport,
+            session_id="replacement-session",
+            pending_output_item=replacement_audio,
+        )
+
+        await router_module._dispatch_client_event(
+            unit,
+            conn_id,
+            {"type": "output_audio_buffer.clear"},
+            transport,
+            transport_kind="webrtc",
+        )
+
+        assert unit.session.pending_output_item is replacement_audio
 
     async def test_output_audio_buffer_clear_rejected_over_websocket(self):
         unit = _make_unit()


### PR DESCRIPTION
## Summary

- discard audio held in the per-session send-loop scratch slot when a WebRTC `output_audio_buffer.clear` event arrives
- preserve stashed response lifecycle and bookkeeping items
- scope the scratch mutation to the matching session so a delayed event cannot affect a replacement session

## Root cause

The send loop can pull a second output item while batching audio and hold it in `SessionState.pending_output_item`. The clear handler emptied `unit.output_queue` and the WebRTC track, but did not inspect that per-session scratch slot. On the next send-loop iteration, the stashed audio was consumed before the queue and could be delivered after the client had explicitly cleared output audio.

## Solution

The clear path now drops only stashed audio for the session that emitted the event. It uses the same non-audio preservation predicate as the output-queue flush, keeping response lifecycle/control bookkeeping intact. The session ID check prevents a stale clear event from mutating scratch state owned by a replacement session.

## Validation

- [x] Regression test failed before the production change with the stashed bytes still present
- [x] Clear-handler regression group: 5 passed
- [x] Full WebRTC test module: 22 passed
- [x] Full test suite: 1014 passed, 1 skipped
- [x] `uv run ruff check src/ tests/`
- [x] `uv run ruff format --check src/ tests/`
- [x] `uv run mypy src/`
- [x] Wheel and source distribution build
- [x] `twine check --strict` for both distributions
- [x] `git diff --check`

Fixes #455
