### PR TITLE
docs: add OrcaRouter to the OpenAI-compatible provider table

### DIFF
--- a/README.md
+++ b/README.md
@@ -332,7 +332,7 @@ The LLM is the most compute-intensive and highest-latency component in the pipel
 
 - **Local inference**: `transformers` on CUDA / CPU and `mlx-lm` on Apple Silicon.
 - **Self-hosted servers**: `responses-api` and `chat-completions` can point at a local [vLLM](https://github.com/vllm-project/vllm) or [llama.cpp](https://github.com/ggerganov/llama.cpp) server.
-- **Provider APIs**: the same backends work with OpenAI, [HF Inference Providers](https://huggingface.co/inference-providers), [OpenRouter](https://openrouter.ai), and other OpenAI-compatible providers.
+- **Provider APIs**: the same backends work with OpenAI, [HF Inference Providers](https://huggingface.co/inference-providers), [OpenRouter](https://openrouter.ai), [OrcaRouter](https://www.orcarouter.ai), and other OpenAI-compatible providers.
 
 Two API backends are available, sharing the same `--responses_api_*` connection flags:
 
@@ -379,6 +379,7 @@ Works with any provider or server that implements the OpenAI Responses API. Poin
 | OpenAI | omit, uses OpenAI default | `$OPENAI_API_KEY` |
 | HF Inference Providers | `https://router.huggingface.co/v1` | `$HF_TOKEN` |
 | OpenRouter | `https://openrouter.ai/api/v1` | `$OPENROUTER_API_KEY` |
+| OrcaRouter | `https://api.orcarouter.ai/v1` | `$ORCAROUTER_API_KEY` |
 | vLLM | `http://localhost:8000/v1` | omit or any string |
 | llama.cpp | `http://127.0.0.1:8080/v1` | empty string |
 


### PR DESCRIPTION
## Summary

Adds [OrcaRouter](https://www.orcarouter.ai) as a model provider in the Responses API provider table and the Provider APIs bullet list in the README, mirroring the existing OpenRouter row. OrcaRouter is an OpenAI-compatible model routing gateway that exposes 150+ models from OpenAI, Anthropic, Google, DeepSeek, Qwen, MiniMax, xAI and others behind a single endpoint and API key — usable with the `--responses_api_base_url` / `--responses_api_api_key` flags already documented here. It also provides gateway-level security controls for AI agents.

## Verification

- README-only change (markdown table + bullet list), no runtime code touched.
- Diff is 2 insertions / 1 deletion, no CJK, no smart quotes.

I'm an engineer on the OrcaRouter team.
