### PR TITLE
Honor explicit reasoning effort for official OpenAI requests

### DIFF
--- a/src/speech_to_speech/LLM/base_openai_compatible_language_model.py
+++ b/src/speech_to_speech/LLM/base_openai_compatible_language_model.py
@@ -243,13 +243,17 @@ class BaseOpenAICompatibleHandler(BaseHandler[LLMIn, LLMOut], ABC):
         ``chat_template_kwargs.enable_thinking=false``, while others (e.g. GLM via
         the HF router) ignore that and require ``reasoning_effort='none'``. A
         non-empty ``reasoning_effort`` therefore takes precedence; otherwise we fall
-        back to the chat-template flag. None of this applies to the official
-        OpenAI server, which rejects unknown extra_body keys.
+        back to the chat-template flag. An explicit effort is honored even for the
+        official OpenAI server, where ``reasoning_effort`` is a documented
+        top-level Chat Completions parameter (e.g. ``none`` is required to combine
+        function tools with reasoning models); the provider-specific
+        chat-template flag never reaches it, as the server rejects unknown
+        extra_body keys.
         """
-        if base_url is None or cls._is_official_openai(base_url):
-            return None
         if reasoning_effort:
             return {"reasoning_effort": reasoning_effort}
+        if base_url is None or cls._is_official_openai(base_url):
+            return None
         if disable_thinking:
             return {"chat_template_kwargs": {"enable_thinking": False}}
         return None

--- a/tests/test_chat_completions_backend.py
+++ b/tests/test_chat_completions_backend.py
@@ -13,6 +13,7 @@ import json
 import queue
 import threading
 from types import SimpleNamespace
+from typing import Optional
 
 import httpx
 import numpy as np
@@ -100,7 +101,7 @@ class _FakeClient:
         return self
 
 
-def _make_handler(stream=True):
+def _make_handler(stream=True, base_url: Optional[str] = "http://fake/v1", reasoning_effort=None):
     """Build a handler whose warmup hits the fake client (no network)."""
     orig_openai = base_mod.OpenAI
     base_mod.OpenAI = _FakeClient
@@ -111,10 +112,11 @@ def _make_handler(stream=True):
             queue.Queue(),
             setup_kwargs=dict(
                 model_name="test-model",
-                base_url="http://fake/v1",
+                base_url=base_url,
                 api_key="k",
                 stream=stream,
                 disable_thinking=True,
+                reasoning_effort=reasoning_effort,
                 compact_history=False,
             ),
         )
@@ -201,11 +203,15 @@ def test_build_extra_body_variants():
     f = ChatCompletionsApiModelHandler._build_extra_body
     assert f("http://x/v1", True, None) == {"chat_template_kwargs": {"enable_thinking": False}}
     assert f("http://x/v1", True, "none") == {"reasoning_effort": "none"}  # explicit effort wins
-    assert f("https://api.openai.com/v1", True, "none") is None  # official OpenAI: no extra_body
-    assert f("https://api.openai.com/v1/", True, "none") is None  # trailing slash still official
+    assert f("https://api.openai.com/v1", True, "none") == {"reasoning_effort": "none"}  # typed top-level param
+    assert f("https://api.openai.com/v1/", True, "none") == {
+        "reasoning_effort": "none"
+    }  # trailing slash still official
+    assert f("https://api.openai.com/v1", True, None) is None  # official OpenAI: no chat-template flag
     assert f("http://x/v1", True, "") == {"chat_template_kwargs": {"enable_thinking": False}}  # empty effort ignored
     assert f("http://x/v1", False, None) is None
     assert f(None, True, None) is None
+    assert f(None, True, "none") == {"reasoning_effort": "none"}  # default endpoint is official OpenAI
 
 
 def test_chat_messages_encodes_tool_arguments_as_string():
@@ -696,6 +702,51 @@ def test_tools_converted_to_chat_format_on_request():
     assert captured["tool_choice"] == "auto"
     assert captured["stream"] is True
     assert captured["stream_options"] == {"include_usage": True}
+
+
+# ── Explicit reasoning effort on official OpenAI endpoints ───────────────────
+
+
+@pytest.mark.parametrize("base_url", [None, "https://api.openai.com/v1", "https://api.openai.com/v1/"])
+def test_explicit_reasoning_effort_reaches_official_openai_request(base_url):
+    """Regression: a configured ``reasoning_effort`` used to be dropped whenever
+    ``base_url`` was unset or pointed at official OpenAI, so a ``gpt-5.6-terra``
+    session exposing function tools was rejected with
+    "Function tools with reasoning_effort are not supported ... set
+    reasoning_effort to 'none'" because the request fell back to the model's
+    default ``medium`` effort. The effort must reach the request instead."""
+    h = _make_handler(stream=True, base_url=base_url, reasoning_effort="none")
+    captured = {}
+
+    def fake_create(**kwargs):
+        captured.update(kwargs)
+        return _FakeStream([_chunk(content="ok.")])
+
+    h.client.chat.completions.create = fake_create
+    _drive(
+        h,
+        tools=[{"type": "function", "name": "f", "parameters": {"type": "object"}}],
+        tool_choice="auto",
+    )
+    assert captured["extra_body"] == {"reasoning_effort": "none"}
+    # tools travel alongside the effort, matching the failing production path
+    assert captured["tools"] == [{"type": "function", "function": {"name": "f", "parameters": {"type": "object"}}}]
+
+
+def test_official_openai_without_explicit_effort_sends_no_chat_template_kwargs():
+    """The provider-specific ``chat_template_kwargs`` flag must still never reach
+    the official OpenAI server (it rejects unknown extra_body keys); only an
+    explicitly configured effort does."""
+    h = _make_handler(stream=True, base_url="https://api.openai.com/v1", reasoning_effort=None)
+    captured = {}
+
+    def fake_create(**kwargs):
+        captured.update(kwargs)
+        return _FakeStream([_chunk(content="ok.")])
+
+    h.client.chat.completions.create = fake_create
+    _drive(h)
+    assert captured["extra_body"] is None
 
 
 # ── Text-only (output_modalities=["text"]) ────────────────────────────────────


### PR DESCRIPTION
## Description
I changed the chat-completions backend so an explicitly configured `responses_api_reasoning_effort` is honored on the official OpenAI API. Previously, `_build_extra_body` returned early for official OpenAI (or an unset base URL) before considering the configured effort, so it was silently dropped and reasoning models exposing function tools fell back to the default effort, which `/v1/chat/completions` rejects; now the effort reaches the request, while `chat_template_kwargs` still never goes to official OpenAI.

Fixes #490

## Why
without the effort the first runtime request with function tools fails with the 400 from the issue, even though warmup succeeds

## Verification
- before, on current `main`: `pytest tests/test_chat_completions_backend.py -q` — the new official-OpenAI cases fail because the effort is dropped
- after: `pytest tests/test_chat_completions_backend.py -q` — 40 passed
- also ran `pytest tests/ -q` — 1125 passed, 2 skipped