### PR TITLE
Fix Markdown pronunciation in TTS output

### DIFF
--- a/src/speech_to_speech/LLM/base_openai_compatible_language_model.py
+++ b/src/speech_to_speech/LLM/base_openai_compatible_language_model.py
@@ -29,7 +29,7 @@ from speech_to_speech.LLM.chat import (
 )
 from speech_to_speech.LLM.compaction_prompt import CompactGenerateFn, build_compactor
 from speech_to_speech.LLM.text_prompt import build_text_system_prompt
-from speech_to_speech.LLM.utils import remove_unspeechable, resolve_auto_language
+from speech_to_speech.LLM.utils import remove_markdown, remove_unspeechable, resolve_auto_language
 from speech_to_speech.LLM.voice_prompt import build_voice_system_prompt
 from speech_to_speech.pipeline.cancel_scope import CancelScope
 from speech_to_speech.pipeline.handler_types import LLMIn, LLMOut
@@ -353,7 +353,7 @@ class BaseOpenAICompatibleHandler(BaseHandler[LLMIn, LLMOut], ABC):
             elif isinstance(event, ToolCall):
                 # Flush any pending spoken text before emitting the tool call.
                 if printable_text.strip():
-                    sentence_batch.append(printable_text.strip())
+                    sentence_batch.append(remove_markdown(printable_text.strip()))
                     printable_text = ""
                 if sentence_batch:
                     if not self._turn_output_allowed(turn.turn_id, turn.turn_revision):
@@ -382,7 +382,7 @@ class BaseOpenAICompatibleHandler(BaseHandler[LLMIn, LLMOut], ABC):
                 sentences = sent_tokenize(printable_text)
                 if len(sentences) > 1:
                     for s in sentences[:-1]:
-                        sentence_batch.append(s)
+                        sentence_batch.append(remove_markdown(s))
                         if len(sentence_batch) >= self.stream_batch_sentences:
                             if not self._turn_output_allowed(turn.turn_id, turn.turn_revision):
                                 logger.info("LLM generation cancelled (stale speculative turn)")
@@ -396,7 +396,7 @@ class BaseOpenAICompatibleHandler(BaseHandler[LLMIn, LLMOut], ABC):
 
         if not cancelled:
             if printable_text.strip():
-                sentence_batch.append(printable_text.strip())
+                sentence_batch.append(remove_markdown(printable_text.strip()))
             if sentence_batch:
                 if self._generation_is_stale(turn.gen):
                     logger.info("LLM generation cancelled (interruption)")
@@ -420,9 +420,10 @@ class BaseOpenAICompatibleHandler(BaseHandler[LLMIn, LLMOut], ABC):
             elif isinstance(event, ToolCall):
                 yield from self._record_tool_call(state, turn, event.item)
             elif isinstance(event, TextDelta):
-                # Text-only keeps every character verbatim; audio strips
-                # TTS-unfriendly symbols via remove_unspeechable.
-                spoken = event.text if not turn.wants_audio else remove_unspeechable(event.text)
+                # Text-only keeps every character verbatim; audio strips markdown
+                # and TTS-unfriendly symbols. Not per-delta here: each TextDelta
+                # in the non-streaming path already carries the full response.
+                spoken = event.text if not turn.wants_audio else remove_markdown(remove_unspeechable(event.text))
                 state.clean_text += spoken
                 out = spoken if not turn.wants_audio else spoken.strip()
                 if (

--- a/src/speech_to_speech/LLM/base_openai_compatible_language_model.py
+++ b/src/speech_to_speech/LLM/base_openai_compatible_language_model.py
@@ -40,7 +40,12 @@ from speech_to_speech.LLM.chat import (
 )
 from speech_to_speech.LLM.compaction_prompt import CompactGenerateFn, build_compactor
 from speech_to_speech.LLM.text_prompt import build_text_system_prompt
-from speech_to_speech.LLM.utils import remove_markdown, remove_unspeechable, resolve_auto_language
+from speech_to_speech.LLM.utils import (
+    remove_markdown,
+    remove_unspeechable,
+    resolve_auto_language,
+    sent_tokenize_preserving_markdown_code,
+)
 from speech_to_speech.LLM.voice_prompt import build_voice_system_prompt
 from speech_to_speech.pipeline.cancel_scope import CancelScope
 from speech_to_speech.pipeline.handler_types import LLMIn, LLMOut
@@ -638,7 +643,7 @@ class BaseOpenAICompatibleHandler(BaseHandler[LLMIn, LLMOut], ABC):
                 state.clean_text += new_text
                 printable_text += new_text
                 trailing_whitespace = printable_text[len(printable_text.rstrip()) :]
-                sentences = sent_tokenize(printable_text)
+                sentences = sent_tokenize_preserving_markdown_code(printable_text, sent_tokenize)
                 if len(sentences) > 1:
                     for s in sentences[:-1]:
                         sentence_batch.append(remove_markdown(s))

--- a/src/speech_to_speech/LLM/language_model.py
+++ b/src/speech_to_speech/LLM/language_model.py
@@ -44,7 +44,7 @@ from speech_to_speech.LLM.text_prompt import build_text_system_prompt
 from speech_to_speech.LLM.tool_call.function_call import extract_function_calls_from_text
 from speech_to_speech.LLM.tool_call.function_tool import FunctionTool
 from speech_to_speech.LLM.tool_call.tool_prompt import END_CODE, ENTER_CODE, build_block_regex, build_tool_system_prompt
-from speech_to_speech.LLM.utils import image_url_to_pil, remove_unspeechable, resolve_auto_language
+from speech_to_speech.LLM.utils import image_url_to_pil, remove_markdown, remove_unspeechable, resolve_auto_language
 from speech_to_speech.LLM.voice_prompt import build_voice_system_prompt
 from speech_to_speech.pipeline.cancel_scope import CancelScope
 from speech_to_speech.pipeline.handler_types import LLMIn, LLMOut
@@ -312,9 +312,10 @@ class BaseLanguageModelHandler(BaseHandler[LLMIn, LLMOut], ABC):
             idx = printable_text.index(ctx.enter_code)
             before = printable_text[:idx]
             code_and_after = printable_text[idx:]
+            wants_audio = response_wants_audio(response)
             if before.strip():
                 for s in sent_tokenize(before):
-                    ctx.sentence_batch.append(s)
+                    ctx.sentence_batch.append(remove_markdown(s) if wants_audio else s)
             if ctx.sentence_batch:
                 chunks.append(
                     LLMResponseChunk(
@@ -391,7 +392,7 @@ class BaseLanguageModelHandler(BaseHandler[LLMIn, LLMOut], ABC):
             sentences = sent_tokenize(printable_text)
             if len(sentences) > 1:
                 for s in sentences[:-1]:
-                    ctx.sentence_batch.append(s)
+                    ctx.sentence_batch.append(remove_markdown(s))
                     if len(ctx.sentence_batch) >= self.stream_batch_sentences:
                         chunks.append(
                             LLMResponseChunk(
@@ -473,7 +474,8 @@ class BaseLanguageModelHandler(BaseHandler[LLMIn, LLMOut], ABC):
 
         if ctx.sentence_batch and not ctx.interrupted:
             if ctx.printable_text.strip():
-                ctx.sentence_batch.append(ctx.printable_text.strip())
+                leftover = ctx.printable_text.strip()
+                ctx.sentence_batch.append(remove_markdown(leftover) if wants_audio else leftover)
                 ctx.printable_text = ""
             if not self._turn_output_allowed(ctx.turn_id, ctx.turn_revision):
                 ctx.cancelled = True
@@ -578,8 +580,9 @@ class BaseLanguageModelHandler(BaseHandler[LLMIn, LLMOut], ABC):
             logger.info(f"Tools: {ctx.tools}")
 
             if turn_output_allowed and ctx.printable_text.strip():
+                leftover = ctx.printable_text.strip()
                 yield LLMResponseChunk(
-                    text=ctx.printable_text.strip(),
+                    text=remove_markdown(leftover) if response_wants_audio(response) else leftover,
                     language_code=language_code,
                     runtime_config=runtime_config,
                     response=response,

--- a/src/speech_to_speech/LLM/language_model.py
+++ b/src/speech_to_speech/LLM/language_model.py
@@ -47,7 +47,13 @@ from speech_to_speech.LLM.text_prompt import build_text_system_prompt
 from speech_to_speech.LLM.tool_call.function_call import extract_function_calls_from_text
 from speech_to_speech.LLM.tool_call.function_tool import FunctionTool
 from speech_to_speech.LLM.tool_call.tool_prompt import END_CODE, ENTER_CODE, build_block_regex, build_tool_system_prompt
-from speech_to_speech.LLM.utils import image_url_to_pil, remove_markdown, remove_unspeechable, resolve_auto_language
+from speech_to_speech.LLM.utils import (
+    image_url_to_pil,
+    remove_markdown,
+    remove_unspeechable,
+    resolve_auto_language,
+    sent_tokenize_preserving_markdown_code,
+)
 from speech_to_speech.LLM.voice_prompt import build_voice_system_prompt
 from speech_to_speech.pipeline.cancel_scope import CancelScope
 from speech_to_speech.pipeline.handler_types import LLMIn, LLMOut
@@ -340,7 +346,7 @@ class BaseLanguageModelHandler(BaseHandler[LLMIn, LLMOut], ABC):
             if text_only and before:
                 chunks.append(text_chunk(before))
             elif before.strip():
-                for s in sent_tokenize(before):
+                for s in sent_tokenize_preserving_markdown_code(before, sent_tokenize):
                     ctx.sentence_batch.append(remove_markdown(s))
             if ctx.sentence_batch:
                 chunks.append(text_chunk(" ".join(ctx.sentence_batch)))
@@ -393,7 +399,7 @@ class BaseLanguageModelHandler(BaseHandler[LLMIn, LLMOut], ABC):
             return chunks, tools, pending_marker
 
         if printable_text:
-            sentences = sent_tokenize(printable_text)
+            sentences = sent_tokenize_preserving_markdown_code(printable_text, sent_tokenize)
             if len(sentences) > 1:
                 for s in sentences[:-1]:
                     ctx.sentence_batch.append(remove_markdown(s))

--- a/src/speech_to_speech/LLM/utils.py
+++ b/src/speech_to_speech/LLM/utils.py
@@ -20,32 +20,40 @@ SPEECHABLE_PATTERN = re.compile(
     flags=re.UNICODE,
 )
 
-MARKDOWN_PATTERN = re.compile(
-    r"\*\*(.*?)\*\*|__(.*?)__|\*(.*?)\*|_(.*?)_|`{1,3}(.*?)`{1,3}|^#{1,6}\s*|^[-*+]\s+",
-    flags=re.MULTILINE | re.DOTALL,
-)
+MARKDOWN_LINK_PATTERN = re.compile(r"\[([^\]\[]*)\]\([^)]*\)")
+MARKDOWN_HEADING_PATTERN = re.compile(r"^#{1,6}[ \t]*", flags=re.MULTILINE)
+MARKDOWN_BULLET_PATTERN = re.compile(r"^[-*+][ \t]+", flags=re.MULTILINE)
 
+# Must run before MARKDOWN_DELIMITER_PATTERN so the language tag is still identifiable.
+MARKDOWN_FENCE_PATTERN = re.compile(r"```[ \t]*[\w+#-]*[ \t]*\n?")
 
-def _markdown_replacement(match: "re.Match[str]") -> str:
-    for group in match.groups():
-        if group is not None:
-            return group
-    return ""
+# Touches non-space on at least one side -> delimiter; `2 * 3` (spaces both sides) survives.
+MARKDOWN_DELIMITER_PATTERN = re.compile(r"(?<=\S)[*`]{1,3}|[*`]{1,3}(?=\S)")
 
 
 def remove_markdown(text: str) -> str:
-    """Strip common Markdown syntax (bold, italic, headings, code, bullets),
-    keeping only the enclosed text so TTS doesn't read out symbols like '**'.
+    """Strip Markdown syntax so TTS doesn't read out symbols like '**' or a raw URL.
+
+    Must run on complete text, not per-token deltas: a delimiter run can arrive
+    split across two streaming chunks.
     """
-    return MARKDOWN_PATTERN.sub(_markdown_replacement, text)
+    text = MARKDOWN_LINK_PATTERN.sub(r"\1", text)
+    text = MARKDOWN_HEADING_PATTERN.sub("", text)
+    text = MARKDOWN_BULLET_PATTERN.sub("", text)
+    text = MARKDOWN_FENCE_PATTERN.sub("", text)
+    text = MARKDOWN_DELIMITER_PATTERN.sub("", text)
+    return text
 
 
 def remove_unspeechable(text: str) -> str:
     """Keep only speechable characters: letters, digits, punctuation, whitespace.
     support unicode characters (english, arabic, chinese, japanese, korean, etc.)
+
+    Safe to call per streaming delta. Markdown stripping is intentionally not
+    included here -- unlike character filtering, it needs complete text (see
+    remove_markdown), so callers apply it separately once a full sentence exists.
     """
     text = text.translate(SMART_PUNCT_TRANSLATION)
-    text = remove_markdown(text)
     return SPEECHABLE_PATTERN.sub("", text)
 
 

--- a/src/speech_to_speech/LLM/utils.py
+++ b/src/speech_to_speech/LLM/utils.py
@@ -20,12 +20,32 @@ SPEECHABLE_PATTERN = re.compile(
     flags=re.UNICODE,
 )
 
+MARKDOWN_PATTERN = re.compile(
+    r"\*\*(.*?)\*\*|__(.*?)__|\*(.*?)\*|_(.*?)_|`{1,3}(.*?)`{1,3}|^#{1,6}\s*|^[-*+]\s+",
+    flags=re.MULTILINE | re.DOTALL,
+)
+
+
+def _markdown_replacement(match: "re.Match[str]") -> str:
+    for group in match.groups():
+        if group is not None:
+            return group
+    return ""
+
+
+def remove_markdown(text: str) -> str:
+    """Strip common Markdown syntax (bold, italic, headings, code, bullets),
+    keeping only the enclosed text so TTS doesn't read out symbols like '**'.
+    """
+    return MARKDOWN_PATTERN.sub(_markdown_replacement, text)
+
 
 def remove_unspeechable(text: str) -> str:
     """Keep only speechable characters: letters, digits, punctuation, whitespace.
     support unicode characters (english, arabic, chinese, japanese, korean, etc.)
     """
     text = text.translate(SMART_PUNCT_TRANSLATION)
+    text = remove_markdown(text)
     return SPEECHABLE_PATTERN.sub("", text)
 
 

--- a/src/speech_to_speech/LLM/utils.py
+++ b/src/speech_to_speech/LLM/utils.py
@@ -23,6 +23,14 @@ SPEECHABLE_PATTERN = re.compile(
 MARKDOWN_HEADING_PATTERN = re.compile(r"^[ \t]{0,3}#{1,6}(?:[ \t]+|$)", flags=re.MULTILINE)
 MARKDOWN_BULLET_PATTERN = re.compile(r"^[ \t]{0,3}[-*+][ \t]+", flags=re.MULTILINE)
 
+# Protect complete code bodies while prose-only Markdown passes run. Fenced
+# blocks are handled first so their backticks are not mistaken for inline code.
+MARKDOWN_FENCED_CODE_PATTERN = re.compile(
+    r"^[ \t]{0,3}`{3,}[^\r\n]*\r?\n(?P<body>.*?)(?:^[ \t]{0,3}`{3,}[ \t]*$)",
+    flags=re.MULTILINE | re.DOTALL,
+)
+MARKDOWN_INLINE_CODE_PATTERN = re.compile(r"(?P<ticks>`{1,})(?P<body>[^\n]*?)(?P=ticks)")
+
 # A word after an opening fence is a language tag only when the fence line ends.
 # Requiring the newline preserves same-line code spans such as ```code```.
 MARKDOWN_FENCE_OPEN_PATTERN = re.compile(
@@ -31,8 +39,11 @@ MARKDOWN_FENCE_OPEN_PATTERN = re.compile(
 )
 MARKDOWN_FENCE_CLOSE_PATTERN = re.compile(r"^[ \t]{0,3}`{3,}[ \t]*$", flags=re.MULTILINE)
 
-# Markdown emphasis uses boundary delimiters. Keeping runs surrounded by word
-# characters preserves compact arithmetic and identifiers such as `2*3`.
+# Matched star pairs may directly adjoin CJK or other word characters. The
+# fallback delimiter pass still requires boundaries, preserving unmatched
+# compact operators such as `2*3` and `5**2`.
+MARKDOWN_DOUBLE_STAR_PAIR_PATTERN = re.compile(r"(?<!\*)\*\*(?!\*)(?P<body>[^\s*](?:[^\n]*?[^\s*])?)\*\*(?!\*)")
+MARKDOWN_SINGLE_STAR_PAIR_PATTERN = re.compile(r"(?<!\*)\*(?!\*)(?P<body>[^\s*](?:[^\n]*?[^\s*])?)\*(?!\*)")
 MARKDOWN_STAR_DELIMITER_PATTERN = re.compile(r"(?<![\w*])\*{1,3}(?=\S)|(?<=\S)\*{1,3}(?![\w*])")
 MARKDOWN_UNDERSCORE_DELIMITER_PATTERN = re.compile(r"(?<!\w)_{1,2}(?=\S)|(?<=\S)_{1,2}(?!\w)")
 MARKDOWN_BACKTICK_DELIMITER_PATTERN = re.compile(r"(?<=\S)`{1,3}|`{1,3}(?=\S)")
@@ -44,13 +55,26 @@ def remove_markdown(text: str) -> str:
     Must run on complete text, not per-token deltas: a delimiter run can arrive
     split across two streaming chunks.
     """
+    protected_code: list[str] = []
+
+    def protect_code(match: re.Match[str]) -> str:
+        token = f"\x00markdown-code-{len(protected_code)}\x00"
+        protected_code.append(match.group("body"))
+        return token
+
+    text = MARKDOWN_FENCED_CODE_PATTERN.sub(protect_code, text)
+    text = MARKDOWN_INLINE_CODE_PATTERN.sub(protect_code, text)
     text = MARKDOWN_HEADING_PATTERN.sub("", text)
     text = MARKDOWN_BULLET_PATTERN.sub("", text)
     text = MARKDOWN_FENCE_OPEN_PATTERN.sub("", text)
     text = MARKDOWN_FENCE_CLOSE_PATTERN.sub("", text)
+    text = MARKDOWN_DOUBLE_STAR_PAIR_PATTERN.sub(r"\g<body>", text)
+    text = MARKDOWN_SINGLE_STAR_PAIR_PATTERN.sub(r"\g<body>", text)
     text = MARKDOWN_STAR_DELIMITER_PATTERN.sub("", text)
     text = MARKDOWN_UNDERSCORE_DELIMITER_PATTERN.sub("", text)
     text = MARKDOWN_BACKTICK_DELIMITER_PATTERN.sub("", text)
+    for index, code_body in enumerate(protected_code):
+        text = text.replace(f"\x00markdown-code-{index}\x00", code_body)
     return text
 
 

--- a/src/speech_to_speech/LLM/utils.py
+++ b/src/speech_to_speech/LLM/utils.py
@@ -1,6 +1,7 @@
 import base64
 import io
 import re
+from collections.abc import Callable
 from typing import Optional
 
 import requests  # type: ignore[import-untyped]
@@ -30,6 +31,10 @@ MARKDOWN_FENCED_CODE_PATTERN = re.compile(
     flags=re.MULTILINE | re.DOTALL,
 )
 MARKDOWN_INLINE_CODE_PATTERN = re.compile(r"(?P<ticks>`{1,})(?P<body>[^\n]*?)(?P=ticks)")
+MARKDOWN_FENCE_LINE_PATTERN = re.compile(
+    r"^[ \t]{0,3}(?P<ticks>`{3,})(?P<rest>[^\r\n]*)$",
+    flags=re.MULTILINE,
+)
 
 # A word after an opening fence is a language tag only when the fence line ends.
 # Requiring the newline preserves same-line code spans such as ```code```.
@@ -42,11 +47,56 @@ MARKDOWN_FENCE_CLOSE_PATTERN = re.compile(r"^[ \t]{0,3}`{3,}[ \t]*$", flags=re.M
 # Matched star pairs may directly adjoin CJK or other word characters. The
 # fallback delimiter pass still requires boundaries, preserving unmatched
 # compact operators such as `2*3` and `5**2`.
-MARKDOWN_DOUBLE_STAR_PAIR_PATTERN = re.compile(r"(?<!\*)\*\*(?!\*)(?P<body>[^\s*](?:[^\n]*?[^\s*])?)\*\*(?!\*)")
-MARKDOWN_SINGLE_STAR_PAIR_PATTERN = re.compile(r"(?<!\*)\*(?!\*)(?P<body>[^\s*](?:[^\n]*?[^\s*])?)\*(?!\*)")
+MARKDOWN_DOUBLE_STAR_PAIR_PATTERN = re.compile(r"(?<!\*)\*\*(?!\*)(?P<body>[^\W\d_]+)\*\*(?!\*)")
+MARKDOWN_SINGLE_STAR_PAIR_PATTERN = re.compile(r"(?<!\*)\*(?!\*)(?P<body>[^\W\d_]+)\*(?!\*)")
 MARKDOWN_STAR_DELIMITER_PATTERN = re.compile(r"(?<![\w*])\*{1,3}(?=\S)|(?<=\S)\*{1,3}(?![\w*])")
 MARKDOWN_UNDERSCORE_DELIMITER_PATTERN = re.compile(r"(?<!\w)_{1,2}(?=\S)|(?<=\S)_{1,2}(?!\w)")
 MARKDOWN_BACKTICK_DELIMITER_PATTERN = re.compile(r"(?<=\S)`{1,3}|`{1,3}(?=\S)")
+
+
+def _protect_markdown_code(text: str, *, keep_delimiters: bool) -> tuple[str, list[str]]:
+    protected_code: list[str] = []
+
+    def protect_code(match: re.Match[str]) -> str:
+        token = f"\x00markdown-code-{len(protected_code)}\x00"
+        protected_code.append(match.group(0) if keep_delimiters else match.group("body"))
+        return token
+
+    text = MARKDOWN_FENCED_CODE_PATTERN.sub(protect_code, text)
+    text = MARKDOWN_INLINE_CODE_PATTERN.sub(protect_code, text)
+    return text, protected_code
+
+
+def _restore_markdown_code(text: str, protected_code: list[str]) -> str:
+    for index, code_body in enumerate(protected_code):
+        text = text.replace(f"\x00markdown-code-{index}\x00", code_body)
+    return text
+
+
+def _has_unclosed_markdown_fence(text: str) -> bool:
+    opening_ticks: int | None = None
+    for match in MARKDOWN_FENCE_LINE_PATTERN.finditer(text):
+        ticks = len(match.group("ticks"))
+        rest = match.group("rest")
+        if opening_ticks is None:
+            # Backticks later on the same line make this an inline code span,
+            # such as the issue's ```code``` example, rather than a fence.
+            if "`" not in rest:
+                opening_ticks = ticks
+        elif ticks >= opening_ticks and not rest.strip():
+            opening_ticks = None
+    return opening_ticks is not None
+
+
+def sent_tokenize_preserving_markdown_code(
+    text: str,
+    tokenizer: Callable[[str], list[str]],
+) -> list[str]:
+    """Tokenize prose without splitting or prematurely cleaning code blocks."""
+    if _has_unclosed_markdown_fence(text):
+        return [text]
+    protected_text, protected_code = _protect_markdown_code(text, keep_delimiters=True)
+    return [_restore_markdown_code(sentence, protected_code) for sentence in tokenizer(protected_text)]
 
 
 def remove_markdown(text: str) -> str:
@@ -55,27 +105,26 @@ def remove_markdown(text: str) -> str:
     Must run on complete text, not per-token deltas: a delimiter run can arrive
     split across two streaming chunks.
     """
-    protected_code: list[str] = []
-
-    def protect_code(match: re.Match[str]) -> str:
-        token = f"\x00markdown-code-{len(protected_code)}\x00"
-        protected_code.append(match.group("body"))
-        return token
-
-    text = MARKDOWN_FENCED_CODE_PATTERN.sub(protect_code, text)
-    text = MARKDOWN_INLINE_CODE_PATTERN.sub(protect_code, text)
+    text, protected_code = _protect_markdown_code(text, keep_delimiters=False)
     text = MARKDOWN_HEADING_PATTERN.sub("", text)
     text = MARKDOWN_BULLET_PATTERN.sub("", text)
     text = MARKDOWN_FENCE_OPEN_PATTERN.sub("", text)
     text = MARKDOWN_FENCE_CLOSE_PATTERN.sub("", text)
-    text = MARKDOWN_DOUBLE_STAR_PAIR_PATTERN.sub(r"\g<body>", text)
-    text = MARKDOWN_SINGLE_STAR_PAIR_PATTERN.sub(r"\g<body>", text)
+
+    def strip_adjacent_star_pair(match: re.Match[str]) -> str:
+        body = match.group("body")
+        before = re.search(r"[A-Za-z]+$", match.string[: match.start()])
+        after = re.match(r"[A-Za-z]+", match.string[match.end() :])
+        if before and after and len(before.group()) == len(body) == len(after.group()) == 1:
+            return match.group(0)
+        return body
+
+    text = MARKDOWN_DOUBLE_STAR_PAIR_PATTERN.sub(strip_adjacent_star_pair, text)
+    text = MARKDOWN_SINGLE_STAR_PAIR_PATTERN.sub(strip_adjacent_star_pair, text)
     text = MARKDOWN_STAR_DELIMITER_PATTERN.sub("", text)
     text = MARKDOWN_UNDERSCORE_DELIMITER_PATTERN.sub("", text)
     text = MARKDOWN_BACKTICK_DELIMITER_PATTERN.sub("", text)
-    for index, code_body in enumerate(protected_code):
-        text = text.replace(f"\x00markdown-code-{index}\x00", code_body)
-    return text
+    return _restore_markdown_code(text, protected_code)
 
 
 def remove_unspeechable(text: str) -> str:

--- a/src/speech_to_speech/LLM/utils.py
+++ b/src/speech_to_speech/LLM/utils.py
@@ -36,22 +36,16 @@ MARKDOWN_FENCE_LINE_PATTERN = re.compile(
     flags=re.MULTILINE,
 )
 
-# A word after an opening fence is a language tag only when the fence line ends.
-# Requiring the newline preserves same-line code spans such as ```code```.
-MARKDOWN_FENCE_OPEN_PATTERN = re.compile(
-    r"^[ \t]{0,3}`{3,}[ \t]*[\w+#-]*[ \t]*\r?\n",
-    flags=re.MULTILINE,
+# Emphasis is removed only when the same delimiter run opens and closes it.
+# The boundary form covers ordinary Markdown prose. Intraword stars are kept
+# for ASCII identifiers/operators, with a narrow exception for CJK and other
+# non-ASCII scripts where adjoining emphasis is common.
+MARKDOWN_BOUNDARY_EMPHASIS_PATTERN = re.compile(
+    r"(?<![\w*_])(?P<delimiter>\*{1,3}|_{1,2})(?![*_])"
+    r"(?P<body>\S(?:[^\n]*?\S)?)(?P=delimiter)(?![\w*_])"
 )
-MARKDOWN_FENCE_CLOSE_PATTERN = re.compile(r"^[ \t]{0,3}`{3,}[ \t]*$", flags=re.MULTILINE)
-
-# Matched star pairs may directly adjoin CJK or other word characters. The
-# fallback delimiter pass still requires boundaries, preserving unmatched
-# compact operators such as `2*3` and `5**2`.
-MARKDOWN_DOUBLE_STAR_PAIR_PATTERN = re.compile(r"(?<!\*)\*\*(?!\*)(?P<body>[^\W\d_]+)\*\*(?!\*)")
-MARKDOWN_SINGLE_STAR_PAIR_PATTERN = re.compile(r"(?<!\*)\*(?!\*)(?P<body>[^\W\d_]+)\*(?!\*)")
-MARKDOWN_STAR_DELIMITER_PATTERN = re.compile(r"(?<![\w*])\*{1,3}(?=\S)|(?<=\S)\*{1,3}(?![\w*])")
-MARKDOWN_UNDERSCORE_DELIMITER_PATTERN = re.compile(r"(?<!\w)_{1,2}(?=\S)|(?<=\S)_{1,2}(?!\w)")
-MARKDOWN_BACKTICK_DELIMITER_PATTERN = re.compile(r"(?<=\S)`{1,3}|`{1,3}(?=\S)")
+MARKDOWN_INTRAWORD_DOUBLE_STAR_PATTERN = re.compile(r"(?<=[^\W\d_])\*\*(?P<body>[^\W\d_]+)\*\*(?=[^\W\d_])")
+MARKDOWN_INTRAWORD_SINGLE_STAR_PATTERN = re.compile(r"(?<=[^\W\d_])\*(?P<body>[^\W\d_]+)\*(?=[^\W\d_])")
 
 
 def _protect_markdown_code(text: str, *, keep_delimiters: bool) -> tuple[str, list[str]]:
@@ -70,6 +64,24 @@ def _protect_markdown_code(text: str, *, keep_delimiters: bool) -> tuple[str, li
 def _restore_markdown_code(text: str, protected_code: list[str]) -> str:
     for index, code_body in enumerate(protected_code):
         text = text.replace(f"\x00markdown-code-{index}\x00", code_body)
+    return text
+
+
+def _protect_matched_emphasis(text: str) -> tuple[str, list[str]]:
+    protected_emphasis: list[str] = []
+
+    def protect_emphasis(match: re.Match[str]) -> str:
+        token = f"\x00markdown-emphasis-{len(protected_emphasis)}\x00"
+        protected_emphasis.append(match.group(0))
+        return token
+
+    text = MARKDOWN_BOUNDARY_EMPHASIS_PATTERN.sub(protect_emphasis, text)
+    return text, protected_emphasis
+
+
+def _restore_matched_emphasis(text: str, protected_emphasis: list[str]) -> str:
+    for index, emphasis in enumerate(protected_emphasis):
+        text = text.replace(f"\x00markdown-emphasis-{index}\x00", emphasis)
     return text
 
 
@@ -92,11 +104,15 @@ def sent_tokenize_preserving_markdown_code(
     text: str,
     tokenizer: Callable[[str], list[str]],
 ) -> list[str]:
-    """Tokenize prose without splitting or prematurely cleaning code blocks."""
+    """Tokenize prose without splitting complete Markdown constructs."""
     if _has_unclosed_markdown_fence(text):
         return [text]
     protected_text, protected_code = _protect_markdown_code(text, keep_delimiters=True)
-    return [_restore_markdown_code(sentence, protected_code) for sentence in tokenizer(protected_text)]
+    protected_text, protected_emphasis = _protect_matched_emphasis(protected_text)
+    return [
+        _restore_markdown_code(_restore_matched_emphasis(sentence, protected_emphasis), protected_code)
+        for sentence in tokenizer(protected_text)
+    ]
 
 
 def remove_markdown(text: str) -> str:
@@ -108,22 +124,18 @@ def remove_markdown(text: str) -> str:
     text, protected_code = _protect_markdown_code(text, keep_delimiters=False)
     text = MARKDOWN_HEADING_PATTERN.sub("", text)
     text = MARKDOWN_BULLET_PATTERN.sub("", text)
-    text = MARKDOWN_FENCE_OPEN_PATTERN.sub("", text)
-    text = MARKDOWN_FENCE_CLOSE_PATTERN.sub("", text)
+    text = MARKDOWN_BOUNDARY_EMPHASIS_PATTERN.sub(r"\g<body>", text)
 
-    def strip_adjacent_star_pair(match: re.Match[str]) -> str:
+    def strip_non_ascii_intraword_emphasis(match: re.Match[str]) -> str:
+        before = match.string[match.start() - 1]
+        after = match.string[match.end()]
         body = match.group("body")
-        before = re.search(r"[A-Za-z]+$", match.string[: match.start()])
-        after = re.match(r"[A-Za-z]+", match.string[match.end() :])
-        if before and after and len(before.group()) == len(body) == len(after.group()) == 1:
-            return match.group(0)
-        return body
+        if not (before.isascii() and body.isascii() and after.isascii()):
+            return body
+        return match.group(0)
 
-    text = MARKDOWN_DOUBLE_STAR_PAIR_PATTERN.sub(strip_adjacent_star_pair, text)
-    text = MARKDOWN_SINGLE_STAR_PAIR_PATTERN.sub(strip_adjacent_star_pair, text)
-    text = MARKDOWN_STAR_DELIMITER_PATTERN.sub("", text)
-    text = MARKDOWN_UNDERSCORE_DELIMITER_PATTERN.sub("", text)
-    text = MARKDOWN_BACKTICK_DELIMITER_PATTERN.sub("", text)
+    text = MARKDOWN_INTRAWORD_DOUBLE_STAR_PATTERN.sub(strip_non_ascii_intraword_emphasis, text)
+    text = MARKDOWN_INTRAWORD_SINGLE_STAR_PATTERN.sub(strip_non_ascii_intraword_emphasis, text)
     return _restore_markdown_code(text, protected_code)
 
 

--- a/src/speech_to_speech/LLM/utils.py
+++ b/src/speech_to_speech/LLM/utils.py
@@ -36,16 +36,12 @@ MARKDOWN_FENCE_LINE_PATTERN = re.compile(
     flags=re.MULTILINE,
 )
 
-# Emphasis is removed only when the same delimiter run opens and closes it.
-# The boundary form covers ordinary Markdown prose. Intraword stars are kept
-# for ASCII identifiers/operators, with a narrow exception for CJK and other
-# non-ASCII scripts where adjoining emphasis is common.
+# Emphasis is removed only when the same delimiter run opens and closes it at
+# conservative word boundaries. Intraword stars are preserved as operators.
 MARKDOWN_BOUNDARY_EMPHASIS_PATTERN = re.compile(
     r"(?<![\w*_])(?P<delimiter>\*{1,3}|_{1,2})(?![*_])"
     r"(?P<body>\S(?:[^\n]*?\S)?)(?P=delimiter)(?![\w*_])"
 )
-MARKDOWN_INTRAWORD_DOUBLE_STAR_PATTERN = re.compile(r"(?<=[^\W\d_])\*\*(?P<body>[^\W\d_]+)\*\*(?=[^\W\d_])")
-MARKDOWN_INTRAWORD_SINGLE_STAR_PATTERN = re.compile(r"(?<=[^\W\d_])\*(?P<body>[^\W\d_]+)\*(?=[^\W\d_])")
 
 
 def _protect_markdown_code(text: str, *, keep_delimiters: bool) -> tuple[str, list[str]]:
@@ -125,17 +121,6 @@ def remove_markdown(text: str) -> str:
     text = MARKDOWN_HEADING_PATTERN.sub("", text)
     text = MARKDOWN_BULLET_PATTERN.sub("", text)
     text = MARKDOWN_BOUNDARY_EMPHASIS_PATTERN.sub(r"\g<body>", text)
-
-    def strip_non_ascii_intraword_emphasis(match: re.Match[str]) -> str:
-        before = match.string[match.start() - 1]
-        after = match.string[match.end()]
-        body = match.group("body")
-        if not (before.isascii() and body.isascii() and after.isascii()):
-            return body
-        return match.group(0)
-
-    text = MARKDOWN_INTRAWORD_DOUBLE_STAR_PATTERN.sub(strip_non_ascii_intraword_emphasis, text)
-    text = MARKDOWN_INTRAWORD_SINGLE_STAR_PATTERN.sub(strip_non_ascii_intraword_emphasis, text)
     return _restore_markdown_code(text, protected_code)
 
 

--- a/tests/test_chat_completions_backend.py
+++ b/tests/test_chat_completions_backend.py
@@ -276,6 +276,38 @@ def test_streaming_text_and_usage():
     assert any(getattr(i, "role", None) == "assistant" for i in chat.buffer)
 
 
+def test_streaming_strips_markdown_delimiters_split_across_deltas():
+    """A '*' pair can arrive split across two token deltas (e.g. '*ita' / 'lic*').
+    remove_markdown must not run per-delta -- it has to see the reassembled
+    sentence, or the delimiters leak straight to TTS."""
+    h = _make_handler(stream=True)
+    h.client.chat.completions.create = lambda **k: _FakeStream(
+        [
+            _chunk(content="This is *ita"),
+            _chunk(content="lic* text. "),
+            _chunk(content="Second sentence."),
+            _chunk(usage=SimpleNamespace(prompt_tokens=1, completion_tokens=1)),
+        ]
+    )
+    text, _tools, _usage, _chat, _end = _drive(h)
+    assert "*" not in text
+    assert "This is italic text." in text
+    assert "Second sentence." in text
+
+
+def test_streaming_strips_markdown_link_to_visible_text():
+    h = _make_handler(stream=True)
+    h.client.chat.completions.create = lambda **k: _FakeStream(
+        [
+            _chunk(content="See the [docs](https://example.com/en/x) "),
+            _chunk(content="for more."),
+            _chunk(usage=SimpleNamespace(prompt_tokens=1, completion_tokens=1)),
+        ]
+    )
+    text, _tools, _usage, _chat, _end = _drive(h)
+    assert text.strip() == "See the docs for more."
+
+
 def test_streaming_tool_call_accumulates_arguments():
     h = _make_handler(stream=True)
     # Arguments arrive split across deltas, as real servers stream them.

--- a/tests/test_chat_completions_backend.py
+++ b/tests/test_chat_completions_backend.py
@@ -434,6 +434,28 @@ def test_streaming_strips_adjacent_cjk_emphasis_split_across_deltas():
     assert tools == []
 
 
+def test_streaming_preserves_fenced_code_body_until_closing_fence():
+    h = _make_handler(stream=True)
+    h.client.chat.completions.create = lambda **k: _FakeStream(
+        [
+            _chunk(content="```python\n"),
+            _chunk(content="def f(*args, **kwargs):\n"),
+            _chunk(content="    return 1.\n"),
+            _chunk(content="```\nDone."),
+            _chunk(usage=SimpleNamespace(prompt_tokens=1, completion_tokens=1)),
+        ]
+    )
+
+    text, tools, _usage, _chat, _end = _drive(h)
+
+    assert "```" not in text
+    assert "python" not in text
+    assert "def f(*args, **kwargs):" in text
+    assert "return 1." in text
+    assert "Done." in text
+    assert tools == []
+
+
 def test_streaming_tool_call_accumulates_arguments():
     h = _make_handler(stream=True)
     # Arguments arrive split across deltas, as real servers stream them.

--- a/tests/test_chat_completions_backend.py
+++ b/tests/test_chat_completions_backend.py
@@ -423,21 +423,22 @@ def test_streaming_tool_call_accumulates_arguments():
     # Arguments arrive split across deltas, as real servers stream them.
     h.client.chat.completions.create = lambda **k: _FakeStream(
         [
-            _chunk(tool_calls=[_tc_delta(0, id="srv_1", name="move_head", arguments='{"direction"')]),
-            _chunk(tool_calls=[_tc_delta(0, arguments=': "left"}')]),
+            _chunk(tool_calls=[_tc_delta(0, id="srv_1", name="search_docs", arguments='{"query": "**bo')]),
+            _chunk(tool_calls=[_tc_delta(0, arguments='ld** _italic_ x*y"}')]),
             _chunk(usage=SimpleNamespace(prompt_tokens=20, completion_tokens=8)),
         ]
     )
     text, tools, usage, chat, _end = _drive(
         h,
-        tools=[{"type": "function", "name": "move_head", "parameters": {"type": "object"}}],
+        tools=[{"type": "function", "name": "search_docs", "parameters": {"type": "object"}}],
         tool_choice="required",
     )
     assert len(tools) == 1
     tc = tools[0]
     assert isinstance(tc, ResponseFunctionToolCall)
-    assert tc.name == "move_head"
-    assert json.loads(tc.arguments) == {"direction": "left"}  # reassembled from two deltas
+    assert tc.name == "search_docs"
+    # Markdown cleanup only applies to spoken text, never structured tool arguments.
+    assert json.loads(tc.arguments) == {"query": "**bold** _italic_ x*y"}
     assert usage == (20, 8)
     # the function_call was stored in history with a freshly minted call_id
     assert chat._pending_tool_calls, "tool call should be recorded in chat history"
@@ -633,11 +634,13 @@ def test_non_streaming_tool_call():
         choices=[
             SimpleNamespace(
                 message=SimpleNamespace(
-                    content="",
+                    content="**Checking.**",
                     tool_calls=[
                         SimpleNamespace(
                             id="srv_9",
-                            function=SimpleNamespace(name="move_head", arguments='{"direction": "right"}'),
+                            function=SimpleNamespace(
+                                name="search_docs", arguments='{"query": "**bold** _italic_ x*y"}'
+                            ),
                         )
                     ],
                 )
@@ -647,11 +650,12 @@ def test_non_streaming_tool_call():
     )
     text, tools, usage, chat, _end = _drive(
         h,
-        tools=[{"type": "function", "name": "move_head", "parameters": {"type": "object"}}],
+        tools=[{"type": "function", "name": "search_docs", "parameters": {"type": "object"}}],
         tool_choice="required",
     )
-    assert len(tools) == 1 and tools[0].name == "move_head"
-    assert json.loads(tools[0].arguments) == {"direction": "right"}
+    assert text == "Checking."
+    assert len(tools) == 1 and tools[0].name == "search_docs"
+    assert json.loads(tools[0].arguments) == {"query": "**bold** _italic_ x*y"}
     assert usage == (7, 3)
 
 

--- a/tests/test_chat_completions_backend.py
+++ b/tests/test_chat_completions_backend.py
@@ -418,22 +418,6 @@ def test_streaming_strips_markdown_delimiters_split_across_deltas():
     assert "Second sentence." in text
 
 
-def test_streaming_strips_adjacent_cjk_emphasis_split_across_deltas():
-    h = _make_handler(stream=True)
-    h.client.chat.completions.create = lambda **k: _FakeStream(
-        [
-            _chunk(content="这是**重"),
-            _chunk(content="点**内容。"),
-            _chunk(usage=SimpleNamespace(prompt_tokens=1, completion_tokens=1)),
-        ]
-    )
-
-    text, tools, _usage, _chat, _end = _drive(h)
-
-    assert text == "这是重点内容。"
-    assert tools == []
-
-
 def test_streaming_preserves_fenced_code_body_until_closing_fence():
     h = _make_handler(stream=True)
     h.client.chat.completions.create = lambda **k: _FakeStream(

--- a/tests/test_chat_completions_backend.py
+++ b/tests/test_chat_completions_backend.py
@@ -418,6 +418,22 @@ def test_streaming_strips_markdown_delimiters_split_across_deltas():
     assert "Second sentence." in text
 
 
+def test_streaming_strips_adjacent_cjk_emphasis_split_across_deltas():
+    h = _make_handler(stream=True)
+    h.client.chat.completions.create = lambda **k: _FakeStream(
+        [
+            _chunk(content="这是**重"),
+            _chunk(content="点**内容。"),
+            _chunk(usage=SimpleNamespace(prompt_tokens=1, completion_tokens=1)),
+        ]
+    )
+
+    text, tools, _usage, _chat, _end = _drive(h)
+
+    assert text == "这是重点内容。"
+    assert tools == []
+
+
 def test_streaming_tool_call_accumulates_arguments():
     h = _make_handler(stream=True)
     # Arguments arrive split across deltas, as real servers stream them.

--- a/tests/test_llm_utils.py
+++ b/tests/test_llm_utils.py
@@ -1,4 +1,4 @@
-from speech_to_speech.LLM.utils import remove_unspeechable
+from speech_to_speech.LLM.utils import remove_markdown, remove_unspeechable
 
 
 def test_remove_unspeechable_normalizes_smart_apostrophes() -> None:
@@ -7,3 +7,60 @@ def test_remove_unspeechable_normalizes_smart_apostrophes() -> None:
 
 def test_remove_unspeechable_keeps_text_and_drops_emoji() -> None:
     assert remove_unspeechable("Hello 👋 lobster 🦞") == "Hello  lobster "
+
+
+def test_remove_markdown_strips_bold_and_italic() -> None:
+    assert remove_markdown("**bold** and *italic* text") == "bold and italic text"
+
+
+def test_remove_markdown_keeps_snake_case_identifiers() -> None:
+    assert remove_markdown("function_call_output") == "function_call_output"
+
+
+def test_remove_markdown_strips_bullets_without_eating_following_lines() -> None:
+    assert remove_markdown("* first\n* second\n* third") == "first\nsecond\nthird"
+    assert remove_markdown("- one\n- two") == "one\ntwo"
+
+
+def test_remove_markdown_strips_headings() -> None:
+    assert remove_markdown("# Title\nsome text") == "Title\nsome text"
+    assert remove_markdown("### Subheading") == "Subheading"
+
+
+def test_remove_markdown_does_not_eat_multiplication() -> None:
+    assert remove_markdown("2 * 3 * 4") == "2 * 3 * 4"
+
+
+def test_remove_markdown_strips_delimiter_glued_to_punctuation() -> None:
+    """A closing '**' butted against punctuation, not a space, still leaked
+    before: `(?!\\s)` only checked for a following space, not for a following
+    non-word character in general."""
+    assert remove_markdown("Do you mean snake case**?") == "Do you mean snake case?"
+    assert remove_markdown("a theme/topic**.") == "a theme/topic."
+
+
+def test_remove_markdown_strips_nested_bold_and_code() -> None:
+    assert remove_markdown("**bold with `code`**") == "bold with code"
+
+
+def test_remove_markdown_strips_inline_code() -> None:
+    assert remove_markdown("`inline`") == "inline"
+
+
+def test_remove_markdown_strips_fenced_code_block_and_language_tag() -> None:
+    assert remove_markdown("```python\nname = 'Alice'\n```") == "name = 'Alice'\n"
+    assert remove_markdown("```\ncode\n```") == "code\n"
+
+
+def test_remove_markdown_rewrites_links_to_visible_text_only() -> None:
+    assert remove_markdown("Check the [docs](https://example.com/en/x) for details.") == "Check the docs for details."
+    assert remove_markdown("[text](url)") == "text"
+
+
+def test_remove_markdown_is_streaming_safe_across_split_deltas() -> None:
+    """remove_markdown must be applied to complete text, not per-delta: a
+    delimiter pair split across two deltas (*ita / lic*) has nothing to match
+    on its own, so callers accumulate first and strip once, as tested here."""
+    deltas = ["*ita", "lic* is a word."]
+    accumulated = "".join(deltas)
+    assert remove_markdown(accumulated) == "italic is a word."

--- a/tests/test_llm_utils.py
+++ b/tests/test_llm_utils.py
@@ -154,6 +154,14 @@ def test_remove_markdown_does_not_eat_multiplication() -> None:
     assert remove_markdown("5**2 = 25") == "5**2 = 25"
 
 
+def test_remove_markdown_does_not_pair_independent_compact_operators() -> None:
+    assert remove_markdown("2*3 + 4*5") == "2*3 + 4*5"
+    assert remove_markdown("5**2 + 3**4") == "5**2 + 3**4"
+    assert remove_markdown("x*y and a*b") == "x*y and a*b"
+    assert remove_markdown("x*y*z") == "x*y*z"
+    assert remove_markdown("x**y**z") == "x**y**z"
+
+
 def test_remove_markdown_strips_delimiter_glued_to_punctuation() -> None:
     """A closing '**' butted against punctuation, not a space, still leaked
     before: `(?!\\s)` only checked for a following space, not for a following

--- a/tests/test_llm_utils.py
+++ b/tests/test_llm_utils.py
@@ -1,12 +1,14 @@
 import importlib
 
 import pytest
+from nltk import sent_tokenize
 
 from speech_to_speech.LLM.utils import (
     WHISPER_LANGUAGE_TO_LLM_LANGUAGE,
     remove_markdown,
     remove_unspeechable,
     resolve_auto_language,
+    sent_tokenize_preserving_markdown_code,
 )
 
 
@@ -127,9 +129,7 @@ def test_remove_markdown_strips_bold_and_italic() -> None:
 def test_remove_markdown_strips_emphasis_adjacent_to_word_characters() -> None:
     assert remove_markdown("这是**重点**内容。") == "这是重点内容。"
     assert remove_markdown("これは**重要**です。") == "これは重要です。"
-    assert remove_markdown("foo**bar**baz") == "foobarbaz"
     assert remove_markdown("这是*重点*内容。") == "这是重点内容。"
-    assert remove_markdown("foo*bar*baz") == "foobarbaz"
 
 
 def test_remove_markdown_keeps_snake_case_identifiers() -> None:
@@ -162,12 +162,15 @@ def test_remove_markdown_does_not_pair_independent_compact_operators() -> None:
     assert remove_markdown("x**y**z") == "x**y**z"
 
 
-def test_remove_markdown_strips_delimiter_glued_to_punctuation() -> None:
-    """A closing '**' butted against punctuation, not a space, still leaked
-    before: `(?!\\s)` only checked for a following space, not for a following
-    non-word character in general."""
-    assert remove_markdown("Do you mean snake case**?") == "Do you mean snake case?"
-    assert remove_markdown("a theme/topic**.") == "a theme/topic."
+def test_remove_markdown_preserves_unmatched_delimiters_and_operators() -> None:
+    assert remove_markdown("*args") == "*args"
+    assert remove_markdown("**kwargs") == "**kwargs"
+    assert remove_markdown("_private") == "_private"
+    assert remove_markdown("file*.txt") == "file*.txt"
+    assert remove_markdown("Price is $5* tax.") == "Price is $5* tax."
+    assert remove_markdown("force*mass*time") == "force*mass*time"
+    assert remove_markdown("`unclosed") == "`unclosed"
+    assert remove_markdown("Do you mean snake case**?") == "Do you mean snake case**?"
 
 
 def test_remove_markdown_strips_nested_bold_and_code() -> None:
@@ -200,3 +203,7 @@ def test_remove_markdown_is_streaming_safe_across_split_deltas() -> None:
     deltas = ["*ita", "lic* is a word."]
     accumulated = "".join(deltas)
     assert remove_markdown(accumulated) == "italic is a word."
+
+
+def test_sentence_tokenization_preserves_complete_emphasis_pairs() -> None:
+    assert sent_tokenize_preserving_markdown_code("**Let me check.**", sent_tokenize) == ["**Let me check.**"]

--- a/tests/test_llm_utils.py
+++ b/tests/test_llm_utils.py
@@ -124,6 +124,14 @@ def test_remove_markdown_strips_bold_and_italic() -> None:
     assert remove_markdown("__bold__ and _italic_ text") == "bold and italic text"
 
 
+def test_remove_markdown_strips_emphasis_adjacent_to_word_characters() -> None:
+    assert remove_markdown("这是**重点**内容。") == "这是重点内容。"
+    assert remove_markdown("これは**重要**です。") == "これは重要です。"
+    assert remove_markdown("foo**bar**baz") == "foobarbaz"
+    assert remove_markdown("这是*重点*内容。") == "这是重点内容。"
+    assert remove_markdown("foo*bar*baz") == "foobarbaz"
+
+
 def test_remove_markdown_keeps_snake_case_identifiers() -> None:
     assert remove_markdown("function_call_output") == "function_call_output"
 
@@ -160,6 +168,15 @@ def test_remove_markdown_strips_nested_bold_and_code() -> None:
 
 def test_remove_markdown_strips_inline_code() -> None:
     assert remove_markdown("`inline`") == "inline"
+
+
+def test_remove_markdown_preserves_markdown_like_characters_inside_code() -> None:
+    assert remove_markdown("Use `*args` and `**kwargs`.") == "Use *args and **kwargs."
+    assert remove_markdown("Match `*.py` files.") == "Match *.py files."
+    assert (
+        remove_markdown("```python\n*args = values\n# keep_this\n**literal**\n```")
+        == "*args = values\n# keep_this\n**literal**\n"
+    )
 
 
 def test_remove_markdown_strips_fenced_code_block_and_language_tag() -> None:

--- a/tests/test_llm_utils.py
+++ b/tests/test_llm_utils.py
@@ -126,12 +126,6 @@ def test_remove_markdown_strips_bold_and_italic() -> None:
     assert remove_markdown("__bold__ and _italic_ text") == "bold and italic text"
 
 
-def test_remove_markdown_strips_emphasis_adjacent_to_word_characters() -> None:
-    assert remove_markdown("这是**重点**内容。") == "这是重点内容。"
-    assert remove_markdown("これは**重要**です。") == "これは重要です。"
-    assert remove_markdown("这是*重点*内容。") == "这是重点内容。"
-
-
 def test_remove_markdown_keeps_snake_case_identifiers() -> None:
     assert remove_markdown("function_call_output") == "function_call_output"
 
@@ -160,6 +154,10 @@ def test_remove_markdown_does_not_pair_independent_compact_operators() -> None:
     assert remove_markdown("x*y and a*b") == "x*y and a*b"
     assert remove_markdown("x*y*z") == "x*y*z"
     assert remove_markdown("x**y**z") == "x**y**z"
+    assert remove_markdown("力*質量*時間") == "力*質量*時間"
+    assert remove_markdown("скорость*время*путь") == "скорость*время*путь"
+    assert remove_markdown("α*β*γ") == "α*β*γ"
+    assert remove_markdown("a*β*c") == "a*β*c"
 
 
 def test_remove_markdown_preserves_unmatched_delimiters_and_operators() -> None:

--- a/tests/test_responses_api_language_model.py
+++ b/tests/test_responses_api_language_model.py
@@ -585,6 +585,34 @@ def test_process_flushes_tool_lead_in_before_function_call_with_sentence_batchin
     assert isinstance(outputs[2], EndOfResponse)
 
 
+def test_markdown_cleanup_does_not_modify_responses_api_tool_arguments():
+    handler = _make_handler()
+    arguments = {"query": "**bold** _italic_ x*y", "tag": "#topic"}
+    streamed_events = [
+        _make_text_delta_event("**Let me check.**"),
+        _make_function_call_done_event(name="search_docs", arguments=json.dumps(arguments)),
+    ]
+    handler.client = SimpleNamespace(
+        responses=SimpleNamespace(
+            create=lambda **kwargs: _make_stream(streamed_events),
+        )
+    )
+
+    request = _make_request("Find it")
+    request.runtime_config.session.tools = [
+        {"type": "function", "name": "search_docs", "parameters": {"type": "object"}}
+    ]
+    outputs = list(handler.process(request))
+    chunks = [output for output in outputs if isinstance(output, LLMResponseChunk)]
+    spoken_chunks = [chunk.text for chunk in chunks if chunk.text]
+    tool_chunks = [chunk for chunk in chunks if chunk.tools]
+
+    assert spoken_chunks == ["Let me check."]
+    assert len(tool_chunks) == 1
+    assert [tool.name for tool in tool_chunks[0].tools] == ["search_docs"]
+    assert json.loads(tool_chunks[0].tools[0].arguments) == arguments
+
+
 def test_process_preserves_streamed_text_after_function_call_order():
     handler = _make_handler()
     handler.stream_batch_sentences = 3

--- a/tests/test_voice_prompt.py
+++ b/tests/test_voice_prompt.py
@@ -1,3 +1,4 @@
+import json
 from threading import Event
 from types import MethodType, SimpleNamespace
 
@@ -227,6 +228,40 @@ def test_local_tool_parser_preserves_interleaved_text_and_tool_calls(monkeypatch
     ]
     assert [tool.name for tool in tools] == ["dance", "camera"]
     assert remaining.strip() == "Last."
+
+
+def test_local_markdown_cleanup_does_not_modify_tool_block(monkeypatch):
+    monkeypatch.setattr(
+        "speech_to_speech.LLM.language_model.sent_tokenize",
+        lambda value: [value.strip()] if value.strip() else [],
+    )
+    handler = object.__new__(LanguageModelHandler)
+    argument = "**bold** _italic_ x*y #topic"
+    ctx = StreamContext(
+        function_tools=[
+            FunctionTool(
+                type="function",
+                name="search_docs",
+                description="Search for text.",
+                parameters={
+                    "type": "object",
+                    "properties": {"query": {"type": "string"}},
+                    "required": ["query"],
+                },
+            )
+        ],
+        block_regex=build_block_regex(),
+        enter_code=ENTER_CODE,
+        end_code=END_CODE,
+    )
+    text = f"**Checking.** {ENTER_CODE}search_docs(query={argument!r}){END_CODE}"
+
+    chunks, tools, remaining = handler._process_printable_text(text, None, [], ctx)
+
+    assert [chunk.text for chunk in chunks] == ["Checking.", ""]
+    assert [tool.name for tool in chunks[1].tools] == ["search_docs"]
+    assert json.loads(tools[0].arguments) == {"query": argument}
+    assert remaining == ""
 
 
 def test_local_text_only_with_tools_preserves_markdown_verbatim():


### PR DESCRIPTION
## Summary

- merge PR #344 onto current `main` without squashing or rewriting its original commits
- strip the Markdown forms from #338 only after streamed text has been reassembled into complete spoken segments
- handle matched emphasis adjacent to CJK or other word characters while preserving compact operator expressions
- buffer streamed fenced code through sentence tokenization, removing its fences without applying prose cleanup inside the code body
- preserve text-only output verbatim and avoid changing compact math, snake_case identifiers, or non-heading `#` text
- keep provider-native and locally parsed tool names and arguments completely outside Markdown cleanup
- keep link rewriting out of this fix because it is not part of #338

Closes #338.

## Test plan

- `uv run pytest tests/ -x -q` — 1,166 passed, 1 skipped
- `uv run ruff check src/ tests/`
- `uv run ruff format --check src/ tests/`
- `uv run mypy src/`

This supersedes #344 while preserving both of its original commits in the merge history.
