### PR TITLE
Add runtime voice/model discovery and switching

### DIFF
--- a/demo/index.html
+++ b/demo/index.html
@@ -273,6 +273,12 @@
               </label>
             </div>
 
+            <label class="field" id="model-field" hidden>
+              <span>Model</span>
+              <select id="model"></select>
+              <small id="model-hint">Loaded in-process. Switching reloads weights, so the next reply is slower.</small>
+            </label>
+
             <label class="field">
               <span>Microphone</span>
               <select id="audio-input">

--- a/demo/main.js
+++ b/demo/main.js
@@ -32,6 +32,7 @@ const STORAGE_KEYS = {
   // (in LB mode the browser never learns the LB address — it POSTs /api/session).
   directUrl: "s2s.ws.directUrl",
   voice: "s2s.ws.voice",
+  model: "s2s.ws.model",
   instructions: "s2s.ws.instructions",
   tools: "s2s.ws.tools",
   searchKey: "s2s.ws.searchKey",
@@ -112,6 +113,9 @@ function loadSettings() {
   return {
     directUrl: localStorage.getItem(STORAGE_KEYS.directUrl) || "",
     voice: localStorage.getItem(STORAGE_KEYS.voice) || DEFAULT_VOICE,
+    // "" means "whatever the server was started with" — the picker only
+    // fills this in once the backend reports models it can switch to.
+    model: localStorage.getItem(STORAGE_KEYS.model) || "",
     instructions: localStorage.getItem(STORAGE_KEYS.instructions) || DEFAULT_INSTRUCTIONS,
     noiseGate: loadGateThreshold(),
     // Default WebSocket: the proven path stays the first-run experience.
@@ -138,6 +142,7 @@ function loadGateThreshold() {
 function saveSettings(s) {
   localStorage.setItem(STORAGE_KEYS.directUrl, s.directUrl);
   localStorage.setItem(STORAGE_KEYS.voice, s.voice);
+  localStorage.setItem(STORAGE_KEYS.model, s.model || "");
   localStorage.setItem(STORAGE_KEYS.instructions, s.instructions);
   localStorage.setItem(STORAGE_KEYS.noiseGate, String(s.noiseGate));
   localStorage.setItem(STORAGE_KEYS.transport, s.transport);
@@ -265,6 +270,9 @@ const transportHint = $("#transport-hint");
 const gateField = $("#gate-field");
 /** @type {HTMLSelectElement} */
 const inputVoice = $("#voice");
+/** @type {HTMLSelectElement} */
+const inputModel = $("#model");
+const modelField = $("#model-field");
 /** @type {HTMLSelectElement} */
 const inputAudioInput = $("#audio-input");
 /** @type {HTMLSelectElement} */
@@ -458,6 +466,7 @@ function setCaption(text, kind = "") {
 function openSettings() {
   syncConnectionUi();
   inputVoice.value = settings.voice;
+  if (!modelField.hidden && settings.model) inputModel.value = settings.model;
   inputInstructions.value = settings.instructions;
   syncGateUi();
   updateRestartAvailability();
@@ -918,6 +927,87 @@ async function fetchConfig() {
   void account.refresh();
   syncToolsUi();
   syncConnectionUi();
+  void fetchVoices();
+  void fetchModels();
+}
+
+/**
+ * Populate the Model picker from `/api/models` (the backend's locally cached
+ * LLM checkpoints). Hidden unless the backend reports more than one: a remote
+ * LLM has nothing local to switch between, and a single cached model is not a
+ * choice.
+ */
+async function fetchModels() {
+  /** @type {{ models?: string[], current?: string|null }} */
+  let json;
+  try {
+    const res = await fetch("api/models");
+    if (!res.ok) return;
+    json = await res.json();
+  } catch {
+    return; // Older backend or static hosting: leave the field hidden.
+  }
+  const models = Array.isArray(json.models) ? json.models.filter((m) => typeof m === "string") : [];
+  if (models.length < 2) return;
+
+  inputModel.replaceChildren(...models.map((name) => {
+    const opt = document.createElement("option");
+    opt.value = name;
+    opt.textContent = name;
+    return opt;
+  }));
+  // A stored pick from a machine with a different cache must not silently
+  // select nothing; fall back to whatever the backend currently has loaded.
+  if (!models.includes(settings.model)) {
+    settings.model = (json.current && models.includes(json.current)) ? json.current : models[0];
+    saveSettings(settings);
+  }
+  inputModel.value = settings.model;
+  modelField.hidden = false;
+  if (DEBUG) console.debug(`[ui] models: n=${models.length} -> ${settings.model}`);
+}
+
+/**
+ * Replace the built-in voice list with the names the running TTS backend
+ * actually accepts (`/api/voices`, proxied to the backend's `/v1/voices`).
+ *
+ * The markup ships Qwen3-TTS speaker names, but the backend can be running
+ * Kokoro (`bm_fable`, `af_heart`, ...) or another TTS entirely, and a name it
+ * does not know is ignored server-side — the picker then silently does
+ * nothing. Any failure leaves the built-in options alone.
+ */
+async function fetchVoices() {
+  /** @type {{ backend?: string|null, voices?: string[], current?: string|null }} */
+  let json;
+  try {
+    const res = await fetch("api/voices");
+    if (!res.ok) return;
+    json = await res.json();
+  } catch {
+    return; // Endpoint missing (older backend / static hosting): keep defaults.
+  }
+  const voices = Array.isArray(json.voices) ? json.voices.filter((v) => typeof v === "string") : [];
+  // An empty list means "not selectable" (voice cloning, or a backend with no
+  // fixed table). Keep the built-in options rather than emptying the picker.
+  if (!voices.length) return;
+
+  inputVoice.replaceChildren(...voices.map((name) => {
+    const opt = document.createElement("option");
+    opt.value = name;
+    opt.textContent = name;
+    return opt;
+  }));
+
+  // The saved voice may belong to a different backend (or a previous run of
+  // this one). Fall back to whatever the backend says it is using, then to the
+  // first offered name, and persist it so the next session starts valid.
+  if (!voices.includes(settings.voice)) {
+    const fallback = (json.current && voices.includes(json.current)) ? json.current : voices[0];
+    settings.voice = fallback;
+    saveSettings(settings);
+  }
+  inputVoice.value = settings.voice;
+  if (DEBUG) console.debug(`[ui] voices: backend=${json.backend} n=${voices.length} -> ${settings.voice}`);
 }
 
 /**
@@ -989,6 +1079,9 @@ function readSettingsFromForm() {
   return {
     directUrl: allowDirect && !pinnedUrl ? inputLbUrl.value.trim() : settings.directUrl,
     voice: inputVoice.value || DEFAULT_VOICE,
+    // Only honoured while the picker is visible, so a saved pick survives
+    // a visit to a deploy whose backend can't switch models.
+    model: modelField.hidden ? settings.model : (inputModel.value || settings.model),
     instructions: inputInstructions.value.trim() || DEFAULT_INSTRUCTIONS,
     noiseGate: readGateThreshold(),
     transport: /** @type {"ws" | "webrtc"} */ (
@@ -1089,7 +1182,11 @@ settingsForm.addEventListener("submit", (event) => {
   // output can switch live when the browser supports AudioContext.setSinkId;
   // mic device changes need a Restart (new getUserMedia stream).
   if (client && LIVE_STATES.has(currentState)) {
-    client.updateSession({ voice: settings.voice, instructions: settings.instructions });
+    client.updateSession({
+      voice: settings.voice,
+      instructions: settings.instructions,
+      model: settings.model,
+    });
     if (typeof client.setAudioOutputDevice === "function") {
       void client.setAudioOutputDevice(settings.audioOutputId);
     }
@@ -1409,6 +1506,7 @@ async function doStart(audioContext = null) {
 
   const common = {
     voice: settings.voice,
+    model: settings.model,
     instructions: settings.instructions,
     startupGreeting,
     acquireMic: acquireMicStream,

--- a/demo/rtc/s2s-rtc-client.js
+++ b/demo/rtc/s2s-rtc-client.js
@@ -714,6 +714,9 @@ export class S2sRtcRealtimeClient extends EventTarget {
         output: { voice: this.options.voice },
       },
     };
+    // Only sent when the user picked one; otherwise the server keeps whatever
+    // model it was started with.
+    if (this.options.model) session.model = this.options.model;
     if (this._tools.length) {
       session.tools = this._tools;
       session.tool_choice = "auto";
@@ -728,6 +731,7 @@ export class S2sRtcRealtimeClient extends EventTarget {
     const session = { type: "realtime" };
     if (patch.instructions) session.instructions = patch.instructions;
     if (patch.voice) session.audio = { output: { voice: patch.voice } };
+    if (patch.model) session.model = patch.model;
     if (Object.keys(session).length > 1) {
       this._send({ type: "session.update", session });
     }

--- a/demo/server.py
+++ b/demo/server.py
@@ -128,6 +128,16 @@ def _webrtc_calls_url(s2s_url: str) -> str:
     return urlunsplit((scheme, parts.netloc, path.rstrip("/") + "/calls", parts.query, ""))
 
 
+def _s2s_http_url(s2s_url: str, path: str) -> str:
+    """``ws://host:port/v1/realtime`` + ``/v1/voices`` -> ``http://host:port/v1/voices``."""
+    s = s2s_url.strip()
+    if not s.startswith(("ws://", "wss://", "http://", "https://")):
+        s = "http://" + s
+    parts = urlsplit(s)
+    scheme = {"ws": "http", "wss": "https"}.get(parts.scheme, parts.scheme)
+    return urlunsplit((scheme, parts.netloc, path, "", ""))
+
+
 SERPER_URL = "https://google.serper.dev/search"
 # Cap results so the tool output stays small enough to feed back to the model.
 MAX_RESULTS = 5
@@ -270,6 +280,38 @@ async def search(req: SearchRequest):
         answer = kg.get("description") or None
 
     return JSONResponse({"query": query, "answer": answer, "results": results})
+
+
+async def _s2s_get(path: str, empty: dict):
+    """GET a JSON endpoint on the pinned s2s server, degrading to ``empty``.
+
+    Proxied server-side for the same reason as /api/calls: the s2s server has
+    no CORS middleware. Forwards only to SPEECH_TO_SPEECH_URL, never to a
+    client-supplied target, so this can't be used as an open proxy.
+    """
+    if not SPEECH_TO_SPEECH_URL:
+        return empty
+    try:
+        async with httpx.AsyncClient(timeout=5.0) as http:
+            resp = await http.get(_s2s_http_url(SPEECH_TO_SPEECH_URL, path))
+        if resp.status_code != 200:
+            return empty
+        return resp.json()
+    except (httpx.RequestError, ValueError) as exc:
+        logger.warning("s2s %s unavailable: %r", path, exc)
+        return empty
+
+
+@app.get("/api/voices")
+async def voices():
+    """Voice names the backend's TTS accepts, for the Settings picker."""
+    return await _s2s_get("/v1/voices", {"backend": None, "voices": [], "current": None})
+
+
+@app.get("/api/models")
+async def models():
+    """Locally cached LLM checkpoints the backend can switch to."""
+    return await _s2s_get("/v1/models", {"backend": None, "models": [], "current": None})
 
 
 @app.post("/api/calls")

--- a/demo/ws/s2s-ws-client.js
+++ b/demo/ws/s2s-ws-client.js
@@ -999,6 +999,9 @@ export class S2sWsRealtimeClient extends EventTarget {
         output: { voice: this.options.voice },
       },
     };
+    // Only sent when the user picked one; otherwise the server keeps whatever
+    // model it was started with.
+    if (this.options.model) session.model = this.options.model;
     // Tools are declared here; the backend already accepts them in
     // session.update and emits response.function_call_arguments.done when the
     // model decides to call one. Only include the keys when we actually have
@@ -1017,6 +1020,7 @@ export class S2sWsRealtimeClient extends EventTarget {
     const session = { type: "realtime" };
     if (patch.instructions) session.instructions = patch.instructions;
     if (patch.voice) session.audio = { output: { voice: patch.voice } };
+    if (patch.model) session.model = patch.model;
     if (Object.keys(session).length > 1) {
       this._send({ type: "session.update", session });
     }

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -73,6 +73,11 @@ faster-whisper = [
 ]
 kokoro = [
     "kokoro>=0.9.2; platform_system != 'Darwin'",
+    # On Apple Silicon the handler goes through mlx-audio's Kokoro pipeline,
+    # which imports misaki -> num2words. mlx-audio does not declare either, so
+    # without these `--tts kokoro` fails at import time on macOS.
+    "misaki>=0.9.3; platform_system == 'Darwin'",
+    "num2words>=0.5.14; platform_system == 'Darwin'",
 ]
 mlx-lm = [
     "mlx-lm==0.31.1; platform_system == 'Darwin'",

--- a/src/speech_to_speech/LLM/language_model.py
+++ b/src/speech_to_speech/LLM/language_model.py
@@ -5,6 +5,7 @@ from abc import ABC, abstractmethod
 from collections.abc import Iterable, Iterator, Sized
 from queue import Empty
 from threading import Lock, Thread
+from time import perf_counter
 from typing import Any, Literal, Optional, Protocol, runtime_checkable
 
 import torch
@@ -43,6 +44,7 @@ from speech_to_speech.LLM.chat import (
     make_user_message,
 )
 from speech_to_speech.LLM.compaction_prompt import CompactGenerateFn, build_compactor
+from speech_to_speech.LLM.local_models import list_local_language_models
 from speech_to_speech.LLM.text_prompt import build_text_system_prompt
 from speech_to_speech.LLM.tool_call.function_call import extract_function_calls_from_text
 from speech_to_speech.LLM.tool_call.function_tool import FunctionTool
@@ -188,6 +190,12 @@ class BaseLanguageModelHandler(BaseHandler[LLMIn, LLMOut], ABC):
         self.enable_thinking = enable_thinking
         self.stream_batch_sentences = max(1, stream_batch_sentences)
         self.enable_lang_prompt = enable_lang_prompt
+        # Kept so switch_model() can reload a different checkpoint with the
+        # same device/dtype/generation settings the server was started with.
+        self._torch_dtype = torch_dtype
+        self._gen_kwargs = gen_kwargs
+        # Names we already refused, so an unusable pick warns once per name.
+        self._unavailable_models: set[str] = set()
 
         self._load_model(model_name, device, torch_dtype, gen_kwargs)
 
@@ -197,6 +205,73 @@ class BaseLanguageModelHandler(BaseHandler[LLMIn, LLMOut], ABC):
         # MLXLockContext instead.
         self._transformers_lock = Lock()
         self.compactor = build_compactor(self._build_compaction_generate_fn()) if compact_history else None
+
+    #: Registry-facing name, so ``GET /v1/models`` can report who answered.
+    backend_name = "local"
+
+    def available_models(self) -> list[str]:
+        """Cached checkpoints this handler could switch to.
+
+        Always includes the model the server was started with, even if it was
+        loaded from a path outside the Hugging Face cache — otherwise a client
+        picker would not be able to show what is currently running.
+        """
+        models = list_local_language_models()
+        if self.model_name and self.model_name not in models:
+            models.append(self.model_name)
+        return sorted(models)
+
+    def current_model(self) -> str:
+        return self.model_name
+
+    def switch_model(self, model_name: str) -> bool:
+        """Load a different checkpoint in place. Returns True if it took.
+
+        Reloading is measured in seconds and gigabytes, so this is only called
+        when the name actually changes. A failed load leaves the previous model
+        in place: the conversation continues on the old weights rather than
+        dying, and the caller is told so it can stop retrying.
+        """
+        if not model_name or model_name == self.model_name:
+            return False
+        if model_name not in self.available_models():
+            logger.warning(
+                "Ignoring request for model %r: not in the local cache. Available: %s",
+                model_name,
+                ", ".join(self.available_models()) or "(none)",
+            )
+            return False
+
+        previous = self.model_name
+        logger.info("Switching LLM: %s -> %s", previous, model_name)
+        started = perf_counter()
+        try:
+            self._load_model(model_name, self.device, self._torch_dtype, self._gen_kwargs)
+        except Exception as exc:
+            logger.error("Failed to load %r (%r); keeping %r", model_name, exc, previous)
+            # _load_model may have partially rebound self.model/self.tokenizer;
+            # restore the known-good checkpoint so the pipeline stays usable.
+            try:
+                self._load_model(previous, self.device, self._torch_dtype, self._gen_kwargs)
+            except Exception:
+                logger.exception("Could not restore %r after a failed switch", previous)
+            return False
+        self.model_name = model_name
+        logger.info("LLM switched to %s in %.2fs", model_name, perf_counter() - started)
+        return True
+
+    def _apply_requested_model(self, runtime_config: RuntimeConfig | None) -> None:
+        """Honour a client's ``session.model`` before generating."""
+        session = getattr(runtime_config, "session", None) if runtime_config else None
+        requested = getattr(session, "model", None) if session is not None else None
+        if not isinstance(requested, str) or not requested:
+            return
+        if requested == self.model_name:
+            return
+        if requested in self._unavailable_models:
+            return  # Already refused once; don't re-log every turn.
+        if not self.switch_model(requested):
+            self._unavailable_models.add(requested)
 
     def _turn_is_latest(self, turn_id: str | None, turn_revision: int | None) -> bool:
         return self.speculative_turns is None or self.speculative_turns.is_latest(turn_id, turn_revision)
@@ -572,6 +647,10 @@ class BaseLanguageModelHandler(BaseHandler[LLMIn, LLMOut], ABC):
             return
 
         runtime_config = request.runtime_config
+        # Before any generation: a client may have picked a different local
+        # checkpoint via session.update. Loading it stalls this turn (seconds,
+        # gigabytes) but every following turn uses the new model.
+        self._apply_requested_model(runtime_config)
         response = request.response
         original_chat = runtime_config.chat
         out_of_band = is_out_of_band(response)

--- a/src/speech_to_speech/LLM/local_models.py
+++ b/src/speech_to_speech/LLM/local_models.py
@@ -1,0 +1,96 @@
+"""Discovery of locally cached language models.
+
+The realtime server picks its LLM at startup, but clients want to offer a
+picker over what is actually on disk. Scanning the Hugging Face cache is the
+only source of truth for that: a repo is usable iff its weights are already
+downloaded, and the same cache also holds TTS/STT/VAD models that must not
+show up in an LLM picker.
+"""
+
+from __future__ import annotations
+
+import json
+import logging
+from pathlib import Path
+from typing import Any
+
+logger = logging.getLogger(__name__)
+
+# A causal-LM checkpoint declares an architecture ending in one of these. This
+# is what separates a chat model from the Kokoro / Parakeet / Qwen3-TTS /
+# smart-turn checkpoints sitting in the same cache.
+_CAUSAL_LM_SUFFIXES = ("ForCausalLM", "ForConditionalGeneration")
+
+# Repos that satisfy the architecture check but are not conversational models.
+_EXCLUDED_MODEL_TYPES = frozenset({"qwen3_tts", "kokoro", "parakeet", "whisper"})
+
+
+def _snapshot_config(repo_dir: Path) -> tuple[Path, dict[str, Any]] | None:
+    """Newest snapshot of ``repo_dir`` that has a readable ``config.json``."""
+    snapshots = repo_dir / "snapshots"
+    if not snapshots.is_dir():
+        return None
+    for snapshot in sorted(snapshots.iterdir(), key=lambda p: p.stat().st_mtime, reverse=True):
+        config_path = snapshot / "config.json"
+        if not config_path.is_file():
+            continue
+        try:
+            with config_path.open() as fh:
+                config = json.load(fh)
+        except (OSError, json.JSONDecodeError):
+            continue
+        if isinstance(config, dict):
+            return snapshot, config
+    return None
+
+
+def _is_causal_lm(config: dict[str, Any]) -> bool:
+    if str(config.get("model_type", "")).lower() in _EXCLUDED_MODEL_TYPES:
+        return False
+    architectures = config.get("architectures")
+    if not isinstance(architectures, list):
+        return False
+    return any(isinstance(a, str) and a.endswith(_CAUSAL_LM_SUFFIXES) for a in architectures)
+
+
+def _has_weights(snapshot: Path) -> bool:
+    """A cache entry can exist with metadata but no weights (interrupted pull)."""
+    return any(snapshot.glob("*.safetensors")) or any(snapshot.glob("*.bin"))
+
+
+def cache_root() -> Path:
+    """The Hugging Face hub cache directory, honouring the usual env overrides."""
+    import os
+
+    hf_hub = os.environ.get("HF_HUB_CACHE")
+    if hf_hub:
+        return Path(hf_hub)
+    hf_home = os.environ.get("HF_HOME")
+    if hf_home:
+        return Path(hf_home) / "hub"
+    return Path.home() / ".cache" / "huggingface" / "hub"
+
+
+def list_local_language_models() -> list[str]:
+    """Repo ids of cached causal-LM checkpoints, e.g. ``["Qwen/Qwen3-0.6B"]``.
+
+    Returns them sorted. Never raises: an unreadable cache yields an empty
+    list, which callers treat as "no picker".
+    """
+    root = cache_root()
+    if not root.is_dir():
+        return []
+
+    found: list[str] = []
+    for repo_dir in root.glob("models--*"):
+        if not repo_dir.is_dir():
+            continue
+        result = _snapshot_config(repo_dir)
+        if result is None:
+            continue
+        snapshot, config = result
+        if not _is_causal_lm(config) or not _has_weights(snapshot):
+            continue
+        # models--Qwen--Qwen3-0.6B -> Qwen/Qwen3-0.6B
+        found.append(repo_dir.name[len("models--"):].replace("--", "/"))
+    return sorted(found)

--- a/src/speech_to_speech/TTS/kokoro_handler.py
+++ b/src/speech_to_speech/TTS/kokoro_handler.py
@@ -72,6 +72,30 @@ KOKORO_LANG_DEFAULT_VOICES = {
     "z": "zf_xiaobei",  # Chinese female
 }
 
+# Every voice Kokoro ships (the per-language listing above, as data). A client
+# may send any string as `session.audio.output.voice` — notably the demo UI
+# offers Qwen3-TTS speaker names ("Aiden", "Ryan", ...) regardless of which TTS
+# backend is running. Loading an unknown name raises inside mlx-audio and kills
+# every response, so unknown names are ignored rather than assigned.
+KOKORO_VOICES = frozenset(
+    {
+        "af_alloy", "af_aoede", "af_bella", "af_heart", "af_jessica", "af_kore",
+        "af_nicole", "af_nova", "af_river", "af_sarah", "af_sky",
+        "am_adam", "am_echo", "am_eric", "am_fenrir", "am_liam", "am_michael",
+        "am_onyx", "am_puck", "am_santa",
+        "bf_alice", "bf_emma", "bf_isabella", "bf_lily",
+        "bm_daniel", "bm_fable", "bm_george", "bm_lewis",
+        "ef_dora", "em_alex", "em_santa",
+        "ff_siwis",
+        "hf_alpha", "hf_beta", "hm_omega", "hm_psi",
+        "if_sara", "im_nicola",
+        "jf_alpha", "jf_gongitsune", "jf_nezumi", "jf_tebukuro", "jm_kumo",
+        "pf_dora", "pm_alex", "pm_santa",
+        "zf_xiaobei", "zf_xiaoni", "zf_xiaoxiao", "zf_xiaoyi",
+        "zm_yunjian", "zm_yunxi", "zm_yunxia", "zm_yunyang",
+    }
+)
+
 
 class KokoroTTSHandler(BaseHandler[TTSIn, TTSOut]):
     """
@@ -118,6 +142,9 @@ class KokoroTTSHandler(BaseHandler[TTSIn, TTSOut]):
         self.blocksize = blocksize
         self.cancel_scope = cancel_scope
         self.speculative_turns = speculative_turns
+        # Client-requested voice names we have already warned about, so an
+        # unusable name is logged once instead of once per response.
+        self._rejected_voices: set[str] = set()
 
         # Determine device
         if device == "auto":
@@ -271,13 +298,32 @@ class KokoroTTSHandler(BaseHandler[TTSIn, TTSOut]):
             audio_cfg = runtime_config.session.audio
             audio_output = audio_cfg.output if audio_cfg is not None else None
             voice = str(audio_output.voice) if audio_output is not None and audio_output.voice else None
-        if voice:
-            self.voice = voice
+        if voice and voice != self.voice:
+            if voice in KOKORO_VOICES:
+                self.voice = voice
+            elif voice not in self._rejected_voices:
+                self._rejected_voices.add(voice)
+                logger.warning(
+                    "Ignoring unknown Kokoro voice %r (client-requested); keeping %r. "
+                    "Valid names look like 'bm_fable' or 'af_heart'.",
+                    voice,
+                    self.voice,
+                )
 
         if self.backend == "mlx":
             yield from self._process_mlx(text, language_code)
         else:
             yield from self._process_kokoro(text, language_code)
+
+    #: Registry name, so ``GET /v1/voices`` can say which backend answered.
+    backend_name = "kokoro"
+
+    def available_voices(self) -> list[str]:
+        """Voice names this handler accepts, for clients building a picker."""
+        return sorted(KOKORO_VOICES)
+
+    def current_voice(self) -> str:
+        return self.voice
 
     def _process_mlx(self, llm_sentence: str, language_code: Optional[str] = None) -> Iterator[np.ndarray]:
         """Process using MLX backend with Apple Silicon optimizations."""

--- a/src/speech_to_speech/TTS/qwen3_tts_handler.py
+++ b/src/speech_to_speech/TTS/qwen3_tts_handler.py
@@ -579,6 +579,22 @@ class Qwen3TTSHandler(BaseHandler[TTSIn, TTSOut]):
         inner = getattr(getattr(self.model, "model", None), "model", None)
         return getattr(inner, "tts_model_type", None) or self._infer_model_type_from_name()
 
+    #: Registry name, so ``GET /v1/voices`` can say which backend answered.
+    backend_name = "qwen3"
+
+    def available_voices(self) -> list[str]:
+        """Voice names this handler accepts, for clients building a picker.
+
+        CustomVoice checkpoints expose their speaker table at runtime; other
+        variants (voice clone / voice design) have no fixed list, so the picker
+        is left empty and the server-side default stands.
+        """
+        speakers = self._supported_speakers()
+        return sorted(speakers, key=str.lower) if speakers else []
+
+    def current_voice(self) -> str:
+        return self.speaker or ""
+
     def _supported_speakers(self) -> list[str] | None:
         for candidate in (
             self.model,

--- a/src/speech_to_speech/api/openai_realtime/websocket_router.py
+++ b/src/speech_to_speech/api/openai_realtime/websocket_router.py
@@ -589,6 +589,62 @@ def create_app(
             "units": [_state(u) for u in pool],
         }
 
+    @app.get("/v1/voices")
+    async def voices_endpoint() -> dict[str, Any]:
+        """Voice names the running TTS backend accepts.
+
+        Clients otherwise have to hardcode a list, which silently breaks when
+        the server runs a different TTS backend: the names are per-backend
+        (Qwen3 speakers vs. Kokoro voice ids) and an unknown name is ignored.
+        An empty ``voices`` means "not selectable" — the backend has no fixed
+        table (voice cloning) or does not expose one; clients should hide the
+        picker rather than offer names that will be dropped.
+        """
+        for unit in pool:
+            for handler in unit.handlers:
+                lister = getattr(handler, "available_voices", None)
+                if not callable(lister):
+                    continue
+                try:
+                    voices = [str(v) for v in lister()]
+                except Exception as exc:  # a model that can't answer must not 500 the endpoint
+                    logger.warning("TTS handler failed to list voices: %r", exc)
+                    voices = []
+                current = getattr(handler, "current_voice", None)
+                return {
+                    "backend": getattr(handler, "backend_name", None),
+                    "voices": voices,
+                    "current": str(current()) if callable(current) else None,
+                }
+        return {"backend": None, "voices": [], "current": None}
+
+    @app.get("/v1/models")
+    async def models_endpoint() -> dict[str, Any]:
+        """Locally cached checkpoints the running LLM handler can switch to.
+
+        Empty ``models`` means the picker should be hidden: either the LLM runs
+        remotely (an API backend has nothing local to enumerate) or nothing
+        usable is cached. Selection is applied by sending ``session.model`` in
+        a ``session.update``.
+        """
+        for unit in pool:
+            for handler in unit.handlers:
+                lister = getattr(handler, "available_models", None)
+                if not callable(lister):
+                    continue
+                try:
+                    models = [str(m) for m in lister()]
+                except Exception as exc:
+                    logger.warning("LLM handler failed to list models: %r", exc)
+                    models = []
+                current = getattr(handler, "current_model", None)
+                return {
+                    "backend": getattr(handler, "backend_name", None),
+                    "models": models,
+                    "current": str(current()) if callable(current) else None,
+                }
+        return {"backend": None, "models": [], "current": None}
+
     @app.post("/v1/realtime/calls")
     async def webrtc_calls_endpoint(request: Request) -> Response:
         """WebRTC SDP handshake (OpenAI GA Realtime 'calls' endpoint).


### PR DESCRIPTION
Expose new `/v1/voices` and `/v1/models` endpoints (plus demo server proxies) so the demo can populate backend-specific voice and local-model pickers at runtime. Wire `session.model` through WS/WebRTC clients and the language model handler to support in-process checkpoint switching from cached Hugging Face models, including safe fallback on failed loads. Also add TTS handle
This pull request adds support for dynamic selection and switching of locally cached language models (LLMs) in the demo application. Users can now pick from available LLM checkpoints in the Settings UI, and the backend will reload the selected model on demand. The implementation ensures that the UI only exposes this option when multiple models are available, and that changes are persisted and communicated to the backend in real time. Several supporting improvements were made to both the frontend and backend to enable this feature.

**Frontend: Model selection UI and state management**
- Added a hidden "Model" dropdown to the Settings UI (`index.html`), which is shown only if the backend reports more than one available LLM. The picker is populated dynamically via a new `/api/models` endpoint, and the user's selection is persisted in local storage. The selected model is sent to the backend with session updates and on session start. [[1]](diffhunk://#diff-b18ccd15ec95e2a9c4fead5bca9085042af688361a24d3463c27138e3c797a5bR276-R281) [[2]](diffhunk://#diff-1bfd37fd0894dc593fca6117306c88cf3201b68932ce418d4afe0935d4570cacR35) [[3]](diffhunk://#diff-1bfd37fd0894dc593fca6117306c88cf3201b68932ce418d4afe0935d4570cacR116-R118) [[4]](diffhunk://#diff-1bfd37fd0894dc593fca6117306c88cf3201b68932ce418d4afe0935d4570cacR145) [[5]](diffhunk://#diff-1bfd37fd0894dc593fca6117306c88cf3201b68932ce418d4afe0935d4570cacR274-R276) [[6]](diffhunk://#diff-1bfd37fd0894dc593fca6117306c88cf3201b68932ce418d4afe0935d4570cacR469) [[7]](diffhunk://#diff-1bfd37fd0894dc593fca6117306c88cf3201b68932ce418d4afe0935d4570cacR930-R1010) [[8]](diffhunk://#diff-1bfd37fd0894dc593fca6117306c88cf3201b68932ce418d4afe0935d4570cacR1082-R1084) [[9]](diffhunk://#diff-1bfd37fd0894dc593fca6117306c88cf3201b68932ce418d4afe0935d4570cacL1092-R1189) [[10]](diffhunk://#diff-1bfd37fd0894dc593fca6117306c88cf3201b68932ce418d4afe0935d4570cacR1509)

**Backend: Model listing, switching, and API endpoints**
- Added backend support for listing available local LLM checkpoints and switching models at runtime. The backend exposes `/api/models` (proxied to `/v1/models`) and `/api/voices` endpoints, reporting available models and the currently loaded one. The backend only switches models if the client requests a different, valid checkpoint, and gracefully handles failed reloads. [[1]](diffhunk://#diff-b0e1bfc3acdce6d654968c7eac6a4d211e6ab1a17998194bf740ddadde7c4f94R131-R140) [[2]](diffhunk://#diff-b0e1bfc3acdce6d654968c7eac6a4d211e6ab1a17998194bf740ddadde7c4f94R285-R316) [[3]](diffhunk://#diff-cc6cf750254684dcaab654d60fd901be1d2cc161e1bc75648afe29499b3abe9fR47) [[4]](diffhunk://#diff-cc6cf750254684dcaab654d60fd901be1d2cc161e1bc75648afe29499b3abe9fR193-R198) [[5]](diffhunk://#diff-cc6cf750254684dcaab654d60fd901be1d2cc161e1bc75648afe29499b3abe9fR209-R275) [[6]](diffhunk://#diff-cc6cf750254684dcaab654d60fd901be1d2cc161e1bc75648afe29499b3abe9fR650-R653)

**Realtime client updates**
- Both WebSocket and WebRTC realtime clients now include the selected model in session creation and session update messages, ensuring the backend can honor the user's choice at any time. [[1]](diffhunk://#diff-5c87c55f013d23368b53ac62fecdb2ab8b67ba186176ae9455b5cd3ea3e747b2R717-R719) [[2]](diffhunk://#diff-5c87c55f013d23368b53ac62fecdb2ab8b67ba186176ae9455b5cd3ea3e747b2R734) [[3]](diffhunk://#diff-0ef6471d08c62c3f8e2f5ea5012f64ee95c44bf98de0c98692803a04fdb8fe37R1002-R1004) [[4]](diffhunk://#diff-0ef6471d08c62c3f8e2f5ea5012f64ee95c44bf98de0c98692803a04fdb8fe37R1023)

**Dependency and compatibility improvements**
- Added missing dependencies (`misaki`, `num2words`) for TTS on Apple Silicon in the Python requirements, ensuring proper operation on macOS.

**Internal API and utility enhancements**
- Refactored internal backend code to support HTTP URL construction for proxying requests and to centralize model listing logic. [[1]](diffhunk://#diff-b0e1bfc3acdce6d654968c7eac6a4d211e6ab1a17998194bf740ddadde7c4f94R131-R140) [[2]](diffhunk://#diff-cc6cf750254684dcaab654d60fd901be1d2cc161e1bc75648afe29499b3abe9fR47)

These changes provide a more flexible and user-driven experience for selecting and switching between local LLMs in the demo application.r voice-list/current-voice reporting, guard Kokoro against invalid client voice names, and include missing macOS Kokoro dependencies (`misaki`, `num2words`).