### PR TITLE
Fix(stt): Propagate Paraformer language_code on Transcription.

### DIFF
--- a/src/speech_to_speech/STT/paraformer_handler.py
+++ b/src/speech_to_speech/STT/paraformer_handler.py
@@ -70,6 +70,7 @@ class ParaformerSTTHandler(BaseSTTHandler):
         else:
             yield Transcription(
                 text=pred_text,
+                language_code="zh",
                 turn_id=vad_audio.turn_id,
                 turn_revision=vad_audio.turn_revision,
                 speech_stopped_at_s=vad_audio.created_at_s,

--- a/src/speech_to_speech/STT/paraformer_handler.py
+++ b/src/speech_to_speech/STT/paraformer_handler.py
@@ -16,20 +16,6 @@ logger = logging.getLogger(__name__)
 console = Console()
 
 
-def language_from_model_name(model_name: str) -> str:
-    """FunASR checkpoints are named ``paraformer-{lang}[-streaming]``.
-
-    ``funasr/paraformer-en`` and ``paraformer-zh-streaming`` both resolve to the
-    language segment after the ``paraformer-`` prefix. Unknown names fall back
-    to Chinese, matching the handler default.
-    """
-    name = model_name.rsplit("/", 1)[-1]
-    parts = name.split("-")
-    if len(parts) >= 2 and parts[1]:
-        return parts[1]
-    return "zh"
-
-
 class ParaformerSTTHandler(BaseSTTHandler):
     """
     Handles the Speech To Text generation using a Paraformer model.
@@ -44,9 +30,9 @@ class ParaformerSTTHandler(BaseSTTHandler):
         gen_kwargs: dict[str, Any] = {},
     ) -> None:
         logger.info("Loading Paraformer STT model: %s", model_name)
-        self.language = language_from_model_name(model_name)
         if len(model_name.split("/")) > 1:
             model_name = model_name.split("/")[-1]
+        self.language = model_name.split("-")[1] if "-" in model_name else "zh"
         self.device = device
         try:
             from funasr import AutoModel

--- a/src/speech_to_speech/STT/paraformer_handler.py
+++ b/src/speech_to_speech/STT/paraformer_handler.py
@@ -16,6 +16,20 @@ logger = logging.getLogger(__name__)
 console = Console()
 
 
+def language_from_model_name(model_name: str) -> str:
+    """FunASR checkpoints are named ``paraformer-{lang}[-streaming]``.
+
+    ``funasr/paraformer-en`` and ``paraformer-zh-streaming`` both resolve to the
+    language segment after the ``paraformer-`` prefix. Unknown names fall back
+    to Chinese, matching the handler default.
+    """
+    name = model_name.rsplit("/", 1)[-1]
+    parts = name.split("-")
+    if len(parts) >= 2 and parts[1]:
+        return parts[1]
+    return "zh"
+
+
 class ParaformerSTTHandler(BaseSTTHandler):
     """
     Handles the Speech To Text generation using a Paraformer model.
@@ -30,6 +44,7 @@ class ParaformerSTTHandler(BaseSTTHandler):
         gen_kwargs: dict[str, Any] = {},
     ) -> None:
         logger.info("Loading Paraformer STT model: %s", model_name)
+        self.language = language_from_model_name(model_name)
         if len(model_name.split("/")) > 1:
             model_name = model_name.split("/")[-1]
         self.device = device
@@ -70,7 +85,7 @@ class ParaformerSTTHandler(BaseSTTHandler):
         else:
             yield Transcription(
                 text=pred_text,
-                language_code="zh",
+                language_code=self.language,
                 turn_id=vad_audio.turn_id,
                 turn_revision=vad_audio.turn_revision,
                 speech_stopped_at_s=vad_audio.created_at_s,

--- a/tests/test_paraformer_transcription_events.py
+++ b/tests/test_paraformer_transcription_events.py
@@ -1,9 +1,12 @@
+import sys
+from unittest.mock import MagicMock
+
 import numpy as np
 import pytest
 
 from speech_to_speech.pipeline.messages import PartialTranscription, Transcription, VADAudio
 from speech_to_speech.STT import paraformer_handler
-from speech_to_speech.STT.paraformer_handler import ParaformerSTTHandler, language_from_model_name
+from speech_to_speech.STT.paraformer_handler import ParaformerSTTHandler
 
 
 class _FakeParaformerModel:
@@ -24,13 +27,22 @@ def _handler(*, language: str = "zh"):
         ("paraformer-zh", "zh"),
         ("paraformer-en", "en"),
         ("funasr/paraformer-en", "en"),
-        ("funasr/paraformer-zh", "zh"),
         ("paraformer-zh-streaming", "zh"),
         ("paraformer", "zh"),
     ],
 )
-def test_language_from_model_name(model_name, expected):
-    assert language_from_model_name(model_name) == expected
+def test_setup_extracts_language_from_model_name(monkeypatch, model_name, expected):
+    fake_model = MagicMock()
+    fake_model.generate.return_value = [{"text": "warmup"}]
+    fake_funasr = MagicMock()
+    fake_funasr.AutoModel = MagicMock(return_value=fake_model)
+    monkeypatch.setitem(sys.modules, "funasr", fake_funasr)
+    monkeypatch.setattr(paraformer_handler.torch.mps, "empty_cache", lambda: None)
+
+    handler = object.__new__(ParaformerSTTHandler)
+    handler.setup(model_name=model_name, device="cpu")
+
+    assert handler.language == expected
 
 
 def test_progressive_paraformer_transcription_is_partial(monkeypatch):

--- a/tests/test_paraformer_transcription_events.py
+++ b/tests/test_paraformer_transcription_events.py
@@ -1,8 +1,9 @@
 import numpy as np
+import pytest
 
 from speech_to_speech.pipeline.messages import PartialTranscription, Transcription, VADAudio
 from speech_to_speech.STT import paraformer_handler
-from speech_to_speech.STT.paraformer_handler import ParaformerSTTHandler
+from speech_to_speech.STT.paraformer_handler import ParaformerSTTHandler, language_from_model_name
 
 
 class _FakeParaformerModel:
@@ -10,10 +11,26 @@ class _FakeParaformerModel:
         return [{"text": " 今 天 天 气 不 错 "}]
 
 
-def _handler():
+def _handler(*, language: str = "zh"):
     handler = object.__new__(ParaformerSTTHandler)
     handler.model = _FakeParaformerModel()
+    handler.language = language
     return handler
+
+
+@pytest.mark.parametrize(
+    ("model_name", "expected"),
+    [
+        ("paraformer-zh", "zh"),
+        ("paraformer-en", "en"),
+        ("funasr/paraformer-en", "en"),
+        ("funasr/paraformer-zh", "zh"),
+        ("paraformer-zh-streaming", "zh"),
+        ("paraformer", "zh"),
+    ],
+)
+def test_language_from_model_name(model_name, expected):
+    assert language_from_model_name(model_name) == expected
 
 
 def test_progressive_paraformer_transcription_is_partial(monkeypatch):
@@ -62,3 +79,19 @@ def test_final_paraformer_transcription_is_final(monkeypatch):
     assert result[0].turn_id == "turn_1"
     assert result[0].turn_revision == 2
     assert result[0].speech_stopped_at_s == 123.0
+
+
+def test_final_paraformer_transcription_uses_english_checkpoint_language(monkeypatch):
+    monkeypatch.setattr(paraformer_handler.console, "print", lambda *args, **kwargs: None)
+    monkeypatch.setattr(paraformer_handler.torch.mps, "empty_cache", lambda: None)
+
+    result = list(
+        _handler(language="en").process(
+            VADAudio(
+                audio=np.zeros(16000, dtype=np.float32),
+                mode="final",
+            )
+        )
+    )
+
+    assert result[0].language_code == "en"

--- a/tests/test_paraformer_transcription_events.py
+++ b/tests/test_paraformer_transcription_events.py
@@ -36,6 +36,7 @@ def test_progressive_paraformer_transcription_is_partial(monkeypatch):
     assert result[0].text == "今天天气不错"
     assert result[0].turn_id == "turn_1"
     assert result[0].turn_revision == 2
+    assert not hasattr(result[0], "language_code")
 
 
 def test_final_paraformer_transcription_is_final(monkeypatch):
@@ -57,6 +58,7 @@ def test_final_paraformer_transcription_is_final(monkeypatch):
     assert len(result) == 1
     assert isinstance(result[0], Transcription)
     assert result[0].text == "今天天气不错"
+    assert result[0].language_code == "zh"
     assert result[0].turn_id == "turn_1"
     assert result[0].turn_revision == 2
     assert result[0].speech_stopped_at_s == 123.0


### PR DESCRIPTION
hey again, (: 

Small follow-up in the same spirit as #492 (FasterWhisper): Paraformer was emitting `Transcription` without `language_code`, so downstream `--enable_lang_prompt` and multilingual TTS saw `None`.

Paraformer has no language detection — the default model is `paraformer-zh` — so this PR declares `language_code="zh"` on final transcriptions.

## Changes
- Set `language_code="zh"` on `Transcription` in `paraformer_handler.py`
- Assert `language_code` in existing Paraformer transcription tests

## Test plan
- [x] `uv run pytest tests/test_paraformer_transcription_events.py -v`