### PR TITLE
Fix(stt): Propagate `FasterWhisper language_code` on Transcription

### DIFF
--- a/src/speech_to_speech/STT/faster_whisper_handler.py
+++ b/src/speech_to_speech/STT/faster_whisper_handler.py
@@ -59,6 +59,7 @@ class FasterWhisperSTTHandler(BaseSTTHandler):
 
             yield Transcription(
                 text=pred_text,
+                language_code=info.language,
                 turn_id=vad_audio.turn_id,
                 turn_revision=vad_audio.turn_revision,
                 speech_stopped_at_s=vad_audio.created_at_s,

--- a/tests/test_faster_whisper_language_code.py
+++ b/tests/test_faster_whisper_language_code.py
@@ -1,0 +1,86 @@
+"""FasterWhisper must put detected language on Transcription like other STT backends.
+
+``model.transcribe()`` already returns ``info.language``, but the handler used to omit
+``language_code`` on ``Transcription``. Downstream lang-prompt / multilingual TTS then
+saw ``None`` and could not switch language.
+"""
+
+from __future__ import annotations
+
+import sys
+from types import SimpleNamespace
+from unittest.mock import MagicMock
+
+import numpy as np
+
+from speech_to_speech.pipeline.messages import PartialTranscription, Transcription, VADAudio
+
+
+def _import_handler(monkeypatch):
+    monkeypatch.setitem(sys.modules, "faster_whisper", MagicMock())
+    sys.modules.pop("speech_to_speech.STT.faster_whisper_handler", None)
+    from speech_to_speech.STT.faster_whisper_handler import FasterWhisperSTTHandler
+
+    return FasterWhisperSTTHandler
+
+
+def _make_handler(monkeypatch, *, segments, language: str | None):
+    FasterWhisperSTTHandler = _import_handler(monkeypatch)
+    handler = object.__new__(FasterWhisperSTTHandler)
+    handler.gen_kwargs = {}
+    handler.model = MagicMock()
+    handler.model.transcribe.return_value = (segments, SimpleNamespace(language=language))
+    return handler
+
+
+def test_faster_whisper_propagates_language_code(monkeypatch) -> None:
+    segment = SimpleNamespace(start=0.0, end=1.0, text=" Jaka pogoda?")
+    handler = _make_handler(monkeypatch, segments=[segment], language="pl")
+
+    outputs = list(
+        handler.process(
+            VADAudio(
+                audio=np.zeros(1600, dtype=np.float32),
+                turn_id="turn-1",
+                turn_revision=1,
+            )
+        )
+    )
+
+    assert len(outputs) == 1
+    assert isinstance(outputs[0], Transcription)
+    assert outputs[0].text == "Jaka pogoda?"
+    assert outputs[0].language_code == "pl"
+    assert outputs[0].turn_id == "turn-1"
+    assert outputs[0].turn_revision == 1
+
+
+def test_faster_whisper_skips_empty_transcript(monkeypatch) -> None:
+    segment = SimpleNamespace(start=0.0, end=0.1, text="   ")
+    handler = _make_handler(monkeypatch, segments=[segment], language="en")
+
+    outputs = list(handler.process(VADAudio(audio=np.zeros(1600, dtype=np.float32))))
+
+    assert outputs == []
+
+
+def test_faster_whisper_progressive_partial_has_no_language_field(monkeypatch) -> None:
+    """PartialTranscription has no language_code field; only finals carry it."""
+    segment = SimpleNamespace(start=0.0, end=0.5, text=" Hello")
+    handler = _make_handler(monkeypatch, segments=[segment], language="en")
+
+    outputs = list(
+        handler.process(
+            VADAudio(
+                audio=np.zeros(1600, dtype=np.float32),
+                mode="progressive",
+                turn_id="turn-1",
+                turn_revision=1,
+            )
+        )
+    )
+
+    assert len(outputs) == 1
+    assert isinstance(outputs[0], PartialTranscription)
+    assert outputs[0].text == "Hello"
+    assert not hasattr(outputs[0], "language_code")


### PR DESCRIPTION
Hi,

Small follow-up in the same spirit as the Facebook MMS language-key fix: FasterWhisper already detects a language via `info.language`, but the handler never put it on `Transcription`, so downstream lang-prompt / multilingual TTS saw `None`.

## Summary
- Set `language_code=info.language` on final `Transcription` outputs from FasterWhisper.
- Add regression tests (mocked `faster_whisper`) for language propagation, empty transcripts, and progressive partials.

## Why / example use case
Other STT backends already emit Whisper-style codes on `Transcription`. With FasterWhisper, a Polish turn could produce text while leaving `language_code=None`, so `--enable_lang_prompt` and multilingual TTS could not follow the detected language.

## Test plan
- [x] `uv run pytest tests/test_faster_whisper_language_code.py -v`
- [ ] Confirm a non-empty FasterWhisper transcript carries `info.language` on `Transcription`
- [ ] Confirm empty / whitespace-only transcripts still yield nothing