### PR TITLE
Add OpenAI-compatible TTS endpoint

### DIFF
--- a/README.md
+++ b/README.md
@@ -175,8 +175,12 @@ This installs the package in editable mode and makes the `speech-to-speech` CLI 
 | TTS | [Pocket TTS](https://github.com/kyutai-labs/pocket-tts) | CPU / CUDA | `pocket` |
 | TTS | [ChatTTS](https://github.com/2noise/ChatTTS) | CUDA / CPU | `chattts` |
 | TTS | [MMS TTS](https://huggingface.co/docs/transformers/model_doc/mms) | CUDA / CPU | built-in |
+| TTS | OpenAI-compatible `/v1/audio/speech` endpoint | local or remote HTTP server | built-in |
 
 Select implementations with `--stt`, `--llm_backend`, and `--tts`. The CLI constructs configuration only for the selected backends; known options for inactive backends remain accepted for compatibility but are ignored with a warning. JSON configuration may likewise include extra inactive-backend keys, which are ignored. Run `speech-to-speech serve -h` for the defaults, or pass selectors before `-h` to see another combination's backend-specific flags (for example, `speech-to-speech serve --stt mlx-audio-whisper -h`).
+
+For client-only TTS serving with vLLM-Omni or another compatible server, see
+[OpenAI-compatible TTS](./docs/openai-compatible-tts.md).
 
 ## Commands
 

--- a/README.md
+++ b/README.md
@@ -203,6 +203,14 @@ or another compatible server, see
 
 `serve` binds to `127.0.0.1` by default; pass `--host 0.0.0.0` explicitly for network exposure. `local` always binds to loopback and connects the same packaged client at `ws://127.0.0.1:<port>/v1/realtime`.
 
+The packaged `local` and `talk` client buffers 196 ms of received audio before
+starting playback. This absorbs short delivery gaps from either local or remote
+backends. Use `--playback-buffer-ms <milliseconds>` to tune the tradeoff: a
+larger value resists stuttering but delays the start of each response, while a
+smaller value starts sooner but is more sensitive to jitter. This setting only
+controls the packaged Python client's speakers; browser and other Realtime
+clients manage their own playback buffers.
+
 The packaged client can opt in to local Python tools with `talk --tool-module <module>` or `local --tool-module <module>`. The module contract, programmatic API, and a Serper web-search example are documented in [Tool calling design](./src/speech_to_speech/api/openai_realtime/README.md#packaged-python-client-tools).
 
 ### Migrating from `--mode`

--- a/docs/openai-compatible-tts.md
+++ b/docs/openai-compatible-tts.md
@@ -42,13 +42,15 @@ speech-to-speech local \
   --openai_tts_base_url http://localhost:8091/v1 \
   --openai_tts_model Qwen/Qwen3-TTS-12Hz-1.7B-CustomVoice \
   --openai_tts_voice aiden \
-  --openai_tts_language Auto \
   --openai_tts_sample_rate 24000 \
   --openai_tts_stream true
 ```
 
 Qwen3-TTS produces 24 kHz audio. The client incrementally converts its raw
 PCM16 response to the pipeline's mono, signed-int16, 16 kHz, 512-sample chunks.
+If a server requires an explicit language, pass its expected value, such as
+`--openai_tts_language English` for Qwen3-TTS. The value is forwarded unchanged
+with every speech request; the TTS handler does not infer it from the pipeline.
 
 ## OpenAI and standard-compatible servers
 

--- a/docs/openai-compatible-tts.md
+++ b/docs/openai-compatible-tts.md
@@ -61,6 +61,6 @@ The client accepts:
 - a complete WAV response with `--openai_tts_stream false` and
   `--openai_tts_response_format wav`.
 
-The raw streaming fields `stream=true` and `stream_format=audio` are vLLM-Omni
-extensions. Disable `--openai_tts_stream` for servers that implement only the
-standard request shape.
+The `stream_format=audio` field is part of the standard request shape;
+`stream=true` is a vLLM-Omni extension. Disable `--openai_tts_stream` for
+servers that reject that extension.

--- a/docs/openai-compatible-tts.md
+++ b/docs/openai-compatible-tts.md
@@ -69,6 +69,35 @@ The default request uses the standard `stream_format=audio` field and consumes
 the HTTP response body incrementally. It does not send the non-standard
 `stream` field.
 
+## Playback buffering
+
+The packaged Python audio client used by `speech-to-speech local` and
+`speech-to-speech talk` waits for 196 ms of audio before starting playback. If
+playback runs out of audio while a response is still arriving, it uses the same
+cushion before restarting. This small client-side delay absorbs uneven network
+or synthesis delivery so the speaker is less likely to underrun and stutter.
+
+The buffer is downstream of TTS and therefore applies to both PCM and WAV and
+to every backend, including hosted OpenAI and a local vLLM deployment. A local
+server may need less buffering because its chunks usually arrive more evenly.
+It does not alter the TTS request, synthesis, resampling, or server deployment.
+
+Override the default for either command with `--playback-buffer-ms`. Higher
+values improve tolerance for delivery jitter at the cost of a later start to
+each response; lower values reduce that startup delay but increase underrun
+risk. For example:
+
+```bash
+speech-to-speech local \
+  --playback-buffer-ms 256 \
+  --tts openai \
+  --openai_tts_base_url https://api.openai.com/v1
+```
+
+Responses shorter than the configured buffer are played as soon as the audio
+response completes. Browser, WebRTC, and third-party Realtime clients use their
+own playback behavior and are not affected by this option.
+
 ## Authentication and compatibility
 
 Set `--openai_tts_api_key` when the endpoint requires bearer authentication.
@@ -81,8 +110,11 @@ fail before the Realtime server accepts sessions.
 The client accepts:
 
 - raw signed PCM16 with a configured `--openai_tts_sample_rate`; or
-- a complete WAV response with `--openai_tts_stream false` and
+- a WAV response with `--openai_tts_stream false` and
   `--openai_tts_response_format wav`.
+
+Both formats are decoded, resampled, and forwarded incrementally as their HTTP
+response bodies arrive.
 
 The `stream_format=audio` field is part of the standard request shape.
 `stream=true` is a vLLM-Omni extension and is disabled by default; enable it

--- a/docs/openai-compatible-tts.md
+++ b/docs/openai-compatible-tts.md
@@ -74,6 +74,10 @@ the HTTP response body incrementally. It does not send the non-standard
 Set `--openai_tts_api_key` when the endpoint requires bearer authentication.
 When it is omitted, the handler uses `OPENAI_API_KEY` if present.
 
+The backend performs a short synthesis request during startup. Invalid endpoint,
+authentication, model, voice, request, and audio-response configuration therefore
+fail before the Realtime server accepts sessions.
+
 The client accepts:
 
 - raw signed PCM16 with a configured `--openai_tts_sample_rate`; or

--- a/docs/openai-compatible-tts.md
+++ b/docs/openai-compatible-tts.md
@@ -50,6 +50,25 @@ speech-to-speech local \
 Qwen3-TTS produces 24 kHz audio. The client incrementally converts its raw
 PCM16 response to the pipeline's mono, signed-int16, 16 kHz, 512-sample chunks.
 
+## OpenAI and standard-compatible servers
+
+Standard OpenAI-compatible endpoints do not need the vLLM streaming extension.
+For example, with `OPENAI_API_KEY` set:
+
+```bash
+speech-to-speech local \
+  --tts openai \
+  --openai_tts_base_url https://api.openai.com/v1 \
+  --openai_tts_model gpt-4o-mini-tts \
+  --openai_tts_voice alloy \
+  --openai_tts_response_format pcm \
+  --openai_tts_sample_rate 24000
+```
+
+The default request uses the standard `stream_format=audio` field and consumes
+the HTTP response body incrementally. It does not send the non-standard
+`stream` field.
+
 ## Authentication and compatibility
 
 Set `--openai_tts_api_key` when the endpoint requires bearer authentication.
@@ -61,9 +80,9 @@ The client accepts:
 - a complete WAV response with `--openai_tts_stream false` and
   `--openai_tts_response_format wav`.
 
-The `stream_format=audio` field is part of the standard request shape;
-`stream=true` is a vLLM-Omni extension. Disable `--openai_tts_stream` for
-servers that reject that extension.
+The `stream_format=audio` field is part of the standard request shape.
+`stream=true` is a vLLM-Omni extension and is disabled by default; enable it
+explicitly with `--openai_tts_stream true` when the server supports it.
 
 Cancellation is best-effort: barge-in and session teardown close the client's
 active HTTP response and prevent further audio publication locally. The

--- a/docs/openai-compatible-tts.md
+++ b/docs/openai-compatible-tts.md
@@ -1,0 +1,66 @@
+# OpenAI-compatible TTS endpoint
+
+The `openai` TTS backend keeps turns, sessions, conversation state, and response
+handling inside speech-to-speech while delegating synthesis to an external
+server:
+
+```text
+LLM text -> POST /v1/audio/speech -> PCM16 at 16 kHz
+```
+
+## vLLM-Omni with Qwen3-TTS
+
+Run Qwen3-TTS in a separate vLLM-Omni process. Keep the installed vLLM and
+vLLM-Omni versions aligned:
+
+```bash
+uv pip install vllm==0.24.0 --torch-backend=auto
+uv pip install vllm-omni
+
+vllm serve Qwen/Qwen3-TTS-12Hz-1.7B-CustomVoice \
+  --deploy-config vllm_omni/deploy/qwen3_tts.yaml \
+  --omni \
+  --port 8091 \
+  --trust-remote-code \
+  --enforce-eager
+```
+
+Check the server before starting the pipeline:
+
+```bash
+curl http://localhost:8091/v1/audio/voices
+```
+
+Then select the remote TTS backend. The STT and LLM flags are only examples and
+can point at any supported backends.
+
+```bash
+speech-to-speech local \
+  --stt parakeet-tdt \
+  --llm_backend responses-api \
+  --tts openai \
+  --openai_tts_base_url http://localhost:8091/v1 \
+  --openai_tts_model Qwen/Qwen3-TTS-12Hz-1.7B-CustomVoice \
+  --openai_tts_voice aiden \
+  --openai_tts_language Auto \
+  --openai_tts_sample_rate 24000 \
+  --openai_tts_stream true
+```
+
+Qwen3-TTS produces 24 kHz audio. The client incrementally converts its raw
+PCM16 response to the pipeline's mono, signed-int16, 16 kHz, 512-sample chunks.
+
+## Authentication and compatibility
+
+Set `--openai_tts_api_key` when the endpoint requires bearer authentication.
+When it is omitted, the handler uses `OPENAI_API_KEY` if present.
+
+The client accepts:
+
+- raw signed PCM16 with a configured `--openai_tts_sample_rate`; or
+- a complete WAV response with `--openai_tts_stream false` and
+  `--openai_tts_response_format wav`.
+
+The raw streaming fields `stream=true` and `stream_format=audio` are vLLM-Omni
+extensions. Disable `--openai_tts_stream` for servers that implement only the
+standard request shape.

--- a/docs/openai-compatible-tts.md
+++ b/docs/openai-compatible-tts.md
@@ -64,3 +64,9 @@ The client accepts:
 The `stream_format=audio` field is part of the standard request shape;
 `stream=true` is a vLLM-Omni extension. Disable `--openai_tts_stream` for
 servers that reject that extension.
+
+Cancellation is best-effort: barge-in and session teardown close the client's
+active HTTP response and prevent further audio publication locally. The
+standard `/v1/audio/speech` interface has no portable server-side cancellation
+operation, so a disconnected client does not guarantee that endpoint
+computation stops immediately.

--- a/src/speech_to_speech/TTS/README.md
+++ b/src/speech_to_speech/TTS/README.md
@@ -9,6 +9,7 @@ Runtime-supported values in `s2s_pipeline.py`:
 - `pocket` → `pocket_tts_handler.py`
 - `kokoro` → `kokoro_handler.py`
 - `qwen3` → `qwen3_tts_handler.py`
+- `openai` → `openai_compatible_handler.py`
 
 Deprecated TTS implementations, including MeloTTS, live in [`../../../archive/TTS`](../../../archive/TTS) and are no longer wired into `s2s_pipeline.py`.
 
@@ -187,6 +188,16 @@ To benchmark the Apple Silicon MLX variants side by side:
 ```
 
 This will run separate benchmark entries for `qwen3[bf16]`, `qwen3[4bit]`, `qwen3[6bit]`, and `qwen3[8bit]`.
+
+### 6) OpenAI-compatible endpoint (`--tts openai`)
+
+The handler sends text to `POST /v1/audio/speech`. It supports streaming raw
+PCM16 and complete WAV responses, resamples them to the pipeline's 16 kHz
+format, and closes the active transport when response generation is cancelled.
+The default settings target Qwen3-TTS on vLLM-Omni.
+
+See [`docs/openai-compatible-tts.md`](../../../docs/openai-compatible-tts.md)
+for server commands and all relevant flags.
 
 ## Setup
 

--- a/src/speech_to_speech/TTS/openai_compatible_handler.py
+++ b/src/speech_to_speech/TTS/openai_compatible_handler.py
@@ -4,6 +4,7 @@ import io
 import logging
 import os
 from collections.abc import Callable
+from queue import Empty, Full, Queue
 from threading import Event, Lock, Thread
 from time import perf_counter
 from typing import Any, Iterator, cast
@@ -44,6 +45,11 @@ class SpeechRequestError(RuntimeError):
     """Sanitized HTTP/protocol failure safe to log or surface."""
 
 
+_SPEECH_STREAM_DONE = object()
+_SPEECH_STREAM_QUEUE_MAXSIZE = 2
+_SPEECH_STREAM_POLL_INTERVAL_S = 0.025
+
+
 class HttpSpeechOperation:
     """Exactly one speech request and its streaming transport lifecycle."""
 
@@ -68,70 +74,127 @@ class HttpSpeechOperation:
     def iter_bytes(self, cancel_check: Callable[[], bool]) -> Iterator[bytes]:
         deadline_at_s = perf_counter() + self.timeout_s
         self._raise_if_stopped(cancel_check)
+        results: Queue[tuple[bool, object]] = Queue(maxsize=_SPEECH_STREAM_QUEUE_MAXSIZE)
         headers = {}
         if self.api_key:
             headers["Authorization"] = f"Bearer {self.api_key}"
 
-        client = httpx.Client(timeout=self.timeout_s)
-        with self._transport_lock:
-            cancelled_before_dispatch = self._cancelled.is_set() or cancel_check()
-            if cancelled_before_dispatch:
-                self._cancelled.set()
-            else:
-                self._client = client
-        if cancelled_before_dispatch:
-            client.close()
-            raise SpeechRequestCancelled
-
-        monitor_stop = Event()
-        monitor = Thread(
-            target=self._monitor_cancellation,
-            args=(cancel_check, monitor_stop, deadline_at_s),
-            name="tts-http-cancel",
+        worker = Thread(
+            target=self._read_stream,
+            args=(headers, results),
+            name="tts-http-reader",
             daemon=True,
         )
-        monitor.start()
+        worker.start()
 
+        completed = False
         try:
-            self._raise_if_stopped(cancel_check)
+            while True:
+                self._raise_if_stopped(cancel_check)
+                remaining_s = deadline_at_s - perf_counter()
+                if remaining_s <= 0:
+                    self._deadline_exceeded.set()
+                    self.cancel()
+                    raise SpeechRequestError("speech request timed out")
+                try:
+                    succeeded, value = results.get(timeout=min(_SPEECH_STREAM_POLL_INTERVAL_S, remaining_s))
+                except Empty:
+                    continue
+                self._raise_if_stopped(cancel_check)
+                if not succeeded:
+                    raise cast(BaseException, value)
+                if value is _SPEECH_STREAM_DONE:
+                    completed = True
+                    return
+                yield cast(bytes, value)
+        finally:
+            if not completed:
+                self.cancel()
+
+    def _read_stream(self, headers: dict[str, str], results: Queue[tuple[bool, object]]) -> None:
+        client: httpx.Client | None = None
+        response: httpx.Response | None = None
+        result: tuple[bool, object] = (True, _SPEECH_STREAM_DONE)
+        try:
+            client = httpx.Client(timeout=self.timeout_s)
+            with self._transport_lock:
+                if self._cancelled.is_set():
+                    cancelled_before_dispatch = True
+                else:
+                    self._client = client
+                    cancelled_before_dispatch = False
+            if cancelled_before_dispatch:
+                return
+
             with client.stream("POST", self.endpoint_url, headers=headers, json=self.payload) as response:
                 with self._transport_lock:
-                    self._response = response
-                self._raise_if_stopped(cancel_check)
+                    if self._cancelled.is_set():
+                        cancelled_before_read = True
+                    else:
+                        self._response = response
+                        cancelled_before_read = False
+                if cancelled_before_read:
+                    return
                 try:
                     response.raise_for_status()
                 except httpx.HTTPStatusError as exc:
                     raise SpeechRequestError(f"speech server returned HTTP {exc.response.status_code}") from exc
+                self._validate_content_type(response)
                 for chunk in response.iter_bytes():
-                    self._raise_if_stopped(cancel_check)
-                    if chunk:
-                        yield chunk
-                self._raise_if_stopped(cancel_check)
-        except SpeechRequestCancelled:
-            raise
-        except SpeechRequestError:
-            raise
-        except httpx.TimeoutException as exc:
-            raise SpeechRequestError("speech request timed out") from exc
-        except httpx.HTTPError as exc:
-            if self._deadline_exceeded.is_set():
-                raise SpeechRequestError("speech request timed out") from exc
-            if self._cancelled.is_set():
-                raise SpeechRequestCancelled from exc
-            raise SpeechRequestError(f"speech transport failed: {type(exc).__name__}") from exc
+                    if self._cancelled.is_set():
+                        return
+                    if chunk and not self._publish(results, (True, chunk)):
+                        return
         except Exception as exc:
-            if self._deadline_exceeded.is_set():
-                raise SpeechRequestError("speech request timed out") from exc
-            if self._cancelled.is_set():
-                raise SpeechRequestCancelled from exc
-            raise
+            result = (False, self._normalize_error(exc))
         finally:
-            monitor_stop.set()
-            monitor.join(timeout=0.2)
             with self._transport_lock:
-                self._response = None
-                self._client = None
-            client.close()
+                if self._response is response:
+                    self._response = None
+                if self._client is client:
+                    self._client = None
+            if client is not None:
+                try:
+                    client.close()
+                except Exception:
+                    logger.debug("Error closing speech client", exc_info=True)
+
+        self._publish(results, result)
+
+    def _publish(self, results: Queue[tuple[bool, object]], result: tuple[bool, object]) -> bool:
+        while not self._cancelled.is_set():
+            try:
+                results.put(result, timeout=_SPEECH_STREAM_POLL_INTERVAL_S)
+            except Full:
+                continue
+            return True
+        return False
+
+    @staticmethod
+    def _validate_content_type(response: httpx.Response) -> None:
+        headers = getattr(response, "headers", None)
+        if headers is None:
+            return
+        media_type = headers.get("content-type", "").partition(";")[0].strip().lower()
+        if media_type.startswith("text/") or media_type == "application/json" or media_type.endswith("+json"):
+            raise SpeechRequestError("speech endpoint returned a non-audio response")
+
+    def _normalize_error(self, exc: Exception) -> BaseException:
+        if isinstance(exc, (SpeechRequestCancelled, SpeechRequestError)):
+            return exc
+        if isinstance(exc, httpx.TimeoutException):
+            return SpeechRequestError("speech request timed out")
+        if isinstance(exc, httpx.HTTPError):
+            if self._deadline_exceeded.is_set():
+                return SpeechRequestError("speech request timed out")
+            if self._cancelled.is_set():
+                return SpeechRequestCancelled()
+            return SpeechRequestError(f"speech transport failed: {type(exc).__name__}")
+        if self._deadline_exceeded.is_set():
+            return SpeechRequestError("speech request timed out")
+        if self._cancelled.is_set():
+            return SpeechRequestCancelled()
+        return exc
 
     def cancel(self) -> None:
         self._cancelled.set()
@@ -155,24 +218,6 @@ class HttpSpeechOperation:
         if self._cancelled.is_set() or cancel_check():
             self.cancel()
             raise SpeechRequestCancelled
-
-    def _monitor_cancellation(
-        self,
-        cancel_check: Callable[[], bool],
-        stop: Event,
-        deadline_at_s: float,
-    ) -> None:
-        while True:
-            remaining_s = deadline_at_s - perf_counter()
-            if remaining_s <= 0:
-                self._deadline_exceeded.set()
-                self.cancel()
-                return
-            if stop.wait(min(0.025, remaining_s)):
-                return
-            if cancel_check():
-                self.cancel()
-                return
 
 
 class _StreamingLinearResampler:

--- a/src/speech_to_speech/TTS/openai_compatible_handler.py
+++ b/src/speech_to_speech/TTS/openai_compatible_handler.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+import asyncio
 import io
 import logging
 import os
@@ -67,8 +68,8 @@ class HttpSpeechOperation:
         self.timeout_s = timeout_s
         self._cancelled = Event()
         self._transport_lock = Lock()
-        self._client: httpx.Client | None = None
-        self._response: httpx.Response | None = None
+        self._worker_loop: asyncio.AbstractEventLoop | None = None
+        self._worker_task: asyncio.Task[None] | None = None
         self._deadline_exceeded = Event()
 
     def iter_bytes(self, cancel_check: Callable[[], bool]) -> Iterator[bytes]:
@@ -110,6 +111,7 @@ class HttpSpeechOperation:
         finally:
             if not completed:
                 self.cancel()
+            worker.join()
 
     def _read_stream(
         self,
@@ -117,55 +119,61 @@ class HttpSpeechOperation:
         results: Queue[tuple[bool, object]],
         cancel_check: Callable[[], bool],
     ) -> None:
-        client: httpx.Client | None = None
-        response: httpx.Response | None = None
         result: tuple[bool, object] = (True, _SPEECH_STREAM_DONE)
+        loop = asyncio.new_event_loop()
+        task = loop.create_task(self._read_stream_async(headers, results, cancel_check))
+        with self._transport_lock:
+            self._worker_loop = loop
+            self._worker_task = task
+            cancelled_before_start = self._cancelled.is_set()
+        if cancelled_before_start:
+            task.cancel()
         try:
-            client = httpx.Client(timeout=self.timeout_s)
+            loop.run_until_complete(task)
+        except asyncio.CancelledError:
+            result = (False, SpeechRequestCancelled())
+        except Exception as exc:
+            result = (False, self._normalize_error(exc))
+        finally:
             with self._transport_lock:
-                if self._cancelled.is_set() or cancel_check():
-                    self._cancelled.set()
-                    cancelled_before_dispatch = True
-                else:
-                    self._client = client
-                    cancelled_before_dispatch = False
-            if cancelled_before_dispatch:
-                return
+                if self._worker_task is task:
+                    self._worker_task = None
+                if self._worker_loop is loop:
+                    self._worker_loop = None
+            loop.close()
 
-            with client.stream("POST", self.endpoint_url, headers=headers, json=self.payload) as response:
-                with self._transport_lock:
-                    if self._cancelled.is_set():
-                        cancelled_before_read = True
-                    else:
-                        self._response = response
-                        cancelled_before_read = False
-                if cancelled_before_read:
-                    return
+        self._publish(results, result)
+
+    async def _read_stream_async(
+        self,
+        headers: dict[str, str],
+        results: Queue[tuple[bool, object]],
+        cancel_check: Callable[[], bool],
+    ) -> None:
+        client = httpx.AsyncClient(timeout=self.timeout_s)
+        try:
+            if self._cancelled.is_set() or cancel_check():
+                self._cancelled.set()
+                raise SpeechRequestCancelled
+
+            async with client.stream("POST", self.endpoint_url, headers=headers, json=self.payload) as response:
                 try:
                     response.raise_for_status()
                 except httpx.HTTPStatusError as exc:
                     raise SpeechRequestError(f"speech server returned HTTP {exc.response.status_code}") from exc
                 self._validate_content_type(response)
-                for chunk in response.iter_bytes():
+                async for chunk in response.aiter_bytes():
                     if self._cancelled.is_set():
                         return
                     if chunk and not self._publish(results, (True, chunk)):
                         return
-        except Exception as exc:
-            result = (False, self._normalize_error(exc))
         finally:
-            with self._transport_lock:
-                if self._response is response:
-                    self._response = None
-                if self._client is client:
-                    self._client = None
-            if client is not None:
-                try:
-                    client.close()
-                except Exception:
-                    logger.debug("Error closing speech client", exc_info=True)
-
-        self._publish(results, result)
+            close_task = asyncio.create_task(client.aclose())
+            try:
+                await asyncio.shield(close_task)
+            except asyncio.CancelledError:
+                await close_task
+                raise
 
     def _publish(self, results: Queue[tuple[bool, object]], result: tuple[bool, object]) -> bool:
         while not self._cancelled.is_set():
@@ -203,20 +211,19 @@ class HttpSpeechOperation:
         return exc
 
     def cancel(self) -> None:
-        self._cancelled.set()
         with self._transport_lock:
-            response = self._response
-            client = self._client
-        if response is not None:
+            if self._cancelled.is_set():
+                return
+            self._cancelled.set()
+            loop = self._worker_loop
+            task = self._worker_task
+        if loop is not None and task is not None:
             try:
-                response.close()
-            except Exception:
-                logger.debug("Error closing speech response", exc_info=True)
-        if client is not None:
-            try:
-                client.close()
-            except Exception:
-                logger.debug("Error closing speech client", exc_info=True)
+                loop.call_soon_threadsafe(task.cancel)
+            except RuntimeError:
+                # The worker may have completed and closed its loop between the
+                # lock snapshot and this cancellation request.
+                pass
 
     def _raise_if_stopped(self, cancel_check: Callable[[], bool]) -> None:
         if self._deadline_exceeded.is_set():

--- a/src/speech_to_speech/TTS/openai_compatible_handler.py
+++ b/src/speech_to_speech/TTS/openai_compatible_handler.py
@@ -6,7 +6,7 @@ import os
 from collections.abc import Callable
 from threading import Event, Lock, Thread
 from time import perf_counter
-from typing import Any, Iterator
+from typing import Any, Iterator, cast
 
 import httpx
 import numpy as np
@@ -388,12 +388,15 @@ class OpenAICompatibleTTSHandler(BaseHandler[TTSIn, TTSOut]):
                 with self._operation_lock:
                     self._failed_responses.add(response_identity)
                 self.queue_out.put(
-                    ResponseFailedEvent(
-                        message=message,
-                        turn_id=tts_input.turn_id,
-                        turn_revision=tts_input.turn_revision,
-                        cancel_generation=cancel_generation,
-                        response_key=tts_input.response_key,
+                    cast(
+                        TTSOut,
+                        ResponseFailedEvent(
+                            message=message,
+                            turn_id=tts_input.turn_id,
+                            turn_revision=tts_input.turn_revision,
+                            cancel_generation=cancel_generation,
+                            response_key=tts_input.response_key,
+                        ),
                     )
                 )
         finally:

--- a/src/speech_to_speech/TTS/openai_compatible_handler.py
+++ b/src/speech_to_speech/TTS/openai_compatible_handler.py
@@ -4,7 +4,6 @@ import io
 import logging
 import os
 from collections.abc import Callable
-from queue import Queue
 from threading import Event, Lock, Thread
 from time import perf_counter
 from typing import Any, Iterator
@@ -15,11 +14,9 @@ import numpy as np
 from speech_to_speech.api.openai_realtime.runtime_config import RuntimeConfig
 from speech_to_speech.baseHandler import BaseHandler
 from speech_to_speech.pipeline.cancel_scope import CancelScope
-from speech_to_speech.pipeline.control import SESSION_END, is_control_message
 from speech_to_speech.pipeline.events import ResponseFailedEvent
 from speech_to_speech.pipeline.handler_types import TTSIn, TTSOut
-from speech_to_speech.pipeline.messages import AUDIO_RESPONSE_DONE, PIPELINE_END, EndOfResponse, TTSInput
-from speech_to_speech.pipeline.queue_types import TextEventItem
+from speech_to_speech.pipeline.messages import AUDIO_RESPONSE_DONE, EndOfResponse, TTSInput
 from speech_to_speech.pipeline.speculative_turns import SpeculativeTurnTracker
 
 logger = logging.getLogger(__name__)
@@ -66,11 +63,11 @@ class HttpSpeechOperation:
         self._transport_lock = Lock()
         self._client: httpx.Client | None = None
         self._response: httpx.Response | None = None
+        self._deadline_exceeded = Event()
 
     def iter_bytes(self, cancel_check: Callable[[], bool]) -> Iterator[bytes]:
-        if cancel_check():
-            self._cancelled.set()
-            raise SpeechRequestCancelled
+        deadline_at_s = perf_counter() + self.timeout_s
+        self._raise_if_stopped(cancel_check)
         headers = {}
         if self.api_key:
             headers["Authorization"] = f"Bearer {self.api_key}"
@@ -89,31 +86,27 @@ class HttpSpeechOperation:
         monitor_stop = Event()
         monitor = Thread(
             target=self._monitor_cancellation,
-            args=(cancel_check, monitor_stop),
+            args=(cancel_check, monitor_stop, deadline_at_s),
             name="tts-http-cancel",
             daemon=True,
         )
         monitor.start()
 
         try:
-            if self._cancelled.is_set() or cancel_check():
-                self.cancel()
-                raise SpeechRequestCancelled
+            self._raise_if_stopped(cancel_check)
             with client.stream("POST", self.endpoint_url, headers=headers, json=self.payload) as response:
                 with self._transport_lock:
                     self._response = response
-                if self._cancelled.is_set():
-                    raise SpeechRequestCancelled
+                self._raise_if_stopped(cancel_check)
                 try:
                     response.raise_for_status()
                 except httpx.HTTPStatusError as exc:
                     raise SpeechRequestError(f"speech server returned HTTP {exc.response.status_code}") from exc
                 for chunk in response.iter_bytes():
-                    if self._cancelled.is_set() or cancel_check():
-                        self.cancel()
-                        raise SpeechRequestCancelled
+                    self._raise_if_stopped(cancel_check)
                     if chunk:
                         yield chunk
+                self._raise_if_stopped(cancel_check)
         except SpeechRequestCancelled:
             raise
         except SpeechRequestError:
@@ -121,9 +114,17 @@ class HttpSpeechOperation:
         except httpx.TimeoutException as exc:
             raise SpeechRequestError("speech request timed out") from exc
         except httpx.HTTPError as exc:
+            if self._deadline_exceeded.is_set():
+                raise SpeechRequestError("speech request timed out") from exc
             if self._cancelled.is_set():
                 raise SpeechRequestCancelled from exc
             raise SpeechRequestError(f"speech transport failed: {type(exc).__name__}") from exc
+        except Exception as exc:
+            if self._deadline_exceeded.is_set():
+                raise SpeechRequestError("speech request timed out") from exc
+            if self._cancelled.is_set():
+                raise SpeechRequestCancelled from exc
+            raise
         finally:
             monitor_stop.set()
             monitor.join(timeout=0.2)
@@ -148,8 +149,27 @@ class HttpSpeechOperation:
             except Exception:
                 logger.debug("Error closing speech client", exc_info=True)
 
-    def _monitor_cancellation(self, cancel_check: Callable[[], bool], stop: Event) -> None:
-        while not stop.wait(0.025):
+    def _raise_if_stopped(self, cancel_check: Callable[[], bool]) -> None:
+        if self._deadline_exceeded.is_set():
+            raise SpeechRequestError("speech request timed out")
+        if self._cancelled.is_set() or cancel_check():
+            self.cancel()
+            raise SpeechRequestCancelled
+
+    def _monitor_cancellation(
+        self,
+        cancel_check: Callable[[], bool],
+        stop: Event,
+        deadline_at_s: float,
+    ) -> None:
+        while True:
+            remaining_s = deadline_at_s - perf_counter()
+            if remaining_s <= 0:
+                self._deadline_exceeded.set()
+                self.cancel()
+                return
+            if stop.wait(min(0.025, remaining_s)):
+                return
             if cancel_check():
                 self.cancel()
                 return
@@ -229,7 +249,6 @@ class OpenAICompatibleTTSHandler(BaseHandler[TTSIn, TTSOut]):
         blocksize: int = 512,
         cancel_scope: CancelScope | None = None,
         speculative_turns: SpeculativeTurnTracker | None = None,
-        text_output_queue: Queue[TextEventItem] | None = None,
         gen_kwargs: dict[str, Any] | None = None,
     ) -> None:
         if response_format not in {"pcm", "wav"}:
@@ -260,11 +279,10 @@ class OpenAICompatibleTTSHandler(BaseHandler[TTSIn, TTSOut]):
         self.blocksize = blocksize
         self.cancel_scope = cancel_scope
         self.speculative_turns = speculative_turns
-        self.text_output_queue = text_output_queue
         self.gen_kwargs = gen_kwargs or {}
         self._operation_lock = Lock()
         self._active_operation: HttpSpeechOperation | None = None
-        self._failed_responses: set[tuple[int | None, str | None, int | None]] = set()
+        self._failed_responses: set[tuple[int | None, str | None, str | None, int | None]] = set()
 
     def process(self, tts_input: TTSIn) -> Iterator[TTSOut]:
         if isinstance(tts_input, EndOfResponse):
@@ -276,7 +294,7 @@ class OpenAICompatibleTTSHandler(BaseHandler[TTSIn, TTSOut]):
                     return
                 tts_input.cleanup_only = True
             with self._operation_lock:
-                self._failed_responses.discard(self._response_key(tts_input))
+                self._failed_responses.discard(self._response_identity(tts_input))
             yield AUDIO_RESPONSE_DONE
             return
 
@@ -292,9 +310,9 @@ class OpenAICompatibleTTSHandler(BaseHandler[TTSIn, TTSOut]):
         cancel_generation = tts_input.cancel_generation
         if cancel_generation is None and self.cancel_scope is not None:
             cancel_generation = self.cancel_scope.generation
-        response_key = self._response_key(tts_input, cancel_generation)
+        response_identity = self._response_identity(tts_input, cancel_generation)
         with self._operation_lock:
-            if response_key in self._failed_responses:
+            if response_identity in self._failed_responses:
                 logger.debug(
                     "Dropping remote TTS input after response failure turn=%s rev=%s",
                     tts_input.turn_id,
@@ -302,11 +320,11 @@ class OpenAICompatibleTTSHandler(BaseHandler[TTSIn, TTSOut]):
                 )
                 return
 
-        text, input_language = self._coalesce_pending_tts_input(tts_input)
+        text = tts_input.text.strip()
         if not text:
             return
         voice = self._resolve_voice(tts_input.runtime_config, tts_input.response)
-        language = self._resolve_language(input_language)
+        language = self._resolve_language(tts_input.language_code)
         payload = self._request_payload(text=text, voice=voice, language=language)
         operation = HttpSpeechOperation(
             endpoint_url=self.endpoint_url,
@@ -359,6 +377,8 @@ class OpenAICompatibleTTSHandler(BaseHandler[TTSIn, TTSOut]):
                         self._log_first_audio_latency(tts_input, started_at_s)
                         first_audio = False
                     yield chunk
+            if first_audio and not cancel_check():
+                raise SpeechRequestError("speech endpoint returned no audio")
         except SpeechRequestCancelled:
             logger.info("OpenAI-compatible TTS request cancelled")
         except Exception as exc:
@@ -366,17 +386,16 @@ class OpenAICompatibleTTSHandler(BaseHandler[TTSIn, TTSOut]):
             logger.error("OpenAI-compatible TTS failed: %s", message, exc_info=True)
             if not cancel_check():
                 with self._operation_lock:
-                    self._failed_responses.add(response_key)
-                if self.text_output_queue is not None:
-                    self.text_output_queue.put(
-                        ResponseFailedEvent(
-                            message=message,
-                            turn_id=tts_input.turn_id,
-                            turn_revision=tts_input.turn_revision,
-                            cancel_generation=cancel_generation,
-                            response_key=tts_input.response_key,
-                        )
+                    self._failed_responses.add(response_identity)
+                self.queue_out.put(
+                    ResponseFailedEvent(
+                        message=message,
+                        turn_id=tts_input.turn_id,
+                        turn_revision=tts_input.turn_revision,
+                        cancel_generation=cancel_generation,
+                        response_key=tts_input.response_key,
                     )
+                )
         finally:
             with self._operation_lock:
                 if self._active_operation is operation:
@@ -392,13 +411,13 @@ class OpenAICompatibleTTSHandler(BaseHandler[TTSIn, TTSOut]):
         )
 
     @staticmethod
-    def _response_key(
+    def _response_identity(
         message: TTSInput | EndOfResponse,
         cancel_generation: int | None = None,
-    ) -> tuple[int | None, str | None, int | None]:
+    ) -> tuple[int | None, str | None, str | None, int | None]:
         if cancel_generation is None:
             cancel_generation = message.cancel_generation
-        return (cancel_generation, message.turn_id, message.turn_revision)
+        return (cancel_generation, message.response_key, message.turn_id, message.turn_revision)
 
     def _request_payload(self, *, text: str, voice: str, language: str | None) -> dict[str, Any]:
         payload: dict[str, Any] = {
@@ -419,32 +438,6 @@ class OpenAICompatibleTTSHandler(BaseHandler[TTSIn, TTSOut]):
         if self.instructions:
             payload["instructions"] = self.instructions
         return payload
-
-    def _coalesce_pending_tts_input(self, current: TTSInput) -> tuple[str, str | None]:
-        parts = [current.text.strip()] if current.text.strip() else []
-        language = current.language_code
-        if not hasattr(self.queue_in, "mutex") or not hasattr(self.queue_in, "queue"):
-            return " ".join(parts), language
-
-        with self.queue_in.mutex:
-            while self.queue_in.queue:
-                next_item = self.queue_in.queue[0]
-                if (
-                    is_control_message(next_item, SESSION_END.kind)
-                    or (isinstance(next_item, bytes) and next_item == PIPELINE_END)
-                    or isinstance(next_item, EndOfResponse)
-                    or not isinstance(next_item, TTSInput)
-                ):
-                    break
-                if current.turn_id != next_item.turn_id or current.turn_revision != next_item.turn_revision:
-                    break
-                if language and next_item.language_code and language != next_item.language_code:
-                    break
-                self.queue_in.queue.popleft()
-                if next_item.text.strip():
-                    parts.append(next_item.text.strip())
-                language = language or next_item.language_code
-        return " ".join(parts).strip(), language
 
     def _resolve_language(self, input_language: str | None) -> str | None:
         if self.language is None:

--- a/src/speech_to_speech/TTS/openai_compatible_handler.py
+++ b/src/speech_to_speech/TTS/openai_compatible_handler.py
@@ -81,7 +81,7 @@ class HttpSpeechOperation:
 
         worker = Thread(
             target=self._read_stream,
-            args=(headers, results),
+            args=(headers, results, cancel_check),
             name="tts-http-reader",
             daemon=True,
         )
@@ -111,14 +111,20 @@ class HttpSpeechOperation:
             if not completed:
                 self.cancel()
 
-    def _read_stream(self, headers: dict[str, str], results: Queue[tuple[bool, object]]) -> None:
+    def _read_stream(
+        self,
+        headers: dict[str, str],
+        results: Queue[tuple[bool, object]],
+        cancel_check: Callable[[], bool],
+    ) -> None:
         client: httpx.Client | None = None
         response: httpx.Response | None = None
         result: tuple[bool, object] = (True, _SPEECH_STREAM_DONE)
         try:
             client = httpx.Client(timeout=self.timeout_s)
             with self._transport_lock:
-                if self._cancelled.is_set():
+                if self._cancelled.is_set() or cancel_check():
+                    self._cancelled.set()
                     cancelled_before_dispatch = True
                 else:
                     self._client = client

--- a/src/speech_to_speech/TTS/openai_compatible_handler.py
+++ b/src/speech_to_speech/TTS/openai_compatible_handler.py
@@ -479,6 +479,8 @@ class OpenAICompatibleTTSHandler(BaseHandler[TTSIn, TTSOut]):
         converted = resampler.push(np.empty(0, dtype=np.int16), final=True)
         sample_remainder = np.concatenate((sample_remainder, converted))
         if byte_remainder:
+            # Preserve valid audio: a trailing byte cannot form a PCM16 sample, so
+            # discard it with a warning instead of failing the whole response.
             logger.warning("Speech endpoint returned an incomplete PCM16 sample")
         while sample_remainder.size >= self.blocksize:
             yield sample_remainder[: self.blocksize].copy()

--- a/src/speech_to_speech/TTS/openai_compatible_handler.py
+++ b/src/speech_to_speech/TTS/openai_compatible_handler.py
@@ -26,18 +26,6 @@ from speech_to_speech.pipeline.speculative_turns import SpeculativeTurnTracker
 logger = logging.getLogger(__name__)
 
 PIPELINE_SAMPLE_RATE = 16000
-LANGUAGE_NAMES = {
-    "zh": "Chinese",
-    "en": "English",
-    "ja": "Japanese",
-    "ko": "Korean",
-    "de": "German",
-    "fr": "French",
-    "ru": "Russian",
-    "pt": "Portuguese",
-    "es": "Spanish",
-    "it": "Italian",
-}
 
 
 class SpeechRequestCancelled(RuntimeError):
@@ -414,7 +402,6 @@ class OpenAICompatibleTTSHandler(BaseHandler[TTSIn, TTSOut]):
         operation = self._make_operation(
             text="Warmup",
             voice=self.voice,
-            language=self._resolve_language(None),
         )
 
         source_chunks = operation.iter_bytes(self.stop_event.is_set)
@@ -476,8 +463,7 @@ class OpenAICompatibleTTSHandler(BaseHandler[TTSIn, TTSOut]):
         if not text:
             return
         voice = self._resolve_voice(tts_input.runtime_config, tts_input.response)
-        language = self._resolve_language(tts_input.language_code)
-        operation = self._make_operation(text=text, voice=voice, language=language)
+        operation = self._make_operation(text=text, voice=voice)
         with self._operation_lock:
             self._active_operation = operation
 
@@ -564,12 +550,11 @@ class OpenAICompatibleTTSHandler(BaseHandler[TTSIn, TTSOut]):
         *,
         text: str,
         voice: str | dict[str, str],
-        language: str | None,
     ) -> HttpSpeechOperation:
         return HttpSpeechOperation(
             endpoint_url=self.endpoint_url,
             api_key=self.api_key,
-            payload=self._request_payload(text=text, voice=voice, language=language),
+            payload=self._request_payload(text=text, voice=voice),
             timeout_s=self.timeout,
         )
 
@@ -578,7 +563,6 @@ class OpenAICompatibleTTSHandler(BaseHandler[TTSIn, TTSOut]):
         *,
         text: str,
         voice: str | dict[str, str],
-        language: str | None,
     ) -> dict[str, Any]:
         payload: dict[str, Any] = {
             "model": self.model,
@@ -593,20 +577,13 @@ class OpenAICompatibleTTSHandler(BaseHandler[TTSIn, TTSOut]):
             payload["stream"] = True
         elif self.speed != 1.0:
             payload["speed"] = self.speed
-        if language:
-            payload["language"] = LANGUAGE_NAMES.get(language.lower(), language)
+        if self.language:
+            payload["language"] = self.language
         if self.task_type:
             payload["task_type"] = self.task_type
         if self.instructions:
             payload["instructions"] = self.instructions
         return payload
-
-    def _resolve_language(self, input_language: str | None) -> str | None:
-        if self.language is None:
-            return None
-        if self.language.strip().lower() == "auto":
-            return input_language or "Auto"
-        return self.language
 
     def _resolve_voice(
         self,

--- a/src/speech_to_speech/TTS/openai_compatible_handler.py
+++ b/src/speech_to_speech/TTS/openai_compatible_handler.py
@@ -1,0 +1,536 @@
+from __future__ import annotations
+
+import io
+import logging
+import os
+from collections.abc import Callable
+from queue import Queue
+from threading import Event, Lock, Thread
+from time import perf_counter
+from typing import Any, Iterator
+
+import httpx
+import numpy as np
+
+from speech_to_speech.api.openai_realtime.runtime_config import RuntimeConfig
+from speech_to_speech.baseHandler import BaseHandler
+from speech_to_speech.pipeline.cancel_scope import CancelScope
+from speech_to_speech.pipeline.control import SESSION_END, is_control_message
+from speech_to_speech.pipeline.events import ResponseFailedEvent
+from speech_to_speech.pipeline.handler_types import TTSIn, TTSOut
+from speech_to_speech.pipeline.messages import AUDIO_RESPONSE_DONE, PIPELINE_END, EndOfResponse, TTSInput
+from speech_to_speech.pipeline.queue_types import TextEventItem
+from speech_to_speech.pipeline.speculative_turns import SpeculativeTurnTracker
+
+logger = logging.getLogger(__name__)
+
+PIPELINE_SAMPLE_RATE = 16000
+LANGUAGE_NAMES = {
+    "zh": "Chinese",
+    "en": "English",
+    "ja": "Japanese",
+    "ko": "Korean",
+    "de": "German",
+    "fr": "French",
+    "ru": "Russian",
+    "pt": "Portuguese",
+    "es": "Spanish",
+    "it": "Italian",
+}
+
+
+class SpeechRequestCancelled(RuntimeError):
+    pass
+
+
+class SpeechRequestError(RuntimeError):
+    """Sanitized HTTP/protocol failure safe to log or surface."""
+
+
+class HttpSpeechOperation:
+    """Exactly one speech request and its streaming transport lifecycle."""
+
+    def __init__(
+        self,
+        *,
+        endpoint_url: str,
+        api_key: str | None,
+        payload: dict[str, Any],
+        timeout_s: float,
+    ) -> None:
+        self.endpoint_url = endpoint_url
+        self.api_key = api_key
+        self.payload = payload
+        self.timeout_s = timeout_s
+        self._cancelled = Event()
+        self._transport_lock = Lock()
+        self._client: httpx.Client | None = None
+        self._response: httpx.Response | None = None
+
+    def iter_bytes(self, cancel_check: Callable[[], bool]) -> Iterator[bytes]:
+        if cancel_check():
+            self._cancelled.set()
+            raise SpeechRequestCancelled
+        headers = {}
+        if self.api_key:
+            headers["Authorization"] = f"Bearer {self.api_key}"
+
+        client = httpx.Client(timeout=self.timeout_s)
+        with self._transport_lock:
+            cancelled_before_dispatch = self._cancelled.is_set() or cancel_check()
+            if cancelled_before_dispatch:
+                self._cancelled.set()
+            else:
+                self._client = client
+        if cancelled_before_dispatch:
+            client.close()
+            raise SpeechRequestCancelled
+
+        monitor_stop = Event()
+        monitor = Thread(
+            target=self._monitor_cancellation,
+            args=(cancel_check, monitor_stop),
+            name="tts-http-cancel",
+            daemon=True,
+        )
+        monitor.start()
+
+        try:
+            if self._cancelled.is_set() or cancel_check():
+                self.cancel()
+                raise SpeechRequestCancelled
+            with client.stream("POST", self.endpoint_url, headers=headers, json=self.payload) as response:
+                with self._transport_lock:
+                    self._response = response
+                if self._cancelled.is_set():
+                    raise SpeechRequestCancelled
+                try:
+                    response.raise_for_status()
+                except httpx.HTTPStatusError as exc:
+                    raise SpeechRequestError(f"speech server returned HTTP {exc.response.status_code}") from exc
+                for chunk in response.iter_bytes():
+                    if self._cancelled.is_set() or cancel_check():
+                        self.cancel()
+                        raise SpeechRequestCancelled
+                    if chunk:
+                        yield chunk
+        except SpeechRequestCancelled:
+            raise
+        except SpeechRequestError:
+            raise
+        except httpx.TimeoutException as exc:
+            raise SpeechRequestError("speech request timed out") from exc
+        except httpx.HTTPError as exc:
+            if self._cancelled.is_set():
+                raise SpeechRequestCancelled from exc
+            raise SpeechRequestError(f"speech transport failed: {type(exc).__name__}") from exc
+        finally:
+            monitor_stop.set()
+            monitor.join(timeout=0.2)
+            with self._transport_lock:
+                self._response = None
+                self._client = None
+            client.close()
+
+    def cancel(self) -> None:
+        self._cancelled.set()
+        with self._transport_lock:
+            response = self._response
+            client = self._client
+        if response is not None:
+            try:
+                response.close()
+            except Exception:
+                logger.debug("Error closing speech response", exc_info=True)
+        if client is not None:
+            try:
+                client.close()
+            except Exception:
+                logger.debug("Error closing speech client", exc_info=True)
+
+    def _monitor_cancellation(self, cancel_check: Callable[[], bool], stop: Event) -> None:
+        while not stop.wait(0.025):
+            if cancel_check():
+                self.cancel()
+                return
+
+
+class _StreamingLinearResampler:
+    """Small stateful PCM resampler that preserves continuity across HTTP chunks."""
+
+    def __init__(self, source_rate: int, target_rate: int) -> None:
+        if source_rate <= 0 or target_rate <= 0:
+            raise ValueError("sample rates must be positive")
+        self.source_rate = source_rate
+        self.target_rate = target_rate
+        self._buffer = np.empty(0, dtype=np.float32)
+        self._buffer_start = 0
+        self._next_output_index = 0
+
+    def push(self, samples: np.ndarray, *, final: bool = False) -> np.ndarray:
+        incoming = np.asarray(samples, dtype=np.float32).reshape(-1)
+        if incoming.size:
+            self._buffer = np.concatenate((self._buffer, incoming))
+        if self._buffer.size == 0:
+            return np.empty(0, dtype=np.int16)
+        if self.source_rate == self.target_rate:
+            same_rate_output = self._buffer
+            self._buffer = np.empty(0, dtype=np.float32)
+            self._buffer_start = 0
+            return np.clip(np.round(same_rate_output), -32768, 32767).astype(np.int16)
+
+        last_source_index = self._buffer_start + self._buffer.size - 1
+        resampled_output: list[float] = []
+        while True:
+            numerator = self._next_output_index * self.source_rate
+            left = numerator // self.target_rate
+            remainder = numerator % self.target_rate
+            right = left + (1 if remainder else 0)
+            if right > last_source_index:
+                if not final or left > last_source_index:
+                    break
+                right = left
+                remainder = 0
+            left_offset = int(left - self._buffer_start)
+            right_offset = int(right - self._buffer_start)
+            fraction = remainder / self.target_rate
+            value = self._buffer[left_offset] * (1.0 - fraction) + self._buffer[right_offset] * fraction
+            resampled_output.append(float(value))
+            self._next_output_index += 1
+
+        next_source = (self._next_output_index * self.source_rate) // self.target_rate
+        keep_from = max(self._buffer_start, int(next_source) - 1)
+        drop = min(self._buffer.size, keep_from - self._buffer_start)
+        if drop > 0:
+            self._buffer = self._buffer[drop:]
+            self._buffer_start += drop
+
+        return np.clip(np.round(resampled_output), -32768, 32767).astype(np.int16)
+
+
+class OpenAICompatibleTTSHandler(BaseHandler[TTSIn, TTSOut]):
+    """Client handler for POST /v1/audio/speech with cancellable PCM streaming."""
+
+    def setup(
+        self,
+        should_listen: Event,
+        base_url: str = "http://localhost:8091/v1",
+        api_key: str | None = None,
+        model: str = "Qwen/Qwen3-TTS-12Hz-1.7B-CustomVoice",
+        voice: str = "aiden",
+        language: str | None = None,
+        task_type: str | None = None,
+        instructions: str | None = None,
+        response_format: str = "pcm",
+        sample_rate: int = 24000,
+        speed: float = 1.0,
+        stream: bool = True,
+        timeout: float = 300.0,
+        blocksize: int = 512,
+        cancel_scope: CancelScope | None = None,
+        speculative_turns: SpeculativeTurnTracker | None = None,
+        text_output_queue: Queue[TextEventItem] | None = None,
+        gen_kwargs: dict[str, Any] | None = None,
+    ) -> None:
+        if response_format not in {"pcm", "wav"}:
+            raise ValueError("OpenAI-compatible TTS currently supports response_format 'pcm' or 'wav'")
+        if stream and response_format != "pcm":
+            raise ValueError("Streaming OpenAI-compatible TTS requires response_format='pcm'")
+        if timeout <= 0:
+            raise ValueError("OpenAI-compatible TTS timeout must be > 0")
+        if blocksize < 1:
+            raise ValueError("OpenAI-compatible TTS blocksize must be >= 1")
+        if stream and speed != 1.0:
+            raise ValueError("Streaming OpenAI-compatible TTS requires speed=1.0")
+
+        self.should_listen = should_listen
+        self.base_url = base_url.rstrip("/")
+        self.endpoint_url = f"{self.base_url}/audio/speech"
+        self.api_key = api_key if api_key is not None else os.getenv("OPENAI_API_KEY")
+        self.model = model
+        self.voice = voice
+        self.language = language
+        self.task_type = task_type
+        self.instructions = instructions
+        self.response_format = response_format
+        self.sample_rate = sample_rate
+        self.speed = speed
+        self.stream = stream
+        self.timeout = timeout
+        self.blocksize = blocksize
+        self.cancel_scope = cancel_scope
+        self.speculative_turns = speculative_turns
+        self.text_output_queue = text_output_queue
+        self.gen_kwargs = gen_kwargs or {}
+        self._operation_lock = Lock()
+        self._active_operation: HttpSpeechOperation | None = None
+        self._failed_responses: set[tuple[int | None, str | None, int | None]] = set()
+
+    def process(self, tts_input: TTSIn) -> Iterator[TTSOut]:
+        if isinstance(tts_input, EndOfResponse):
+            if self.speculative_turns and not self.speculative_turns.is_latest_after_reopen_grace(
+                tts_input.turn_id,
+                tts_input.turn_revision,
+            ):
+                if tts_input.response_key is None:
+                    return
+                tts_input.cleanup_only = True
+            with self._operation_lock:
+                self._failed_responses.discard(self._response_key(tts_input))
+            yield AUDIO_RESPONSE_DONE
+            return
+
+        if self.speculative_turns and not self.speculative_turns.is_latest_after_reopen_grace(
+            tts_input.turn_id,
+            tts_input.turn_revision,
+        ):
+            logger.debug(
+                "Dropping stale remote TTS input for turn=%s rev=%s", tts_input.turn_id, tts_input.turn_revision
+            )
+            return
+
+        cancel_generation = tts_input.cancel_generation
+        if cancel_generation is None and self.cancel_scope is not None:
+            cancel_generation = self.cancel_scope.generation
+        response_key = self._response_key(tts_input, cancel_generation)
+        with self._operation_lock:
+            if response_key in self._failed_responses:
+                logger.debug(
+                    "Dropping remote TTS input after response failure turn=%s rev=%s",
+                    tts_input.turn_id,
+                    tts_input.turn_revision,
+                )
+                return
+
+        text, input_language = self._coalesce_pending_tts_input(tts_input)
+        if not text:
+            return
+        voice = self._resolve_voice(tts_input.runtime_config, tts_input.response)
+        language = self._resolve_language(input_language)
+        payload = self._request_payload(text=text, voice=voice, language=language)
+        operation = HttpSpeechOperation(
+            endpoint_url=self.endpoint_url,
+            api_key=self.api_key,
+            payload=payload,
+            timeout_s=self.timeout,
+        )
+        with self._operation_lock:
+            self._active_operation = operation
+
+        def cancel_check() -> bool:
+            cancelled = self.stop_event.is_set() or (
+                cancel_generation is not None
+                and self.cancel_scope is not None
+                and self.cancel_scope.is_stale(cancel_generation)
+            )
+            if cancelled:
+                return True
+            return self.speculative_turns is not None and not self.speculative_turns.is_latest(
+                tts_input.turn_id,
+                tts_input.turn_revision,
+            )
+
+        first_audio = True
+        started_at_s = perf_counter()
+        try:
+            if self.response_format == "pcm":
+                source_chunks = operation.iter_bytes(cancel_check)
+                for chunk in self._decode_pcm_stream(source_chunks):
+                    if cancel_check():
+                        operation.cancel()
+                        return
+                    if first_audio:
+                        if not self._commit_first_audio(tts_input):
+                            operation.cancel()
+                            return
+                        self._log_first_audio_latency(tts_input, started_at_s)
+                        first_audio = False
+                    yield chunk
+            else:
+                encoded = b"".join(operation.iter_bytes(cancel_check))
+                for chunk in self._decode_wav(encoded):
+                    if cancel_check():
+                        operation.cancel()
+                        return
+                    if first_audio:
+                        if not self._commit_first_audio(tts_input):
+                            operation.cancel()
+                            return
+                        self._log_first_audio_latency(tts_input, started_at_s)
+                        first_audio = False
+                    yield chunk
+        except SpeechRequestCancelled:
+            logger.info("OpenAI-compatible TTS request cancelled")
+        except Exception as exc:
+            message = str(exc) if isinstance(exc, SpeechRequestError) else "speech request failed"
+            logger.error("OpenAI-compatible TTS failed: %s", message, exc_info=True)
+            if not cancel_check():
+                with self._operation_lock:
+                    self._failed_responses.add(response_key)
+                if self.text_output_queue is not None:
+                    self.text_output_queue.put(
+                        ResponseFailedEvent(
+                            message=message,
+                            turn_id=tts_input.turn_id,
+                            turn_revision=tts_input.turn_revision,
+                            cancel_generation=cancel_generation,
+                            response_key=tts_input.response_key,
+                        )
+                    )
+        finally:
+            with self._operation_lock:
+                if self._active_operation is operation:
+                    self._active_operation = None
+
+    def _commit_first_audio(self, tts_input: TTSInput) -> bool:
+        tracker = self.speculative_turns
+        if tracker is None or tts_input.turn_id is None or tts_input.turn_revision is None:
+            return True
+        return tracker.commit_if_latest_after_reopen_grace(
+            tts_input.turn_id,
+            tts_input.turn_revision,
+        )
+
+    @staticmethod
+    def _response_key(
+        message: TTSInput | EndOfResponse,
+        cancel_generation: int | None = None,
+    ) -> tuple[int | None, str | None, int | None]:
+        if cancel_generation is None:
+            cancel_generation = message.cancel_generation
+        return (cancel_generation, message.turn_id, message.turn_revision)
+
+    def _request_payload(self, *, text: str, voice: str, language: str | None) -> dict[str, Any]:
+        payload: dict[str, Any] = {
+            "model": self.model,
+            "input": text,
+            "voice": voice,
+            "response_format": self.response_format,
+            **self.gen_kwargs,
+        }
+        if self.stream:
+            payload.update({"stream": True, "stream_format": "audio"})
+        elif self.speed != 1.0:
+            payload["speed"] = self.speed
+        if language:
+            payload["language"] = LANGUAGE_NAMES.get(language.lower(), language)
+        if self.task_type:
+            payload["task_type"] = self.task_type
+        if self.instructions:
+            payload["instructions"] = self.instructions
+        return payload
+
+    def _coalesce_pending_tts_input(self, current: TTSInput) -> tuple[str, str | None]:
+        parts = [current.text.strip()] if current.text.strip() else []
+        language = current.language_code
+        if not hasattr(self.queue_in, "mutex") or not hasattr(self.queue_in, "queue"):
+            return " ".join(parts), language
+
+        with self.queue_in.mutex:
+            while self.queue_in.queue:
+                next_item = self.queue_in.queue[0]
+                if (
+                    is_control_message(next_item, SESSION_END.kind)
+                    or (isinstance(next_item, bytes) and next_item == PIPELINE_END)
+                    or isinstance(next_item, EndOfResponse)
+                    or not isinstance(next_item, TTSInput)
+                ):
+                    break
+                if current.turn_id != next_item.turn_id or current.turn_revision != next_item.turn_revision:
+                    break
+                if language and next_item.language_code and language != next_item.language_code:
+                    break
+                self.queue_in.queue.popleft()
+                if next_item.text.strip():
+                    parts.append(next_item.text.strip())
+                language = language or next_item.language_code
+        return " ".join(parts).strip(), language
+
+    def _resolve_language(self, input_language: str | None) -> str | None:
+        if self.language is None:
+            return None
+        if self.language.strip().lower() == "auto":
+            return input_language or "Auto"
+        return self.language
+
+    def _resolve_voice(self, runtime_config: RuntimeConfig | None, response: Any) -> str:
+        if response and response.audio and response.audio.output and response.audio.output.voice:
+            return str(response.audio.output.voice)
+        if runtime_config is not None:
+            audio = runtime_config.session.audio
+            output = audio.output if audio is not None else None
+            if output is not None and output.voice:
+                return str(output.voice)
+        return self.voice
+
+    def _decode_pcm_stream(self, encoded_chunks: Iterator[bytes]) -> Iterator[np.ndarray]:
+        resampler = _StreamingLinearResampler(self.sample_rate, PIPELINE_SAMPLE_RATE)
+        byte_remainder = b""
+        sample_remainder = np.empty(0, dtype=np.int16)
+        for encoded in encoded_chunks:
+            encoded = byte_remainder + encoded
+            usable = len(encoded) - (len(encoded) % 2)
+            byte_remainder = encoded[usable:]
+            if usable == 0:
+                continue
+            samples = np.frombuffer(encoded[:usable], dtype="<i2")
+            converted = resampler.push(samples)
+            sample_remainder = np.concatenate((sample_remainder, converted))
+            while sample_remainder.size >= self.blocksize:
+                yield sample_remainder[: self.blocksize].copy()
+                sample_remainder = sample_remainder[self.blocksize :]
+
+        converted = resampler.push(np.empty(0, dtype=np.int16), final=True)
+        sample_remainder = np.concatenate((sample_remainder, converted))
+        if byte_remainder:
+            logger.warning("Speech endpoint returned an incomplete PCM16 sample")
+        while sample_remainder.size >= self.blocksize:
+            yield sample_remainder[: self.blocksize].copy()
+            sample_remainder = sample_remainder[self.blocksize :]
+        if sample_remainder.size:
+            yield np.pad(sample_remainder, (0, self.blocksize - sample_remainder.size))
+
+    def _decode_wav(self, encoded: bytes) -> Iterator[np.ndarray]:
+        from scipy.io import wavfile
+        from scipy.signal import resample_poly
+
+        sample_rate, samples = wavfile.read(io.BytesIO(encoded))
+        waveform = np.asarray(samples)
+        if waveform.ndim == 2:
+            waveform = waveform.mean(axis=1)
+        if np.issubdtype(waveform.dtype, np.floating):
+            waveform = np.clip(waveform, -1.0, 1.0) * 32767.0
+        waveform = waveform.astype(np.float32)
+        if sample_rate != PIPELINE_SAMPLE_RATE:
+            gcd = int(np.gcd(sample_rate, PIPELINE_SAMPLE_RATE))
+            waveform = resample_poly(
+                waveform,
+                up=PIPELINE_SAMPLE_RATE // gcd,
+                down=sample_rate // gcd,
+            )
+        pcm = np.clip(np.round(waveform), -32768, 32767).astype(np.int16)
+        for offset in range(0, pcm.size, self.blocksize):
+            chunk = pcm[offset : offset + self.blocksize]
+            if chunk.size < self.blocksize:
+                chunk = np.pad(chunk, (0, self.blocksize - chunk.size))
+            yield chunk
+
+    def _log_first_audio_latency(self, tts_input: TTSInput, request_started_at_s: float) -> None:
+        logger.info("OpenAI-compatible TTS time to first audio: %.3fs", perf_counter() - request_started_at_s)
+        if tts_input.speech_stopped_at_s is not None:
+            logger.info(
+                "Last speech detected to first speech out: %.3fs (turn=%s rev=%s)",
+                max(0.0, perf_counter() - tts_input.speech_stopped_at_s),
+                tts_input.turn_id,
+                tts_input.turn_revision,
+            )
+
+    def on_session_end(self) -> None:
+        with self._operation_lock:
+            operation = self._active_operation
+            self._failed_responses.clear()
+        if operation is not None:
+            operation.cancel()
+
+    def cleanup(self) -> None:
+        self.on_session_end()

--- a/src/speech_to_speech/TTS/openai_compatible_handler.py
+++ b/src/speech_to_speech/TTS/openai_compatible_handler.py
@@ -341,6 +341,35 @@ class OpenAICompatibleTTSHandler(BaseHandler[TTSIn, TTSOut]):
         self._operation_lock = Lock()
         self._active_operation: HttpSpeechOperation | None = None
         self._failed_responses: set[tuple[int | None, str | None, str | None, int | None]] = set()
+        self.warmup()
+
+    def warmup(self) -> None:
+        """Validate the configured speech endpoint before accepting sessions."""
+        logger.info("Warming up %s", self.__class__.__name__)
+        started_at_s = perf_counter()
+        operation = self._make_operation(
+            text="Warmup",
+            voice=self.voice,
+            language=self._resolve_language(None),
+        )
+
+        if self.response_format == "pcm":
+            decoded_chunks = self._decode_pcm_stream(operation.iter_bytes(self.stop_event.is_set))
+        else:
+            encoded = b"".join(operation.iter_bytes(self.stop_event.is_set))
+            decoded_chunks = self._decode_wav(encoded)
+
+        received_audio = False
+        for chunk in decoded_chunks:
+            received_audio = received_audio or chunk.size > 0
+        if not received_audio:
+            raise SpeechRequestError("speech endpoint returned no audio")
+
+        logger.info(
+            "%s warmed up in %.3fs",
+            self.__class__.__name__,
+            perf_counter() - started_at_s,
+        )
 
     def process(self, tts_input: TTSIn) -> Iterator[TTSOut]:
         if isinstance(tts_input, EndOfResponse):
@@ -383,13 +412,7 @@ class OpenAICompatibleTTSHandler(BaseHandler[TTSIn, TTSOut]):
             return
         voice = self._resolve_voice(tts_input.runtime_config, tts_input.response)
         language = self._resolve_language(tts_input.language_code)
-        payload = self._request_payload(text=text, voice=voice, language=language)
-        operation = HttpSpeechOperation(
-            endpoint_url=self.endpoint_url,
-            api_key=self.api_key,
-            payload=payload,
-            timeout_s=self.timeout,
-        )
+        operation = self._make_operation(text=text, voice=voice, language=language)
         with self._operation_lock:
             self._active_operation = operation
 
@@ -479,6 +502,20 @@ class OpenAICompatibleTTSHandler(BaseHandler[TTSIn, TTSOut]):
         if cancel_generation is None:
             cancel_generation = message.cancel_generation
         return (cancel_generation, message.response_key, message.turn_id, message.turn_revision)
+
+    def _make_operation(
+        self,
+        *,
+        text: str,
+        voice: str | dict[str, str],
+        language: str | None,
+    ) -> HttpSpeechOperation:
+        return HttpSpeechOperation(
+            endpoint_url=self.endpoint_url,
+            api_key=self.api_key,
+            payload=self._request_payload(text=text, voice=voice, language=language),
+            timeout_s=self.timeout,
+        )
 
     def _request_payload(
         self,

--- a/src/speech_to_speech/TTS/openai_compatible_handler.py
+++ b/src/speech_to_speech/TTS/openai_compatible_handler.py
@@ -302,7 +302,7 @@ class OpenAICompatibleTTSHandler(BaseHandler[TTSIn, TTSOut]):
         response_format: str = "pcm",
         sample_rate: int = 24000,
         speed: float = 1.0,
-        stream: bool = True,
+        stream: bool = False,
         timeout: float = 300.0,
         blocksize: int = 512,
         cancel_scope: CancelScope | None = None,
@@ -312,13 +312,13 @@ class OpenAICompatibleTTSHandler(BaseHandler[TTSIn, TTSOut]):
         if response_format not in {"pcm", "wav"}:
             raise ValueError("OpenAI-compatible TTS currently supports response_format 'pcm' or 'wav'")
         if stream and response_format != "pcm":
-            raise ValueError("Streaming OpenAI-compatible TTS requires response_format='pcm'")
+            raise ValueError("The vLLM streaming extension requires response_format='pcm'")
         if timeout <= 0:
             raise ValueError("OpenAI-compatible TTS timeout must be > 0")
         if blocksize < 1:
             raise ValueError("OpenAI-compatible TTS blocksize must be >= 1")
         if stream and speed != 1.0:
-            raise ValueError("Streaming OpenAI-compatible TTS requires speed=1.0")
+            raise ValueError("The vLLM streaming extension requires speed=1.0")
 
         self.should_listen = should_listen
         self.base_url = base_url.rstrip("/")
@@ -480,7 +480,13 @@ class OpenAICompatibleTTSHandler(BaseHandler[TTSIn, TTSOut]):
             cancel_generation = message.cancel_generation
         return (cancel_generation, message.response_key, message.turn_id, message.turn_revision)
 
-    def _request_payload(self, *, text: str, voice: str, language: str | None) -> dict[str, Any]:
+    def _request_payload(
+        self,
+        *,
+        text: str,
+        voice: str | dict[str, str],
+        language: str | None,
+    ) -> dict[str, Any]:
         payload: dict[str, Any] = {
             "model": self.model,
             "input": text,
@@ -488,8 +494,10 @@ class OpenAICompatibleTTSHandler(BaseHandler[TTSIn, TTSOut]):
             "response_format": self.response_format,
             **self.gen_kwargs,
         }
+        if self.response_format == "pcm":
+            payload["stream_format"] = "audio"
         if self.stream:
-            payload.update({"stream": True, "stream_format": "audio"})
+            payload["stream"] = True
         elif self.speed != 1.0:
             payload["speed"] = self.speed
         if language:
@@ -507,15 +515,28 @@ class OpenAICompatibleTTSHandler(BaseHandler[TTSIn, TTSOut]):
             return input_language or "Auto"
         return self.language
 
-    def _resolve_voice(self, runtime_config: RuntimeConfig | None, response: Any) -> str:
+    def _resolve_voice(
+        self,
+        runtime_config: RuntimeConfig | None,
+        response: Any,
+    ) -> str | dict[str, str]:
         if response and response.audio and response.audio.output and response.audio.output.voice:
-            return str(response.audio.output.voice)
+            return self._serialize_voice(response.audio.output.voice)
         if runtime_config is not None:
             audio = runtime_config.session.audio
             output = audio.output if audio is not None else None
             if output is not None and output.voice:
-                return str(output.voice)
+                return self._serialize_voice(output.voice)
         return self.voice
+
+    @staticmethod
+    def _serialize_voice(voice: Any) -> str | dict[str, str]:
+        if isinstance(voice, str):
+            return voice
+        voice_id = voice.get("id") if isinstance(voice, dict) else getattr(voice, "id", None)
+        if isinstance(voice_id, str) and voice_id:
+            return {"id": voice_id}
+        raise ValueError("Realtime voice overrides must be a voice name or custom voice ID")
 
     def _decode_pcm_stream(self, encoded_chunks: Iterator[bytes]) -> Iterator[np.ndarray]:
         resampler = _StreamingLinearResampler(self.sample_rate, PIPELINE_SAMPLE_RATE)

--- a/src/speech_to_speech/TTS/openai_compatible_handler.py
+++ b/src/speech_to_speech/TTS/openai_compatible_handler.py
@@ -4,6 +4,7 @@ import asyncio
 import io
 import logging
 import os
+import wave
 from collections.abc import Callable
 from queue import Empty, Full, Queue
 from threading import Event, Lock, Thread
@@ -12,6 +13,7 @@ from typing import Any, Iterator, cast
 
 import httpx
 import numpy as np
+from scipy.signal import firwin, lfilter
 
 from speech_to_speech.api.openai_realtime.runtime_config import RuntimeConfig
 from speech_to_speech.baseHandler import BaseHandler
@@ -233,61 +235,123 @@ class HttpSpeechOperation:
             raise SpeechRequestCancelled
 
 
-class _StreamingLinearResampler:
-    """Small stateful PCM resampler that preserves continuity across HTTP chunks."""
+class _StreamingFIRResampler:
+    """Stateful anti-aliased resampler with stable output across input chunks."""
 
     def __init__(self, source_rate: int, target_rate: int) -> None:
         if source_rate <= 0 or target_rate <= 0:
             raise ValueError("sample rates must be positive")
         self.source_rate = source_rate
         self.target_rate = target_rate
-        self._buffer = np.empty(0, dtype=np.float32)
-        self._buffer_start = 0
-        self._next_output_index = 0
+        gcd = int(np.gcd(source_rate, target_rate))
+        self._up = target_rate // gcd
+        self._down = source_rate // gcd
+        self._input_samples = 0
+        self._upsampled_samples = 0
+        self._output_samples = 0
+        self._finalized = False
+
+        if self._up == self._down:
+            self._taps = np.ones(1, dtype=np.float64)
+            self._filter_state = np.empty(0, dtype=np.float64)
+            self._delay = 0
+            return
+
+        max_rate = max(self._up, self._down)
+        half_length = 10 * max_rate
+        self._taps = (
+            firwin(
+                2 * half_length + 1,
+                cutoff=1.0 / max_rate,
+                window=("kaiser", 5.0),
+            )
+            * self._up
+        )
+        self._filter_state = np.zeros(self._taps.size - 1, dtype=np.float64)
+        self._delay = (self._taps.size - 1) // 2
 
     def push(self, samples: np.ndarray, *, final: bool = False) -> np.ndarray:
-        incoming = np.asarray(samples, dtype=np.float32).reshape(-1)
+        if self._finalized:
+            raise RuntimeError("resampler has already been finalized")
+
+        incoming = np.asarray(samples, dtype=np.float64).reshape(-1)
+        self._input_samples += incoming.size
+        if self._up == self._down:
+            if final:
+                self._finalized = True
+            return self._to_int16(incoming)
+
+        output_parts: list[np.ndarray] = []
         if incoming.size:
-            self._buffer = np.concatenate((self._buffer, incoming))
-        if self._buffer.size == 0:
-            return np.empty(0, dtype=np.int16)
-        if self.source_rate == self.target_rate:
-            same_rate_output = self._buffer
-            self._buffer = np.empty(0, dtype=np.float32)
-            self._buffer_start = 0
-            return np.clip(np.round(same_rate_output), -32768, 32767).astype(np.int16)
+            upsampled = np.zeros(incoming.size * self._up, dtype=np.float64)
+            upsampled[:: self._up] = incoming
+            output_parts.append(self._filter_and_decimate(upsampled))
 
-        last_source_index = self._buffer_start + self._buffer.size - 1
-        resampled_output: list[float] = []
-        while True:
-            numerator = self._next_output_index * self.source_rate
-            left = numerator // self.target_rate
-            remainder = numerator % self.target_rate
-            right = left + (1 if remainder else 0)
-            if right > last_source_index:
-                if not final or left > last_source_index:
-                    break
-                right = left
-                remainder = 0
-            left_offset = int(left - self._buffer_start)
-            right_offset = int(right - self._buffer_start)
-            fraction = remainder / self.target_rate
-            value = self._buffer[left_offset] * (1.0 - fraction) + self._buffer[right_offset] * fraction
-            resampled_output.append(float(value))
-            self._next_output_index += 1
+        if final:
+            self._finalized = True
+            # Flush the FIR tail so the centered final samples are not truncated.
+            output_parts.append(self._filter_and_decimate(np.zeros(self._taps.size - 1, dtype=np.float64)))
 
-        next_source = (self._next_output_index * self.source_rate) // self.target_rate
-        keep_from = max(self._buffer_start, int(next_source) - 1)
-        drop = min(self._buffer.size, keep_from - self._buffer_start)
-        if drop > 0:
-            self._buffer = self._buffer[drop:]
-            self._buffer_start += drop
+        output = np.concatenate(output_parts) if output_parts else np.empty(0, dtype=np.float64)
+        target_total = (self._input_samples * self.target_rate + self.source_rate - 1) // self.source_rate
+        remaining = max(0, target_total - self._output_samples)
+        if output.size > remaining:
+            output = output[:remaining]
+        self._output_samples += output.size
+        return self._to_int16(output)
 
-        return np.clip(np.round(resampled_output), -32768, 32767).astype(np.int16)
+    def _filter_and_decimate(self, upsampled: np.ndarray) -> np.ndarray:
+        filtered, self._filter_state = lfilter(
+            self._taps,
+            np.ones(1, dtype=np.float64),
+            upsampled,
+            zi=self._filter_state,
+        )
+        global_start = self._upsampled_samples
+        self._upsampled_samples += upsampled.size
+        minimum_index = max(global_start, self._delay)
+        phase = (minimum_index - self._delay) % self._down
+        first_index = minimum_index if phase == 0 else minimum_index + self._down - phase
+        local_start = first_index - global_start
+        if local_start >= filtered.size:
+            return np.empty(0, dtype=np.float64)
+        return filtered[local_start :: self._down]
+
+    @staticmethod
+    def _to_int16(samples: np.ndarray) -> np.ndarray:
+        return np.clip(np.round(samples), -32768, 32767).astype(np.int16)
+
+
+class _StreamingByteReader(io.RawIOBase):
+    """Expose an iterator of HTTP bytes as the file API used by ``wave``."""
+
+    def __init__(self, chunks: Iterator[bytes]) -> None:
+        super().__init__()
+        self._chunks = iter(chunks)
+        self._buffer = bytearray()
+        self._eof = False
+
+    def read(self, size: int = -1) -> bytes:
+        if size < 0:
+            for chunk in self._chunks:
+                self._buffer.extend(chunk)
+            self._eof = True
+            size = len(self._buffer)
+        while len(self._buffer) < size and not self._eof:
+            try:
+                self._buffer.extend(next(self._chunks))
+            except StopIteration:
+                self._eof = True
+        result = bytes(self._buffer[:size])
+        del self._buffer[:size]
+        return result
+
+    def readable(self) -> bool:
+        return True
 
 
 class OpenAICompatibleTTSHandler(BaseHandler[TTSIn, TTSOut]):
-    """Client handler for POST /v1/audio/speech with cancellable PCM streaming."""
+    """Client handler for POST /v1/audio/speech with cancellable audio streaming."""
 
     def setup(
         self,
@@ -353,11 +417,12 @@ class OpenAICompatibleTTSHandler(BaseHandler[TTSIn, TTSOut]):
             language=self._resolve_language(None),
         )
 
-        if self.response_format == "pcm":
-            decoded_chunks = self._decode_pcm_stream(operation.iter_bytes(self.stop_event.is_set))
-        else:
-            encoded = b"".join(operation.iter_bytes(self.stop_event.is_set))
-            decoded_chunks = self._decode_wav(encoded)
+        source_chunks = operation.iter_bytes(self.stop_event.is_set)
+        decoded_chunks = (
+            self._decode_pcm_stream(source_chunks)
+            if self.response_format == "pcm"
+            else self._decode_wav_stream(source_chunks)
+        )
 
         received_audio = False
         for chunk in decoded_chunks:
@@ -432,32 +497,23 @@ class OpenAICompatibleTTSHandler(BaseHandler[TTSIn, TTSOut]):
         first_audio = True
         started_at_s = perf_counter()
         try:
-            if self.response_format == "pcm":
-                source_chunks = operation.iter_bytes(cancel_check)
-                for chunk in self._decode_pcm_stream(source_chunks):
-                    if cancel_check():
+            source_chunks = operation.iter_bytes(cancel_check)
+            decoded_chunks = (
+                self._decode_pcm_stream(source_chunks)
+                if self.response_format == "pcm"
+                else self._decode_wav_stream(source_chunks)
+            )
+            for chunk in decoded_chunks:
+                if cancel_check():
+                    operation.cancel()
+                    return
+                if first_audio:
+                    if not self._commit_first_audio(tts_input):
                         operation.cancel()
                         return
-                    if first_audio:
-                        if not self._commit_first_audio(tts_input):
-                            operation.cancel()
-                            return
-                        self._log_first_audio_latency(tts_input, started_at_s)
-                        first_audio = False
-                    yield chunk
-            else:
-                encoded = b"".join(operation.iter_bytes(cancel_check))
-                for chunk in self._decode_wav(encoded):
-                    if cancel_check():
-                        operation.cancel()
-                        return
-                    if first_audio:
-                        if not self._commit_first_audio(tts_input):
-                            operation.cancel()
-                            return
-                        self._log_first_audio_latency(tts_input, started_at_s)
-                        first_audio = False
-                    yield chunk
+                    self._log_first_audio_latency(tts_input, started_at_s)
+                    first_audio = False
+                yield chunk
             if first_audio and not cancel_check():
                 raise SpeechRequestError("speech endpoint returned no audio")
         except SpeechRequestCancelled:
@@ -576,58 +632,96 @@ class OpenAICompatibleTTSHandler(BaseHandler[TTSIn, TTSOut]):
         raise ValueError("Realtime voice overrides must be a voice name or custom voice ID")
 
     def _decode_pcm_stream(self, encoded_chunks: Iterator[bytes]) -> Iterator[np.ndarray]:
-        resampler = _StreamingLinearResampler(self.sample_rate, PIPELINE_SAMPLE_RATE)
         byte_remainder = b""
+
+        def sample_chunks() -> Iterator[np.ndarray]:
+            nonlocal byte_remainder
+            for encoded in encoded_chunks:
+                encoded = byte_remainder + encoded
+                usable = len(encoded) - (len(encoded) % 2)
+                byte_remainder = encoded[usable:]
+                if usable:
+                    yield np.frombuffer(encoded[:usable], dtype="<i2")
+            if byte_remainder:
+                # Preserve valid audio: a trailing byte cannot form a PCM16 sample, so
+                # discard it with a warning instead of failing the whole response.
+                logger.warning("Speech endpoint returned an incomplete PCM16 sample")
+
+        yield from self._resample_to_blocks(sample_chunks(), self.sample_rate)
+
+    def _decode_wav_stream(self, encoded_chunks: Iterator[bytes]) -> Iterator[np.ndarray]:
+        stream = _StreamingByteReader(encoded_chunks)
+        try:
+            wav_reader = wave.open(cast(Any, stream), "rb")
+        except (EOFError, wave.Error) as exc:
+            raise SpeechRequestError("speech endpoint returned an invalid WAV stream") from exc
+
+        try:
+            channels = wav_reader.getnchannels()
+            sample_width = wav_reader.getsampwidth()
+            sample_rate = wav_reader.getframerate()
+            if wav_reader.getcomptype() != "NONE" or channels < 1 or sample_width not in {1, 2, 3, 4}:
+                raise SpeechRequestError("speech endpoint returned an unsupported WAV format")
+            source_frames_per_read = max(
+                1024,
+                (self.blocksize * sample_rate + PIPELINE_SAMPLE_RATE - 1) // PIPELINE_SAMPLE_RATE + 64,
+            )
+
+            def sample_chunks() -> Iterator[np.ndarray]:
+                byte_remainder = b""
+                frame_size = channels * sample_width
+                while encoded := wav_reader.readframes(source_frames_per_read):
+                    encoded = byte_remainder + encoded
+                    usable = len(encoded) - (len(encoded) % frame_size)
+                    byte_remainder = encoded[usable:]
+                    if usable:
+                        yield self._decode_wav_frames(encoded[:usable], channels, sample_width)
+                if byte_remainder:
+                    logger.warning("Speech endpoint returned an incomplete WAV audio frame")
+
+            yield from self._resample_to_blocks(sample_chunks(), sample_rate)
+        except wave.Error as exc:
+            raise SpeechRequestError("speech endpoint returned an invalid WAV stream") from exc
+        finally:
+            wav_reader.close()
+
+    @staticmethod
+    def _decode_wav_frames(encoded: bytes, channels: int, sample_width: int) -> np.ndarray:
+        if sample_width == 1:
+            waveform = (np.frombuffer(encoded, dtype=np.uint8).astype(np.float64) - 128.0) * 256.0
+        elif sample_width == 2:
+            waveform = np.frombuffer(encoded, dtype="<i2").astype(np.float64)
+        elif sample_width == 3:
+            octets = np.frombuffer(encoded, dtype=np.uint8).reshape(-1, 3).astype(np.int32)
+            values = octets[:, 0] | (octets[:, 1] << 8) | (octets[:, 2] << 16)
+            values = np.where(values & 0x800000, values - 0x1000000, values)
+            waveform = values.astype(np.float64) / 256.0
+        else:
+            waveform = np.frombuffer(encoded, dtype="<i4").astype(np.float64) / 65536.0
+        frames = waveform.reshape(-1, channels)
+        return frames.mean(axis=1) if channels > 1 else frames[:, 0]
+
+    def _resample_to_blocks(
+        self,
+        sample_chunks: Iterator[np.ndarray],
+        source_rate: int,
+    ) -> Iterator[np.ndarray]:
+        resampler = _StreamingFIRResampler(source_rate, PIPELINE_SAMPLE_RATE)
         sample_remainder = np.empty(0, dtype=np.int16)
-        for encoded in encoded_chunks:
-            encoded = byte_remainder + encoded
-            usable = len(encoded) - (len(encoded) % 2)
-            byte_remainder = encoded[usable:]
-            if usable == 0:
-                continue
-            samples = np.frombuffer(encoded[:usable], dtype="<i2")
+        for samples in sample_chunks:
             converted = resampler.push(samples)
             sample_remainder = np.concatenate((sample_remainder, converted))
             while sample_remainder.size >= self.blocksize:
                 yield sample_remainder[: self.blocksize].copy()
                 sample_remainder = sample_remainder[self.blocksize :]
 
-        converted = resampler.push(np.empty(0, dtype=np.int16), final=True)
+        converted = resampler.push(np.empty(0, dtype=np.float64), final=True)
         sample_remainder = np.concatenate((sample_remainder, converted))
-        if byte_remainder:
-            # Preserve valid audio: a trailing byte cannot form a PCM16 sample, so
-            # discard it with a warning instead of failing the whole response.
-            logger.warning("Speech endpoint returned an incomplete PCM16 sample")
         while sample_remainder.size >= self.blocksize:
             yield sample_remainder[: self.blocksize].copy()
             sample_remainder = sample_remainder[self.blocksize :]
         if sample_remainder.size:
             yield np.pad(sample_remainder, (0, self.blocksize - sample_remainder.size))
-
-    def _decode_wav(self, encoded: bytes) -> Iterator[np.ndarray]:
-        from scipy.io import wavfile
-        from scipy.signal import resample_poly
-
-        sample_rate, samples = wavfile.read(io.BytesIO(encoded))
-        waveform = np.asarray(samples)
-        if waveform.ndim == 2:
-            waveform = waveform.mean(axis=1)
-        if np.issubdtype(waveform.dtype, np.floating):
-            waveform = np.clip(waveform, -1.0, 1.0) * 32767.0
-        waveform = waveform.astype(np.float32)
-        if sample_rate != PIPELINE_SAMPLE_RATE:
-            gcd = int(np.gcd(sample_rate, PIPELINE_SAMPLE_RATE))
-            waveform = resample_poly(
-                waveform,
-                up=PIPELINE_SAMPLE_RATE // gcd,
-                down=sample_rate // gcd,
-            )
-        pcm = np.clip(np.round(waveform), -32768, 32767).astype(np.int16)
-        for offset in range(0, pcm.size, self.blocksize):
-            chunk = pcm[offset : offset + self.blocksize]
-            if chunk.size < self.blocksize:
-                chunk = np.pad(chunk, (0, self.blocksize - chunk.size))
-            yield chunk
 
     def _log_first_audio_latency(self, tts_input: TTSInput, request_started_at_s: float) -> None:
         logger.info("OpenAI-compatible TTS time to first audio: %.3fs", perf_counter() - request_started_at_s)

--- a/src/speech_to_speech/api/openai_realtime/audio_client.py
+++ b/src/speech_to_speech/api/openai_realtime/audio_client.py
@@ -34,7 +34,7 @@ logger = logging.getLogger(__name__)
 _AssistantTranscriptStream = tuple[str | None, str | None, int | None, int | None]
 ToolExecutor = Callable[[str, dict[str, Any]], Awaitable[Any]]
 _TOOL_CREATE_ID_METADATA_KEY = "s2s_local_tool_create_id"
-_PLAYBACK_START_BUFFER_MS = 96.0
+_PLAYBACK_START_BUFFER_MS = 128.0
 
 
 @dataclass(frozen=True)

--- a/src/speech_to_speech/api/openai_realtime/audio_client.py
+++ b/src/speech_to_speech/api/openai_realtime/audio_client.py
@@ -34,7 +34,7 @@ logger = logging.getLogger(__name__)
 _AssistantTranscriptStream = tuple[str | None, str | None, int | None, int | None]
 ToolExecutor = Callable[[str, dict[str, Any]], Awaitable[Any]]
 _TOOL_CREATE_ID_METADATA_KEY = "s2s_local_tool_create_id"
-_PLAYBACK_START_BUFFER_MS = 128.0
+_PLAYBACK_START_BUFFER_MS = 196.0
 
 
 @dataclass(frozen=True)

--- a/src/speech_to_speech/api/openai_realtime/audio_client.py
+++ b/src/speech_to_speech/api/openai_realtime/audio_client.py
@@ -54,6 +54,7 @@ class RealtimeAudioClientConfig:
     api_key: Optional[str] = None
     send_rate: int = 16000
     recv_rate: int = 16000
+    playback_buffer_ms: float = _PLAYBACK_START_BUFFER_MS
     chunk_size: int = 1024
     input_device: Optional[int] = None
     output_device: Optional[int] = None
@@ -66,6 +67,10 @@ class RealtimeAudioClientConfig:
     tools: list[dict[str, Any]] = field(default_factory=list)
     tool_executor: ToolExecutor | None = None
     tool_response_create: bool = True
+
+    def __post_init__(self) -> None:
+        if not 0 <= self.playback_buffer_ms < float("inf"):
+            raise ValueError("playback_buffer_ms must be a finite non-negative number")
 
 
 def load_realtime_tool_module(module_name: str) -> tuple[list[dict[str, Any]], ToolExecutor, bool]:
@@ -208,8 +213,8 @@ class PlaybackBuffer:
     def __init__(self, recv_rate: int, startup_buffer_ms: float = _PLAYBACK_START_BUFFER_MS) -> None:
         if recv_rate <= 0:
             raise ValueError("recv_rate must be positive")
-        if startup_buffer_ms < 0:
-            raise ValueError("startup_buffer_ms must not be negative")
+        if not 0 <= startup_buffer_ms < float("inf"):
+            raise ValueError("startup_buffer_ms must be a finite non-negative number")
         self.recv_rate = recv_rate
         self._startup_buffer_bytes = int(recv_rate * 2 * startup_buffer_ms / 1000)
         self._startup_buffer_bytes -= self._startup_buffer_bytes % 2
@@ -835,7 +840,7 @@ async def _run_audio_session(
     import sounddevice as sd
 
     mic_queue: Queue[bytes] = Queue(maxsize=128)
-    playback = PlaybackBuffer(config.recv_rate)
+    playback = PlaybackBuffer(config.recv_rate, startup_buffer_ms=config.playback_buffer_ms)
     renderer = _FriendlyEventRenderer()
     tool_calls = _ToolCallCoordinator(conn, config)
 

--- a/src/speech_to_speech/api/openai_realtime/audio_client.py
+++ b/src/speech_to_speech/api/openai_realtime/audio_client.py
@@ -34,6 +34,7 @@ logger = logging.getLogger(__name__)
 _AssistantTranscriptStream = tuple[str | None, str | None, int | None, int | None]
 ToolExecutor = Callable[[str, dict[str, Any]], Awaitable[Any]]
 _TOOL_CREATE_ID_METADATA_KEY = "s2s_local_tool_create_id"
+_PLAYBACK_START_BUFFER_MS = 96.0
 
 
 @dataclass(frozen=True)
@@ -204,21 +205,42 @@ def build_session_update(config: RealtimeAudioClientConfig) -> dict[str, Any]:
 class PlaybackBuffer:
     """Thread-safe audio state shared by the Realtime loop and sounddevice callbacks."""
 
-    def __init__(self, recv_rate: int) -> None:
+    def __init__(self, recv_rate: int, startup_buffer_ms: float = _PLAYBACK_START_BUFFER_MS) -> None:
+        if recv_rate <= 0:
+            raise ValueError("recv_rate must be positive")
+        if startup_buffer_ms < 0:
+            raise ValueError("startup_buffer_ms must not be negative")
         self.recv_rate = recv_rate
+        self._startup_buffer_bytes = int(recv_rate * 2 * startup_buffer_ms / 1000)
+        self._startup_buffer_bytes -= self._startup_buffer_bytes % 2
         self._audio = bytearray()
         self._lock = Lock()
         self._active_until = 0.0
+        self._playing = False
+        self._input_complete = False
 
     def clear(self) -> None:
         with self._lock:
             self._active_until = 0.0
             self._audio.clear()
+            self._playing = False
+            self._input_complete = False
 
     def append(self, audio: bytes) -> None:
+        if not audio:
+            return
         with self._lock:
+            if self._input_complete and not self._audio:
+                self._playing = False
+            self._input_complete = False
             self._audio.extend(audio)
             self._active_until = time.monotonic() + max(0.15, len(audio) / (2 * self.recv_rate))
+
+    def finish(self) -> None:
+        """Allow a completed short response to play before reaching the startup target."""
+
+        with self._lock:
+            self._input_complete = True
 
     def is_active(self) -> bool:
         with self._lock:
@@ -227,12 +249,21 @@ class PlaybackBuffer:
     def write(self, outdata: Any) -> None:
         needed = len(outdata)
         with self._lock:
+            if not self._playing:
+                ready = len(self._audio) >= self._startup_buffer_bytes
+                if not ready and not (self._input_complete and self._audio):
+                    outdata[:] = b"\x00" * needed
+                    return
+                self._playing = True
             available = min(needed, len(self._audio))
             if available:
                 outdata[:available] = self._audio[:available]
                 del self._audio[:available]
             if available < needed:
                 outdata[available:] = b"\x00" * (needed - available)
+                self._playing = False
+            if not self._audio and self._input_complete:
+                self._playing = False
 
     @property
     def buffered_bytes(self) -> int:
@@ -367,6 +398,7 @@ def handle_server_event(
     elif event.type == "response.output_audio.delta":
         playback.append(base64.b64decode(event.delta))
     elif event.type == "response.output_audio.done":
+        playback.finish()
         renderer.finish_live_assistant_text()
         print("ASSISTANT: <audio done>", flush=True)
     elif event.type == "response.output_audio_transcript.delta":
@@ -383,6 +415,8 @@ def handle_server_event(
         renderer.finish_assistant_response(getattr(event.response, "id", None))
         if event.response.status == "cancelled":
             playback.clear()
+        else:
+            playback.finish()
         print(f"ASSISTANT: <response {event.response.status}>", flush=True)
     elif event.type == "output_audio_buffer.cleared":
         playback.clear()

--- a/src/speech_to_speech/api/openai_realtime/handlers/response.py
+++ b/src/speech_to_speech/api/openai_realtime/handlers/response.py
@@ -1,7 +1,7 @@
 from __future__ import annotations
 
 import logging
-from typing import TYPE_CHECKING, Literal, Optional
+from typing import TYPE_CHECKING, Literal
 
 from openai.types.realtime import (
     ConversationItem,
@@ -432,13 +432,13 @@ class ResponseHandler(RealtimeBaseHandler):
         rp = st.current_response_params
         metadata = rp.metadata if rp and rp.metadata else None
 
-        voice: Optional[str] = None
+        voice: str | None = None
         if rp and rp.audio and rp.audio.output and rp.audio.output.voice:
-            voice = str(rp.audio.output.voice)
+            voice = self._response_voice_id(rp.audio.output.voice)
         if not voice:
             audio_cfg = st.runtime_config.session.audio
             audio_output = audio_cfg.output if audio_cfg is not None else None
-            voice = str(audio_output.voice) if audio_output is not None and audio_output.voice else None
+            voice = self._response_voice_id(audio_output.voice) if audio_output is not None else None
 
         # Out-of-band responses are not threaded into any conversation: report a null id.
         conversation_id = None if is_out_of_band(rp) else st.conversation_id
@@ -448,7 +448,7 @@ class ResponseHandler(RealtimeBaseHandler):
             object="realtime.response",
             status=status,
             status_details=status_details,
-            audio=Audio(output=AudioOutput(voice=str(voice) if voice else None)),  # type: ignore[arg-type]
+            audio=Audio(output=AudioOutput(voice=voice)),  # type: ignore[arg-type]
             conversation_id=conversation_id,
             metadata=metadata,
             output=self._build_output_items(conn_id, status),
@@ -458,6 +458,14 @@ class ResponseHandler(RealtimeBaseHandler):
                 total_tokens=st.response_usage.input_tokens + st.response_usage.output_tokens,
             ),
         )
+
+    @staticmethod
+    def _response_voice_id(voice: object | None) -> str | None:
+        """Return the protocol string for a built-in or custom voice."""
+        if isinstance(voice, str):
+            return voice
+        voice_id = getattr(voice, "id", None)
+        return voice_id if isinstance(voice_id, str) else None
 
     # Annotated with ConversationItem (the SDK's own 9-type item union) rather
     # than the two types actually produced: list is invariant, so a narrower

--- a/src/speech_to_speech/api/openai_realtime/service.py
+++ b/src/speech_to_speech/api/openai_realtime/service.py
@@ -533,6 +533,19 @@ class RealtimeService:
         if isinstance(event, TokenUsageEvent):
             return self._on_token_usage(conn_id, event)
 
+        if isinstance(event, (AssistantOutputEvent, AssistantToolCallReadyEvent)):
+            # A TTS failure can overtake assistant content that the LLM already
+            # queued for the same response. Do not publish text or tools after
+            # that response has been marked failed.
+            st = self._state(conn_id)
+            event_response_key = event.response_key
+            failed_response_owns_event = st.response_failed and (
+                event_response_key is None or event_response_key == st.current_response_key
+            )
+            if failed_response_owns_event:
+                logger.info("Ignoring %s after response failure", event.type)
+                return []
+
         is_stale = self._is_stale_turn_event(event, wait_for_pending_reopen=wait_for_pending_reopen)
         if is_stale is None:
             return None

--- a/src/speech_to_speech/arguments_classes/local_audio_arguments.py
+++ b/src/speech_to_speech/arguments_classes/local_audio_arguments.py
@@ -24,9 +24,9 @@ class LocalAudioArguments:
         metadata={"help": "Microphone and speaker callback block size in samples. Default is 1024."},
     )
     local_audio_playback_buffer_ms: float = field(
-        default=128.0,
+        default=196.0,
         metadata={
-            "help": "Audio to buffer before local playback starts, in milliseconds. Default is 128.",
+            "help": "Audio to buffer before local playback starts, in milliseconds. Default is 196.",
             "aliases": ["--playback-buffer-ms"],
         },
     )

--- a/src/speech_to_speech/arguments_classes/local_audio_arguments.py
+++ b/src/speech_to_speech/arguments_classes/local_audio_arguments.py
@@ -23,6 +23,13 @@ class LocalAudioArguments:
         default=1024,
         metadata={"help": "Microphone and speaker callback block size in samples. Default is 1024."},
     )
+    local_audio_playback_buffer_ms: float = field(
+        default=128.0,
+        metadata={
+            "help": "Audio to buffer before local playback starts, in milliseconds. Default is 128.",
+            "aliases": ["--playback-buffer-ms"],
+        },
+    )
     local_audio_block_mic_during_playback: bool = field(
         default=False,
         metadata={

--- a/src/speech_to_speech/arguments_classes/openai_tts_arguments.py
+++ b/src/speech_to_speech/arguments_classes/openai_tts_arguments.py
@@ -1,0 +1,62 @@
+from dataclasses import dataclass, field
+from typing import Optional
+
+
+@dataclass
+class OpenAICompatibleTTSHandlerArguments:
+    """Connection and audio settings for an OpenAI-compatible TTS server."""
+
+    openai_tts_base_url: str = field(
+        default="http://localhost:8091/v1",
+        metadata={"help": "Base URL of the OpenAI-compatible server, including /v1."},
+    )
+    openai_tts_api_key: Optional[str] = field(
+        default=None,
+        metadata={"help": "Optional bearer token. If unset, OPENAI_API_KEY is used when available."},
+    )
+    openai_tts_model: str = field(
+        default="Qwen/Qwen3-TTS-12Hz-1.7B-CustomVoice",
+        metadata={"help": "Model identifier sent to POST /audio/speech."},
+    )
+    openai_tts_voice: str = field(
+        default="aiden",
+        metadata={"help": "Voice name sent with speech requests."},
+    )
+    openai_tts_language: Optional[str] = field(
+        default=None,
+        metadata={
+            "help": "Optional vLLM-Omni language extension. Use 'Auto' to forward the STT language when available."
+        },
+    )
+    openai_tts_task_type: Optional[str] = field(
+        default=None,
+        metadata={"help": "Optional vLLM-Omni task type such as CustomVoice, VoiceDesign, or Base."},
+    )
+    openai_tts_instructions: Optional[str] = field(
+        default=None,
+        metadata={"help": "Optional voice style instructions for compatible servers."},
+    )
+    openai_tts_response_format: str = field(
+        default="pcm",
+        metadata={"help": "Audio response format. The adapter currently supports pcm and wav."},
+    )
+    openai_tts_sample_rate: int = field(
+        default=24000,
+        metadata={"help": "Sample rate of raw PCM returned by the server. Qwen3-TTS uses 24000."},
+    )
+    openai_tts_speed: float = field(
+        default=1.0,
+        metadata={"help": "Speech speed for compatible non-streaming endpoints."},
+    )
+    openai_tts_stream: bool = field(
+        default=True,
+        metadata={"help": "Request vLLM-Omni raw audio streaming extensions."},
+    )
+    openai_tts_timeout: float = field(
+        default=300.0,
+        metadata={"help": "HTTP request timeout in seconds."},
+    )
+    openai_tts_blocksize: int = field(
+        default=512,
+        metadata={"help": "Pipeline output chunk size in 16 kHz samples."},
+    )

--- a/src/speech_to_speech/arguments_classes/openai_tts_arguments.py
+++ b/src/speech_to_speech/arguments_classes/openai_tts_arguments.py
@@ -24,9 +24,7 @@ class OpenAICompatibleTTSHandlerArguments:
     )
     openai_tts_language: Optional[str] = field(
         default=None,
-        metadata={
-            "help": "Optional vLLM-Omni language extension. Use 'Auto' to forward the STT language when available."
-        },
+        metadata={"help": "Optional fixed language value forwarded unchanged with every speech request."},
     )
     openai_tts_task_type: Optional[str] = field(
         default=None,

--- a/src/speech_to_speech/arguments_classes/openai_tts_arguments.py
+++ b/src/speech_to_speech/arguments_classes/openai_tts_arguments.py
@@ -49,8 +49,8 @@ class OpenAICompatibleTTSHandlerArguments:
         metadata={"help": "Speech speed for compatible non-streaming endpoints."},
     )
     openai_tts_stream: bool = field(
-        default=True,
-        metadata={"help": "Request vLLM-Omni raw audio streaming extensions."},
+        default=False,
+        metadata={"help": "Opt in to the vLLM-Omni stream=true extension."},
     )
     openai_tts_timeout: float = field(
         default=300.0,

--- a/src/speech_to_speech/backend_registry.py
+++ b/src/speech_to_speech/backend_registry.py
@@ -277,7 +277,6 @@ def _create_openai_tts(context: HandlerContext, config: Mapping[str, Any]) -> An
             **config,
             "cancel_scope": context.cancel_scope,
             "speculative_turns": context.speculative_turns,
-            "text_output_queue": context.text_output_queue,
         },
     )
 

--- a/src/speech_to_speech/backend_registry.py
+++ b/src/speech_to_speech/backend_registry.py
@@ -22,6 +22,7 @@ from speech_to_speech.arguments_classes.language_model_arguments import Language
 from speech_to_speech.arguments_classes.mlx_audio_whisper_arguments import (
     MLXAudioWhisperSTTHandlerArguments,
 )
+from speech_to_speech.arguments_classes.openai_tts_arguments import OpenAICompatibleTTSHandlerArguments
 from speech_to_speech.arguments_classes.paraformer_stt_arguments import ParaformerSTTHandlerArguments
 from speech_to_speech.arguments_classes.parakeet_tdt_arguments import (
     ParakeetTDTSTTHandlerArguments,
@@ -262,6 +263,25 @@ def _create_parakeet(context: HandlerContext, config: Mapping[str, Any]) -> Any:
     return handler
 
 
+def _create_openai_tts(context: HandlerContext, config: Mapping[str, Any]) -> Any:
+    handler_class = _load_handler(
+        "speech_to_speech.TTS.openai_compatible_handler",
+        "OpenAICompatibleTTSHandler",
+    )
+    return handler_class(
+        context.stop_event,
+        queue_in=context.queue_in,
+        queue_out=context.queue_out,
+        setup_args=(context.should_listen,),
+        setup_kwargs={
+            **config,
+            "cancel_scope": context.cancel_scope,
+            "speculative_turns": context.speculative_turns,
+            "text_output_queue": context.text_output_queue,
+        },
+    )
+
+
 def _create_local_llm(backend: Literal["transformers", "mlx-lm"]) -> HandlerFactory:
     def create(context: HandlerContext, config: Mapping[str, Any]) -> Any:
         setup_kwargs = dict(config)
@@ -472,6 +492,13 @@ TTS_BACKENDS = build_backend_registry(
                 context_kwargs=True,
             ),
             config_prefix="qwen3_tts",
+        ),
+        BackendSpec(
+            "openai",
+            "tts",
+            OpenAICompatibleTTSHandlerArguments,
+            _create_openai_tts,
+            config_prefix="openai_tts",
         ),
     ],
 )

--- a/src/speech_to_speech/cli.py
+++ b/src/speech_to_speech/cli.py
@@ -119,6 +119,12 @@ def parse_talk_arguments(argv: Sequence[str]) -> RealtimeAudioClientConfig:
     )
     parser.add_argument("--send-rate", type=int, default=defaults.send_rate)
     parser.add_argument("--recv-rate", type=int, default=defaults.recv_rate)
+    parser.add_argument(
+        "--playback-buffer-ms",
+        type=float,
+        default=defaults.playback_buffer_ms,
+        help="Audio to buffer before playback starts, in milliseconds.",
+    )
     parser.add_argument("--chunk-size", type=int, default=defaults.chunk_size)
     parser.add_argument("--input-device", type=int, default=defaults.input_device)
     parser.add_argument("--output-device", type=int, default=defaults.output_device)
@@ -164,6 +170,7 @@ def parse_talk_arguments(argv: Sequence[str]) -> RealtimeAudioClientConfig:
         api_key=namespace.api_key,
         send_rate=namespace.send_rate,
         recv_rate=namespace.recv_rate,
+        playback_buffer_ms=namespace.playback_buffer_ms,
         chunk_size=namespace.chunk_size,
         input_device=namespace.input_device,
         output_device=namespace.output_device,

--- a/src/speech_to_speech/s2s_pipeline.py
+++ b/src/speech_to_speech/s2s_pipeline.py
@@ -608,6 +608,7 @@ def build_local_pipeline(args: ParsedArguments, stop_event: Event) -> ThreadMana
             url=f"ws://127.0.0.1:{args.realtime_server_kwargs.port}/v1/realtime",
             api_key="local",
             chunk_size=local_audio.local_audio_chunk_size,
+            playback_buffer_ms=local_audio.local_audio_playback_buffer_ms,
             input_device=local_audio.local_audio_input_device,
             output_device=local_audio.local_audio_output_device,
             print_json=local_audio.local_audio_print_json,

--- a/tests/openai_realtime/test_audio_client.py
+++ b/tests/openai_realtime/test_audio_client.py
@@ -224,6 +224,37 @@ def test_audio_client_rejects_unsupported_explicit_pcm_rates(rate):
         build_session_update(RealtimeAudioClientConfig(send_rate=rate))
 
 
+def test_playback_buffer_waits_for_startup_audio_before_playing():
+    playback = PlaybackBuffer(1000, startup_buffer_ms=100)
+    playback.append(b"\x01" * 100)
+    first_callback = bytearray(100)
+
+    playback.write(first_callback)
+
+    assert first_callback == b"\x00" * 100
+    assert playback.buffered_bytes == 100
+
+    playback.append(b"\x02" * 100)
+    second_callback = bytearray(100)
+    playback.write(second_callback)
+
+    assert second_callback == b"\x01" * 100
+    assert playback.buffered_bytes == 100
+
+
+def test_playback_buffer_flushes_completed_audio_shorter_than_startup_buffer():
+    playback = PlaybackBuffer(1000, startup_buffer_ms=100)
+    playback.append(b"\x03" * 100)
+    playback.finish()
+    callback = bytearray(200)
+
+    playback.write(callback)
+
+    assert callback[:100] == b"\x03" * 100
+    assert callback[100:] == b"\x00" * 100
+    assert playback.buffered_bytes == 0
+
+
 def test_audio_client_clears_unplayed_audio_on_barge_in(capsys):
     playback = PlaybackBuffer(16000)
     renderer = _FriendlyEventRenderer()

--- a/tests/openai_realtime/test_audio_client.py
+++ b/tests/openai_realtime/test_audio_client.py
@@ -255,6 +255,12 @@ def test_playback_buffer_flushes_completed_audio_shorter_than_startup_buffer():
     assert playback.buffered_bytes == 0
 
 
+@pytest.mark.parametrize("buffer_ms", [-1, float("inf"), float("nan")])
+def test_audio_client_rejects_invalid_playback_buffer(buffer_ms):
+    with pytest.raises(ValueError, match="playback_buffer_ms"):
+        RealtimeAudioClientConfig(playback_buffer_ms=buffer_ms)
+
+
 def test_audio_client_clears_unplayed_audio_on_barge_in(capsys):
     playback = PlaybackBuffer(16000)
     renderer = _FriendlyEventRenderer()
@@ -1245,6 +1251,13 @@ def test_audio_client_does_not_duplicate_partial_transcript_on_cancel(capsys):
 
 async def test_audio_streams_are_cleaned_up_when_output_start_fails(monkeypatch):
     events = []
+    playback_args = []
+
+    original_playback_buffer = PlaybackBuffer
+
+    def recording_playback_buffer(recv_rate, startup_buffer_ms):
+        playback_args.append((recv_rate, startup_buffer_ms))
+        return original_playback_buffer(recv_rate, startup_buffer_ms)
 
     class FakeStream:
         def __init__(self, name, *, fail_start=False):
@@ -1269,14 +1282,16 @@ async def test_audio_streams_are_cleaned_up_when_output_start_fails(monkeypatch)
         RawOutputStream=lambda **_kwargs: output_stream,
     )
     monkeypatch.setitem(sys.modules, "sounddevice", fake_sounddevice)
+    monkeypatch.setattr(audio_client_module, "PlaybackBuffer", recording_playback_buffer)
 
     with pytest.raises(RuntimeError, match="output start failed"):
         await audio_client_module._run_audio_session(
             SimpleNamespace(),
-            RealtimeAudioClientConfig(),
+            RealtimeAudioClientConfig(playback_buffer_ms=240),
             Event(),
         )
 
+    assert playback_args == [(16000, 240)]
     assert events == [
         "input.start",
         "output.start",

--- a/tests/openai_realtime/test_pipeline_builder.py
+++ b/tests/openai_realtime/test_pipeline_builder.py
@@ -43,6 +43,7 @@ def test_local_composes_loopback_client_with_same_server_builder(monkeypatch):
     args = _default_args()
     args.realtime_server_kwargs.host = "192.0.2.10"
     args.realtime_server_kwargs.port = 9876
+    args.local_audio_kwargs.local_audio_playback_buffer_ms = 240
     pipeline_handler = object()
     unit = SimpleNamespace(handlers=[pipeline_handler])
     monkeypatch.setattr("speech_to_speech.s2s_pipeline._build_pipeline_unit", lambda **_kwargs: unit)
@@ -59,3 +60,4 @@ def test_local_composes_loopback_client_with_same_server_builder(monkeypatch):
     assert server.port == 9876
     assert client.config.url == f"ws://127.0.0.1:{server.port}/v1/realtime"
     assert client.config.api_key == "local"
+    assert client.config.playback_buffer_ms == 240

--- a/tests/openai_realtime/test_realtime_service.py
+++ b/tests/openai_realtime/test_realtime_service.py
@@ -2102,6 +2102,36 @@ class TestHandleResponseCreate:
         assert isinstance(result, ResponseCreatedEvent)
         assert result.response.conversation_id == service._state(conn_id).conversation_id
 
+    def test_response_custom_voice_id_is_reported_in_created_and_done_events(self, service, conn_id):
+        created = service.handle_response_create(
+            conn_id,
+            ResponseCreateEvent(
+                type="response.create",
+                response={"audio": {"output": {"voice": {"id": "voice_response"}}}},
+            ),
+        )
+
+        assert isinstance(created, ResponseCreatedEvent)
+        assert created.response.audio.output.voice == "voice_response"
+        done = next(event for event in service.finish_response(conn_id) if isinstance(event, ResponseDoneEvent))
+        assert done.response.audio.output.voice == "voice_response"
+
+    def test_session_custom_voice_id_is_reported_in_created_and_done_events(self, service, conn_id):
+        service.handle_session_update(
+            conn_id,
+            SessionUpdateEvent(
+                type="session.update",
+                session={"type": "realtime", "audio": {"output": {"voice": {"id": "voice_session"}}}},
+            ),
+        )
+
+        created = service.handle_response_create(conn_id, ResponseCreateEvent(type="response.create"))
+
+        assert isinstance(created, ResponseCreatedEvent)
+        assert created.response.audio.output.voice == "voice_session"
+        done = next(event for event in service.finish_response(conn_id) if isinstance(event, ResponseDoneEvent))
+        assert done.response.audio.output.voice == "voice_session"
+
 
 # ===================================================================
 # Response cancel

--- a/tests/openai_realtime/test_realtime_service.py
+++ b/tests/openai_realtime/test_realtime_service.py
@@ -4065,6 +4065,52 @@ class TestDispatchPipelineEvent:
         assert response_done.response.output[0].status == "incomplete"
         assert response_done.response.status_details.error.type == "response_failed"
 
+    def test_response_failure_suppresses_late_assistant_content(self, service, conn_id):
+        response_key = "response-1"
+        service.response._ensure_response(conn_id, response_key)
+        service.dispatch_pipeline_event(
+            conn_id,
+            ResponseFailedEvent(message="speech provider failed", response_key=response_key),
+        )
+
+        assert (
+            service.dispatch_pipeline_event(
+                conn_id,
+                AssistantOutputEvent(text="never synthesized", response_key=response_key),
+            )
+            == []
+        )
+        assert (
+            service.dispatch_pipeline_event(
+                conn_id,
+                AssistantToolCallReadyEvent(
+                    part=AssistantToolCallPart(
+                        tool={
+                            "type": "function_call",
+                            "call_id": "call-late",
+                            "name": "lookup",
+                            "arguments": "{}",
+                        }
+                    ),
+                    output_sequence=1,
+                    response_key=response_key,
+                ),
+            )
+            == []
+        )
+        service.dispatch_pipeline_event(
+            conn_id,
+            TokenUsageEvent(input_tokens=3, output_tokens=2, response_key=response_key),
+        )
+
+        state = service._state(conn_id)
+        assert state.pending_text_outputs == []
+        assert state.pending_function_calls == {}
+        assert state.response_usage.input_tokens == 3
+        assert state.response_usage.output_tokens == 2
+        done = service.finish_response(conn_id, response_key=response_key)
+        assert done[-1].response.status == "failed"
+
     def test_response_failed_while_pending_emits_error_and_failed_done(self, service, conn_id):
         service.dispatch_pipeline_event(
             conn_id,

--- a/tests/test_backend_registry.py
+++ b/tests/test_backend_registry.py
@@ -171,9 +171,10 @@ def test_test_backend_only_needs_config_factory_and_registry_entry():
     assert calls[0][1] is selection.config
 
 
-def test_openai_tts_backend_constructs_through_registry():
+def test_openai_tts_backend_constructs_through_registry(monkeypatch):
     from speech_to_speech.TTS.openai_compatible_handler import OpenAICompatibleTTSHandler
 
+    monkeypatch.setattr(OpenAICompatibleTTSHandler, "warmup", lambda self: None)
     args = parse_arguments(["--tts", "openai"])
     tts = create_backend_handler(args.tts_backend, _context())
 

--- a/tests/test_backend_registry.py
+++ b/tests/test_backend_registry.py
@@ -65,6 +65,7 @@ def test_builtin_registry_lookup_and_cli_choices_share_one_catalog():
     assert STT_BACKENDS["parakeet-tdt"].kind == "stt"
     assert LLM_BACKENDS["responses-api"].kind == "llm"
     assert TTS_BACKENDS["qwen3"].kind == "tts"
+    assert TTS_BACKENDS["openai"].kind == "tts"
     assert LLM_BACKENDS["responses-api"].capabilities.supports_llm_proxy
     assert LLM_BACKENDS["chat-completions"].capabilities.supports_llm_proxy
     assert LLM_BACKENDS["chat-completions"].capabilities.supports_audio_input
@@ -140,6 +141,15 @@ def test_test_backend_only_needs_config_factory_and_registry_entry():
     assert selection.config == {"option": "selected", "gen_kwargs": {}}
     assert parsed_config.fake_option == "selected"
     assert calls[0][1] is selection.config
+
+
+def test_openai_tts_backend_constructs_through_registry():
+    from speech_to_speech.TTS.openai_compatible_handler import OpenAICompatibleTTSHandler
+
+    args = parse_arguments(["--tts", "openai"])
+    tts = create_backend_handler(args.tts_backend, _context())
+
+    assert isinstance(tts, OpenAICompatibleTTSHandler)
 
 
 def test_new_stt_backend_gets_transcription_notifier_by_default(monkeypatch):

--- a/tests/test_cli_defaults.py
+++ b/tests/test_cli_defaults.py
@@ -237,6 +237,23 @@ def test_parse_arguments_accepts_qwen3_tts_backend_override():
     assert args.tts_backend.config["backend"] == "torch"
 
 
+def test_parse_arguments_accepts_openai_tts_backend():
+    args = parse_arguments(
+        [
+            "--tts",
+            "openai",
+            "--openai_tts_base_url",
+            "http://localhost:8091/v1",
+            "--openai_tts_voice",
+            "vivian",
+        ]
+    )
+
+    assert args.tts_backend.name == "openai"
+    assert args.tts_backend.config["base_url"] == "http://localhost:8091/v1"
+    assert args.tts_backend.config["voice"] == "vivian"
+
+
 def test_parse_arguments_accepts_qwen3_tts_ggml_options():
     original_argv = sys.argv[:]
     try:

--- a/tests/test_cli_defaults.py
+++ b/tests/test_cli_defaults.py
@@ -252,6 +252,13 @@ def test_parse_arguments_accepts_openai_tts_backend():
     assert args.tts_backend.name == "openai"
     assert args.tts_backend.config["base_url"] == "http://localhost:8091/v1"
     assert args.tts_backend.config["voice"] == "vivian"
+    assert args.tts_backend.config["stream"] is False
+
+
+def test_parse_arguments_accepts_vllm_tts_stream_extension():
+    args = parse_arguments(["--tts", "openai", "--openai_tts_stream", "true"])
+
+    assert args.tts_backend.config["stream"] is True
 
 
 def test_parse_arguments_accepts_qwen3_tts_ggml_options():

--- a/tests/test_cli_defaults.py
+++ b/tests/test_cli_defaults.py
@@ -380,6 +380,12 @@ def test_talk_leaves_api_key_unset_for_sdk_environment_authentication():
     assert parse_talk_arguments(["--api-key", "explicit-secret"]).api_key == "explicit-secret"
 
 
+def test_talk_accepts_custom_playback_buffer():
+    config = parse_talk_arguments(["--playback-buffer-ms", "240"])
+
+    assert config.playback_buffer_ms == 240
+
+
 @pytest.mark.parametrize("flag", ["--log-transcripts", "--log_transcripts"])
 def test_talk_accepts_transcript_logging_opt_in(flag):
     assert parse_talk_arguments([]).log_transcripts is False
@@ -446,11 +452,15 @@ def test_serve_rejects_local_audio_flags():
 
 
 def test_local_accepts_audio_flags_but_rejects_host():
-    args = parse_arguments(["--port", "9876", "--local_audio_input_device", "2"], command="local")
+    args = parse_arguments(
+        ["--port", "9876", "--local_audio_input_device", "2", "--playback-buffer-ms", "240"],
+        command="local",
+    )
 
     assert args.realtime_server_kwargs.host == "127.0.0.1"
     assert args.realtime_server_kwargs.port == 9876
     assert args.local_audio_kwargs.local_audio_input_device == 2
+    assert args.local_audio_kwargs.local_audio_playback_buffer_ms == 240
     with pytest.raises(ValueError, match="--host"):
         parse_arguments(["--host", "0.0.0.0"], command="local")
 

--- a/tests/test_cli_defaults.py
+++ b/tests/test_cli_defaults.py
@@ -386,6 +386,11 @@ def test_talk_accepts_custom_playback_buffer():
     assert config.playback_buffer_ms == 240
 
 
+def test_packaged_audio_clients_default_to_196_ms_playback_buffer():
+    assert parse_talk_arguments([]).playback_buffer_ms == 196
+    assert LocalAudioArguments().local_audio_playback_buffer_ms == 196
+
+
 @pytest.mark.parametrize("flag", ["--log-transcripts", "--log_transcripts"])
 def test_talk_accepts_transcript_logging_opt_in(flag):
     assert parse_talk_arguments([]).log_transcripts is False

--- a/tests/test_openai_tts_handler.py
+++ b/tests/test_openai_tts_handler.py
@@ -95,7 +95,7 @@ def _openai_tts_handler(
 ) -> OpenAICompatibleTTSHandler:
     _reset_fake_speech_operation()
     monkeypatch.setattr(tts_module, "HttpSpeechOperation", _FakeSpeechOperation)
-    return OpenAICompatibleTTSHandler(
+    handler = OpenAICompatibleTTSHandler(
         Event(),
         queue_in=Queue(),
         queue_out=Queue(),
@@ -107,6 +107,59 @@ def _openai_tts_handler(
             "speculative_turns": speculative_turns,
         },
     )
+    _reset_fake_speech_operation()
+    return handler
+
+
+def test_openai_tts_warmup_uses_configured_request(monkeypatch):
+    _reset_fake_speech_operation()
+    monkeypatch.setattr(tts_module, "HttpSpeechOperation", _FakeSpeechOperation)
+
+    OpenAICompatibleTTSHandler(
+        Event(),
+        queue_in=Queue(),
+        queue_out=Queue(),
+        setup_args=(Event(),),
+        setup_kwargs={
+            "base_url": "http://speech.example/v1",
+            "api_key": "test-key",
+            "model": "test-model",
+            "voice": "test-voice",
+            "language": "Auto",
+            "sample_rate": 24000,
+            "stream": True,
+            "timeout": 12,
+            "blocksize": 512,
+        },
+    )
+
+    assert len(_FakeSpeechOperation.instances) == 1
+    operation = _FakeSpeechOperation.instances[0]
+    assert operation.payload == {
+        "model": "test-model",
+        "input": "Warmup",
+        "voice": "test-voice",
+        "response_format": "pcm",
+        "stream_format": "audio",
+        "stream": True,
+        "language": "Auto",
+    }
+    assert operation.cancelled is False
+
+
+def test_openai_tts_warmup_http_failure_aborts_construction(monkeypatch):
+    transport = tts_module.httpx.MockTransport(lambda request: tts_module.httpx.Response(404, request=request))
+    client = tts_module.httpx.AsyncClient(transport=transport)
+    monkeypatch.setattr(tts_module.httpx, "AsyncClient", lambda **kwargs: client)
+
+    with pytest.raises(tts_module.SpeechRequestError, match="speech server returned HTTP 404"):
+        OpenAICompatibleTTSHandler(
+            Event(),
+            queue_in=Queue(),
+            queue_out=Queue(),
+            setup_args=(Event(),),
+            setup_kwargs={"sample_rate": 24000, "blocksize": 512},
+        )
 
 
 def test_openai_tts_streams_resampled_fixed_size_pcm(monkeypatch):
@@ -193,6 +246,7 @@ def test_openai_tts_standard_request_yields_audio_before_response_eof(monkeypatc
     transport = tts_module.httpx.MockTransport(respond)
     client = tts_module.httpx.AsyncClient(transport=transport)
     monkeypatch.setattr(tts_module.httpx, "AsyncClient", lambda **kwargs: client)
+    monkeypatch.setattr(OpenAICompatibleTTSHandler, "warmup", lambda self: None)
     handler = OpenAICompatibleTTSHandler(
         Event(),
         queue_in=Queue(),
@@ -705,6 +759,7 @@ def test_openai_tts_rejects_non_audio_success_responses(monkeypatch, content_typ
     )
     client = tts_module.httpx.AsyncClient(transport=transport)
     monkeypatch.setattr(tts_module.httpx, "AsyncClient", lambda **kwargs: client)
+    monkeypatch.setattr(OpenAICompatibleTTSHandler, "warmup", lambda self: None)
     handler = OpenAICompatibleTTSHandler(
         Event(),
         queue_in=Queue(),
@@ -780,7 +835,7 @@ def test_http_speech_cancellation_closes_transport_before_response_headers():
         server_thread.join(timeout=1)
 
 
-def test_openai_tts_cancellation_unblocks_a_stalled_socket_and_session_end():
+def test_openai_tts_cancellation_unblocks_a_stalled_socket_and_session_end(monkeypatch):
     listener = socket.socket(socket.AF_INET, socket.SOCK_STREAM)
     listener.setsockopt(socket.SOL_SOCKET, socket.SO_REUSEADDR, 1)
     listener.bind(("127.0.0.1", 0))
@@ -805,6 +860,7 @@ def test_openai_tts_cancellation_unblocks_a_stalled_socket_and_session_end():
     server_thread = Thread(target=serve_stalled_response, daemon=True)
     server_thread.start()
     cancel_scope = CancelScope()
+    monkeypatch.setattr(OpenAICompatibleTTSHandler, "warmup", lambda self: None)
     handler = OpenAICompatibleTTSHandler(
         Event(),
         queue_in=Queue(),

--- a/tests/test_openai_tts_handler.py
+++ b/tests/test_openai_tts_handler.py
@@ -49,6 +49,8 @@ class _FakeSpeechOperation:
             samples = np.arange(2400, dtype="<i2")
             encoded = samples.tobytes()
         for index, offset in enumerate(range(0, len(encoded), 301)):
+            if self.cancelled:
+                raise SpeechRequestCancelled
             if type(self).failure_after_chunks == index:
                 raise tts_module.SpeechRequestError("speech stream failed")
             if cancel_check():
@@ -439,6 +441,42 @@ def test_openai_tts_cancellation_stops_publication_and_closes_operation(monkeypa
     assert isinstance(first, np.ndarray)
     assert list(generation) == []
     assert _FakeSpeechOperation.instances[0].cancelled is True
+
+
+def test_openai_tts_session_teardown_stops_publication_and_closes_operation(monkeypatch):
+    handler = _openai_tts_handler(monkeypatch)
+    generation = handler.process(TTSInput(text="Hello"))
+    first = next(generation)
+    operation = _FakeSpeechOperation.instances[0]
+
+    handler.on_session_end()
+
+    assert isinstance(first, np.ndarray)
+    assert list(generation) == []
+    assert operation.cancelled is True
+    assert handler._active_operation is None
+    assert handler.queue_out.empty()
+
+
+def test_http_speech_cancellation_after_completion_is_harmless(monkeypatch):
+    transport = tts_module.httpx.MockTransport(
+        lambda request: tts_module.httpx.Response(200, content=b"\x00\x00", request=request)
+    )
+    client = tts_module.httpx.Client(transport=transport)
+    monkeypatch.setattr(tts_module.httpx, "Client", lambda **kwargs: client)
+    operation = HttpSpeechOperation(
+        endpoint_url="http://localhost:8000/v1/audio/speech",
+        api_key=None,
+        payload={"input": "hello"},
+        timeout_s=2,
+    )
+
+    assert list(operation.iter_bytes(lambda: False)) == [b"\x00\x00"]
+    assert client.is_closed
+    operation.cancel()
+    operation.cancel()
+
+    assert client.is_closed
 
 
 def test_http_speech_cancellation_during_client_construction_prevents_dispatch(monkeypatch):

--- a/tests/test_openai_tts_handler.py
+++ b/tests/test_openai_tts_handler.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+import asyncio
 import io
 import socket
 from queue import Queue
@@ -464,8 +465,8 @@ def test_http_speech_cancellation_after_completion_is_harmless(monkeypatch):
     transport = tts_module.httpx.MockTransport(
         lambda request: tts_module.httpx.Response(200, content=b"\x00\x00", request=request)
     )
-    client = tts_module.httpx.Client(transport=transport)
-    monkeypatch.setattr(tts_module.httpx, "Client", lambda **kwargs: client)
+    client = tts_module.httpx.AsyncClient(transport=transport)
+    monkeypatch.setattr(tts_module.httpx, "AsyncClient", lambda **kwargs: client)
     operation = HttpSpeechOperation(
         endpoint_url="http://localhost:8000/v1/audio/speech",
         api_key=None,
@@ -500,10 +501,10 @@ def test_http_speech_cancellation_during_client_construction_prevents_dispatch(m
             stream_calls += 1
             raise AssertionError("cancelled operation must not enter client.stream()")
 
-        def close(self) -> None:
+        async def aclose(self) -> None:
             pass
 
-    monkeypatch.setattr(tts_module.httpx, "Client", BlockingClient)
+    monkeypatch.setattr(tts_module.httpx, "AsyncClient", BlockingClient)
     operation = HttpSpeechOperation(
         endpoint_url="http://localhost:8000/v1/audio/speech",
         api_key=None,
@@ -545,22 +546,23 @@ def test_http_speech_timeout_is_a_total_deadline(monkeypatch):
     closed = Event()
 
     class TricklingResponse:
-        def __enter__(self):
+        async def __aenter__(self):
             return self
 
-        def __exit__(self, *args) -> None:
+        async def __aexit__(self, *args) -> None:
             del args
-            self.close()
+            await self.aclose()
 
-        def close(self) -> None:
+        async def aclose(self) -> None:
             closed.set()
 
         def raise_for_status(self) -> None:
             pass
 
-        def iter_bytes(self):
+        async def aiter_bytes(self):
             while not closed.wait(0.01):
                 yield b"\x00\x00"
+                await asyncio.sleep(0)
 
     response = TricklingResponse()
 
@@ -572,10 +574,10 @@ def test_http_speech_timeout_is_a_total_deadline(monkeypatch):
             del args, kwargs
             return response
 
-        def close(self) -> None:
-            response.close()
+        async def aclose(self) -> None:
+            await response.aclose()
 
-    monkeypatch.setattr(tts_module.httpx, "Client", TricklingClient)
+    monkeypatch.setattr(tts_module.httpx, "AsyncClient", TricklingClient)
     operation = HttpSpeechOperation(
         endpoint_url="http://localhost:8000/v1/audio/speech",
         api_key=None,
@@ -604,8 +606,8 @@ def test_openai_tts_rejects_non_audio_success_responses(monkeypatch, content_typ
             request=request,
         )
     )
-    client = tts_module.httpx.Client(transport=transport)
-    monkeypatch.setattr(tts_module.httpx, "Client", lambda **kwargs: client)
+    client = tts_module.httpx.AsyncClient(transport=transport)
+    monkeypatch.setattr(tts_module.httpx, "AsyncClient", lambda **kwargs: client)
     handler = OpenAICompatibleTTSHandler(
         Event(),
         queue_in=Queue(),
@@ -620,6 +622,65 @@ def test_openai_tts_rejects_non_audio_success_responses(monkeypatch, content_typ
     assert isinstance(failure, ResponseFailedEvent)
     assert failure.message == "speech endpoint returned a non-audio response"
     assert failure.response_key == "response-1"
+
+
+def test_http_speech_cancellation_closes_transport_before_response_headers():
+    listener = socket.socket(socket.AF_INET, socket.SOCK_STREAM)
+    listener.setsockopt(socket.SOL_SOCKET, socket.SO_REUSEADDR, 1)
+    listener.bind(("127.0.0.1", 0))
+    listener.listen()
+    host, port = listener.getsockname()
+    request_received = Event()
+    connection_closed = Event()
+    cancelled = Event()
+
+    def serve_stalled_response() -> None:
+        connection, _ = listener.accept()
+        with connection:
+            request = b""
+            while b"\r\n\r\n" not in request:
+                data = connection.recv(4096)
+                if not data:
+                    return
+                request += data
+            request_received.set()
+            while connection.recv(4096):
+                pass
+            connection_closed.set()
+
+    server_thread = Thread(target=serve_stalled_response, daemon=True)
+    server_thread.start()
+    operation = HttpSpeechOperation(
+        endpoint_url=f"http://{host}:{port}/v1/audio/speech",
+        api_key=None,
+        payload={"input": "hello"},
+        timeout_s=30,
+    )
+    errors: list[BaseException] = []
+
+    def consume() -> None:
+        try:
+            list(operation.iter_bytes(cancelled.is_set))
+        except BaseException as exc:
+            errors.append(exc)
+
+    consumer = Thread(target=consume)
+    consumer.start()
+
+    try:
+        assert request_received.wait(1)
+        cancelled.set()
+        consumer.join(timeout=1)
+
+        assert not consumer.is_alive()
+        assert len(errors) == 1
+        assert isinstance(errors[0], SpeechRequestCancelled)
+        assert connection_closed.wait(1)
+        assert operation._worker_task is None
+        assert operation._worker_loop is None
+    finally:
+        listener.close()
+        server_thread.join(timeout=1)
 
 
 def test_openai_tts_cancellation_unblocks_a_stalled_socket_and_session_end():

--- a/tests/test_openai_tts_handler.py
+++ b/tests/test_openai_tts_handler.py
@@ -1,0 +1,347 @@
+from __future__ import annotations
+
+from queue import Queue
+from threading import Event, Thread
+
+import numpy as np
+
+from speech_to_speech.pipeline.cancel_scope import CancelScope
+from speech_to_speech.pipeline.events import ResponseFailedEvent
+from speech_to_speech.pipeline.messages import (
+    AUDIO_RESPONSE_DONE,
+    AudioOutput,
+    EndOfResponse,
+    TTSInput,
+)
+from speech_to_speech.pipeline.speculative_turns import SpeculativeTurnTracker
+from speech_to_speech.TTS import openai_compatible_handler as tts_module
+from speech_to_speech.TTS.openai_compatible_handler import (
+    HttpSpeechOperation,
+    OpenAICompatibleTTSHandler,
+    SpeechRequestCancelled,
+)
+
+
+class _FakeSpeechOperation:
+    instances: list["_FakeSpeechOperation"] = []
+    startup_action = None
+    startup_error: Exception | None = None
+    failure_after_chunks: int | None = None
+
+    def __init__(self, **kwargs) -> None:
+        self.payload = kwargs["payload"]
+        self.cancelled = False
+        type(self).instances.append(self)
+
+    def iter_bytes(self, cancel_check):
+        if type(self).startup_action is not None:
+            type(self).startup_action()
+        if type(self).startup_error is not None:
+            raise type(self).startup_error
+        samples = np.arange(2400, dtype="<i2")
+        encoded = samples.tobytes()
+        for index, offset in enumerate(range(0, len(encoded), 301)):
+            if type(self).failure_after_chunks == index:
+                raise tts_module.SpeechRequestError("speech stream failed")
+            if cancel_check():
+                self.cancel()
+                return
+            yield encoded[offset : offset + 301]
+
+    def cancel(self) -> None:
+        self.cancelled = True
+
+
+class _CountingSpeculativeTurnTracker(SpeculativeTurnTracker):
+    def __init__(self) -> None:
+        super().__init__()
+        self.commit_calls = 0
+
+    def commit_if_latest_after_reopen_grace(self, turn_id: str | None, revision: int | None) -> bool:
+        self.commit_calls += 1
+        return super().commit_if_latest_after_reopen_grace(turn_id, revision)
+
+
+def _reset_fake_speech_operation() -> None:
+    _FakeSpeechOperation.instances.clear()
+    _FakeSpeechOperation.startup_action = None
+    _FakeSpeechOperation.startup_error = None
+    _FakeSpeechOperation.failure_after_chunks = None
+
+
+def _openai_tts_handler(
+    monkeypatch,
+    *,
+    cancel_scope: CancelScope | None = None,
+    speculative_turns: SpeculativeTurnTracker | None = None,
+    text_output_queue: Queue | None = None,
+) -> OpenAICompatibleTTSHandler:
+    _reset_fake_speech_operation()
+    monkeypatch.setattr(tts_module, "HttpSpeechOperation", _FakeSpeechOperation)
+    return OpenAICompatibleTTSHandler(
+        Event(),
+        queue_in=Queue(),
+        queue_out=Queue(),
+        setup_args=(Event(),),
+        setup_kwargs={
+            "sample_rate": 24000,
+            "blocksize": 512,
+            "cancel_scope": cancel_scope,
+            "speculative_turns": speculative_turns,
+            "text_output_queue": text_output_queue,
+        },
+    )
+
+
+def test_openai_tts_streams_resampled_fixed_size_pcm(monkeypatch):
+    handler = _openai_tts_handler(monkeypatch, cancel_scope=CancelScope())
+    handler.model = "Qwen/Qwen3-TTS-12Hz-1.7B-CustomVoice"
+    handler.voice = "aiden"
+    handler.language = "Auto"
+
+    chunks = list(handler.process(TTSInput(text="Hello", language_code="en")))
+
+    assert chunks
+    assert all(isinstance(chunk, np.ndarray) for chunk in chunks)
+    assert all(chunk.dtype == np.int16 and chunk.shape == (512,) for chunk in chunks)
+    assert sum(chunk.size for chunk in chunks) == 2048
+    payload = _FakeSpeechOperation.instances[0].payload
+    assert payload["input"] == "Hello"
+    assert payload["voice"] == "aiden"
+    assert payload["language"] == "English"
+    assert payload["stream"] is True
+    assert payload["stream_format"] == "audio"
+
+
+def test_openai_tts_http_failure_before_audio_does_not_commit(monkeypatch):
+    tracker = _CountingSpeculativeTurnTracker()
+    tracker.observe("turn-1", 0)
+    text_output_queue = Queue()
+    handler = _openai_tts_handler(
+        monkeypatch,
+        speculative_turns=tracker,
+        text_output_queue=text_output_queue,
+    )
+    _FakeSpeechOperation.startup_error = tts_module.SpeechRequestError("speech server returned HTTP 500")
+
+    chunks = list(
+        handler.process(
+            TTSInput(
+                text="Hello",
+                turn_id="turn-1",
+                turn_revision=0,
+                response_key="response-1",
+            )
+        )
+    )
+
+    assert chunks == []
+    assert tracker.commit_calls == 0
+    assert not tracker.is_committed("turn-1", 0)
+    failure = text_output_queue.get_nowait()
+    assert isinstance(failure, ResponseFailedEvent)
+    assert failure.message == "speech server returned HTTP 500"
+    assert failure.turn_id == "turn-1"
+    assert failure.turn_revision == 0
+    assert failure.response_key == "response-1"
+
+
+def test_openai_tts_stale_keyed_terminal_becomes_cleanup(monkeypatch):
+    tracker = SpeculativeTurnTracker()
+    tracker.observe("turn-1", 0)
+    handler = _openai_tts_handler(monkeypatch, speculative_turns=tracker)
+    terminal = EndOfResponse(
+        response_key="response-1",
+        turn_id="turn-1",
+        turn_revision=0,
+        cancel_generation=7,
+    )
+    tracker.observe("turn-1", 1)
+
+    outputs = list(handler.process(terminal))
+    queued = handler.output_for_queue(outputs[0], terminal)
+
+    assert outputs == [AUDIO_RESPONSE_DONE]
+    assert terminal.cleanup_only is True
+    assert isinstance(queued, AudioOutput)
+    assert queued.response_key == "response-1"
+    assert queued.cancel_generation == 7
+    assert queued.cleanup_only is True
+
+
+def test_openai_tts_failure_after_audio_emits_response_failure(monkeypatch):
+    text_output_queue = Queue()
+    handler = _openai_tts_handler(monkeypatch, text_output_queue=text_output_queue)
+    _FakeSpeechOperation.failure_after_chunks = 8
+    generation = handler.process(TTSInput(text="Hello", turn_id="turn-1", turn_revision=0))
+
+    first_audio = next(generation)
+    remaining = list(generation)
+
+    assert isinstance(first_audio, np.ndarray)
+    assert remaining == []
+    failure = text_output_queue.get_nowait()
+    assert isinstance(failure, ResponseFailedEvent)
+    assert failure.message == "speech stream failed"
+    assert failure.turn_id == "turn-1"
+    assert failure.turn_revision == 0
+
+
+def test_openai_tts_suppresses_remaining_chunks_after_failure_until_response_end(monkeypatch):
+    handler = _openai_tts_handler(monkeypatch)
+    _FakeSpeechOperation.startup_error = tts_module.SpeechRequestError("speech server returned HTTP 500")
+    tts_input = TTSInput(
+        text="Hello",
+        turn_id="turn-1",
+        turn_revision=0,
+        cancel_generation=3,
+    )
+
+    assert list(handler.process(tts_input)) == []
+    assert len(_FakeSpeechOperation.instances) == 1
+    assert list(handler.process(tts_input)) == []
+    assert len(_FakeSpeechOperation.instances) == 1
+
+    assert list(
+        handler.process(
+            EndOfResponse(
+                turn_id="turn-1",
+                turn_revision=0,
+                cancel_generation=3,
+            )
+        )
+    ) == [AUDIO_RESPONSE_DONE]
+    _FakeSpeechOperation.startup_error = None
+    assert list(handler.process(tts_input))
+    assert len(_FakeSpeechOperation.instances) == 2
+
+
+def test_openai_tts_cancellation_before_audio_does_not_commit(monkeypatch):
+    tracker = _CountingSpeculativeTurnTracker()
+    tracker.observe("turn-1", 0)
+    cancel_scope = CancelScope()
+    handler = _openai_tts_handler(
+        monkeypatch,
+        cancel_scope=cancel_scope,
+        speculative_turns=tracker,
+    )
+    _FakeSpeechOperation.startup_action = cancel_scope.cancel
+
+    chunks = list(
+        handler.process(
+            TTSInput(
+                text="Hello",
+                turn_id="turn-1",
+                turn_revision=0,
+                cancel_generation=cancel_scope.generation,
+            )
+        )
+    )
+
+    assert chunks == []
+    assert tracker.commit_calls == 0
+    assert not tracker.is_committed("turn-1", 0)
+    assert _FakeSpeechOperation.instances[0].cancelled is True
+
+
+def test_openai_tts_first_emitted_audio_commits_exactly_once(monkeypatch):
+    tracker = _CountingSpeculativeTurnTracker()
+    tracker.observe("turn-1", 0)
+    handler = _openai_tts_handler(monkeypatch, speculative_turns=tracker)
+
+    chunks = list(
+        handler.process(
+            TTSInput(
+                text="Hello",
+                turn_id="turn-1",
+                turn_revision=0,
+            )
+        )
+    )
+
+    assert chunks
+    assert tracker.commit_calls == 1
+    assert tracker.is_committed("turn-1", 0)
+
+
+def test_openai_tts_reopened_during_startup_suppresses_old_revision(monkeypatch):
+    tracker = _CountingSpeculativeTurnTracker()
+    tracker.observe("turn-1", 0)
+    handler = _openai_tts_handler(monkeypatch, speculative_turns=tracker)
+    _FakeSpeechOperation.startup_action = lambda: tracker.observe("turn-1", 1)
+
+    chunks = list(
+        handler.process(
+            TTSInput(
+                text="Hello",
+                turn_id="turn-1",
+                turn_revision=0,
+            )
+        )
+    )
+
+    assert chunks == []
+    assert tracker.commit_calls == 0
+    assert not tracker.is_committed("turn-1", 0)
+    assert _FakeSpeechOperation.instances[0].cancelled is True
+
+
+def test_openai_tts_cancellation_stops_publication_and_closes_operation(monkeypatch):
+    cancel_scope = CancelScope()
+    handler = _openai_tts_handler(monkeypatch, cancel_scope=cancel_scope)
+
+    generation = handler.process(TTSInput(text="Hello", cancel_generation=cancel_scope.generation))
+    first = next(generation)
+    cancel_scope.cancel()
+
+    assert isinstance(first, np.ndarray)
+    assert list(generation) == []
+    assert _FakeSpeechOperation.instances[0].cancelled is True
+
+
+def test_http_speech_cancellation_during_client_construction_prevents_dispatch(monkeypatch):
+    construction_started = Event()
+    resume_construction = Event()
+    stream_calls = 0
+
+    class BlockingClient:
+        def __init__(self, **kwargs) -> None:
+            del kwargs
+            construction_started.set()
+            assert resume_construction.wait(1)
+
+        def stream(self, *args, **kwargs):
+            nonlocal stream_calls
+            del args, kwargs
+            stream_calls += 1
+            raise AssertionError("cancelled operation must not enter client.stream()")
+
+        def close(self) -> None:
+            pass
+
+    monkeypatch.setattr(tts_module.httpx, "Client", BlockingClient)
+    operation = HttpSpeechOperation(
+        endpoint_url="http://localhost:8000/v1/audio/speech",
+        api_key=None,
+        payload={"input": "hello"},
+        timeout_s=2,
+    )
+    errors: list[BaseException] = []
+
+    def consume() -> None:
+        try:
+            list(operation.iter_bytes(lambda: False))
+        except BaseException as exc:
+            errors.append(exc)
+
+    thread = Thread(target=consume)
+    thread.start()
+    assert construction_started.wait(1)
+    operation.cancel()
+    resume_construction.set()
+    thread.join(timeout=1)
+
+    assert not thread.is_alive()
+    assert len(errors) == 1
+    assert isinstance(errors[0], SpeechRequestCancelled)
+    assert stream_calls == 0

--- a/tests/test_openai_tts_handler.py
+++ b/tests/test_openai_tts_handler.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 import io
+import socket
 from queue import Queue
 from threading import Event, Thread
 from time import perf_counter
@@ -10,6 +11,7 @@ import pytest
 from scipy.io import wavfile
 
 from speech_to_speech.pipeline.cancel_scope import CancelScope
+from speech_to_speech.pipeline.control import SESSION_END
 from speech_to_speech.pipeline.events import ResponseFailedEvent
 from speech_to_speech.pipeline.messages import (
     AUDIO_RESPONSE_DONE,
@@ -575,3 +577,97 @@ def test_http_speech_timeout_is_a_total_deadline(monkeypatch):
 
     assert closed.is_set()
     assert perf_counter() - started_at_s < 0.5
+
+
+@pytest.mark.parametrize(
+    "content_type",
+    ["application/json; charset=utf-8", "application/problem+json", "text/plain"],
+)
+def test_openai_tts_rejects_non_audio_success_responses(monkeypatch, content_type):
+    transport = tts_module.httpx.MockTransport(
+        lambda request: tts_module.httpx.Response(
+            200,
+            headers={"Content-Type": content_type},
+            content=b'{"error":"upstream failure"}',
+            request=request,
+        )
+    )
+    client = tts_module.httpx.Client(transport=transport)
+    monkeypatch.setattr(tts_module.httpx, "Client", lambda **kwargs: client)
+    handler = OpenAICompatibleTTSHandler(
+        Event(),
+        queue_in=Queue(),
+        queue_out=Queue(),
+        setup_args=(Event(),),
+        setup_kwargs={"sample_rate": 24000, "blocksize": 512},
+    )
+
+    assert list(handler.process(TTSInput(text="Hello", response_key="response-1"))) == []
+
+    failure = handler.queue_out.get_nowait()
+    assert isinstance(failure, ResponseFailedEvent)
+    assert failure.message == "speech endpoint returned a non-audio response"
+    assert failure.response_key == "response-1"
+
+
+def test_openai_tts_cancellation_unblocks_a_stalled_socket_and_session_end():
+    listener = socket.socket(socket.AF_INET, socket.SOCK_STREAM)
+    listener.setsockopt(socket.SOL_SOCKET, socket.SO_REUSEADDR, 1)
+    listener.bind(("127.0.0.1", 0))
+    listener.listen()
+    host, port = listener.getsockname()
+    headers_sent = Event()
+    release_server = Event()
+
+    def serve_stalled_response() -> None:
+        connection, _ = listener.accept()
+        with connection:
+            request = b""
+            while b"\r\n\r\n" not in request:
+                data = connection.recv(4096)
+                if not data:
+                    return
+                request += data
+            connection.sendall(b"HTTP/1.1 200 OK\r\nContent-Type: audio/pcm\r\nTransfer-Encoding: chunked\r\n\r\n")
+            headers_sent.set()
+            release_server.wait(5)
+
+    server_thread = Thread(target=serve_stalled_response, daemon=True)
+    server_thread.start()
+    cancel_scope = CancelScope()
+    handler = OpenAICompatibleTTSHandler(
+        Event(),
+        queue_in=Queue(),
+        queue_out=Queue(),
+        setup_args=(Event(),),
+        setup_kwargs={
+            "base_url": f"http://{host}:{port}/v1",
+            "sample_rate": 24000,
+            "blocksize": 512,
+            "timeout": 30,
+            "cancel_scope": cancel_scope,
+        },
+    )
+    handler.queue_in.put(
+        TTSInput(
+            text="Hello",
+            cancel_generation=cancel_scope.generation,
+        )
+    )
+    handler_thread = Thread(target=handler.run, daemon=True)
+    handler_thread.start()
+
+    try:
+        assert headers_sent.wait(1)
+        cancel_scope.cancel()
+        handler.queue_in.put(SESSION_END)
+        handler.queue_in.put(PIPELINE_END)
+
+        assert handler.queue_out.get(timeout=1) == SESSION_END
+        handler_thread.join(timeout=1)
+        assert not handler_thread.is_alive()
+        assert handler.queue_out.get_nowait() == PIPELINE_END
+    finally:
+        release_server.set()
+        listener.close()
+        server_thread.join(timeout=1)

--- a/tests/test_openai_tts_handler.py
+++ b/tests/test_openai_tts_handler.py
@@ -125,7 +125,7 @@ def test_openai_tts_warmup_uses_configured_request(monkeypatch):
             "api_key": "test-key",
             "model": "test-model",
             "voice": "test-voice",
-            "language": "Auto",
+            "language": "English",
             "sample_rate": 24000,
             "stream": True,
             "timeout": 12,
@@ -142,7 +142,7 @@ def test_openai_tts_warmup_uses_configured_request(monkeypatch):
         "response_format": "pcm",
         "stream_format": "audio",
         "stream": True,
-        "language": "Auto",
+        "language": "English",
     }
     assert operation.cancelled is False
 
@@ -166,9 +166,9 @@ def test_openai_tts_streams_resampled_fixed_size_pcm(monkeypatch):
     handler = _openai_tts_handler(monkeypatch, cancel_scope=CancelScope())
     handler.model = "Qwen/Qwen3-TTS-12Hz-1.7B-CustomVoice"
     handler.voice = "aiden"
-    handler.language = "Auto"
+    handler.language = "English"
 
-    chunks = list(handler.process(TTSInput(text="Hello", language_code="en")))
+    chunks = list(handler.process(TTSInput(text="Hello", language_code="de")))
 
     assert chunks
     assert all(isinstance(chunk, np.ndarray) for chunk in chunks)
@@ -180,6 +180,15 @@ def test_openai_tts_streams_resampled_fixed_size_pcm(monkeypatch):
     assert payload["language"] == "English"
     assert "stream" not in payload
     assert payload["stream_format"] == "audio"
+
+
+def test_openai_tts_does_not_infer_language_from_pipeline(monkeypatch):
+    handler = _openai_tts_handler(monkeypatch)
+
+    assert list(handler.process(TTSInput(text="Hello", language_code="en")))
+
+    payload = _FakeSpeechOperation.instances[0].payload
+    assert "language" not in payload
 
 
 def test_openai_tts_streaming_resampler_is_chunk_invariant_and_anti_aliased():

--- a/tests/test_openai_tts_handler.py
+++ b/tests/test_openai_tts_handler.py
@@ -182,6 +182,33 @@ def test_openai_tts_streams_resampled_fixed_size_pcm(monkeypatch):
     assert payload["stream_format"] == "audio"
 
 
+def test_openai_tts_streaming_resampler_is_chunk_invariant_and_anti_aliased():
+    sample_rate = 24000
+    duration_s = 0.2
+    timeline = np.arange(int(sample_rate * duration_s)) / sample_rate
+    passband = np.round(16000 * np.sin(2 * np.pi * 1000 * timeline)).astype(np.int16)
+    stopband = np.round(16000 * np.sin(2 * np.pi * 10000 * timeline)).astype(np.int16)
+
+    def resample(samples, chunk_sizes):
+        resampler = tts_module._StreamingFIRResampler(sample_rate, 16000)
+        output = []
+        offset = 0
+        for chunk_size in chunk_sizes:
+            output.append(resampler.push(samples[offset : offset + chunk_size]))
+            offset += chunk_size
+        output.append(resampler.push(samples[offset:]))
+        output.append(resampler.push(np.empty(0, dtype=np.int16), final=True))
+        return np.concatenate(output)
+
+    passband_streamed = resample(passband, [1, 301, 17, 1024, 3])
+    passband_single = resample(passband, [])
+    stopband_streamed = resample(stopband, [299, 2, 777, 31])
+
+    np.testing.assert_array_equal(passband_streamed, passband_single)
+    assert np.sqrt(np.mean(passband_streamed.astype(np.float64) ** 2)) > 10000
+    assert np.sqrt(np.mean(stopband_streamed.astype(np.float64) ** 2)) < 500
+
+
 def test_openai_tts_vllm_stream_extension_is_opt_in(monkeypatch):
     handler = _openai_tts_handler(monkeypatch)
     handler.stream = True
@@ -496,7 +523,7 @@ def test_openai_tts_empty_success_response_emits_failure(monkeypatch):
     assert failure.response_key == "response-1"
 
 
-def test_openai_tts_decodes_non_streaming_wav(monkeypatch):
+def test_openai_tts_decodes_wav_stream(monkeypatch):
     handler = _openai_tts_handler(monkeypatch)
     handler.response_format = "wav"
     handler.stream = False
@@ -512,6 +539,77 @@ def test_openai_tts_decodes_non_streaming_wav(monkeypatch):
     payload = _FakeSpeechOperation.instances[0].payload
     assert payload["response_format"] == "wav"
     assert "stream" not in payload
+
+
+def test_openai_tts_wav_yields_audio_before_response_eof(monkeypatch):
+    release_response = Event()
+    response_finished = Event()
+    encoded = io.BytesIO()
+    wavfile.write(encoded, 24000, np.arange(4800, dtype=np.int16))
+    wav_bytes = bytearray(encoded.getvalue())
+    wav_bytes[4:8] = b"\xff\xff\xff\xff"
+    wav_bytes[40:44] = b"\xff\xff\xff\xff"
+    first_part_size = 44 + 2400 * 2
+
+    class GatedWavStream(tts_module.httpx.AsyncByteStream):
+        async def __aiter__(self):
+            yield bytes(wav_bytes[:first_part_size])
+            while not release_response.is_set():
+                await asyncio.sleep(0.01)
+            yield bytes(wav_bytes[first_part_size:])
+            response_finished.set()
+
+        async def aclose(self) -> None:
+            pass
+
+    def respond(request):
+        return tts_module.httpx.Response(
+            200,
+            headers={"Content-Type": "audio/wav"},
+            stream=GatedWavStream(),
+            request=request,
+        )
+
+    client = tts_module.httpx.AsyncClient(transport=tts_module.httpx.MockTransport(respond))
+    monkeypatch.setattr(tts_module.httpx, "AsyncClient", lambda **kwargs: client)
+    monkeypatch.setattr(OpenAICompatibleTTSHandler, "warmup", lambda self: None)
+    handler = OpenAICompatibleTTSHandler(
+        Event(),
+        queue_in=Queue(),
+        queue_out=Queue(),
+        setup_args=(Event(),),
+        setup_kwargs={"response_format": "wav", "blocksize": 512},
+    )
+
+    generation = handler.process(TTSInput(text="Hello"))
+    try:
+        first_audio = next(generation)
+        finished_before_first_audio = response_finished.is_set()
+    finally:
+        release_response.set()
+    remaining_audio = list(generation)
+
+    assert isinstance(first_audio, np.ndarray)
+    assert remaining_audio
+    assert finished_before_first_audio is False
+    assert response_finished.is_set()
+
+
+def test_openai_tts_decodes_streaming_wav_with_unknown_data_length(monkeypatch):
+    handler = _openai_tts_handler(monkeypatch)
+    handler.response_format = "wav"
+    encoded = io.BytesIO()
+    wavfile.write(encoded, 24000, np.arange(2400, dtype=np.int16))
+    wav_bytes = bytearray(encoded.getvalue())
+    wav_bytes[4:8] = b"\xff\xff\xff\xff"
+    wav_bytes[40:44] = b"\xff\xff\xff\xff"
+    _FakeSpeechOperation.response_bytes = bytes(wav_bytes)
+
+    chunks = list(handler.process(TTSInput(text="Hello")))
+
+    assert chunks
+    assert all(chunk.dtype == np.int16 and chunk.shape == (512,) for chunk in chunks)
+    assert sum(chunk.size for chunk in chunks) == 2048
 
 
 def test_openai_tts_cancellation_before_audio_does_not_commit(monkeypatch):

--- a/tests/test_openai_tts_handler.py
+++ b/tests/test_openai_tts_handler.py
@@ -3,7 +3,7 @@ from __future__ import annotations
 import io
 import socket
 from queue import Queue
-from threading import Event, Thread
+from threading import Event, Thread, current_thread
 from time import perf_counter
 
 import numpy as np
@@ -484,6 +484,8 @@ def test_http_speech_cancellation_after_completion_is_harmless(monkeypatch):
 def test_http_speech_cancellation_during_client_construction_prevents_dispatch(monkeypatch):
     construction_started = Event()
     resume_construction = Event()
+    cancelled = Event()
+    worker_observed_cancellation = Event()
     stream_calls = 0
 
     class BlockingClient:
@@ -510,22 +512,32 @@ def test_http_speech_cancellation_during_client_construction_prevents_dispatch(m
     )
     errors: list[BaseException] = []
 
+    def cancel_check() -> bool:
+        if not cancelled.is_set():
+            return False
+        if current_thread().name == "tts-http-reader":
+            worker_observed_cancellation.set()
+        else:
+            assert worker_observed_cancellation.wait(1)
+        return True
+
     def consume() -> None:
         try:
-            list(operation.iter_bytes(lambda: False))
+            list(operation.iter_bytes(cancel_check))
         except BaseException as exc:
             errors.append(exc)
 
     thread = Thread(target=consume)
     thread.start()
     assert construction_started.wait(1)
-    operation.cancel()
+    cancelled.set()
     resume_construction.set()
     thread.join(timeout=1)
 
     assert not thread.is_alive()
     assert len(errors) == 1
     assert isinstance(errors[0], SpeechRequestCancelled)
+    assert worker_observed_cancellation.is_set()
     assert stream_calls == 0
 
 

--- a/tests/test_openai_tts_handler.py
+++ b/tests/test_openai_tts_handler.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 import asyncio
 import io
+import json
 import socket
 from queue import Queue
 from threading import Event, Thread, current_thread
@@ -9,8 +10,11 @@ from time import perf_counter
 
 import numpy as np
 import pytest
+from openai.types.realtime import RealtimeSessionCreateRequest
+from openai.types.realtime.realtime_response_create_params import RealtimeResponseCreateParams
 from scipy.io import wavfile
 
+from speech_to_speech.api.openai_realtime.runtime_config import RuntimeConfig
 from speech_to_speech.pipeline.cancel_scope import CancelScope
 from speech_to_speech.pipeline.control import SESSION_END
 from speech_to_speech.pipeline.events import ResponseFailedEvent
@@ -121,8 +125,101 @@ def test_openai_tts_streams_resampled_fixed_size_pcm(monkeypatch):
     assert payload["input"] == "Hello"
     assert payload["voice"] == "aiden"
     assert payload["language"] == "English"
+    assert "stream" not in payload
+    assert payload["stream_format"] == "audio"
+
+
+def test_openai_tts_vllm_stream_extension_is_opt_in(monkeypatch):
+    handler = _openai_tts_handler(monkeypatch)
+    handler.stream = True
+
+    assert list(handler.process(TTSInput(text="Hello")))
+
+    payload = _FakeSpeechOperation.instances[0].payload
     assert payload["stream"] is True
     assert payload["stream_format"] == "audio"
+
+
+def test_openai_tts_preserves_session_custom_voice_id(monkeypatch):
+    handler = _openai_tts_handler(monkeypatch)
+    runtime_config = RuntimeConfig(
+        session=RealtimeSessionCreateRequest(
+            type="realtime",
+            audio={"output": {"voice": {"id": "voice_session"}}},
+        )
+    )
+
+    assert list(handler.process(TTSInput(text="Hello", runtime_config=runtime_config)))
+
+    assert _FakeSpeechOperation.instances[0].payload["voice"] == {"id": "voice_session"}
+
+
+def test_openai_tts_preserves_per_response_custom_voice_id(monkeypatch):
+    handler = _openai_tts_handler(monkeypatch)
+    response = RealtimeResponseCreateParams(
+        audio={"output": {"voice": {"id": "voice_response"}}},
+    )
+
+    assert list(handler.process(TTSInput(text="Hello", response=response)))
+
+    assert _FakeSpeechOperation.instances[0].payload["voice"] == {"id": "voice_response"}
+
+
+def test_openai_tts_standard_request_yields_audio_before_response_eof(monkeypatch):
+    release_response = Event()
+    response_finished = Event()
+    received_payload: dict[str, object] = {}
+    encoded = np.arange(2400, dtype="<i2").tobytes()
+
+    class GatedAudioStream(tts_module.httpx.AsyncByteStream):
+        async def __aiter__(self):
+            yield encoded
+            while not release_response.is_set():
+                await asyncio.sleep(0.01)
+            response_finished.set()
+
+        async def aclose(self) -> None:
+            pass
+
+    def respond(request):
+        received_payload.update(json.loads(request.content))
+        return tts_module.httpx.Response(
+            200,
+            headers={"Content-Type": "audio/pcm"},
+            stream=GatedAudioStream(),
+            request=request,
+        )
+
+    transport = tts_module.httpx.MockTransport(respond)
+    client = tts_module.httpx.AsyncClient(transport=transport)
+    monkeypatch.setattr(tts_module.httpx, "AsyncClient", lambda **kwargs: client)
+    handler = OpenAICompatibleTTSHandler(
+        Event(),
+        queue_in=Queue(),
+        queue_out=Queue(),
+        setup_args=(Event(),),
+        setup_kwargs={"sample_rate": 24000, "blocksize": 512},
+    )
+
+    generation = handler.process(TTSInput(text="Hello"))
+    try:
+        first_audio = next(generation)
+        finished_before_first_audio = response_finished.is_set()
+    finally:
+        release_response.set()
+    remaining_audio = list(generation)
+
+    assert isinstance(first_audio, np.ndarray)
+    assert remaining_audio
+    assert finished_before_first_audio is False
+    assert response_finished.is_set()
+    assert received_payload == {
+        "model": "Qwen/Qwen3-TTS-12Hz-1.7B-CustomVoice",
+        "input": "Hello",
+        "voice": "aiden",
+        "response_format": "pcm",
+        "stream_format": "audio",
+    }
 
 
 def test_openai_tts_http_failure_before_audio_does_not_commit(monkeypatch):

--- a/tests/test_openai_tts_handler.py
+++ b/tests/test_openai_tts_handler.py
@@ -1,14 +1,19 @@
 from __future__ import annotations
 
+import io
 from queue import Queue
 from threading import Event, Thread
+from time import perf_counter
 
 import numpy as np
+import pytest
+from scipy.io import wavfile
 
 from speech_to_speech.pipeline.cancel_scope import CancelScope
 from speech_to_speech.pipeline.events import ResponseFailedEvent
 from speech_to_speech.pipeline.messages import (
     AUDIO_RESPONSE_DONE,
+    PIPELINE_END,
     AudioOutput,
     EndOfResponse,
     TTSInput,
@@ -27,6 +32,7 @@ class _FakeSpeechOperation:
     startup_action = None
     startup_error: Exception | None = None
     failure_after_chunks: int | None = None
+    response_bytes: bytes | None = None
 
     def __init__(self, **kwargs) -> None:
         self.payload = kwargs["payload"]
@@ -38,8 +44,10 @@ class _FakeSpeechOperation:
             type(self).startup_action()
         if type(self).startup_error is not None:
             raise type(self).startup_error
-        samples = np.arange(2400, dtype="<i2")
-        encoded = samples.tobytes()
+        encoded = type(self).response_bytes
+        if encoded is None:
+            samples = np.arange(2400, dtype="<i2")
+            encoded = samples.tobytes()
         for index, offset in enumerate(range(0, len(encoded), 301)):
             if type(self).failure_after_chunks == index:
                 raise tts_module.SpeechRequestError("speech stream failed")
@@ -67,6 +75,7 @@ def _reset_fake_speech_operation() -> None:
     _FakeSpeechOperation.startup_action = None
     _FakeSpeechOperation.startup_error = None
     _FakeSpeechOperation.failure_after_chunks = None
+    _FakeSpeechOperation.response_bytes = None
 
 
 def _openai_tts_handler(
@@ -74,7 +83,6 @@ def _openai_tts_handler(
     *,
     cancel_scope: CancelScope | None = None,
     speculative_turns: SpeculativeTurnTracker | None = None,
-    text_output_queue: Queue | None = None,
 ) -> OpenAICompatibleTTSHandler:
     _reset_fake_speech_operation()
     monkeypatch.setattr(tts_module, "HttpSpeechOperation", _FakeSpeechOperation)
@@ -88,7 +96,6 @@ def _openai_tts_handler(
             "blocksize": 512,
             "cancel_scope": cancel_scope,
             "speculative_turns": speculative_turns,
-            "text_output_queue": text_output_queue,
         },
     )
 
@@ -116,12 +123,7 @@ def test_openai_tts_streams_resampled_fixed_size_pcm(monkeypatch):
 def test_openai_tts_http_failure_before_audio_does_not_commit(monkeypatch):
     tracker = _CountingSpeculativeTurnTracker()
     tracker.observe("turn-1", 0)
-    text_output_queue = Queue()
-    handler = _openai_tts_handler(
-        monkeypatch,
-        speculative_turns=tracker,
-        text_output_queue=text_output_queue,
-    )
+    handler = _openai_tts_handler(monkeypatch, speculative_turns=tracker)
     _FakeSpeechOperation.startup_error = tts_module.SpeechRequestError("speech server returned HTTP 500")
 
     chunks = list(
@@ -138,7 +140,7 @@ def test_openai_tts_http_failure_before_audio_does_not_commit(monkeypatch):
     assert chunks == []
     assert tracker.commit_calls == 0
     assert not tracker.is_committed("turn-1", 0)
-    failure = text_output_queue.get_nowait()
+    failure = handler.queue_out.get_nowait()
     assert isinstance(failure, ResponseFailedEvent)
     assert failure.message == "speech server returned HTTP 500"
     assert failure.turn_id == "turn-1"
@@ -170,8 +172,7 @@ def test_openai_tts_stale_keyed_terminal_becomes_cleanup(monkeypatch):
 
 
 def test_openai_tts_failure_after_audio_emits_response_failure(monkeypatch):
-    text_output_queue = Queue()
-    handler = _openai_tts_handler(monkeypatch, text_output_queue=text_output_queue)
+    handler = _openai_tts_handler(monkeypatch)
     _FakeSpeechOperation.failure_after_chunks = 8
     generation = handler.process(TTSInput(text="Hello", turn_id="turn-1", turn_revision=0))
 
@@ -180,11 +181,57 @@ def test_openai_tts_failure_after_audio_emits_response_failure(monkeypatch):
 
     assert isinstance(first_audio, np.ndarray)
     assert remaining == []
-    failure = text_output_queue.get_nowait()
+    failure = handler.queue_out.get_nowait()
     assert isinstance(failure, ResponseFailedEvent)
     assert failure.message == "speech stream failed"
     assert failure.turn_id == "turn-1"
     assert failure.turn_revision == 0
+
+
+def test_openai_tts_serializes_failure_after_emitted_audio(monkeypatch):
+    handler = _openai_tts_handler(monkeypatch)
+    _FakeSpeechOperation.failure_after_chunks = 8
+    handler.queue_in.put(
+        TTSInput(
+            text="Hello",
+            turn_id="turn-1",
+            turn_revision=0,
+            cancel_generation=3,
+            response_key="response-1",
+        )
+    )
+    handler.queue_in.put(
+        EndOfResponse(
+            turn_id="turn-1",
+            turn_revision=0,
+            cancel_generation=3,
+            response_key="response-1",
+        )
+    )
+    handler.queue_in.put(PIPELINE_END)
+
+    thread = Thread(target=handler.run)
+    thread.start()
+    thread.join(timeout=1)
+
+    assert not thread.is_alive()
+    outputs = []
+    while not handler.queue_out.empty():
+        outputs.append(handler.queue_out.get_nowait())
+    audio_indexes = [
+        index
+        for index, output in enumerate(outputs)
+        if isinstance(output, AudioOutput) and isinstance(output.audio, np.ndarray)
+    ]
+    failure_index = next(index for index, output in enumerate(outputs) if isinstance(output, ResponseFailedEvent))
+    done_index = next(
+        index
+        for index, output in enumerate(outputs)
+        if isinstance(output, AudioOutput) and isinstance(output.audio, bytes) and output.audio == AUDIO_RESPONSE_DONE
+    )
+
+    assert audio_indexes
+    assert max(audio_indexes) < failure_index < done_index
 
 
 def test_openai_tts_suppresses_remaining_chunks_after_failure_until_response_end(monkeypatch):
@@ -214,6 +261,101 @@ def test_openai_tts_suppresses_remaining_chunks_after_failure_until_response_end
     _FakeSpeechOperation.startup_error = None
     assert list(handler.process(tts_input))
     assert len(_FakeSpeechOperation.instances) == 2
+
+
+def test_openai_tts_failure_does_not_suppress_another_response(monkeypatch):
+    handler = _openai_tts_handler(monkeypatch)
+    _FakeSpeechOperation.startup_error = tts_module.SpeechRequestError("speech server returned HTTP 500")
+
+    assert (
+        list(
+            handler.process(
+                TTSInput(
+                    text="First",
+                    turn_id="turn-1",
+                    turn_revision=0,
+                    cancel_generation=3,
+                    response_key="response-1",
+                )
+            )
+        )
+        == []
+    )
+    _FakeSpeechOperation.startup_error = None
+
+    chunks = list(
+        handler.process(
+            TTSInput(
+                text="Second",
+                turn_id="turn-1",
+                turn_revision=0,
+                cancel_generation=3,
+                response_key="response-2",
+            )
+        )
+    )
+
+    assert chunks
+    assert len(_FakeSpeechOperation.instances) == 2
+    assert _FakeSpeechOperation.instances[1].payload["input"] == "Second"
+
+
+def test_openai_tts_does_not_merge_queued_responses(monkeypatch):
+    handler = _openai_tts_handler(monkeypatch)
+    second = TTSInput(
+        text="Second",
+        turn_id="turn-1",
+        turn_revision=0,
+        cancel_generation=3,
+        response_key="response-2",
+    )
+    handler.queue_in.put(second)
+
+    first_chunks = list(
+        handler.process(
+            TTSInput(
+                text="First",
+                turn_id="turn-1",
+                turn_revision=0,
+                cancel_generation=3,
+                response_key="response-1",
+            )
+        )
+    )
+
+    assert first_chunks
+    assert _FakeSpeechOperation.instances[0].payload["input"] == "First"
+    assert handler.queue_in.get_nowait() is second
+
+
+def test_openai_tts_empty_success_response_emits_failure(monkeypatch):
+    handler = _openai_tts_handler(monkeypatch)
+    _FakeSpeechOperation.response_bytes = b""
+
+    assert list(handler.process(TTSInput(text="Hello", response_key="response-1"))) == []
+
+    failure = handler.queue_out.get_nowait()
+    assert isinstance(failure, ResponseFailedEvent)
+    assert failure.message == "speech endpoint returned no audio"
+    assert failure.response_key == "response-1"
+
+
+def test_openai_tts_decodes_non_streaming_wav(monkeypatch):
+    handler = _openai_tts_handler(monkeypatch)
+    handler.response_format = "wav"
+    handler.stream = False
+    encoded = io.BytesIO()
+    wavfile.write(encoded, 24000, np.arange(2400, dtype=np.int16))
+    _FakeSpeechOperation.response_bytes = encoded.getvalue()
+
+    chunks = list(handler.process(TTSInput(text="Hello")))
+
+    assert chunks
+    assert all(chunk.dtype == np.int16 and chunk.shape == (512,) for chunk in chunks)
+    assert sum(chunk.size for chunk in chunks) == 2048
+    payload = _FakeSpeechOperation.instances[0].payload
+    assert payload["response_format"] == "wav"
+    assert "stream" not in payload
 
 
 def test_openai_tts_cancellation_before_audio_does_not_commit(monkeypatch):
@@ -345,3 +487,53 @@ def test_http_speech_cancellation_during_client_construction_prevents_dispatch(m
     assert len(errors) == 1
     assert isinstance(errors[0], SpeechRequestCancelled)
     assert stream_calls == 0
+
+
+def test_http_speech_timeout_is_a_total_deadline(monkeypatch):
+    closed = Event()
+
+    class TricklingResponse:
+        def __enter__(self):
+            return self
+
+        def __exit__(self, *args) -> None:
+            del args
+            self.close()
+
+        def close(self) -> None:
+            closed.set()
+
+        def raise_for_status(self) -> None:
+            pass
+
+        def iter_bytes(self):
+            while not closed.wait(0.01):
+                yield b"\x00\x00"
+
+    response = TricklingResponse()
+
+    class TricklingClient:
+        def __init__(self, **kwargs) -> None:
+            del kwargs
+
+        def stream(self, *args, **kwargs):
+            del args, kwargs
+            return response
+
+        def close(self) -> None:
+            response.close()
+
+    monkeypatch.setattr(tts_module.httpx, "Client", TricklingClient)
+    operation = HttpSpeechOperation(
+        endpoint_url="http://localhost:8000/v1/audio/speech",
+        api_key=None,
+        payload={"input": "hello"},
+        timeout_s=0.05,
+    )
+
+    started_at_s = perf_counter()
+    with pytest.raises(tts_module.SpeechRequestError, match="speech request timed out"):
+        list(operation.iter_bytes(lambda: False))
+
+    assert closed.is_set()
+    assert perf_counter() - started_at_s < 0.5


### PR DESCRIPTION
## Summary

- add a client-only `openai` TTS backend for `/v1/audio/speech`
- support cancellable raw PCM streaming and complete WAV responses
- wire provider configuration through the backend registry and CLI
- document vLLM-Omni/Qwen3-TTS usage

This is the first focused slice of #369. It intentionally contains no STT or endpoint-admission changes.

## Validation

- `pytest -q tests/test_openai_tts_handler.py` (10 passed)
- registry construction smoke test
- `ruff check` on changed Python files
- `git diff --check`