### PR TITLE
Fix WebRTC ICE task cleanup

### DIFF
--- a/src/speech_to_speech/api/openai_realtime/webrtc_session.py
+++ b/src/speech_to_speech/api/openai_realtime/webrtc_session.py
@@ -24,6 +24,7 @@ from typing import TYPE_CHECKING, Callable, Optional
 
 import av
 import numpy as np
+from aioice.ice import ICE_FAILED
 from aiortc import RTCConfiguration, RTCIceServer, RTCPeerConnection, RTCSessionDescription
 from aiortc.mediastreams import MediaStreamError, MediaStreamTrack
 
@@ -179,6 +180,7 @@ class WebRTCSession(SessionTransport):
         self._on_closed = on_closed
         self._dc = None
         self._closed = False
+        self._close_complete = asyncio.Event()
         self._track = PipelineAudioTrack()
         self._out_resampler = PcmResampler(WEBRTC_SAMPLE_RATE)
         self._in_resampler = PcmResampler(PIPELINE_SAMPLE_RATE)
@@ -268,22 +270,26 @@ class WebRTCSession(SessionTransport):
 
     async def close(self) -> None:
         if self._closed:
+            await self._close_complete.wait()
             return
         self._closed = True
-        # close() itself often runs as a _spawn()ed task (dc close handler),
-        # so it is in _tasks — cancelling the current task here would abort
-        # this method before the release callback runs.
-        current = asyncio.current_task()
-        for task in self._tasks:
-            if task is not current:
-                task.cancel()
-        self._track.stop()
         try:
-            await self._pc.close()
-        except Exception as e:  # noqa: BLE001
-            logger.warning(f"[WebRTC] Error closing peer connection: {e}")
-        self._on_closed()
-        logger.info("[WebRTC] Session closed")
+            # close() itself often runs as a _spawn()ed task (dc close handler),
+            # so it is in _tasks — cancelling the current task here would abort
+            # this method before the release callback runs.
+            current = asyncio.current_task()
+            for task in self._tasks:
+                if task is not current:
+                    task.cancel()
+            self._track.stop()
+            try:
+                await self._close_peer_connection()
+            except Exception as e:  # noqa: BLE001
+                logger.warning(f"[WebRTC] Error closing peer connection: {e}")
+            self._on_closed()
+            logger.info("[WebRTC] Session closed")
+        finally:
+            self._close_complete.set()
 
     # ── SessionTransport interface ────────────────
 
@@ -322,6 +328,71 @@ class WebRTCSession(SessionTransport):
     def _spawn(self, coro: Awaitable[None]) -> None:
         task = asyncio.ensure_future(coro)
         self._tasks.append(task)
+
+    async def _close_peer_connection(self) -> None:
+        try:
+            await self._cancel_ice_checks()
+        finally:
+            try:
+                await self._pc.close()
+            finally:
+                try:
+                    await self._close_ice_connections()
+                finally:
+                    await self._cancel_ice_checks()
+                    await self._await_ice_connect_tasks()
+
+    def _ice_transports(self) -> set:
+        ice_transports = {
+            transceiver.receiver.transport.transport
+            for transceiver in self._pc.getTransceivers()
+        }
+        if self._pc.sctp is not None:
+            ice_transports.add(self._pc.sctp.transport.transport)
+        return ice_transports
+
+    async def _close_ice_connections(self) -> None:
+        connections = {
+            ice_transport._connection
+            for ice_transport in self._ice_transports()
+            if not ice_transport._connection._closed
+        }
+        if connections:
+            results = await asyncio.gather(
+                *(connection.close() for connection in connections),
+                return_exceptions=True,
+            )
+            for result in results:
+                if isinstance(result, BaseException):
+                    raise result
+
+    async def _cancel_ice_checks(self) -> None:
+        """Cancel and await aioice connectivity checks owned by this peer."""
+        tasks = set()
+        for ice_transport in self._ice_transports():
+            await ice_transport.addRemoteCandidate(None)
+            connection = ice_transport._connection
+            if connection._check_list and not connection._check_list_done and connection._check_list_state.empty():
+                connection._check_list_state.put_nowait(ICE_FAILED)
+            for pair in connection._check_list:
+                if pair.task is None:
+                    if pair.state in (pair.State.FROZEN, pair.State.WAITING):
+                        pair.state = pair.State.FAILED
+                else:
+                    pair.task.cancel()
+                    tasks.add(pair.task)
+        if tasks:
+            await asyncio.gather(*tasks, return_exceptions=True)
+
+    async def _await_ice_connect_tasks(self) -> None:
+        start_events = [
+            event
+            for ice_transport in self._ice_transports()
+            if (event := getattr(ice_transport, "_RTCIceTransport__start")) is not None
+        ]
+        if start_events:
+            await asyncio.gather(*(event.wait() for event in start_events))
+            await asyncio.sleep(0)
 
     async def _connect_watchdog(self) -> None:
         await asyncio.sleep(CONNECT_TIMEOUT_S)

--- a/src/speech_to_speech/api/openai_realtime/webrtc_session.py
+++ b/src/speech_to_speech/api/openai_realtime/webrtc_session.py
@@ -180,7 +180,7 @@ class WebRTCSession(SessionTransport):
         self._on_closed = on_closed
         self._dc = None
         self._closed = False
-        self._close_complete = asyncio.Event()
+        self._close_task: asyncio.Task[None] | None = None
         self._track = PipelineAudioTrack()
         self._out_resampler = PcmResampler(WEBRTC_SAMPLE_RATE)
         self._in_resampler = PcmResampler(PIPELINE_SAMPLE_RATE)
@@ -269,27 +269,10 @@ class WebRTCSession(SessionTransport):
         return self._pc.localDescription.sdp
 
     async def close(self) -> None:
-        if self._closed:
-            await self._close_complete.wait()
-            return
-        self._closed = True
-        try:
-            # close() itself often runs as a _spawn()ed task (dc close handler),
-            # so it is in _tasks — cancelling the current task here would abort
-            # this method before the release callback runs.
-            current = asyncio.current_task()
-            for task in self._tasks:
-                if task is not current:
-                    task.cancel()
-            self._track.stop()
-            try:
-                await self._close_peer_connection()
-            except Exception as e:  # noqa: BLE001
-                logger.warning(f"[WebRTC] Error closing peer connection: {e}")
-            self._on_closed()
-            logger.info("[WebRTC] Session closed")
-        finally:
-            self._close_complete.set()
+        if self._close_task is None:
+            self._closed = True
+            self._close_task = asyncio.create_task(self._run_close())
+        await asyncio.shield(self._close_task)
 
     # ── SessionTransport interface ────────────────
 
@@ -328,6 +311,20 @@ class WebRTCSession(SessionTransport):
     def _spawn(self, coro: Awaitable[None]) -> None:
         task = asyncio.ensure_future(coro)
         self._tasks.append(task)
+
+    async def _run_close(self) -> None:
+        # close() often runs as a _spawn()ed task (dc close handler). The
+        # separate cleanup task lets us cancel session work without cancelling
+        # teardown, even when the close() caller itself is cancelled.
+        for task in self._tasks:
+            task.cancel()
+        self._track.stop()
+        try:
+            await self._close_peer_connection()
+        except Exception as e:  # noqa: BLE001
+            logger.warning(f"[WebRTC] Error closing peer connection: {e}")
+        self._on_closed()
+        logger.info("[WebRTC] Session closed")
 
     async def _close_peer_connection(self) -> None:
         try:

--- a/src/speech_to_speech/api/openai_realtime/webrtc_session.py
+++ b/src/speech_to_speech/api/openai_realtime/webrtc_session.py
@@ -343,10 +343,7 @@ class WebRTCSession(SessionTransport):
                     await self._await_ice_connect_tasks()
 
     def _ice_transports(self) -> set:
-        ice_transports = {
-            transceiver.receiver.transport.transport
-            for transceiver in self._pc.getTransceivers()
-        }
+        ice_transports = {transceiver.receiver.transport.transport for transceiver in self._pc.getTransceivers()}
         if self._pc.sctp is not None:
             ice_transports.add(self._pc.sctp.transport.transport)
         return ice_transports

--- a/tests/openai_realtime/test_webrtc.py
+++ b/tests/openai_realtime/test_webrtc.py
@@ -28,6 +28,7 @@ aiortc = pytest.importorskip("aiortc")
 av = pytest.importorskip("av")
 
 import httpx  # noqa: E402  (ships with the openai dependency)
+from aioice.ice import Connection  # noqa: E402
 from aiortc import RTCPeerConnection, RTCSessionDescription  # noqa: E402
 from aiortc.mediastreams import AudioStreamTrack, MediaStreamError  # noqa: E402
 from starlette.testclient import TestClient  # noqa: E402
@@ -41,6 +42,7 @@ from speech_to_speech.api.openai_realtime.webrtc_session import (  # noqa: E402
     WEBRTC_SAMPLE_RATE,
     PcmResampler,
     PipelineAudioTrack,
+    WebRTCSession,
 )
 from speech_to_speech.pipeline.cancel_scope import CancelScope  # noqa: E402
 from speech_to_speech.pipeline.events import (  # noqa: E402
@@ -415,6 +417,108 @@ class _DataChannelInbox:
 
 
 class TestWebRTCLoopback:
+    async def test_close_awaits_pending_ice_checks(self, monkeypatch):
+        client_pc = RTCPeerConnection()
+        server_pc = RTCPeerConnection()
+        first_close = None
+        second_close = None
+        release_sweep = asyncio.Event()
+        closed_calls = []
+        close_server_pc = server_pc.close
+
+        def _pending_ice_checks():
+            return {
+                task
+                for task in asyncio.all_tasks()
+                if getattr(task.get_coro(), "cr_code", None) is Connection.check_start.__code__
+            }
+
+        connect_code = getattr(RTCPeerConnection, "_RTCPeerConnection__connect").__code__
+
+        def _pending_server_connects():
+            tasks = set()
+            for task in asyncio.all_tasks():
+                coro = task.get_coro()
+                frame = getattr(coro, "cr_frame", None)
+                if (
+                    getattr(coro, "cr_code", None) is connect_code
+                    and frame is not None
+                    and frame.f_locals.get("self") is server_pc
+                ):
+                    tasks.add(task)
+            return tasks
+
+        async def _on_client_event(_raw):
+            pass
+
+        async def _on_open():
+            pass
+
+        session = WebRTCSession(
+            server_pc,
+            on_client_event=_on_client_event,
+            on_audio=lambda _pcm: None,
+            on_open=_on_open,
+            on_closed=lambda: closed_calls.append(None),
+        )
+        session.setup()
+        try:
+            client_pc.createDataChannel("oai-events")
+            client_pc.addTrack(AudioStreamTrack())
+            offer = await client_pc.createOffer()
+            await client_pc.setLocalDescription(offer)
+            offer_sdp = client_pc.localDescription.sdp
+            partial_offer_sdp = offer_sdp.replace("a=end-of-candidates\r\n", "")
+            assert partial_offer_sdp != offer_sdp
+            await session.negotiate(partial_offer_sdp)
+
+            deadline = time.monotonic() + 1.0
+            while time.monotonic() < deadline:
+                if _pending_ice_checks():
+                    break
+                await asyncio.sleep(0.01)
+            else:
+                raise AssertionError("aioice did not start a connectivity check")
+            assert _pending_server_connects()
+
+            sweep_started = asyncio.Event()
+            cancel_ice_checks = session._cancel_ice_checks
+            sweep_count = 0
+
+            async def _pause_first_sweep():
+                nonlocal sweep_count
+                sweep_count += 1
+                if sweep_count == 1:
+                    sweep_started.set()
+                    await release_sweep.wait()
+                await cancel_ice_checks()
+
+            async def _fail_peer_close():
+                raise RuntimeError("peer close failed")
+
+            monkeypatch.setattr(session, "_cancel_ice_checks", _pause_first_sweep)
+            monkeypatch.setattr(server_pc, "close", _fail_peer_close)
+            first_close = asyncio.create_task(session.close())
+            await asyncio.wait_for(sweep_started.wait(), timeout=1.0)
+            second_close = asyncio.create_task(session.close())
+            await asyncio.sleep(0)
+            assert not second_close.done()
+
+            release_sweep.set()
+            await asyncio.gather(first_close, second_close)
+            assert not _pending_ice_checks()
+            assert not _pending_server_connects()
+            assert len(closed_calls) == 1
+        finally:
+            release_sweep.set()
+            close_tasks = [task for task in (first_close, second_close) if task is not None]
+            if close_tasks:
+                await asyncio.gather(*close_tasks, return_exceptions=True)
+            monkeypatch.setattr(server_pc, "close", close_server_pc)
+            await session.close()
+            await server_pc.close()
+            await client_pc.close()
+
     async def test_handshake_events_and_multi_output_audio_roundtrip(self, server_env):
         pc = RTCPeerConnection()
         try:

--- a/tests/openai_realtime/test_webrtc.py
+++ b/tests/openai_realtime/test_webrtc.py
@@ -417,6 +417,57 @@ class _DataChannelInbox:
 
 
 class TestWebRTCLoopback:
+    async def test_cancelled_close_keeps_teardown_running(self, monkeypatch):
+        server_pc = RTCPeerConnection()
+        teardown_started = asyncio.Event()
+        release_teardown = asyncio.Event()
+        closed_calls = []
+
+        async def _on_client_event(_raw):
+            pass
+
+        async def _on_open():
+            pass
+
+        session = WebRTCSession(
+            server_pc,
+            on_client_event=_on_client_event,
+            on_audio=lambda _pcm: None,
+            on_open=_on_open,
+            on_closed=lambda: closed_calls.append(None),
+        )
+        session.setup()
+        close_peer_connection = session._close_peer_connection
+
+        async def _pause_peer_close():
+            teardown_started.set()
+            await release_teardown.wait()
+            await close_peer_connection()
+
+        monkeypatch.setattr(session, "_close_peer_connection", _pause_peer_close)
+        first_close = asyncio.create_task(session.close())
+        second_close = None
+        try:
+            await asyncio.wait_for(teardown_started.wait(), timeout=1.0)
+            first_close.cancel()
+            with pytest.raises(asyncio.CancelledError):
+                await first_close
+
+            second_close = asyncio.create_task(session.close())
+            await asyncio.sleep(0)
+            assert not second_close.done()
+
+            release_teardown.set()
+            await second_close
+            assert server_pc.connectionState == "closed"
+            assert len(closed_calls) == 1
+        finally:
+            release_teardown.set()
+            close_tasks = [task for task in (first_close, second_close) if task is not None]
+            await asyncio.gather(*close_tasks, return_exceptions=True)
+            await session.close()
+            await server_pc.close()
+
     async def test_close_awaits_pending_ice_checks(self, monkeypatch):
         client_pc = RTCPeerConnection()
         server_pc = RTCPeerConnection()


### PR DESCRIPTION
## Summary

- quiesce and await peer-scoped aioice connectivity checks before WebRTC transport teardown completes
- make concurrent close callers await one cancellation-safe cleanup task and retain a low-level ICE close fallback
- cover half-negotiated, partial-candidate, concurrent, cancelled-caller, and peer-close-failure teardown

## Root cause

`RTCPeerConnection.close()` can close datagram transports while aioice connectivity-check and connection-driver tasks are still running. Those tasks later retry against the closed transport during event-loop shutdown, producing unhandled `Task exception was never retrieved` tracebacks even though the tests pass.

## Impact

WebRTC sessions now finish their owned ICE work before reporting closure, even if the initiating caller is cancelled, so test and application shutdown no longer leave background connectivity tasks behind.

## Validation

- `uv run pytest -q tests/openai_realtime` — 362 passed
- `uv run pytest -q tests/openai_realtime/test_webrtc.py` — 21 passed
- cancellation and ICE lifecycle regressions repeated under `PYTHONASYNCIODEBUG=1`
- Ruff and mypy passed
- two consecutive from-scratch reviews approved the final change

Closes #465
