### PR TITLE
Add configurable language support for PocketTTS

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -85,7 +85,7 @@ paraformer = [
     "onnxruntime<1.24; python_version < '3.11'",
 ]
 pocket = [
-    "pocket-tts>=0.1.0",
+    "pocket-tts>=2.0.0",
 ]
 webrtc = [
     "aiortc>=1.9.0",

--- a/src/speech_to_speech/TTS/pocket_tts_handler.py
+++ b/src/speech_to_speech/TTS/pocket_tts_handler.py
@@ -29,6 +29,7 @@ class PocketTTSHandler(BaseHandler[TTSIn, TTSOut]):
         should_listen: Event,
         device: str = "cpu",
         voice: str = "alba",  # Default voice from catalog
+        language: str = "english",
         sample_rate: int = 16000,  # Match the pipeline's native audio output rate.
         blocksize: int = 512,
         max_tokens: int = 50,
@@ -46,6 +47,7 @@ class PocketTTSHandler(BaseHandler[TTSIn, TTSOut]):
                 - A preset name: 'alba', 'marius', 'javert', 'jean', 'fantine', 'cosette', 'eponine', 'azelma'
                 - A local audio file path
                 - A Hugging Face path like "hf://kyutai/tts-voices/..."
+            language: PocketTTS language/model configuration to load
             sample_rate: Output sample rate (pocket-tts generates at 24kHz and will be resampled to this rate). Default 16kHz matches the pipeline's audio output.
             blocksize: Size of audio blocks to yield
             max_tokens: Maximum tokens to generate
@@ -55,6 +57,7 @@ class PocketTTSHandler(BaseHandler[TTSIn, TTSOut]):
         self.speculative_turns = speculative_turns
         self.device = device
         self.voice = voice
+        self.language = language
         self.sample_rate = sample_rate
         self.blocksize = blocksize
         self.max_tokens = max_tokens
@@ -67,8 +70,8 @@ class PocketTTSHandler(BaseHandler[TTSIn, TTSOut]):
         # Import and load model
         from pocket_tts import TTSModel
 
-        logger.info("Loading Pocket TTS model")
-        self.model = TTSModel.load_model()
+        logger.info(f"Loading Pocket TTS model for language: {self.language}")
+        self.model = TTSModel.load_model(language=self.language)
 
         # Move model to specified device
         if device == "cuda":

--- a/src/speech_to_speech/arguments_classes/pocket_tts_arguments.py
+++ b/src/speech_to_speech/arguments_classes/pocket_tts_arguments.py
@@ -29,3 +29,7 @@ class PocketTTSHandlerArguments:
         default=50,
         metadata={"help": "Maximum number of tokens to generate per sentence in Pocket TTS. Default is 50."},
     )
+    pocket_tts_language: str = field(
+        default="english",
+        metadata={"help": "PocketTTS language/model configuration to load."},
+    )

--- a/tests/test_backend_registry.py
+++ b/tests/test_backend_registry.py
@@ -211,6 +211,8 @@ def test_parser_carries_only_selected_normalized_configs():
             "pocket",
             "--pocket_tts_voice",
             "alba",
+            "--pocket_tts_language",
+            "french_24l",
         ]
     )
 
@@ -224,6 +226,7 @@ def test_parser_carries_only_selected_normalized_configs():
     assert args.llm_backend.config["gen_kwargs"]["max_new_tokens"] == 64
     assert args.tts_backend.name == "pocket"
     assert args.tts_backend.config["voice"] == "alba"
+    assert args.tts_backend.config["language"] == "french_24l"
     assert not hasattr(args, "whisper_stt_handler_kwargs")
     assert not hasattr(args, "qwen3_tts_handler_kwargs")
 

--- a/tests/test_pocket_tts_handler.py
+++ b/tests/test_pocket_tts_handler.py
@@ -1,3 +1,4 @@
+import sys
 from threading import Event
 from types import SimpleNamespace
 
@@ -14,8 +15,6 @@ from speech_to_speech.TTS.pocket_tts_handler import PocketTTSHandler
     ],
 )
 def test_pocket_tts_setup_loads_language(monkeypatch, setup_kwargs, expected_language):
-    import pocket_tts
-
     loaded_languages = []
 
     fake_model = SimpleNamespace(
@@ -28,12 +27,11 @@ def test_pocket_tts_setup_loads_language(monkeypatch, setup_kwargs, expected_lan
         loaded_languages.append(language)
         return fake_model
 
-    monkeypatch.setattr(
-        pocket_tts.TTSModel,
-        "load_model",
-        fake_load_model,
+    fake_pocket_tts = SimpleNamespace(
+        TTSModel=SimpleNamespace(load_model=fake_load_model),
     )
 
+    monkeypatch.setitem(sys.modules, "pocket_tts", fake_pocket_tts)
     handler = object.__new__(PocketTTSHandler)
 
     handler.setup(

--- a/tests/test_pocket_tts_handler.py
+++ b/tests/test_pocket_tts_handler.py
@@ -1,0 +1,44 @@
+from threading import Event
+from types import SimpleNamespace
+
+import pytest
+
+from speech_to_speech.TTS.pocket_tts_handler import PocketTTSHandler
+
+
+@pytest.mark.parametrize(
+    ("setup_kwargs", "expected_language"),
+    [
+        ({}, "english"),
+        ({"language": "french_24l"}, "french_24l"),
+    ],
+)
+def test_pocket_tts_setup_loads_language(monkeypatch, setup_kwargs, expected_language):
+    import pocket_tts
+
+    loaded_languages = []
+
+    fake_model = SimpleNamespace(
+        to=lambda *args, **kwargs: None,
+        get_state_for_audio_prompt=lambda *args, **kwargs: object(),
+        sample_rate=24000,
+    )
+
+    def fake_load_model(*, language):
+        loaded_languages.append(language)
+        return fake_model
+
+    monkeypatch.setattr(
+        pocket_tts.TTSModel,
+        "load_model",
+        fake_load_model,
+    )
+
+    handler = object.__new__(PocketTTSHandler)
+
+    handler.setup(
+        should_listen=Event(),
+        **setup_kwargs,
+    )
+
+    assert loaded_languages == [expected_language]


### PR DESCRIPTION
## Summary

Addresses #482 by adding startup language configuration for the PocketTTS backend.

- Add a `--pocket_tts_language` option.
- Pass the configured language to `TTSModel.load_model()`.
- Preserve `english` as the default.
- Add tests for backend argument normalization and PocketTTS model initialization.

## Testing

- Full test suite passes: `1149 passed, 1 skipped`.
- Verified `--pocket_tts_language french_24l` is exposed through the CLI.
- Verified the speech-to-speech pipeline initializes PocketTTS with the `french_24l` model.
- Manually synthesized French speech using both the default model and `french_24l`; the language-specific model produced better French pronunciation.

## Scope

This change configures the PocketTTS language at model initialization.

Dynamic per-utterance switching based on `tts_input.language_code` is intentionally not included here, since that would require defining model reload/caching behavior.