### PR TITLE
Keep unsupported whisper-mlx transcriptions

### DIFF
--- a/src/speech_to_speech/STT/lightning_whisper_mlx_handler.py
+++ b/src/speech_to_speech/STT/lightning_whisper_mlx_handler.py
@@ -80,11 +80,6 @@ class LightningWhisperSTTHandler(BaseSTTHandler):
             language_code = transcription_dict["language"]
             if language_code not in SUPPORTED_LANGUAGES:
                 logger.warning(f"Whisper detected unsupported language: {language_code}")
-                if self.last_language in SUPPORTED_LANGUAGES:  # reprocess with the last language
-                    with MLXLockContext(handler_name=self.__class__.__name__):
-                        transcription_dict = self.model.transcribe(audio, language=self.last_language)
-                else:
-                    transcription_dict = {"text": "", "language": "en"}
             else:
                 self.last_language = language_code
 

--- a/tests/test_whisper_progressive_transcription.py
+++ b/tests/test_whisper_progressive_transcription.py
@@ -222,3 +222,21 @@ def test_absent_mode_still_yields_transcription(backend, monkeypatch):
     assert len(outputs) == 1
     assert isinstance(outputs[0], Transcription)
     assert outputs[0].text == FULL_UTTERANCE
+
+
+def test_lightning_whisper_mlx_keeps_unsupported_language_transcription(monkeypatch):
+    handler = build_lightning_whisper_mlx(monkeypatch)
+    handler.start_language = "auto"
+    calls = []
+
+    def transcribe(audio, **kwargs):
+        calls.append(kwargs)
+        return {"text": "Privet, kak dela?", "language": "ru"}
+
+    handler.model = SimpleNamespace(transcribe=transcribe)
+
+    outputs = list(handler.process(vad_chunk("final", 3)))
+
+    assert outputs[0].text == "Privet, kak dela?"
+    assert outputs[0].language_code == "ru-auto"
+    assert calls == [{}]


### PR DESCRIPTION
Fixes #404

## Summary

When whisper-mlx detects a language outside `SUPPORTED_LANGUAGES`, keep the original transcription instead of discarding it or transcribing the audio again with the previous language. The warning and supported-language tracking remain unchanged.

## Test

- `pytest tests/test_whisper_progressive_transcription.py -q`
- `ruff check src/speech_to_speech/STT/lightning_whisper_mlx_handler.py tests/test_whisper_progressive_transcription.py`
- `ruff format --check src/speech_to_speech/STT/lightning_whisper_mlx_handler.py tests/test_whisper_progressive_transcription.py`