### PR TITLE
Preserve reasoning effort for OpenAI Chat Completions

### DIFF
--- a/src/speech_to_speech/LLM/base_openai_compatible_language_model.py
+++ b/src/speech_to_speech/LLM/base_openai_compatible_language_model.py
@@ -242,14 +242,14 @@ class BaseOpenAICompatibleHandler(BaseHandler[LLMIn, LLMOut], ABC):
         Providers differ in how reasoning is turned off: vLLM/Qwen honour
         ``chat_template_kwargs.enable_thinking=false``, while others (e.g. GLM via
         the HF router) ignore that and require ``reasoning_effort='none'``. A
-        non-empty ``reasoning_effort`` therefore takes precedence; otherwise we fall
-        back to the chat-template flag. None of this applies to the official
-        OpenAI server, which rejects unknown extra_body keys.
+        non-empty ``reasoning_effort`` therefore takes precedence, including for
+        official OpenAI requests; otherwise we fall back to the provider-specific
+        chat-template flag, which the official OpenAI server does not accept.
         """
-        if base_url is None or cls._is_official_openai(base_url):
-            return None
         if reasoning_effort:
             return {"reasoning_effort": reasoning_effort}
+        if base_url is None or cls._is_official_openai(base_url):
+            return None
         if disable_thinking:
             return {"chat_template_kwargs": {"enable_thinking": False}}
         return None

--- a/tests/test_chat_completions_backend.py
+++ b/tests/test_chat_completions_backend.py
@@ -100,7 +100,7 @@ class _FakeClient:
         return self
 
 
-def _make_handler(stream=True):
+def _make_handler(stream=True, *, base_url="http://fake/v1", reasoning_effort=None):
     """Build a handler whose warmup hits the fake client (no network)."""
     orig_openai = base_mod.OpenAI
     base_mod.OpenAI = _FakeClient
@@ -111,10 +111,11 @@ def _make_handler(stream=True):
             queue.Queue(),
             setup_kwargs=dict(
                 model_name="test-model",
-                base_url="http://fake/v1",
+                base_url=base_url,
                 api_key="k",
                 stream=stream,
                 disable_thinking=True,
+                reasoning_effort=reasoning_effort,
                 compact_history=False,
             ),
         )
@@ -201,8 +202,9 @@ def test_build_extra_body_variants():
     f = ChatCompletionsApiModelHandler._build_extra_body
     assert f("http://x/v1", True, None) == {"chat_template_kwargs": {"enable_thinking": False}}
     assert f("http://x/v1", True, "none") == {"reasoning_effort": "none"}  # explicit effort wins
-    assert f("https://api.openai.com/v1", True, "none") is None  # official OpenAI: no extra_body
-    assert f("https://api.openai.com/v1/", True, "none") is None  # trailing slash still official
+    assert f("https://api.openai.com/v1", True, "none") == {"reasoning_effort": "none"}
+    assert f("https://api.openai.com/v1/", True, "none") == {"reasoning_effort": "none"}
+    assert f(None, True, "none") == {"reasoning_effort": "none"}
     assert f("http://x/v1", True, "") == {"chat_template_kwargs": {"enable_thinking": False}}  # empty effort ignored
     assert f("http://x/v1", False, None) is None
     assert f(None, True, None) is None
@@ -696,6 +698,22 @@ def test_tools_converted_to_chat_format_on_request():
     assert captured["tool_choice"] == "auto"
     assert captured["stream"] is True
     assert captured["stream_options"] == {"include_usage": True}
+
+
+@pytest.mark.parametrize("base_url", [None, "https://api.openai.com/v1"])
+def test_official_openai_request_includes_configured_reasoning_effort_with_tools(base_url):
+    h = _make_handler(stream=True, base_url=base_url, reasoning_effort="none")
+    captured = {}
+
+    def fake_create(**kwargs):
+        captured.update(kwargs)
+        return _FakeStream([_chunk(content="ok.")])
+
+    h.client.chat.completions.create = fake_create
+    _drive(h, tools=[{"type": "function", "name": "f", "parameters": {"type": "object"}}])
+
+    assert captured["extra_body"] == {"reasoning_effort": "none"}
+    assert captured["tools"] == [{"type": "function", "function": {"name": "f", "parameters": {"type": "object"}}}]
 
 
 # ── Text-only (output_modalities=["text"]) ────────────────────────────────────


### PR DESCRIPTION
## Summary

- preserve an explicitly configured `reasoning_effort` for official OpenAI Chat Completions endpoints
- cover both the default endpoint and explicit `https://api.openai.com/v1` requests containing function tools
- keep the existing provider-specific `chat_template_kwargs.enable_thinking=false` fallback unchanged

## Root cause

The official-OpenAI guard returned before `_build_extra_body()` considered the configured reasoning effort, so runtime requests omitted `reasoning_effort: "none"` and tool-enabled `gpt-5.6-terra` calls failed.

## Impact

Chat Completions sessions using official OpenAI endpoints can now combine function tools with an explicitly configured `reasoning_effort=none`. Requests without an explicit effort and non-OpenAI provider behavior are unchanged.

## Validation

- focused regression tests: 3 passed
- Chat Completions backend tests: 38 passed
- full test suite: 1144 passed, 1 skipped
- Ruff lint and format checks
- mypy
- wheel and sdist build with strict Twine metadata checks
- OpenAI SDK 2.28.0 mock-transport JSON body check

Fixes #490
