### PR TITLE
Speak fallback on pre-output LLM failures

### DIFF
--- a/src/speech_to_speech/LLM/base_openai_compatible_language_model.py
+++ b/src/speech_to_speech/LLM/base_openai_compatible_language_model.py
@@ -53,6 +53,7 @@ logger = logging.getLogger(__name__)
 
 # About 18–24 seconds of default SDK backoff before warmup fails.
 WARMUP_MAX_RETRIES = 6
+PROVIDER_FAILURE_FALLBACK = "I'm having trouble responding right now. Please try again."
 
 
 # ── Normalised provider events ────────────────────────────────────────────────
@@ -590,6 +591,7 @@ class BaseOpenAICompatibleHandler(BaseHandler[LLMIn, LLMOut], ABC):
         generation_completed = False
         history_committed = False
         transaction_rolled_back = False
+        provider_request_started = False
         consumed_image_ids: set[str] = set()
 
         def rollback_transaction() -> None:
@@ -619,6 +621,7 @@ class BaseOpenAICompatibleHandler(BaseHandler[LLMIn, LLMOut], ABC):
                     # would reject this; fail with a clear message instead of an opaque error.
                     error_message = "Cannot generate a response: no instructions and no input were provided."
                 else:
+                    provider_request_started = True
                     api_response = (request_fn or self._request)(api_input, optional_kwargs)
                 if api_response is not None:
                     events = (event_iterator_fn or self._iter_events)(api_response)
@@ -631,33 +634,7 @@ class BaseOpenAICompatibleHandler(BaseHandler[LLMIn, LLMOut], ABC):
                     "OpenAI API read timed out after %.1fs; ending the current response",
                     self.request_timeout_s,
                 )
-                if state.output_emitted or state.pending:
-                    error_message = f"Language model generation timed out after {self.request_timeout_s:.1f}s."
-                elif not self._generation_is_stale(turn.gen) and self._turn_output_allowed(
-                    turn.turn_id, turn.turn_revision
-                ):
-                    # Canned apology carries no language_code (mirrors the prior handlers).
-                    apology = "Wow I'm a bit slow today, could you repeat that?"
-                    state.clean_text += apology
-                    state.pending.append(
-                        RealtimeConversationItemAssistantMessage(
-                            type="message",
-                            role="assistant",
-                            content=[AssistantContent(type="output_text", text=apology)],
-                        )
-                    )
-                    state.output_emitted = True
-                    generation_completed = True
-                    yield LLMResponseChunk(
-                        text=apology,
-                        runtime_config=turn.runtime_config,
-                        response=turn.response,
-                        turn_id=turn.turn_id,
-                        turn_revision=turn.turn_revision,
-                        speech_stopped_at_s=turn.speech_stopped_at_s,
-                        cancel_generation=turn.gen,
-                        response_key=turn.response_key,
-                    )
+                error_message = f"Language model generation timed out after {self.request_timeout_s:.1f}s."
             except Exception as exc:
                 # Any other generation failure must still terminate the response: record
                 # the error and fall through to the EndOfResponse below. Without this the
@@ -666,6 +643,25 @@ class BaseOpenAICompatibleHandler(BaseHandler[LLMIn, LLMOut], ABC):
                 logger.exception("LLM generation failed; ending the current response")
                 if error_message is None:
                     error_message = f"Language model generation failed: {exc}"
+
+            if (
+                provider_request_started
+                and error_message is not None
+                and not state.output_emitted
+                and not self._generation_is_stale(turn.gen)
+                and self._turn_output_allowed(turn.turn_id, turn.turn_revision)
+            ):
+                state.output_emitted = True
+                yield LLMResponseChunk(
+                    text=PROVIDER_FAILURE_FALLBACK,
+                    runtime_config=turn.runtime_config,
+                    response=turn.response,
+                    turn_id=turn.turn_id,
+                    turn_revision=turn.turn_revision,
+                    speech_stopped_at_s=turn.speech_stopped_at_s,
+                    cancel_generation=turn.gen,
+                    response_key=turn.response_key,
+                )
 
             can_commit = (
                 error_message is None

--- a/tests/test_chat_completions_backend.py
+++ b/tests/test_chat_completions_backend.py
@@ -14,7 +14,10 @@ import queue
 import threading
 from types import SimpleNamespace
 
+import httpx
 import numpy as np
+import pytest
+from openai import APIConnectionError, InternalServerError, RateLimitError
 from openai.types.realtime.conversation_item import (
     RealtimeConversationItemFunctionCall,
     RealtimeConversationItemFunctionCallOutput,
@@ -34,13 +37,17 @@ from speech_to_speech.LLM.chat_completions_language_model import (
     _to_chat_tool_choice,
     _to_chat_tools,
 )
+from speech_to_speech.LLM.lm_output_processor import LMOutputProcessor
 from speech_to_speech.pipeline.cancel_scope import CancelScope
+from speech_to_speech.pipeline.events import AssistantOutputEvent, ResponseFailedEvent
 from speech_to_speech.pipeline.messages import (
     EndOfResponse,
     GenerateResponseRequest,
     LLMResponseChunk,
     TokenUsage,
+    TTSInput,
 )
+from speech_to_speech.pipeline.speculative_turns import SpeculativeTurnTracker
 
 # ── Fakes ────────────────────────────────────────────────────────────────────
 
@@ -741,6 +748,94 @@ def test_generation_error_emits_failed_end_of_response():
     text, tools, usage, chat, end = _drive(h)
     assert end is not None and end.error is not None
     assert "kaboom" in end.error
+    assert text == base_mod.PROVIDER_FAILURE_FALLBACK
+
+
+def _api_error_response(status_code):
+    request = httpx.Request("POST", "https://provider.example/v1/chat/completions")
+    return httpx.Response(status_code, request=request)
+
+
+@pytest.mark.parametrize(
+    ("error", "message"),
+    [
+        (APIConnectionError(request=httpx.Request("POST", "https://provider.example")), "Connection error"),
+        (RateLimitError("rate limited", response=_api_error_response(429), body=None), "rate limited"),
+        (InternalServerError("server failed", response=_api_error_response(500), body=None), "server failed"),
+    ],
+)
+def test_provider_failure_before_output_speaks_fallback_then_fails_without_history(error, message):
+    h = _make_handler(stream=True)
+
+    def fail(**kwargs):
+        raise error
+
+    h.client.chat.completions.create = fail
+    chat = Chat(10)
+    chat.add_item(make_user_message("Hallo"))
+    runtime_config = RuntimeConfig(
+        chat=chat,
+        session=RealtimeSessionCreateRequest(type="realtime", instructions="Du bist ein Roboter."),
+    )
+    request = GenerateResponseRequest(
+        runtime_config=runtime_config,
+        language_code="de",
+        turn_id="t",
+        turn_revision=0,
+    )
+
+    outputs = list(h.process(request))
+
+    assert [type(output) for output in outputs] == [LLMResponseChunk, EndOfResponse]
+    assert outputs[0].text == base_mod.PROVIDER_FAILURE_FALLBACK
+    assert outputs[0].language_code is None
+    assert outputs[1].error is not None and message in outputs[1].error
+    assert [getattr(item, "role", None) for item in chat.buffer] == ["user"]
+
+    processor = LMOutputProcessor.__new__(LMOutputProcessor)
+    processor.setup()
+    pipeline_outputs = [processed for output in outputs for processed in processor.process(output)]
+    assert [type(output) for output in pipeline_outputs] == [
+        AssistantOutputEvent,
+        TTSInput,
+        ResponseFailedEvent,
+        EndOfResponse,
+    ]
+
+
+def test_cancelled_provider_failure_does_not_emit_fallback():
+    scope = CancelScope()
+    h = _make_handler(stream=True)
+    h.cancel_scope = scope
+
+    def fail(**kwargs):
+        scope.cancel()
+        raise RuntimeError("cancelled request failed")
+
+    h.client.chat.completions.create = fail
+    text, tools, usage, chat, end = _drive(h)
+
+    assert text == ""
+    assert end is not None and "cancelled request failed" in end.error
+    assert not any(getattr(item, "role", None) == "assistant" for item in chat.buffer)
+
+
+def test_stale_provider_failure_does_not_emit_fallback():
+    tracker = SpeculativeTurnTracker()
+    tracker.observe("t", 0)
+    h = _make_handler(stream=True)
+    h.speculative_turns = tracker
+
+    def fail(**kwargs):
+        tracker.observe("t", 1)
+        raise RuntimeError("stale request failed")
+
+    h.client.chat.completions.create = fail
+    text, tools, usage, chat, end = _drive(h)
+
+    assert text == ""
+    assert end is not None and "stale request failed" in end.error
+    assert not any(getattr(item, "role", None) == "assistant" for item in chat.buffer)
 
 
 # ── Out-of-band (conversation="none") responses ───────────────────────────────

--- a/tests/test_responses_api_language_model.py
+++ b/tests/test_responses_api_language_model.py
@@ -607,7 +607,7 @@ def test_setup_does_not_inject_dummy_key_for_remote_custom_url(monkeypatch):
     }
 
 
-def test_process_read_timeout_ends_response_cleanly():
+def test_process_read_timeout_speaks_fallback_and_preserves_failure():
     handler = _make_handler()
 
     def make_timeout_stream():
@@ -621,16 +621,11 @@ def test_process_read_timeout_ends_response_cleanly():
     outputs = list(handler.process(request))
 
     assert len(outputs) == 2
-    assert (
-        isinstance(outputs[0], LLMResponseChunk)
-        and outputs[0].text == "Wow I'm a bit slow today, could you repeat that?"
-    )
+    assert isinstance(outputs[0], LLMResponseChunk)
+    assert outputs[0].text == base_openai_compatible_language_model.PROVIDER_FAILURE_FALLBACK
     assert isinstance(outputs[1], EndOfResponse)
-    assert outputs[1].error is None
-    assert [item.type for item in request.runtime_config.chat.buffer] == ["message", "message"]
-    assistant = request.runtime_config.chat.buffer[-1]
-    assert isinstance(assistant, RealtimeConversationItemAssistantMessage)
-    assert assistant.content[0].text == outputs[0].text
+    assert outputs[1].error is not None and "timed out" in outputs[1].error
+    assert [getattr(item, "role", None) for item in request.runtime_config.chat.buffer] == ["user"]
 
 
 def test_read_timeout_after_partial_text_fails_without_apology_or_history_commit():
@@ -693,14 +688,16 @@ def test_generation_error_emits_failed_end_of_response():
 
     handler.client = SimpleNamespace(responses=SimpleNamespace(create=boom))
 
-    outputs = list(handler.process(_make_request("Hi")))
+    request = _make_request("Hi")
+    outputs = list(handler.process(request))
 
     eors = [o for o in outputs if isinstance(o, EndOfResponse)]
     assert len(eors) == 1
     assert eors[0].error is not None
     assert "input must not be empty" in eors[0].error
-    # No partial output committed; the only thing emitted is the failed EndOfResponse.
-    assert all(isinstance(o, EndOfResponse) for o in outputs)
+    chunks = [o for o in outputs if isinstance(o, LLMResponseChunk)]
+    assert [chunk.text for chunk in chunks] == [base_openai_compatible_language_model.PROVIDER_FAILURE_FALLBACK]
+    assert [getattr(item, "role", None) for item in request.runtime_config.chat.buffer] == ["user"]
 
 
 def test_empty_context_fails_with_clear_message_without_calling_provider():
@@ -1081,15 +1078,13 @@ def test_failed_audio_request_rolls_back_provisional_history():
     )
     cfg = _make_runtime_config(chat_size=5)
 
-    generation = handler.process(_make_audio_request(cfg))
-    output = next(generation)
+    outputs = list(handler.process(_make_audio_request(cfg)))
 
-    assert isinstance(output, EndOfResponse)
-    assert output.error is not None and "provider rejected audio" in output.error
+    assert [type(output) for output in outputs] == [LLMResponseChunk, EndOfResponse]
+    assert outputs[0].text == base_openai_compatible_language_model.PROVIDER_FAILURE_FALLBACK
+    assert outputs[1].error is not None and "provider rejected audio" in outputs[1].error
     assert cfg.chat.buffer == []
     assert cfg.chat._user_turn_count == 0
-    with pytest.raises(StopIteration):
-        next(generation)
 
 
 def test_interrupted_audio_tool_turn_rolls_back_user_call_and_fast_output():


### PR DESCRIPTION
## Summary

- speak a short fallback when an OpenAI-compatible provider fails before emitting assistant output
- preserve the original provider failure and keep the fallback out of conversation history
- suppress the fallback for cancelled, stale, and partially delivered responses
- cover connection, rate-limit, server-error, timeout, history, and event-ordering behavior

## Root cause

Provider exceptions before the first output terminated the response as failed without sending anything through TTS. The existing timeout-only fallback also completed the response successfully and stored the synthetic apology as assistant history, hiding the underlying failure.

## Impact

Voice users hear a provider-independent retry message before the failed `response.done`, while clients still receive the original failure details. Retry behavior is unchanged.

## Validation

- `uv run pytest -q` — 1,052 passed, 1 skipped
- `uv run ruff check src/ tests/`
- `uv run ruff format --check src/ tests/`
- `uv run mypy src/`

Closes #461
