### PR TITLE
Fix PRO tier resolution from Hub profile

### DIFF
--- a/demo/auth.py
+++ b/demo/auth.py
@@ -88,9 +88,9 @@ def _field(obj, name, default=None):
 # verifying org gating on the live Space without guessing.
 AUTH_DEBUG = bool(os.environ.get("AUTH_DEBUG"))
 
-# whoami-v2 org lookups are cached for the process lifetime, keyed by token, so
-# /api/me + /api/session don't each hit the Hub.
-_orgs_cache: "dict[str, set[str]]" = {}
+# whoami-v2 profiles are cached for the process lifetime, keyed by token, so
+# tier and org resolution across /api/me + /api/session share one Hub request.
+_whoami_cache: "dict[str, dict]" = {}
 
 
 def current_oauth(request):
@@ -171,14 +171,13 @@ def _user_org_names(user) -> "set[str]":
     return names
 
 
-def _orgs_via_token(token: str) -> "set[str]":
-    """Fallback org lookup via the Hub `whoami-v2` API, using the user's OAuth
-    access token. Covers the case where the userinfo claim omits `orgs`."""
+def _whoami_via_token(token: str) -> dict:
+    """The authenticated Hub `whoami-v2` profile, cached by OAuth token."""
     if not token:
-        return set()
-    if token in _orgs_cache:
-        return _orgs_cache[token]
-    names: "set[str]" = set()
+        return {}
+    if token in _whoami_cache:
+        return _whoami_cache[token]
+    profile = {}
     try:
         import httpx
 
@@ -188,14 +187,23 @@ def _orgs_via_token(token: str) -> "set[str]":
             timeout=5.0,
         )
         resp.raise_for_status()
-        for org in resp.json().get("orgs", []) or []:
-            for key in ("name", "fullname"):
-                val = org.get(key)
-                if val:
-                    names.add(str(val).lower())
+        data = resp.json()
+        if isinstance(data, dict):
+            profile = data
     except Exception as exc:  # pragma: no cover - network/permission dependent
-        logger.info("whoami-v2 org lookup failed: %r", exc)
-    _orgs_cache[token] = names
+        logger.info("whoami-v2 profile lookup failed: %r", exc)
+    _whoami_cache[token] = profile
+    return profile
+
+
+def _orgs_via_token(token: str) -> "set[str]":
+    """Org names from the cached authenticated Hub profile."""
+    names: "set[str]" = set()
+    for org in _whoami_via_token(token).get("orgs", []) or []:
+        for key in ("name", "fullname"):
+            val = _field(org, key)
+            if val:
+                names.add(str(val).lower())
     return names
 
 
@@ -213,6 +221,8 @@ def resolve_tier(user, token=None) -> str:
     """Tier for a signed-in user: 'pro' (paying), 'org' (allow-listed org
     member, unlimited), or 'free'. PRO wins over org if both apply."""
     if bool(_field(user, "is_pro", False)):
+        return "pro"
+    if bool(_whoami_via_token(token).get("isPro", False)):
         return "pro"
     allow = _unlimited_orgs()
     names = _org_names(user, token, allow)

--- a/demo/auth.py
+++ b/demo/auth.py
@@ -177,7 +177,6 @@ def _whoami_via_token(token: str) -> dict:
         return {}
     if token in _whoami_cache:
         return _whoami_cache[token]
-    profile = {}
     try:
         import httpx
 
@@ -188,18 +187,21 @@ def _whoami_via_token(token: str) -> dict:
         )
         resp.raise_for_status()
         data = resp.json()
-        if isinstance(data, dict):
-            profile = data
+        if not isinstance(data, dict):
+            raise ValueError("whoami-v2 returned a non-object response")
     except Exception as exc:  # pragma: no cover - network/permission dependent
         logger.info("whoami-v2 profile lookup failed: %r", exc)
-    _whoami_cache[token] = profile
-    return profile
+        return {}
+    _whoami_cache[token] = data
+    return data
 
 
-def _orgs_via_token(token: str) -> "set[str]":
+def _orgs_via_token(token: str, profile=None) -> "set[str]":
     """Org names from the cached authenticated Hub profile."""
+    if profile is None:
+        profile = _whoami_via_token(token)
     names: "set[str]" = set()
-    for org in _whoami_via_token(token).get("orgs", []) or []:
+    for org in profile.get("orgs", []) or []:
         for key in ("name", "fullname"):
             val = _field(org, key)
             if val:
@@ -207,13 +209,13 @@ def _orgs_via_token(token: str) -> "set[str]":
     return names
 
 
-def _org_names(user, token=None, allow=None) -> "set[str]":
+def _org_names(user, token=None, allow=None, profile=None) -> "set[str]":
     """The user's org usernames from the OAuth userinfo claim. If that doesn't
     already satisfy `allow`, fall back to the Hub `whoami-v2` API (the claim is
     often empty or partial), so membership is resolved either way."""
     names = _user_org_names(user)
     if token and (allow is None or not (allow & names)):
-        names = names | _orgs_via_token(token)
+        names = names | _orgs_via_token(token, profile)
     return names
 
 
@@ -222,10 +224,11 @@ def resolve_tier(user, token=None) -> str:
     member, unlimited), or 'free'. PRO wins over org if both apply."""
     if bool(_field(user, "is_pro", False)):
         return "pro"
-    if bool(_whoami_via_token(token).get("isPro", False)):
+    profile = _whoami_via_token(token)
+    if bool(profile.get("isPro", False)):
         return "pro"
     allow = _unlimited_orgs()
-    names = _org_names(user, token, allow)
+    names = _org_names(user, token, allow, profile)
     tier = "org" if (allow & names) else "free"
     if AUTH_DEBUG:
         logger.info("tier=%s orgs=%s allow=%s", tier, sorted(names), sorted(allow))

--- a/demo/auth.py
+++ b/demo/auth.py
@@ -235,7 +235,7 @@ def resolve_tier(user, token=None) -> str:
     return tier
 
 
-def user_view(request) -> dict:
+def user_view(request, tier=None) -> dict:
     """Public profile for /api/me."""
     info = current_oauth(request)
     user = _field(info, "user_info")
@@ -250,7 +250,7 @@ def user_view(request) -> dict:
         "loggedIn": True,
         "username": _field(user, "preferred_username") or _field(user, "name") or "you",
         "avatar": _field(user, "picture"),
-        "tier": resolve_tier(user, token),
+        "tier": tier if tier is not None else resolve_tier(user, token),
     }
     if AUTH_DEBUG:
         out["orgs"] = sorted(_org_names(user, token))

--- a/demo/server.py
+++ b/demo/server.py
@@ -214,15 +214,14 @@ async def me(request: Request):
     sets the anonymous tracking cookie when first seen."""
     if not LIMITER_ENABLED:
         return {"enabled": False}
-    view = auth.user_view(request)
     tier, keys, set_cookie = auth.resolve_identity(request)
+    view = auth.user_view(request, tier=tier)
     unlimited = limiter.budget_for(tier) is None
     rem = None if unlimited else await asyncio.to_thread(limiter.remaining, keys, tier)
     out = {
         "enabled": True,
         "auth": AUTH_ENABLED,
         **view,
-        "tier": tier,
         "remainingSec": rem,
         "limitSec": limiter.budget_for(tier),
         "loginUrl": auth.OAUTH_LOGIN_PATH if AUTH_ENABLED else None,

--- a/demo/server.py
+++ b/demo/server.py
@@ -222,6 +222,7 @@ async def me(request: Request):
         "enabled": True,
         "auth": AUTH_ENABLED,
         **view,
+        "tier": tier,
         "remainingSec": rem,
         "limitSec": limiter.budget_for(tier),
         "loginUrl": auth.OAUTH_LOGIN_PATH if AUTH_ENABLED else None,

--- a/tests/test_demo_server.py
+++ b/tests/test_demo_server.py
@@ -78,15 +78,70 @@ def test_token_backed_non_pro_tiers_remain_unchanged(monkeypatch, whoami, expect
     assert demo_auth.resolve_tier({"is_pro": False}, "hf_user_token") == expected
 
 
-def test_failed_whoami_preserves_free_fallback(monkeypatch):
+def test_failed_whoami_falls_back_without_blocking_retry(monkeypatch):
     monkeypatch.setattr(demo_auth, "_whoami_cache", {})
+    calls = []
 
-    def fail_get(*args, **kwargs):
-        raise httpx.ConnectError("Hub unavailable")
+    def get(url, **kwargs):
+        calls.append((url, kwargs))
+        if len(calls) == 1:
+            raise httpx.ConnectError("Hub unavailable")
+        return httpx.Response(
+            200,
+            json={"isPro": True, "orgs": []},
+            request=httpx.Request("GET", url),
+        )
 
-    monkeypatch.setattr(httpx, "get", fail_get)
+    monkeypatch.setattr(httpx, "get", get)
 
     assert demo_auth.resolve_tier({"is_pro": False}, "hf_user_token") == "free"
+    assert demo_auth._whoami_cache == {}
+    assert demo_auth.resolve_tier({"is_pro": False}, "hf_user_token") == "pro"
+    assert demo_auth.resolve_tier({"is_pro": False}, "hf_user_token") == "pro"
+    assert len(calls) == 2
+
+
+async def test_me_uses_effective_tier_when_whoami_retry_succeeds(monkeypatch):
+    monkeypatch.setattr(demo_server, "LIMITER_ENABLED", True)
+    monkeypatch.setattr(demo_server, "AUTH_ENABLED", True)
+    monkeypatch.setattr(demo_auth, "_whoami_cache", {})
+    monkeypatch.setattr(
+        demo_auth,
+        "current_oauth",
+        lambda request: {
+            "access_token": "hf_user_token",
+            "user_info": {"sub": "123", "preferred_username": "alice"},
+        },
+    )
+    calls = []
+
+    def get(url, **kwargs):
+        calls.append((url, kwargs))
+        if len(calls) == 1:
+            raise httpx.ConnectError("Hub unavailable")
+        return httpx.Response(
+            200,
+            json={"isPro": True, "orgs": []},
+            request=httpx.Request("GET", url),
+        )
+
+    monkeypatch.setattr(httpx, "get", get)
+
+    response = await demo_server.me(object())
+
+    assert json.loads(response.body) == {
+        "enabled": True,
+        "auth": True,
+        "loggedIn": True,
+        "username": "alice",
+        "avatar": None,
+        "tier": "pro",
+        "remainingSec": None,
+        "limitSec": None,
+        "loginUrl": demo_auth.OAUTH_LOGIN_PATH,
+        "logoutUrl": demo_auth.OAUTH_LOGOUT_PATH,
+    }
+    assert len(calls) == 2
 
 
 def test_tier_and_org_resolution_share_one_whoami_request(monkeypatch):

--- a/tests/test_demo_server.py
+++ b/tests/test_demo_server.py
@@ -16,6 +16,91 @@ demo_auth = importlib.import_module("auth")
 demo_server = importlib.import_module("server")
 
 
+def _mock_whoami(monkeypatch, payload):
+    calls = []
+
+    def get(url, **kwargs):
+        calls.append((url, kwargs))
+        return httpx.Response(200, json=payload, request=httpx.Request("GET", url))
+
+    monkeypatch.setattr(httpx, "get", get)
+    monkeypatch.setattr(demo_auth, "_whoami_cache", {})
+    return calls
+
+
+def test_resolve_tier_prefers_oauth_pro_without_hub_lookup(monkeypatch):
+    def unexpected_get(*args, **kwargs):
+        pytest.fail("OAuth PRO users must not require a whoami-v2 lookup")
+
+    monkeypatch.setattr(httpx, "get", unexpected_get)
+
+    assert demo_auth.resolve_tier({"is_pro": True}, "hf_user_token") == "pro"
+
+
+@pytest.mark.parametrize("oauth_is_pro", [None, False])
+def test_user_view_uses_token_backed_pro_status(monkeypatch, oauth_is_pro):
+    calls = _mock_whoami(
+        monkeypatch,
+        {"name": "alice", "isPro": True, "orgs": [], "private": "server-only"},
+    )
+    monkeypatch.setattr(
+        demo_auth,
+        "current_oauth",
+        lambda request: {
+            "access_token": "hf_user_token",
+            "user_info": {
+                "sub": "123",
+                "preferred_username": "alice",
+                "is_pro": oauth_is_pro,
+            },
+        },
+    )
+
+    assert demo_auth.user_view(object()) == {
+        "loggedIn": True,
+        "username": "alice",
+        "avatar": None,
+        "tier": "pro",
+    }
+    assert len(calls) == 1
+
+
+@pytest.mark.parametrize(
+    ("whoami", "expected"),
+    [
+        ({"isPro": False, "orgs": []}, "free"),
+        ({"isPro": False, "orgs": [{"name": "smolagents"}]}, "org"),
+    ],
+)
+def test_token_backed_non_pro_tiers_remain_unchanged(monkeypatch, whoami, expected):
+    _mock_whoami(monkeypatch, whoami)
+
+    assert demo_auth.resolve_tier({"is_pro": False}, "hf_user_token") == expected
+
+
+def test_failed_whoami_preserves_free_fallback(monkeypatch):
+    monkeypatch.setattr(demo_auth, "_whoami_cache", {})
+
+    def fail_get(*args, **kwargs):
+        raise httpx.ConnectError("Hub unavailable")
+
+    monkeypatch.setattr(httpx, "get", fail_get)
+
+    assert demo_auth.resolve_tier({"is_pro": False}, "hf_user_token") == "free"
+
+
+def test_tier_and_org_resolution_share_one_whoami_request(monkeypatch):
+    calls = _mock_whoami(
+        monkeypatch,
+        {"isPro": False, "orgs": [{"name": "smolagents"}]},
+    )
+    user = {"is_pro": False}
+
+    assert demo_auth.resolve_tier(user, "hf_user_token") == "org"
+    assert demo_auth._org_names(user, "hf_user_token") == {"smolagents"}
+    assert len(calls) == 1
+
+
 def test_current_access_token_normalizes_oauth_token(monkeypatch):
     monkeypatch.setattr(
         demo_auth,

--- a/tests/test_demo_server.py
+++ b/tests/test_demo_server.py
@@ -101,10 +101,11 @@ def test_failed_whoami_falls_back_without_blocking_retry(monkeypatch):
     assert len(calls) == 2
 
 
-async def test_me_uses_effective_tier_when_whoami_retry_succeeds(monkeypatch):
+async def test_me_reuses_whoami_resolution_and_retries_next_request(monkeypatch):
     monkeypatch.setattr(demo_server, "LIMITER_ENABLED", True)
     monkeypatch.setattr(demo_server, "AUTH_ENABLED", True)
     monkeypatch.setattr(demo_auth, "_whoami_cache", {})
+    monkeypatch.setattr(demo_server.limiter, "remaining", lambda keys, tier: 600)
     monkeypatch.setattr(
         demo_auth,
         "current_oauth",
@@ -127,20 +128,19 @@ async def test_me_uses_effective_tier_when_whoami_retry_succeeds(monkeypatch):
 
     monkeypatch.setattr(httpx, "get", get)
 
-    response = await demo_server.me(object())
+    first = json.loads((await demo_server.me(object())).body)
 
-    assert json.loads(response.body) == {
-        "enabled": True,
-        "auth": True,
-        "loggedIn": True,
-        "username": "alice",
-        "avatar": None,
-        "tier": "pro",
-        "remainingSec": None,
-        "limitSec": None,
-        "loginUrl": demo_auth.OAUTH_LOGIN_PATH,
-        "logoutUrl": demo_auth.OAUTH_LOGOUT_PATH,
-    }
+    assert first["tier"] == "free"
+    assert first["remainingSec"] == 600
+    assert first["limitSec"] == 600
+    assert demo_auth._whoami_cache == {}
+    assert len(calls) == 1
+
+    second = json.loads((await demo_server.me(object())).body)
+
+    assert second["tier"] == "pro"
+    assert second["remainingSec"] is None
+    assert second["limitSec"] is None
     assert len(calls) == 2
 
 


### PR DESCRIPTION
## Summary

- cache complete successful authenticated `whoami-v2` profiles instead of only derived organization names
- classify signed-in users as PRO when either OAuth user info or token-backed Hub data reports PRO
- continue deriving allow-listed organization membership from the same request-local/cached profile
- leave failed Hub lookups uncached so later requests can recover
- resolve the effective tier once per `/api/me` request, so a failed Hub lookup is not repeated until the next HTTP request
- keep the public `/api/me` tier coherent with the effective limiter tier

## Root cause

The OAuth `is_pro` snapshot can be missing, stale, or false. The existing token-backed `whoami-v2` fallback discarded its top-level `isPro` value, so affected PRO users fell through to the free tier and received the 10-minute daily budget.

## Validation

- `uv run pytest tests/test_demo_server.py -q` — 18 passed
- `uv run pytest tests/ -x -q` — 1155 passed, 1 skipped
- `uv run ruff check src/ tests/` — passed
- `uv run ruff format --check src/ tests/` — 146 files formatted
- `uv run mypy src/` — passed (92 files)
- `uv build` — sdist and wheel built successfully in a temporary directory

## Follow-up

After this repository fix is merged, redeploy the HF Realtime Voice Space as requested by the issue.

Closes #498