### PR TITLE
Add OpenAI-compatible STT endpoint

### DIFF
--- a/README.md
+++ b/README.md
@@ -167,6 +167,7 @@ This installs the package in editable mode and makes the `speech-to-speech` CLI 
 | STT | [Lightning Whisper MLX](https://github.com/mustafaaljadery/lightning-whisper-mlx) | Apple Silicon | `whisper-mlx` |
 | STT | [MLX Audio Whisper](https://github.com/huggingface/mlx-audio) | Apple Silicon | built-in on macOS |
 | STT | [Paraformer](https://github.com/modelscope/FunASR) | CUDA / CPU | `paraformer` |
+| STT | OpenAI-compatible `/v1/audio/transcriptions` endpoint | local or remote HTTP server | built-in |
 | LLM | OpenAI-compatible API (`responses-api`, `chat-completions`) | hosted providers or self-hosted servers | built-in |
 | LLM | [Transformers](https://huggingface.co/models?pipeline_tag=text-generation&sort=trending) | CUDA / CPU | built-in |
 | LLM | [mlx-lm](https://github.com/ml-explore/mlx-lm) | Apple Silicon | built-in on macOS |
@@ -177,6 +178,9 @@ This installs the package in editable mode and makes the `speech-to-speech` CLI 
 | TTS | [MMS TTS](https://huggingface.co/docs/transformers/model_doc/mms) | CUDA / CPU | built-in |
 
 Select implementations with `--stt`, `--llm_backend`, and `--tts`. The CLI constructs configuration only for the selected backends; known options for inactive backends remain accepted for compatibility but are ignored with a warning. JSON configuration may likewise include extra inactive-backend keys, which are ignored. Run `speech-to-speech serve -h` for the defaults, or pass selectors before `-h` to see another combination's backend-specific flags (for example, `speech-to-speech serve --stt mlx-audio-whisper -h`).
+
+For client-only speech recognition with vLLM, NVIDIA Speech NIM, or another
+compatible server, see [OpenAI-compatible STT](./docs/openai-compatible-stt.md).
 
 ## Commands
 

--- a/README.md
+++ b/README.md
@@ -179,8 +179,9 @@ This installs the package in editable mode and makes the `speech-to-speech` CLI 
 
 Select implementations with `--stt`, `--llm_backend`, and `--tts`. The CLI constructs configuration only for the selected backends; known options for inactive backends remain accepted for compatibility but are ignored with a warning. JSON configuration may likewise include extra inactive-backend keys, which are ignored. Run `speech-to-speech serve -h` for the defaults, or pass selectors before `-h` to see another combination's backend-specific flags (for example, `speech-to-speech serve --stt mlx-audio-whisper -h`).
 
-For client-only speech recognition with vLLM, NVIDIA Speech NIM, or another
-compatible server, see [OpenAI-compatible STT](./docs/openai-compatible-stt.md).
+For client-only speech recognition with vLLM, OpenAI's hosted Transcription API,
+or another compatible server, see
+[OpenAI-compatible STT](./docs/openai-compatible-stt.md).
 
 ## Commands
 

--- a/demo/s2s-realtime-client.js
+++ b/demo/s2s-realtime-client.js
@@ -460,6 +460,25 @@ export class S2sRealtimeClient extends EventTarget {
         if (itemId && itemId === this._currentUserItemId) this._currentUserItemId = "";
         break;
       }
+      case "conversation.item.input_audio_transcription.failed": {
+        const itemId = typeof event.item_id === "string" ? event.item_id : "";
+        const isCurrentUserItem = this._currentUserItemId
+          ? Boolean(itemId) && itemId === this._currentUserItemId
+          : true;
+        this._userTranscriptByItem.delete(itemId);
+        if (itemId && itemId === this._currentUserItemId) this._currentUserItemId = "";
+        if (
+          isCurrentUserItem
+          && this._status === "processing"
+          && !this._activeResponseId
+          && !this._responseRequested
+        ) {
+          this._setStatus("connected");
+        }
+        const message = event.error?.message ?? "Input audio transcription failed";
+        this.dispatchEvent(new CustomEvent("server-error", { detail: { error: new Error(message) } }));
+        break;
+      }
       case "response.audio_transcript.delta":
       case "response.output_audio_transcript.delta": {
         const responseId = typeof event.response_id === "string" ? event.response_id : "";

--- a/demo/tests/agents-adapter.test.mjs
+++ b/demo/tests/agents-adapter.test.mjs
@@ -50,3 +50,62 @@ test("the pinned SDK changes the live voice and explicitly clears all tools", as
     session: { type: "realtime", tools: [], tool_choice: "none" },
   });
 });
+
+test("a current transcription failure clears its item and resumes listening", () => {
+  globalThis.localStorage = { getItem() { return null; } };
+  globalThis.OpenAIAgentsRealtime = realtime;
+
+  const client = new S2sRealtimeClient({
+    transport: "websocket",
+    directUrl: "ws://unused",
+  });
+  client._status = "processing";
+  client._currentUserItemId = "item-current";
+  client._userTranscriptByItem.set("item-current", "partial words");
+  const statuses = [];
+  const errors = [];
+  client.addEventListener("status", (event) => statuses.push(event.detail.status));
+  client.addEventListener("server-error", (event) => errors.push(event.detail.error.message));
+
+  client._onTransportEvent({
+    type: "conversation.item.input_audio_transcription.failed",
+    item_id: "item-current",
+    content_index: 0,
+    error: { message: "transcription request timed out" },
+  });
+
+  assert.equal(client.status, "connected");
+  assert.equal(client._currentUserItemId, "");
+  assert.equal(client._userTranscriptByItem.has("item-current"), false);
+  assert.deepEqual(statuses, ["connected"]);
+  assert.deepEqual(errors, ["transcription request timed out"]);
+});
+
+test("an older transcription failure does not reset the current item", () => {
+  globalThis.localStorage = { getItem() { return null; } };
+  globalThis.OpenAIAgentsRealtime = realtime;
+
+  const client = new S2sRealtimeClient({
+    transport: "websocket",
+    directUrl: "ws://unused",
+  });
+  client._status = "processing";
+  client._currentUserItemId = "item-current";
+  client._userTranscriptByItem.set("item-old", "old partial");
+  client._userTranscriptByItem.set("item-current", "current partial");
+  const errors = [];
+  client.addEventListener("server-error", (event) => errors.push(event.detail.error.message));
+
+  client._onTransportEvent({
+    type: "conversation.item.input_audio_transcription.failed",
+    item_id: "item-old",
+    content_index: 0,
+    error: { message: "old transcription failed" },
+  });
+
+  assert.equal(client.status, "processing");
+  assert.equal(client._currentUserItemId, "item-current");
+  assert.equal(client._userTranscriptByItem.has("item-old"), false);
+  assert.equal(client._userTranscriptByItem.get("item-current"), "current partial");
+  assert.deepEqual(errors, ["old transcription failed"]);
+});

--- a/docs/openai-compatible-stt.md
+++ b/docs/openai-compatible-stt.md
@@ -48,7 +48,9 @@ speech-to-speech local \
 ## Authentication and compatibility
 
 Set `--openai_stt_api_key` when the endpoint requires bearer authentication.
-When it is omitted, the handler uses `OPENAI_API_KEY` if present.
+When the base URL is `https://api.openai.com/v1` and this flag is omitted, the
+handler uses `OPENAI_API_KEY` if present. Other endpoints never receive that
+environment credential implicitly.
 
 The client accepts JSON and text responses. Use
 `--openai_stt_response_format text` for a plain-text server. Transport and HTTP

--- a/docs/openai-compatible-stt.md
+++ b/docs/openai-compatible-stt.md
@@ -9,11 +9,14 @@ VAD audio -> POST /v1/audio/transcriptions
 ```
 
 Each request uploads an in-memory mono PCM16 WAV at 16 kHz and accepts either
-JSON with a string `text` field or a plain-text response.
+JSON with a string `text` field or a plain-text response. With live
+transcription enabled, progressive updates upload the accumulated utterance
+again, increasing request volume and provider usage.
 
 ## vLLM with Qwen3-ASR
 
-Run a supported ASR model behind vLLM:
+Run a supported ASR model behind vLLM. Install vLLM in its own environment on
+the machine serving STT; it does not need to be inside this repository.
 
 ```bash
 pip install "vllm[audio]"
@@ -32,18 +35,24 @@ speech-to-speech local \
   --openai_stt_model Qwen/Qwen3-ASR-1.7B
 ```
 
-## NVIDIA Speech NIM
+## OpenAI-hosted transcription
 
-NVIDIA Speech ASR NIM exposes the same multipart endpoint. Select the NIM model
-at deployment time, then let the request select its language when appropriate:
+The same backend can call OpenAI's hosted
+[Transcription API](https://developers.openai.com/api/docs/guides/speech-to-text).
+Export an API key and select a transcription model:
 
 ```bash
+export OPENAI_API_KEY=...
+
 speech-to-speech local \
   --stt openai \
-  --openai_stt_base_url http://localhost:9000/v1 \
-  --openai_stt_model "" \
-  --openai_stt_language en-US
+  --openai_stt_base_url https://api.openai.com/v1 \
+  --openai_stt_model gpt-transcribe \
+  --openai_stt_response_format json
 ```
+
+The LLM and TTS backends remain independently configurable; using OpenAI for
+STT does not require using it for the rest of the pipeline.
 
 ## Authentication and compatibility
 
@@ -61,6 +70,7 @@ During setup, the handler transcribes one second of synthetic silence through
 the configured endpoint. Endpoint, authentication, model, or response-format
 failures therefore prevent the realtime server from accepting sessions.
 
-This first endpoint adapter intentionally uses the existing serial STT handler
-lifecycle. Endpoint-wide concurrency limits, bounded queues, coalescing, and
-final-request priority can be added independently as an admission layer.
+Progressive requests are best-effort. Each pipeline keeps at most one
+progressive request in flight and drops newer progressive updates while it is
+running. A final request is submitted independently, so it does not wait for an
+in-flight progressive request; late progressive results are discarded.

--- a/docs/openai-compatible-stt.md
+++ b/docs/openai-compatible-stt.md
@@ -1,0 +1,60 @@
+# OpenAI-compatible STT endpoint
+
+The `openai` STT backend keeps VAD, turns, sessions, conversation state, and
+response handling inside speech-to-speech while delegating recognition to an
+external server:
+
+```text
+VAD audio -> POST /v1/audio/transcriptions
+```
+
+Each request uploads an in-memory mono PCM16 WAV at 16 kHz and accepts either
+JSON with a string `text` field or a plain-text response.
+
+## vLLM with Qwen3-ASR
+
+Run a supported ASR model behind vLLM:
+
+```bash
+pip install "vllm[audio]"
+vllm serve Qwen/Qwen3-ASR-1.7B --port 8000
+```
+
+Check the server, then select the remote backend. The LLM and TTS flags can
+point at any other supported backends.
+
+```bash
+curl http://localhost:8000/v1/models
+
+speech-to-speech local \
+  --stt openai \
+  --openai_stt_base_url http://localhost:8000/v1 \
+  --openai_stt_model Qwen/Qwen3-ASR-1.7B
+```
+
+## NVIDIA Speech NIM
+
+NVIDIA Speech ASR NIM exposes the same multipart endpoint. Select the NIM model
+at deployment time, then let the request select its language when appropriate:
+
+```bash
+speech-to-speech local \
+  --stt openai \
+  --openai_stt_base_url http://localhost:9000/v1 \
+  --openai_stt_model "" \
+  --openai_stt_language en-US
+```
+
+## Authentication and compatibility
+
+Set `--openai_stt_api_key` when the endpoint requires bearer authentication.
+When it is omitted, the handler uses `OPENAI_API_KEY` if present.
+
+The client accepts JSON and text responses. Use
+`--openai_stt_response_format text` for a plain-text server. Transport and HTTP
+errors are sanitized before they are surfaced to realtime clients, and failed
+final requests do not create LLM work.
+
+This first endpoint adapter intentionally uses the existing serial STT handler
+lifecycle. Endpoint-wide concurrency limits, bounded queues, coalescing, and
+final-request priority can be added independently as an admission layer.

--- a/docs/openai-compatible-stt.md
+++ b/docs/openai-compatible-stt.md
@@ -57,6 +57,10 @@ The client accepts JSON and text responses. Use
 errors are sanitized before they are surfaced to realtime clients, and failed
 final requests do not create LLM work.
 
+During setup, the handler transcribes one second of synthetic silence through
+the configured endpoint. Endpoint, authentication, model, or response-format
+failures therefore prevent the realtime server from accepting sessions.
+
 This first endpoint adapter intentionally uses the existing serial STT handler
 lifecycle. Endpoint-wide concurrency limits, bounded queues, coalescing, and
 final-request priority can be added independently as an admission layer.

--- a/docs/openai-compatible-stt.md
+++ b/docs/openai-compatible-stt.md
@@ -61,6 +61,12 @@ When the base URL is `https://api.openai.com/v1` and this flag is omitted, the
 handler uses `OPENAI_API_KEY` if present. Other endpoints never receive that
 environment credential implicitly.
 
+The request and response shapes follow OpenAI's Audio API. In particular,
+`gpt-transcribe` sends language hints with the official plural `languages[]`
+field and reads the first detected language code from the plural `languages`
+response. Older models and compatible servers continue to use the singular
+`language` field.
+
 The client accepts JSON and text responses. Use
 `--openai_stt_response_format text` for a plain-text server. Transport and HTTP
 errors are sanitized before they are surfaced to realtime clients, and failed

--- a/src/speech_to_speech/STT/README.md
+++ b/src/speech_to_speech/STT/README.md
@@ -82,7 +82,8 @@ This document summarizes the Speech-to-Text (STT) implementations in the `STT/` 
 - Endpoint: `POST /v1/audio/transcriptions`
 - Upload: mono PCM16 WAV at 16 kHz
 - Supports JSON (`{"text": "..."}`) and plain-text responses
-- Uses the same serial processing and stale-turn filtering as other STT handlers
+- Keeps at most one best-effort progressive request in flight per pipeline while
+  final requests are submitted independently; stale-turn filtering still applies
 - See [`docs/openai-compatible-stt.md`](../../../docs/openai-compatible-stt.md)
 
 ## Language Abbreviations (ISO-style codes seen in STT handlers)

--- a/src/speech_to_speech/STT/README.md
+++ b/src/speech_to_speech/STT/README.md
@@ -10,6 +10,7 @@ This document summarizes the Speech-to-Text (STT) implementations in the `STT/` 
 - `faster-whisper` → `STT/faster_whisper_handler.py`
 - `parakeet-tdt` → `STT/parakeet_tdt_handler.py`
 - `paraformer` → `STT/paraformer_handler.py`
+- `openai` → `STT/openai_compatible_handler.py`
 
 ## Language Support by Handler
 
@@ -74,6 +75,15 @@ This document summarizes the Speech-to-Text (STT) implementations in the `STT/` 
 - Practical support:
   - Depends on selected FunASR model checkpoint
   - Default setup is Chinese-oriented (`zh`)
+
+### 7) OpenAI-compatible endpoint (`--stt openai`)
+
+- Handler: `OpenAICompatibleSTTHandler`
+- Endpoint: `POST /v1/audio/transcriptions`
+- Upload: mono PCM16 WAV at 16 kHz
+- Supports JSON (`{"text": "..."}`) and plain-text responses
+- Uses the same serial processing and stale-turn filtering as other STT handlers
+- See [`docs/openai-compatible-stt.md`](../../../docs/openai-compatible-stt.md)
 
 ## Language Abbreviations (ISO-style codes seen in STT handlers)
 

--- a/src/speech_to_speech/STT/openai_compatible_handler.py
+++ b/src/speech_to_speech/STT/openai_compatible_handler.py
@@ -215,7 +215,7 @@ class OpenAICompatibleSTTHandler(BaseSTTHandler):
             )
 
         logger.info(
-            "OpenAI-compatible STT completed turn=%s rev=%s mode=%s in %.3fs",
+            "OpenAI-compatible STT request completed turn=%s rev=%s mode=%s in %.3fs",
             vad_audio.turn_id,
             vad_audio.turn_revision,
             vad_audio.mode,

--- a/src/speech_to_speech/STT/openai_compatible_handler.py
+++ b/src/speech_to_speech/STT/openai_compatible_handler.py
@@ -5,12 +5,9 @@ import json
 import logging
 import os
 import wave
-from collections.abc import Callable
 from dataclasses import dataclass
-from threading import Event, Lock, Thread
 from time import perf_counter
 from typing import Any, Iterator
-from uuid import uuid4
 
 import httpx
 import numpy as np
@@ -28,13 +25,7 @@ from speech_to_speech.STT.base_stt_handler import BaseSTTHandler
 logger = logging.getLogger(__name__)
 
 PIPELINE_SAMPLE_RATE = 16000
-
-
-class TranscriptionRequestCancelled(RuntimeError):
-    def __init__(self, request_id: str, reason: str) -> None:
-        self.request_id = request_id
-        self.reason = reason
-        super().__init__(f"transcription request {request_id} cancelled: {reason}")
+OPENAI_BASE_URL = "https://api.openai.com/v1"
 
 
 class TranscriptionRequestError(RuntimeError):
@@ -47,154 +38,49 @@ class HttpTranscriptionResult:
     language: str | None = None
 
 
+@dataclass(frozen=True)
 class HttpTranscriptionOperation:
-    """Exactly one transcription request and its transport lifecycle."""
+    """One synchronous transcription request."""
 
-    def __init__(
-        self,
-        *,
-        request_id: str,
-        endpoint_url: str,
-        api_key: str | None,
-        model: str | None,
-        wav_bytes: bytes,
-        language: str | None,
-        response_format: str,
-        timeout_s: float,
-        extra_fields: dict[str, Any] | None = None,
-    ) -> None:
-        self.request_id = request_id
-        self.endpoint_url = endpoint_url
-        self.api_key = api_key
-        self.model = model
-        self.wav_bytes = wav_bytes
-        self.language = language
-        self.response_format = response_format
-        self.timeout_s = timeout_s
-        self.extra_fields = extra_fields or {}
-        self._cancelled = Event()
-        self._transport_lock = Lock()
-        self._client: httpx.Client | None = None
-        self._response: httpx.Response | None = None
-        self._cancel_reason: str | None = None
+    endpoint_url: str
+    api_key: str | None
+    model: str | None
+    wav_bytes: bytes
+    language: str | None
+    response_format: str
+    timeout_s: float
+    extra_fields: dict[str, Any] | None = None
 
-    def run(self, cancel_check: Callable[[], bool] | None = None) -> HttpTranscriptionResult:
-        cancel_check = cancel_check or (lambda: False)
-        if self._cancelled.is_set() or cancel_check():
-            self.cancel("stale")
-            raise self._cancellation_exception()
-
+    def run(self) -> HttpTranscriptionResult:
         headers = {}
         if self.api_key:
             headers["Authorization"] = f"Bearer {self.api_key}"
-        data: dict[str, Any] = {"response_format": self.response_format, **self.extra_fields}
+        data: dict[str, Any] = {
+            "response_format": self.response_format,
+            **(self.extra_fields or {}),
+        }
         if self.model:
             data["model"] = self.model
         if self.language:
             data["language"] = self.language
 
-        client = httpx.Client(timeout=self.timeout_s)
-        with self._transport_lock:
-            cancelled_before_dispatch = self._cancelled.is_set() or cancel_check()
-            if cancelled_before_dispatch:
-                self._cancelled.set()
-                self._cancel_reason = self._cancel_reason or "stale"
-            else:
-                self._client = client
-        if cancelled_before_dispatch:
-            client.close()
-            raise self._cancellation_exception()
-
-        monitor_stop = Event()
-        monitor = Thread(
-            target=self._monitor_cancellation,
-            args=(cancel_check, monitor_stop),
-            name="stt-http-cancel",
-            daemon=True,
-        )
-        monitor.start()
-
         try:
-            if self._cancelled.is_set() or cancel_check():
-                self.cancel("stale")
-                raise self._cancellation_exception()
-            with client.stream(
-                "POST",
+            response = httpx.post(
                 self.endpoint_url,
                 headers=headers,
                 data=data,
                 files={"file": ("audio.wav", self.wav_bytes, "audio/wav")},
-            ) as response:
-                with self._transport_lock:
-                    self._response = response
-                if self._cancelled.is_set():
-                    raise self._cancellation_exception()
-                try:
-                    response.raise_for_status()
-                except httpx.HTTPStatusError as exc:
-                    if self._cancelled.is_set():
-                        raise self._cancellation_exception() from exc
-                    raise TranscriptionRequestError(
-                        f"transcription server returned HTTP {exc.response.status_code}"
-                    ) from exc
-
-                body = response.read()
-                if self._cancelled.is_set() or cancel_check():
-                    self.cancel("stale")
-                    raise self._cancellation_exception()
-                return self._parse_response(body, response.headers.get("content-type", ""))
-        except TranscriptionRequestCancelled:
-            raise
-        except TranscriptionRequestError:
-            raise
+                timeout=self.timeout_s,
+            )
+            response.raise_for_status()
+        except httpx.HTTPStatusError as exc:
+            raise TranscriptionRequestError(f"transcription server returned HTTP {exc.response.status_code}") from exc
         except httpx.TimeoutException as exc:
-            if self._cancelled.is_set():
-                raise self._cancellation_exception() from exc
             raise TranscriptionRequestError("transcription request timed out") from exc
         except httpx.HTTPError as exc:
-            if self._cancelled.is_set():
-                raise self._cancellation_exception() from exc
             raise TranscriptionRequestError(f"transcription transport failed: {type(exc).__name__}") from exc
-        except RuntimeError as exc:
-            if self._cancelled.is_set():
-                raise self._cancellation_exception() from exc
-            raise
-        finally:
-            monitor_stop.set()
-            monitor.join(timeout=0.2)
-            with self._transport_lock:
-                self._response = None
-                self._client = None
-            client.close()
 
-    def cancel(self, reason: str) -> None:
-        with self._transport_lock:
-            if self._cancel_reason is None:
-                self._cancel_reason = reason
-            self._cancelled.set()
-            response = self._response
-            client = self._client
-        if response is not None:
-            try:
-                response.close()
-            except Exception:
-                logger.debug("Error closing transcription response", exc_info=True)
-        if client is not None:
-            try:
-                client.close()
-            except Exception:
-                logger.debug("Error closing transcription client", exc_info=True)
-
-    def _cancellation_exception(self) -> TranscriptionRequestCancelled:
-        with self._transport_lock:
-            reason = self._cancel_reason or "cancelled"
-        return TranscriptionRequestCancelled(self.request_id, reason)
-
-    def _monitor_cancellation(self, cancel_check: Callable[[], bool], stop: Event) -> None:
-        while not stop.wait(0.025):
-            if cancel_check():
-                self.cancel("stale")
-                return
+        return self._parse_response(response.content, response.headers.get("content-type", ""))
 
     def _parse_response(self, body: bytes, content_type: str) -> HttpTranscriptionResult:
         if self.response_format == "text" or "text/plain" in content_type:
@@ -203,7 +89,7 @@ class HttpTranscriptionOperation:
             payload = json.loads(body)
         except (UnicodeDecodeError, json.JSONDecodeError) as exc:
             raise TranscriptionRequestError("transcription server returned an invalid JSON response") from exc
-        text = payload.get("text")
+        text = payload.get("text") if isinstance(payload, dict) else None
         if not isinstance(text, str):
             raise TranscriptionRequestError("transcription response is missing a string 'text' field")
         language = payload.get("language")
@@ -239,7 +125,9 @@ class OpenAICompatibleSTTHandler(BaseSTTHandler):
 
         self.base_url = base_url.rstrip("/")
         self.endpoint_url = f"{self.base_url}/audio/transcriptions"
-        self.api_key = api_key if api_key is not None else os.getenv("OPENAI_API_KEY")
+        self.api_key = api_key
+        if self.api_key is None and self.base_url == OPENAI_BASE_URL:
+            self.api_key = os.getenv("OPENAI_API_KEY")
         self.model = model
         self.language = language
         self.response_format = response_format
@@ -247,35 +135,16 @@ class OpenAICompatibleSTTHandler(BaseSTTHandler):
         self.speculative_turns = speculative_turns
         self.final_revision_settle_s = final_revision_settle_s
         self.gen_kwargs = gen_kwargs or {}
-        self._state_lock = Lock()
-        self._session_generation = 0
-        self._active_operation: HttpTranscriptionOperation | None = None
-        self._progressive_hypotheses: dict[tuple[int, str, int], str] = {}
 
     def process(self, vad_audio: STTIn) -> Iterator[STTOut]:
-        request_id = uuid4().hex
-        started_at_s = perf_counter()
-        with self._state_lock:
-            session_generation = self._session_generation
-        operation = self._make_operation(request_id, vad_audio.audio)
-        with self._state_lock:
-            self._active_operation = operation
-
-        def cancel_check() -> bool:
-            return self.stop_event.is_set() or not self._is_request_relevant(vad_audio, session_generation)
-
-        try:
-            result = operation.run(cancel_check)
-        except TranscriptionRequestCancelled:
-            logger.debug(
-                "OpenAI-compatible STT request cancelled turn=%s rev=%s mode=%s",
-                vad_audio.turn_id,
-                vad_audio.turn_revision,
-                vad_audio.mode,
-            )
+        if not self._is_request_relevant(vad_audio):
             return
+
+        started_at_s = perf_counter()
+        try:
+            result = self._make_operation(vad_audio.audio).run()
         except Exception as exc:
-            if not self._is_request_relevant(vad_audio, session_generation):
+            if not self._is_request_relevant(vad_audio):
                 return
             message = str(exc) if isinstance(exc, TranscriptionRequestError) else "transcription request failed"
             if vad_audio.mode == "progressive":
@@ -299,20 +168,17 @@ class OpenAICompatibleSTTHandler(BaseSTTHandler):
                 speech_stopped_at_s=vad_audio.created_at_s,
             )
             return
-        finally:
-            with self._state_lock:
-                if self._active_operation is operation:
-                    self._active_operation = None
 
-        if cancel_check():
-            operation.cancel("stale")
+        if not self._is_request_relevant(vad_audio):
             return
 
-        output: STTOut | None
         if vad_audio.mode == "progressive":
-            output = self._progressive_delta(vad_audio, result.text, session_generation)
+            output: STTOut = PartialTranscription(
+                text=result.text,
+                turn_id=vad_audio.turn_id,
+                turn_revision=vad_audio.turn_revision,
+            )
         else:
-            self._clear_progressive_hypothesis(vad_audio, session_generation)
             output = Transcription(
                 text=result.text,
                 language_code=result.language,
@@ -320,19 +186,18 @@ class OpenAICompatibleSTTHandler(BaseSTTHandler):
                 turn_revision=vad_audio.turn_revision,
                 speech_stopped_at_s=vad_audio.created_at_s,
             )
-        if output is not None:
-            yield output
-            logger.info(
-                "OpenAI-compatible STT completed turn=%s rev=%s mode=%s in %.3fs",
-                vad_audio.turn_id,
-                vad_audio.turn_revision,
-                vad_audio.mode,
-                perf_counter() - started_at_s,
-            )
 
-    def _make_operation(self, request_id: str, audio: np.ndarray) -> HttpTranscriptionOperation:
+        yield output
+        logger.info(
+            "OpenAI-compatible STT completed turn=%s rev=%s mode=%s in %.3fs",
+            vad_audio.turn_id,
+            vad_audio.turn_revision,
+            vad_audio.mode,
+            perf_counter() - started_at_s,
+        )
+
+    def _make_operation(self, audio: np.ndarray) -> HttpTranscriptionOperation:
         return HttpTranscriptionOperation(
-            request_id=request_id,
             endpoint_url=self.endpoint_url,
             api_key=self.api_key,
             model=self.model,
@@ -362,59 +227,8 @@ class OpenAICompatibleSTTHandler(BaseSTTHandler):
             wav.writeframes(pcm.tobytes())
         return output.getvalue()
 
-    def _is_request_relevant(self, source: VADAudio, session_generation: int) -> bool:
+    def _is_request_relevant(self, source: VADAudio) -> bool:
         if self.stop_event.is_set():
             return False
-        with self._state_lock:
-            if session_generation != self._session_generation:
-                return False
         tracker = self.speculative_turns
         return tracker is None or tracker.is_latest(source.turn_id, source.turn_revision)
-
-    def _progressive_delta(
-        self,
-        source: VADAudio,
-        hypothesis: str,
-        session_generation: int,
-    ) -> PartialTranscription | None:
-        if source.turn_id is None or source.turn_revision is None:
-            return PartialTranscription(text=hypothesis)
-        key = (session_generation, source.turn_id, source.turn_revision)
-        with self._state_lock:
-            previous = self._progressive_hypotheses.get(key, "")
-            if hypothesis == previous:
-                return None
-            if previous and not hypothesis.startswith(previous):
-                logger.debug(
-                    "Suppressing rewritten progressive STT hypothesis turn=%s rev=%s",
-                    source.turn_id,
-                    source.turn_revision,
-                )
-                return None
-            self._progressive_hypotheses[key] = hypothesis
-        return PartialTranscription(
-            text=hypothesis[len(previous) :],
-            turn_id=source.turn_id,
-            turn_revision=source.turn_revision,
-        )
-
-    def _clear_progressive_hypothesis(self, source: VADAudio, session_generation: int) -> None:
-        if source.turn_id is None or source.turn_revision is None:
-            return
-        with self._state_lock:
-            self._progressive_hypotheses.pop((session_generation, source.turn_id, source.turn_revision), None)
-
-    def on_session_end(self) -> None:
-        with self._state_lock:
-            self._session_generation += 1
-            self._progressive_hypotheses.clear()
-            operation = self._active_operation
-        if operation is not None:
-            operation.cancel("session_end")
-        super().on_session_end()
-
-    def cleanup(self) -> None:
-        with self._state_lock:
-            operation = self._active_operation
-        if operation is not None:
-            operation.cancel("shutdown")

--- a/src/speech_to_speech/STT/openai_compatible_handler.py
+++ b/src/speech_to_speech/STT/openai_compatible_handler.py
@@ -135,6 +135,18 @@ class OpenAICompatibleSTTHandler(BaseSTTHandler):
         self.speculative_turns = speculative_turns
         self.final_revision_settle_s = final_revision_settle_s
         self.gen_kwargs = gen_kwargs or {}
+        self.warmup()
+
+    def warmup(self) -> None:
+        """Validate the configured transcription endpoint before accepting sessions."""
+        logger.info("Warming up %s", self.__class__.__name__)
+        started_at_s = perf_counter()
+        self._make_operation(np.zeros(PIPELINE_SAMPLE_RATE, dtype=np.float32)).run()
+        logger.info(
+            "%s warmed up in %.3fs",
+            self.__class__.__name__,
+            perf_counter() - started_at_s,
+        )
 
     def process(self, vad_audio: STTIn) -> Iterator[STTOut]:
         if not self._is_request_relevant(vad_audio):

--- a/src/speech_to_speech/STT/openai_compatible_handler.py
+++ b/src/speech_to_speech/STT/openai_compatible_handler.py
@@ -1,0 +1,420 @@
+from __future__ import annotations
+
+import io
+import json
+import logging
+import os
+import wave
+from collections.abc import Callable
+from dataclasses import dataclass
+from threading import Event, Lock, Thread
+from time import perf_counter
+from typing import Any, Iterator
+from uuid import uuid4
+
+import httpx
+import numpy as np
+
+from speech_to_speech.pipeline.handler_types import STTIn, STTOut
+from speech_to_speech.pipeline.messages import (
+    PartialTranscription,
+    Transcription,
+    TranscriptionFailure,
+    VADAudio,
+)
+from speech_to_speech.pipeline.speculative_turns import SpeculativeTurnTracker
+from speech_to_speech.STT.base_stt_handler import BaseSTTHandler
+
+logger = logging.getLogger(__name__)
+
+PIPELINE_SAMPLE_RATE = 16000
+
+
+class TranscriptionRequestCancelled(RuntimeError):
+    def __init__(self, request_id: str, reason: str) -> None:
+        self.request_id = request_id
+        self.reason = reason
+        super().__init__(f"transcription request {request_id} cancelled: {reason}")
+
+
+class TranscriptionRequestError(RuntimeError):
+    """Sanitized HTTP/protocol failure safe to surface to a client."""
+
+
+@dataclass(frozen=True)
+class HttpTranscriptionResult:
+    text: str
+    language: str | None = None
+
+
+class HttpTranscriptionOperation:
+    """Exactly one transcription request and its transport lifecycle."""
+
+    def __init__(
+        self,
+        *,
+        request_id: str,
+        endpoint_url: str,
+        api_key: str | None,
+        model: str | None,
+        wav_bytes: bytes,
+        language: str | None,
+        response_format: str,
+        timeout_s: float,
+        extra_fields: dict[str, Any] | None = None,
+    ) -> None:
+        self.request_id = request_id
+        self.endpoint_url = endpoint_url
+        self.api_key = api_key
+        self.model = model
+        self.wav_bytes = wav_bytes
+        self.language = language
+        self.response_format = response_format
+        self.timeout_s = timeout_s
+        self.extra_fields = extra_fields or {}
+        self._cancelled = Event()
+        self._transport_lock = Lock()
+        self._client: httpx.Client | None = None
+        self._response: httpx.Response | None = None
+        self._cancel_reason: str | None = None
+
+    def run(self, cancel_check: Callable[[], bool] | None = None) -> HttpTranscriptionResult:
+        cancel_check = cancel_check or (lambda: False)
+        if self._cancelled.is_set() or cancel_check():
+            self.cancel("stale")
+            raise self._cancellation_exception()
+
+        headers = {}
+        if self.api_key:
+            headers["Authorization"] = f"Bearer {self.api_key}"
+        data: dict[str, Any] = {"response_format": self.response_format, **self.extra_fields}
+        if self.model:
+            data["model"] = self.model
+        if self.language:
+            data["language"] = self.language
+
+        client = httpx.Client(timeout=self.timeout_s)
+        with self._transport_lock:
+            cancelled_before_dispatch = self._cancelled.is_set() or cancel_check()
+            if cancelled_before_dispatch:
+                self._cancelled.set()
+                self._cancel_reason = self._cancel_reason or "stale"
+            else:
+                self._client = client
+        if cancelled_before_dispatch:
+            client.close()
+            raise self._cancellation_exception()
+
+        monitor_stop = Event()
+        monitor = Thread(
+            target=self._monitor_cancellation,
+            args=(cancel_check, monitor_stop),
+            name="stt-http-cancel",
+            daemon=True,
+        )
+        monitor.start()
+
+        try:
+            if self._cancelled.is_set() or cancel_check():
+                self.cancel("stale")
+                raise self._cancellation_exception()
+            with client.stream(
+                "POST",
+                self.endpoint_url,
+                headers=headers,
+                data=data,
+                files={"file": ("audio.wav", self.wav_bytes, "audio/wav")},
+            ) as response:
+                with self._transport_lock:
+                    self._response = response
+                if self._cancelled.is_set():
+                    raise self._cancellation_exception()
+                try:
+                    response.raise_for_status()
+                except httpx.HTTPStatusError as exc:
+                    if self._cancelled.is_set():
+                        raise self._cancellation_exception() from exc
+                    raise TranscriptionRequestError(
+                        f"transcription server returned HTTP {exc.response.status_code}"
+                    ) from exc
+
+                body = response.read()
+                if self._cancelled.is_set() or cancel_check():
+                    self.cancel("stale")
+                    raise self._cancellation_exception()
+                return self._parse_response(body, response.headers.get("content-type", ""))
+        except TranscriptionRequestCancelled:
+            raise
+        except TranscriptionRequestError:
+            raise
+        except httpx.TimeoutException as exc:
+            if self._cancelled.is_set():
+                raise self._cancellation_exception() from exc
+            raise TranscriptionRequestError("transcription request timed out") from exc
+        except httpx.HTTPError as exc:
+            if self._cancelled.is_set():
+                raise self._cancellation_exception() from exc
+            raise TranscriptionRequestError(f"transcription transport failed: {type(exc).__name__}") from exc
+        except RuntimeError as exc:
+            if self._cancelled.is_set():
+                raise self._cancellation_exception() from exc
+            raise
+        finally:
+            monitor_stop.set()
+            monitor.join(timeout=0.2)
+            with self._transport_lock:
+                self._response = None
+                self._client = None
+            client.close()
+
+    def cancel(self, reason: str) -> None:
+        with self._transport_lock:
+            if self._cancel_reason is None:
+                self._cancel_reason = reason
+            self._cancelled.set()
+            response = self._response
+            client = self._client
+        if response is not None:
+            try:
+                response.close()
+            except Exception:
+                logger.debug("Error closing transcription response", exc_info=True)
+        if client is not None:
+            try:
+                client.close()
+            except Exception:
+                logger.debug("Error closing transcription client", exc_info=True)
+
+    def _cancellation_exception(self) -> TranscriptionRequestCancelled:
+        with self._transport_lock:
+            reason = self._cancel_reason or "cancelled"
+        return TranscriptionRequestCancelled(self.request_id, reason)
+
+    def _monitor_cancellation(self, cancel_check: Callable[[], bool], stop: Event) -> None:
+        while not stop.wait(0.025):
+            if cancel_check():
+                self.cancel("stale")
+                return
+
+    def _parse_response(self, body: bytes, content_type: str) -> HttpTranscriptionResult:
+        if self.response_format == "text" or "text/plain" in content_type:
+            return HttpTranscriptionResult(text=body.decode("utf-8").strip(), language=self.language)
+        try:
+            payload = json.loads(body)
+        except (UnicodeDecodeError, json.JSONDecodeError) as exc:
+            raise TranscriptionRequestError("transcription server returned an invalid JSON response") from exc
+        text = payload.get("text")
+        if not isinstance(text, str):
+            raise TranscriptionRequestError("transcription response is missing a string 'text' field")
+        language = payload.get("language")
+        return HttpTranscriptionResult(
+            text=text,
+            language=language if isinstance(language, str) else self.language,
+        )
+
+
+class OpenAICompatibleSTTHandler(BaseSTTHandler):
+    """Serial client handler for POST /v1/audio/transcriptions."""
+
+    def setup(
+        self,
+        base_url: str = "http://localhost:8000/v1",
+        api_key: str | None = None,
+        model: str | None = "nvidia/parakeet-tdt-0.6b-v3",
+        language: str | None = None,
+        response_format: str = "json",
+        timeout: float = 60.0,
+        speculative_turns: SpeculativeTurnTracker | None = None,
+        final_revision_settle_s: float = 0.0,
+        gen_kwargs: dict[str, Any] | None = None,
+    ) -> None:
+        if response_format not in {"json", "text"}:
+            raise ValueError("OpenAI-compatible STT response_format must be 'json' or 'text'")
+        if timeout <= 0:
+            raise ValueError("OpenAI-compatible STT timeout must be > 0")
+        model = model.strip() if model else None
+        language = language.strip() if language else None
+        if model is None and language is None:
+            raise ValueError("OpenAI-compatible STT requires either a model or language")
+
+        self.base_url = base_url.rstrip("/")
+        self.endpoint_url = f"{self.base_url}/audio/transcriptions"
+        self.api_key = api_key if api_key is not None else os.getenv("OPENAI_API_KEY")
+        self.model = model
+        self.language = language
+        self.response_format = response_format
+        self.timeout = timeout
+        self.speculative_turns = speculative_turns
+        self.final_revision_settle_s = final_revision_settle_s
+        self.gen_kwargs = gen_kwargs or {}
+        self._state_lock = Lock()
+        self._session_generation = 0
+        self._active_operation: HttpTranscriptionOperation | None = None
+        self._progressive_hypotheses: dict[tuple[int, str, int], str] = {}
+
+    def process(self, vad_audio: STTIn) -> Iterator[STTOut]:
+        request_id = uuid4().hex
+        started_at_s = perf_counter()
+        with self._state_lock:
+            session_generation = self._session_generation
+        operation = self._make_operation(request_id, vad_audio.audio)
+        with self._state_lock:
+            self._active_operation = operation
+
+        def cancel_check() -> bool:
+            return self.stop_event.is_set() or not self._is_request_relevant(vad_audio, session_generation)
+
+        try:
+            result = operation.run(cancel_check)
+        except TranscriptionRequestCancelled:
+            logger.debug(
+                "OpenAI-compatible STT request cancelled turn=%s rev=%s mode=%s",
+                vad_audio.turn_id,
+                vad_audio.turn_revision,
+                vad_audio.mode,
+            )
+            return
+        except Exception as exc:
+            if not self._is_request_relevant(vad_audio, session_generation):
+                return
+            message = str(exc) if isinstance(exc, TranscriptionRequestError) else "transcription request failed"
+            if vad_audio.mode == "progressive":
+                logger.warning(
+                    "OpenAI-compatible progressive STT failed turn=%s rev=%s: %s",
+                    vad_audio.turn_id,
+                    vad_audio.turn_revision,
+                    message,
+                )
+                return
+            logger.error(
+                "OpenAI-compatible STT failed turn=%s rev=%s: %s",
+                vad_audio.turn_id,
+                vad_audio.turn_revision,
+                message,
+            )
+            yield TranscriptionFailure(
+                message=message,
+                turn_id=vad_audio.turn_id,
+                turn_revision=vad_audio.turn_revision,
+                speech_stopped_at_s=vad_audio.created_at_s,
+            )
+            return
+        finally:
+            with self._state_lock:
+                if self._active_operation is operation:
+                    self._active_operation = None
+
+        if cancel_check():
+            operation.cancel("stale")
+            return
+
+        output: STTOut | None
+        if vad_audio.mode == "progressive":
+            output = self._progressive_delta(vad_audio, result.text, session_generation)
+        else:
+            self._clear_progressive_hypothesis(vad_audio, session_generation)
+            output = Transcription(
+                text=result.text,
+                language_code=result.language,
+                turn_id=vad_audio.turn_id,
+                turn_revision=vad_audio.turn_revision,
+                speech_stopped_at_s=vad_audio.created_at_s,
+            )
+        if output is not None:
+            yield output
+            logger.info(
+                "OpenAI-compatible STT completed turn=%s rev=%s mode=%s in %.3fs",
+                vad_audio.turn_id,
+                vad_audio.turn_revision,
+                vad_audio.mode,
+                perf_counter() - started_at_s,
+            )
+
+    def _make_operation(self, request_id: str, audio: np.ndarray) -> HttpTranscriptionOperation:
+        return HttpTranscriptionOperation(
+            request_id=request_id,
+            endpoint_url=self.endpoint_url,
+            api_key=self.api_key,
+            model=self.model,
+            wav_bytes=self._encode_wav(audio),
+            language=self.language,
+            response_format=self.response_format,
+            timeout_s=self.timeout,
+            extra_fields=self.gen_kwargs,
+        )
+
+    @staticmethod
+    def _encode_wav(audio: np.ndarray) -> bytes:
+        waveform = np.asarray(audio).squeeze()
+        if waveform.ndim != 1:
+            raise ValueError(f"STT audio must be mono, got shape {waveform.shape}")
+        if np.issubdtype(waveform.dtype, np.floating):
+            pcm = np.clip(waveform, -1.0, 1.0)
+            pcm = np.round(pcm * 32767.0).astype("<i2")
+        else:
+            pcm = np.clip(waveform, -32768, 32767).astype("<i2")
+
+        output = io.BytesIO()
+        with wave.open(output, "wb") as wav:
+            wav.setnchannels(1)
+            wav.setsampwidth(2)
+            wav.setframerate(PIPELINE_SAMPLE_RATE)
+            wav.writeframes(pcm.tobytes())
+        return output.getvalue()
+
+    def _is_request_relevant(self, source: VADAudio, session_generation: int) -> bool:
+        if self.stop_event.is_set():
+            return False
+        with self._state_lock:
+            if session_generation != self._session_generation:
+                return False
+        tracker = self.speculative_turns
+        return tracker is None or tracker.is_latest(source.turn_id, source.turn_revision)
+
+    def _progressive_delta(
+        self,
+        source: VADAudio,
+        hypothesis: str,
+        session_generation: int,
+    ) -> PartialTranscription | None:
+        if source.turn_id is None or source.turn_revision is None:
+            return PartialTranscription(text=hypothesis)
+        key = (session_generation, source.turn_id, source.turn_revision)
+        with self._state_lock:
+            previous = self._progressive_hypotheses.get(key, "")
+            if hypothesis == previous:
+                return None
+            if previous and not hypothesis.startswith(previous):
+                logger.debug(
+                    "Suppressing rewritten progressive STT hypothesis turn=%s rev=%s",
+                    source.turn_id,
+                    source.turn_revision,
+                )
+                return None
+            self._progressive_hypotheses[key] = hypothesis
+        return PartialTranscription(
+            text=hypothesis[len(previous) :],
+            turn_id=source.turn_id,
+            turn_revision=source.turn_revision,
+        )
+
+    def _clear_progressive_hypothesis(self, source: VADAudio, session_generation: int) -> None:
+        if source.turn_id is None or source.turn_revision is None:
+            return
+        with self._state_lock:
+            self._progressive_hypotheses.pop((session_generation, source.turn_id, source.turn_revision), None)
+
+    def on_session_end(self) -> None:
+        with self._state_lock:
+            self._session_generation += 1
+            self._progressive_hypotheses.clear()
+            operation = self._active_operation
+        if operation is not None:
+            operation.cancel("session_end")
+        super().on_session_end()
+
+    def cleanup(self) -> None:
+        with self._state_lock:
+            operation = self._active_operation
+        if operation is not None:
+            operation.cancel("shutdown")

--- a/src/speech_to_speech/STT/openai_compatible_handler.py
+++ b/src/speech_to_speech/STT/openai_compatible_handler.py
@@ -6,6 +6,7 @@ import logging
 import os
 import wave
 from dataclasses import dataclass
+from threading import Lock, Thread
 from time import perf_counter
 from typing import Any, Iterator
 
@@ -13,6 +14,7 @@ import httpx
 import numpy as np
 
 from speech_to_speech.pipeline.handler_types import STTIn, STTOut
+from speech_to_speech.pipeline.log_context import pipeline_log_ctx
 from speech_to_speech.pipeline.messages import (
     PartialTranscription,
     Transcription,
@@ -100,7 +102,7 @@ class HttpTranscriptionOperation:
 
 
 class OpenAICompatibleSTTHandler(BaseSTTHandler):
-    """Serial client handler for POST /v1/audio/transcriptions."""
+    """Client handler for POST /v1/audio/transcriptions."""
 
     def setup(
         self,
@@ -135,6 +137,9 @@ class OpenAICompatibleSTTHandler(BaseSTTHandler):
         self.speculative_turns = speculative_turns
         self.final_revision_settle_s = final_revision_settle_s
         self.gen_kwargs = gen_kwargs or {}
+        self._progressive_lock = Lock()
+        self._progressive_key: tuple[str | None, int | None] | None = None
+        self._progressive_thread: Thread | None = None
         self.warmup()
 
     def warmup(self) -> None:
@@ -152,37 +157,47 @@ class OpenAICompatibleSTTHandler(BaseSTTHandler):
         if not self._is_request_relevant(vad_audio):
             return
 
+        if vad_audio.mode == "progressive":
+            self._start_progressive_request(vad_audio)
+            return
+
+        self._suppress_matching_progressive(vad_audio)
+        output = self._run_request(vad_audio)
+        if output is not None:
+            yield output
+
+    def _run_request(self, vad_audio: VADAudio) -> STTOut | None:
         started_at_s = perf_counter()
         try:
             result = self._make_operation(vad_audio.audio).run()
         except Exception as exc:
             if not self._is_request_relevant(vad_audio):
-                return
+                return None
             message = str(exc) if isinstance(exc, TranscriptionRequestError) else "transcription request failed"
             if vad_audio.mode == "progressive":
-                logger.warning(
-                    "OpenAI-compatible progressive STT failed turn=%s rev=%s: %s",
-                    vad_audio.turn_id,
-                    vad_audio.turn_revision,
-                    message,
-                )
-                return
+                if self._progressive_result_is_current(vad_audio):
+                    logger.warning(
+                        "OpenAI-compatible progressive STT failed turn=%s rev=%s: %s",
+                        vad_audio.turn_id,
+                        vad_audio.turn_revision,
+                        message,
+                    )
+                return None
             logger.error(
                 "OpenAI-compatible STT failed turn=%s rev=%s: %s",
                 vad_audio.turn_id,
                 vad_audio.turn_revision,
                 message,
             )
-            yield TranscriptionFailure(
+            return TranscriptionFailure(
                 message=message,
                 turn_id=vad_audio.turn_id,
                 turn_revision=vad_audio.turn_revision,
                 speech_stopped_at_s=vad_audio.created_at_s,
             )
-            return
 
         if not self._is_request_relevant(vad_audio):
-            return
+            return None
 
         if vad_audio.mode == "progressive":
             output: STTOut = PartialTranscription(
@@ -199,7 +214,6 @@ class OpenAICompatibleSTTHandler(BaseSTTHandler):
                 speech_stopped_at_s=vad_audio.created_at_s,
             )
 
-        yield output
         logger.info(
             "OpenAI-compatible STT completed turn=%s rev=%s mode=%s in %.3fs",
             vad_audio.turn_id,
@@ -207,6 +221,75 @@ class OpenAICompatibleSTTHandler(BaseSTTHandler):
             vad_audio.mode,
             perf_counter() - started_at_s,
         )
+        return output
+
+    def _start_progressive_request(self, vad_audio: VADAudio) -> None:
+        with self._progressive_lock:
+            if self._progressive_thread is not None and self._progressive_thread.is_alive():
+                logger.debug(
+                    "Skipping OpenAI-compatible progressive STT while a request is in flight "
+                    "turn=%s rev=%s",
+                    vad_audio.turn_id,
+                    vad_audio.turn_revision,
+                )
+                return
+            self._progressive_key = self._request_key(vad_audio)
+            thread = Thread(
+                target=self._run_progressive_request,
+                args=(vad_audio,),
+                name=f"{self.__class__.__name__}-progressive",
+                daemon=True,
+            )
+            self._progressive_thread = thread
+            try:
+                thread.start()
+            except Exception:
+                self._progressive_key = None
+                self._progressive_thread = None
+                raise
+
+    def _run_progressive_request(self, vad_audio: VADAudio) -> None:
+        if self.pipeline_index is not None:
+            pipeline_log_ctx.set(self.pipeline_index)
+        try:
+            output = self._run_request(vad_audio)
+            if not isinstance(output, PartialTranscription) or not self.should_emit_output(output):
+                return
+            with self._progressive_lock:
+                if not self._progressive_result_is_current_locked(vad_audio):
+                    return
+                self.queue_out.put(output)
+        finally:
+            with self._progressive_lock:
+                self._progressive_key = None
+
+    def _suppress_matching_progressive(self, vad_audio: VADAudio) -> None:
+        key = self._request_key(vad_audio)
+        with self._progressive_lock:
+            if self._progressive_key == key:
+                self._progressive_key = None
+
+    def _progressive_result_is_current(self, vad_audio: VADAudio) -> bool:
+        with self._progressive_lock:
+            return self._progressive_result_is_current_locked(vad_audio)
+
+    def _progressive_result_is_current_locked(self, vad_audio: VADAudio) -> bool:
+        return self._progressive_key == self._request_key(vad_audio) and self._is_request_relevant(vad_audio)
+
+    @staticmethod
+    def _request_key(vad_audio: VADAudio) -> tuple[str | None, int | None]:
+        return (vad_audio.turn_id, vad_audio.turn_revision)
+
+    def on_session_end(self) -> None:
+        with self._progressive_lock:
+            self._progressive_key = None
+        super().on_session_end()
+
+    def cleanup(self) -> None:
+        # A blocking HTTP request cannot be cancelled safely. Its daemon worker
+        # exits on the configured timeout; suppress any output after shutdown.
+        with self._progressive_lock:
+            self._progressive_key = None
 
     def _make_operation(self, audio: np.ndarray) -> HttpTranscriptionOperation:
         return HttpTranscriptionOperation(

--- a/src/speech_to_speech/STT/openai_compatible_handler.py
+++ b/src/speech_to_speech/STT/openai_compatible_handler.py
@@ -227,8 +227,7 @@ class OpenAICompatibleSTTHandler(BaseSTTHandler):
         with self._progressive_lock:
             if self._progressive_thread is not None and self._progressive_thread.is_alive():
                 logger.debug(
-                    "Skipping OpenAI-compatible progressive STT while a request is in flight "
-                    "turn=%s rev=%s",
+                    "Skipping OpenAI-compatible progressive STT while a request is in flight turn=%s rev=%s",
                     vad_audio.turn_id,
                     vad_audio.turn_revision,
                 )

--- a/src/speech_to_speech/STT/openai_compatible_handler.py
+++ b/src/speech_to_speech/STT/openai_compatible_handler.py
@@ -64,7 +64,10 @@ class HttpTranscriptionOperation:
         if self.model:
             data["model"] = self.model
         if self.language:
-            data["language"] = self.language
+            if self.model == "gpt-transcribe":
+                data["languages[]"] = self.language
+            else:
+                data["language"] = self.language
 
         try:
             response = httpx.post(
@@ -94,10 +97,18 @@ class HttpTranscriptionOperation:
         text = payload.get("text") if isinstance(payload, dict) else None
         if not isinstance(text, str):
             raise TranscriptionRequestError("transcription response is missing a string 'text' field")
-        language = payload.get("language")
+        language = None
+        languages = payload.get("languages")
+        if isinstance(languages, list):
+            for detected_language in languages:
+                if isinstance(detected_language, dict) and isinstance(detected_language.get("code"), str):
+                    language = detected_language["code"]
+                    break
+        if language is None and isinstance(payload.get("language"), str):
+            language = payload["language"]
         return HttpTranscriptionResult(
             text=text,
-            language=language if isinstance(language, str) else self.language,
+            language=language or self.language,
         )
 
 

--- a/src/speech_to_speech/STT/transcription_notifier.py
+++ b/src/speech_to_speech/STT/transcription_notifier.py
@@ -6,9 +6,17 @@ from threading import Event
 from typing import Iterator
 
 from speech_to_speech.baseHandler import BaseHandler
-from speech_to_speech.pipeline.events import PartialTranscriptionEvent, TranscriptionCompletedEvent
+from speech_to_speech.pipeline.events import (
+    PartialTranscriptionEvent,
+    TranscriptionCompletedEvent,
+    TranscriptionFailedEvent,
+)
 from speech_to_speech.pipeline.handler_types import LLMIn, STTOut
-from speech_to_speech.pipeline.messages import PartialTranscription, Transcription
+from speech_to_speech.pipeline.messages import (
+    PartialTranscription,
+    Transcription,
+    TranscriptionFailure,
+)
 from speech_to_speech.pipeline.queue_types import TextEventItem
 
 logger = logging.getLogger(__name__)
@@ -41,6 +49,19 @@ class TranscriptionNotifier(BaseHandler[STTOut, LLMIn]):
                     )
                 )
                 logger.debug("Partial transcription: %s", str(transcription.text)[:80])
+            return
+
+        if isinstance(transcription, TranscriptionFailure):
+            if self.text_output_queue is not None:
+                self.text_output_queue.put(
+                    TranscriptionFailedEvent(
+                        message=transcription.message,
+                        turn_id=transcription.turn_id,
+                        turn_revision=transcription.turn_revision,
+                    )
+                )
+            if self.should_listen is not None:
+                self.should_listen.set()
             return
 
         if isinstance(transcription, Transcription):

--- a/src/speech_to_speech/STT/transcription_notifier.py
+++ b/src/speech_to_speech/STT/transcription_notifier.py
@@ -60,8 +60,6 @@ class TranscriptionNotifier(BaseHandler[STTOut, LLMIn]):
                         turn_revision=transcription.turn_revision,
                     )
                 )
-            if self.should_listen is not None:
-                self.should_listen.set()
             return
 
         if isinstance(transcription, Transcription):

--- a/src/speech_to_speech/api/openai_realtime/handlers/conversation.py
+++ b/src/speech_to_speech/api/openai_realtime/handlers/conversation.py
@@ -10,9 +10,13 @@ from openai.types.realtime import (
     ConversationItemCreateEvent,
     ConversationItemInputAudioTranscriptionCompletedEvent,
     ConversationItemInputAudioTranscriptionDeltaEvent,
+    ConversationItemInputAudioTranscriptionFailedEvent,
 )
 from openai.types.realtime.conversation_item_input_audio_transcription_completed_event import (
     UsageTranscriptTextUsageDuration,
+)
+from openai.types.realtime.conversation_item_input_audio_transcription_failed_event import (
+    Error as InputAudioTranscriptionError,
 )
 from openai.types.realtime.realtime_conversation_item_function_call_output import (
     RealtimeConversationItemFunctionCallOutput,
@@ -23,7 +27,11 @@ from openai.types.realtime.realtime_conversation_item_user_message import (
 
 from speech_to_speech.api.openai_realtime.handlers.base import RealtimeBaseHandler
 from speech_to_speech.LLM.chat import ChatItemError, add_supported_item
-from speech_to_speech.pipeline.events import PartialTranscriptionEvent, TranscriptionCompletedEvent
+from speech_to_speech.pipeline.events import (
+    PartialTranscriptionEvent,
+    TranscriptionCompletedEvent,
+    TranscriptionFailedEvent,
+)
 
 if TYPE_CHECKING:
     from speech_to_speech.api.openai_realtime.service import ServerEvent
@@ -355,6 +363,41 @@ class ConversationHandler(RealtimeBaseHandler):
                 usage=UsageTranscriptTextUsageDuration(
                     seconds=duration_s,
                     type="duration",
+                ),
+            )
+        ]
+
+    def on_transcription_failed(
+        self,
+        conn_id: str,
+        event: TranscriptionFailedEvent,
+    ) -> list[ConversationItemInputAudioTranscriptionFailedEvent]:
+        """Terminalize one transcript item and emit its item-scoped failure."""
+        st = self._state(conn_id)
+        if event.turn_id is not None:
+            item_id = st.input_item_by_turn_revision.get((event.turn_id, event.turn_revision))
+        else:
+            item_id = st.current_input_item_id
+        if item_id is None:
+            logger.debug(
+                "Ignoring transcription failure for unknown turn=%s rev=%s",
+                event.turn_id,
+                event.turn_revision,
+            )
+            return []
+        if self.terminalize_input_item(conn_id, item_id) is None:
+            return []
+        return [
+            ConversationItemInputAudioTranscriptionFailedEvent(
+                type="conversation.item.input_audio_transcription.failed",
+                event_id=self._next_event_id(),
+                content_index=0,
+                item_id=item_id,
+                error=InputAudioTranscriptionError(
+                    type="transcription_error",
+                    code="transcription_failed",
+                    message=event.message,
+                    param=None,
                 ),
             )
         ]

--- a/src/speech_to_speech/api/openai_realtime/service.py
+++ b/src/speech_to_speech/api/openai_realtime/service.py
@@ -10,6 +10,7 @@ from openai.types.realtime import (
     ConversationItemCreateEvent,
     ConversationItemInputAudioTranscriptionCompletedEvent,
     ConversationItemInputAudioTranscriptionDeltaEvent,
+    ConversationItemInputAudioTranscriptionFailedEvent,
     ConversationItemTruncateEvent,
     InputAudioBufferAppendEvent,
     InputAudioBufferCommitEvent,
@@ -113,6 +114,7 @@ ServerEvent = Union[
     ConversationItemCreatedEvent,
     ConversationItemInputAudioTranscriptionDeltaEvent,
     ConversationItemInputAudioTranscriptionCompletedEvent,
+    ConversationItemInputAudioTranscriptionFailedEvent,
     ResponseCreatedEvent,
     ResponseDoneEvent,
     ResponseAudioDeltaEvent,
@@ -667,8 +669,13 @@ class RealtimeService:
 
     def _on_transcription_failed(self, conn_id: str, event: TranscriptionFailedEvent) -> list[ServerEvent]:
         """Surface a final STT failure without creating conversation or LLM work."""
-        self._state(conn_id)
-        return [self.make_error(event.message, "transcription_failed")]
+        st = self._state(conn_id)
+        current_input_item_id = st.current_input_item_id
+        failed_events = self.conversation.on_transcription_failed(conn_id, event)
+        owns_current_input = failed_events and failed_events[0].item_id == current_input_item_id
+        if owns_current_input and self.should_listen is not None:
+            self.should_listen.set()
+        return [*failed_events]
 
     def _on_audio_input_completed(self, conn_id: str, event: AudioInputCompletedEvent) -> list[ServerEvent]:
         """Record final input audio and queue its realtime LM request."""

--- a/src/speech_to_speech/api/openai_realtime/service.py
+++ b/src/speech_to_speech/api/openai_realtime/service.py
@@ -65,6 +65,7 @@ from speech_to_speech.pipeline.events import (
     SpeechStoppedEvent,
     TokenUsageEvent,
     TranscriptionCompletedEvent,
+    TranscriptionFailedEvent,
 )
 from speech_to_speech.pipeline.messages import GenerateResponseRequest
 from speech_to_speech.pipeline.queue_types import TextPromptItem
@@ -314,6 +315,7 @@ class RealtimeService:
             SpeechStoppedEvent: self.audio.on_speech_stopped,
             PartialTranscriptionEvent: self.conversation.on_partial_transcription,
             TranscriptionCompletedEvent: self._on_transcription_completed,
+            TranscriptionFailedEvent: self._on_transcription_failed,
             AudioInputCompletedEvent: self._on_audio_input_completed,
             ResponseGenerationDoneEvent: self.response.on_response_generation_done,
             AssistantToolCallReadyEvent: self.response.on_assistant_tool_call_ready,
@@ -568,6 +570,7 @@ class RealtimeService:
             (
                 PartialTranscriptionEvent,
                 TranscriptionCompletedEvent,
+                TranscriptionFailedEvent,
                 AudioInputCompletedEvent,
                 AssistantOutputEvent,
                 AssistantResponseDoneEvent,
@@ -661,6 +664,11 @@ class RealtimeService:
             queue.put(request)
 
         return [*completed_events]
+
+    def _on_transcription_failed(self, conn_id: str, event: TranscriptionFailedEvent) -> list[ServerEvent]:
+        """Surface a final STT failure without creating conversation or LLM work."""
+        self._state(conn_id)
+        return [self.make_error(event.message, "transcription_failed")]
 
     def _on_audio_input_completed(self, conn_id: str, event: AudioInputCompletedEvent) -> list[ServerEvent]:
         """Record final input audio and queue its realtime LM request."""

--- a/src/speech_to_speech/api/openai_realtime/websocket_router.py
+++ b/src/speech_to_speech/api/openai_realtime/websocket_router.py
@@ -44,6 +44,7 @@ from speech_to_speech.pipeline.events import (
     SpeechStoppedEvent,
     TokenUsageEvent,
     TranscriptionCompletedEvent,
+    TranscriptionFailedEvent,
 )
 from speech_to_speech.pipeline.log_context import pipeline_log_ctx
 from speech_to_speech.pipeline.messages import AUDIO_RESPONSE_DONE, PIPELINE_END, AudioOutput
@@ -97,6 +98,7 @@ def _keep_user_text_event(item: Any) -> bool:
             SpeechStoppedEvent,
             PartialTranscriptionEvent,
             TranscriptionCompletedEvent,
+            TranscriptionFailedEvent,
             AudioInputCompletedEvent,
         ),
     )

--- a/src/speech_to_speech/arguments_classes/openai_stt_arguments.py
+++ b/src/speech_to_speech/arguments_classes/openai_stt_arguments.py
@@ -1,0 +1,35 @@
+from dataclasses import dataclass, field
+from typing import Optional
+
+
+@dataclass
+class OpenAICompatibleSTTHandlerArguments:
+    """Connection settings for an OpenAI-compatible STT server."""
+
+    openai_stt_base_url: str = field(
+        default="http://localhost:8000/v1",
+        metadata={"help": "Base URL of the OpenAI-compatible server, including /v1."},
+    )
+    openai_stt_api_key: Optional[str] = field(
+        default=None,
+        metadata={"help": "Optional bearer token. If unset, OPENAI_API_KEY is used when available."},
+    )
+    openai_stt_model: Optional[str] = field(
+        default="nvidia/parakeet-tdt-0.6b-v3",
+        metadata={
+            "help": "Optional model identifier sent to POST /audio/transcriptions. "
+            "May be omitted when the server selects a model from the language."
+        },
+    )
+    openai_stt_language: Optional[str] = field(
+        default=None,
+        metadata={"help": "Optional ISO language hint sent with each transcription request."},
+    )
+    openai_stt_response_format: str = field(
+        default="json",
+        metadata={"help": "Transcription response format. The adapter supports json and text."},
+    )
+    openai_stt_timeout: float = field(
+        default=60.0,
+        metadata={"help": "HTTP request timeout in seconds."},
+    )

--- a/src/speech_to_speech/arguments_classes/openai_stt_arguments.py
+++ b/src/speech_to_speech/arguments_classes/openai_stt_arguments.py
@@ -12,7 +12,10 @@ class OpenAICompatibleSTTHandlerArguments:
     )
     openai_stt_api_key: Optional[str] = field(
         default=None,
-        metadata={"help": "Optional bearer token. If unset, OPENAI_API_KEY is used when available."},
+        metadata={
+            "help": "Optional bearer token. For https://api.openai.com/v1 only, "
+            "OPENAI_API_KEY is used when this flag is unset."
+        },
     )
     openai_stt_model: Optional[str] = field(
         default="nvidia/parakeet-tdt-0.6b-v3",

--- a/src/speech_to_speech/backend_registry.py
+++ b/src/speech_to_speech/backend_registry.py
@@ -22,6 +22,7 @@ from speech_to_speech.arguments_classes.language_model_arguments import Language
 from speech_to_speech.arguments_classes.mlx_audio_whisper_arguments import (
     MLXAudioWhisperSTTHandlerArguments,
 )
+from speech_to_speech.arguments_classes.openai_stt_arguments import OpenAICompatibleSTTHandlerArguments
 from speech_to_speech.arguments_classes.paraformer_stt_arguments import ParaformerSTTHandlerArguments
 from speech_to_speech.arguments_classes.parakeet_tdt_arguments import (
     ParakeetTDTSTTHandlerArguments,
@@ -358,6 +359,17 @@ STT_BACKENDS = build_backend_registry(
             ),
             config_prefix="paraformer_stt",
             required_extra="paraformer",
+        ),
+        BackendSpec(
+            "openai",
+            "stt",
+            OpenAICompatibleSTTHandlerArguments,
+            _simple_handler_factory(
+                "speech_to_speech.STT.openai_compatible_handler",
+                "OpenAICompatibleSTTHandler",
+                attach_speculative_turns=True,
+            ),
+            config_prefix="openai_stt",
         ),
     ],
 )

--- a/src/speech_to_speech/pipeline/events.py
+++ b/src/speech_to_speech/pipeline/events.py
@@ -75,6 +75,13 @@ class TranscriptionCompletedEvent(PipelineEvent):
     speech_stopped_at_s: float | None = Field(default=None, exclude=True)
 
 
+class TranscriptionFailedEvent(PipelineEvent):
+    type: Literal["transcription_failed"] = "transcription_failed"
+    message: str
+    turn_id: str | None = None
+    turn_revision: int | None = None
+
+
 # ── Direct audio events (AudioInputNotifier) ─────────────────────────
 
 

--- a/src/speech_to_speech/pipeline/handler_types.py
+++ b/src/speech_to_speech/pipeline/handler_types.py
@@ -22,6 +22,7 @@ from speech_to_speech.pipeline.messages import (
     TTSInput,
     TokenUsage,
     Transcription,
+    TranscriptionFailure,
     VADAudio,
 )
 
@@ -33,7 +34,7 @@ VADOut: TypeAlias = VADAudio
 
 # ── STT stage ─────────────────────────────────────────────────────────
 STTIn: TypeAlias = VADAudio
-STTOut: TypeAlias = PartialTranscription | Transcription
+STTOut: TypeAlias = PartialTranscription | Transcription | TranscriptionFailure
 
 # ── LLM stage ─────────────────────────────────────────────────────────
 LLMIn: TypeAlias = GenerateResponseRequest

--- a/src/speech_to_speech/pipeline/messages.py
+++ b/src/speech_to_speech/pipeline/messages.py
@@ -78,6 +78,16 @@ class Transcription(PipelineMessage):
     speech_stopped_at_s: float | None = None
 
 
+class TranscriptionFailure(PipelineMessage):
+    """A final STT operation failed without producing LLM input."""
+
+    tag: Literal["transcription_failure"] = "transcription_failure"
+    message: str
+    turn_id: str | None = None
+    turn_revision: int | None = None
+    speech_stopped_at_s: float | None = None
+
+
 # ── LLM → LMOutputProcessor ──────────────────────────────────────────
 
 

--- a/tests/openai_realtime/test_realtime_service.py
+++ b/tests/openai_realtime/test_realtime_service.py
@@ -17,6 +17,7 @@ from openai.types.realtime import (
     ConversationItemCreateEvent,
     ConversationItemInputAudioTranscriptionCompletedEvent,
     ConversationItemInputAudioTranscriptionDeltaEvent,
+    ConversationItemInputAudioTranscriptionFailedEvent,
     ConversationItemTruncateEvent,
     InputAudioBufferAppendEvent,
     InputAudioBufferSpeechStartedEvent,
@@ -2594,7 +2595,13 @@ class TestDispatchPipelineEvent:
         service,
         conn_id,
         text_prompt_queue,
+        should_listen,
     ):
+        should_listen.clear()
+        started = service.dispatch_pipeline_event(
+            conn_id,
+            SpeechStartedEvent(turn_id="turn_1", turn_revision=0),
+        )
         events = service.dispatch_pipeline_event(
             conn_id,
             TranscriptionFailedEvent(
@@ -2605,10 +2612,111 @@ class TestDispatchPipelineEvent:
         )
 
         assert len(events) == 1
-        assert isinstance(events[0], RealtimeErrorEvent)
-        assert events[0].error.type == "transcription_failed"
+        assert isinstance(events[0], ConversationItemInputAudioTranscriptionFailedEvent)
+        assert events[0].item_id == started[0].item_id
+        assert events[0].content_index == 0
+        assert events[0].error.type == "transcription_error"
+        assert events[0].error.code == "transcription_failed"
         assert events[0].error.message == "transcription request timed out"
+        assert should_listen.is_set()
         assert text_prompt_queue.empty()
+        state = service._state(conn_id)
+        assert state.current_input_item_id is None
+        assert state.input_items == {}
+        assert state.input_item_by_turn_revision == {}
+        assert state.response_pending is False
+
+    def test_stale_transcription_failure_does_not_reenable_listening(self, runtime_config):
+        text_prompt_queue = Queue()
+        should_listen = Event()
+        tracker = SpeculativeTurnTracker()
+        service = RealtimeService(
+            text_prompt_queue=text_prompt_queue,
+            should_listen=should_listen,
+            speculative_turns=tracker,
+        )
+        conn_id = service.register()
+        service._state(conn_id).runtime_config = runtime_config
+        service.dispatch_pipeline_event(
+            conn_id,
+            SpeechStartedEvent(turn_id="turn_1", turn_revision=0),
+        )
+        tracker.observe("turn_1", 1)
+
+        events = service.dispatch_pipeline_event(
+            conn_id,
+            TranscriptionFailedEvent(
+                message="transcription request timed out",
+                turn_id="turn_1",
+                turn_revision=0,
+            ),
+        )
+
+        assert events == []
+        assert not should_listen.is_set()
+        assert text_prompt_queue.empty()
+        service.unregister(conn_id)
+
+    def test_late_failure_does_not_reenable_listening_for_overlapping_item(
+        self,
+        service,
+        conn_id,
+        should_listen,
+    ):
+        first_started = service.dispatch_pipeline_event(
+            conn_id,
+            SpeechStartedEvent(turn_id="turn_1", turn_revision=0),
+        )
+        second_started = service.dispatch_pipeline_event(
+            conn_id,
+            SpeechStartedEvent(turn_id="turn_2", turn_revision=0),
+        )
+        should_listen.clear()
+
+        events = service.dispatch_pipeline_event(
+            conn_id,
+            TranscriptionFailedEvent(
+                message="transcription request timed out",
+                turn_id="turn_1",
+                turn_revision=0,
+            ),
+        )
+
+        assert events[0].item_id == first_started[0].item_id
+        assert not should_listen.is_set()
+        state = service._state(conn_id)
+        assert state.current_input_item_id == second_started[0].item_id
+        assert first_started[0].item_id not in state.input_items
+
+    def test_duplicate_late_failure_does_not_terminalize_newer_item(
+        self,
+        service,
+        conn_id,
+        should_listen,
+    ):
+        service.dispatch_pipeline_event(
+            conn_id,
+            SpeechStartedEvent(turn_id="turn_1", turn_revision=0),
+        )
+        failure = TranscriptionFailedEvent(
+            message="transcription request timed out",
+            turn_id="turn_1",
+            turn_revision=0,
+        )
+        service.dispatch_pipeline_event(conn_id, failure)
+        newer_started = service.dispatch_pipeline_event(
+            conn_id,
+            SpeechStartedEvent(turn_id="turn_2", turn_revision=0),
+        )
+        should_listen.clear()
+
+        events = service.dispatch_pipeline_event(conn_id, failure)
+
+        assert events == []
+        assert not should_listen.is_set()
+        state = service._state(conn_id)
+        assert state.current_input_item_id == newer_started[0].item_id
+        assert newer_started[0].item_id in state.input_items
 
     def test_speech_started_emits_event(self, service, conn_id):
         events = service.dispatch_pipeline_event(

--- a/tests/openai_realtime/test_realtime_service.py
+++ b/tests/openai_realtime/test_realtime_service.py
@@ -62,6 +62,7 @@ from speech_to_speech.pipeline.events import (
     SpeechStoppedEvent,
     TokenUsageEvent,
     TranscriptionCompletedEvent,
+    TranscriptionFailedEvent,
 )
 from speech_to_speech.pipeline.messages import (
     AssistantTextPart,
@@ -2587,6 +2588,27 @@ class TestResponseDoneOutputItems:
 
 class TestDispatchPipelineEvent:
     # -- speech_started --
+
+    def test_transcription_failure_emits_error_without_llm_work(
+        self,
+        service,
+        conn_id,
+        text_prompt_queue,
+    ):
+        events = service.dispatch_pipeline_event(
+            conn_id,
+            TranscriptionFailedEvent(
+                message="transcription request timed out",
+                turn_id="turn_1",
+                turn_revision=0,
+            ),
+        )
+
+        assert len(events) == 1
+        assert isinstance(events[0], RealtimeErrorEvent)
+        assert events[0].error.type == "transcription_failed"
+        assert events[0].error.message == "transcription request timed out"
+        assert text_prompt_queue.empty()
 
     def test_speech_started_emits_event(self, service, conn_id):
         events = service.dispatch_pipeline_event(

--- a/tests/openai_realtime/test_websocket_router.py
+++ b/tests/openai_realtime/test_websocket_router.py
@@ -32,6 +32,7 @@ from speech_to_speech.pipeline.events import (
     ResponseGenerationDoneEvent,
     SpeechStartedEvent,
     TokenUsageEvent,
+    TranscriptionFailedEvent,
 )
 from speech_to_speech.pipeline.messages import (
     AUDIO_RESPONSE_DONE,
@@ -1294,6 +1295,21 @@ class TestDrainRelease:
         router_module._flush_queue(q, preserve=router_module._keep_user_text_event)
 
         assert q.get_nowait() is audio_event
+        assert q.empty()
+
+    def test_barge_in_flush_preserves_transcription_failure(self):
+        q: Queue = Queue()
+        failure_event = TranscriptionFailedEvent(
+            message="transcription request timed out",
+            turn_id="turn-1",
+            turn_revision=0,
+        )
+        q.put(AssistantOutputEvent(text="stale"))
+        q.put(failure_event)
+
+        router_module._flush_queue(q, preserve=router_module._keep_user_text_event)
+
+        assert q.get_nowait() is failure_event
         assert q.empty()
 
     def test_barge_in_flush_preserves_session_end(self):

--- a/tests/test_backend_registry.py
+++ b/tests/test_backend_registry.py
@@ -143,9 +143,10 @@ def test_test_backend_only_needs_config_factory_and_registry_entry():
     assert calls[0][1] is selection.config
 
 
-def test_openai_stt_backend_constructs_through_registry():
+def test_openai_stt_backend_constructs_through_registry(monkeypatch):
     from speech_to_speech.STT.openai_compatible_handler import OpenAICompatibleSTTHandler
 
+    monkeypatch.setattr(OpenAICompatibleSTTHandler, "warmup", lambda self: None)
     args = parse_arguments(["--stt", "openai"])
     stt = create_backend_handler(args.stt_backend, _context())
 

--- a/tests/test_backend_registry.py
+++ b/tests/test_backend_registry.py
@@ -63,6 +63,7 @@ def test_builtin_registry_lookup_and_cli_choices_share_one_catalog():
     assert tuple(LLM_BACKENDS) == module_fields["llm_backend"].metadata["choices"]
     assert tuple(TTS_BACKENDS) == module_fields["tts"].metadata["choices"]
     assert STT_BACKENDS["parakeet-tdt"].kind == "stt"
+    assert STT_BACKENDS["openai"].kind == "stt"
     assert LLM_BACKENDS["responses-api"].kind == "llm"
     assert TTS_BACKENDS["qwen3"].kind == "tts"
     assert LLM_BACKENDS["responses-api"].capabilities.supports_llm_proxy
@@ -140,6 +141,15 @@ def test_test_backend_only_needs_config_factory_and_registry_entry():
     assert selection.config == {"option": "selected", "gen_kwargs": {}}
     assert parsed_config.fake_option == "selected"
     assert calls[0][1] is selection.config
+
+
+def test_openai_stt_backend_constructs_through_registry():
+    from speech_to_speech.STT.openai_compatible_handler import OpenAICompatibleSTTHandler
+
+    args = parse_arguments(["--stt", "openai"])
+    stt = create_backend_handler(args.stt_backend, _context())
+
+    assert isinstance(stt, OpenAICompatibleSTTHandler)
 
 
 def test_new_stt_backend_gets_transcription_notifier_by_default(monkeypatch):

--- a/tests/test_cli_defaults.py
+++ b/tests/test_cli_defaults.py
@@ -237,6 +237,23 @@ def test_parse_arguments_accepts_qwen3_tts_backend_override():
     assert args.tts_backend.config["backend"] == "torch"
 
 
+def test_parse_arguments_accepts_openai_stt_backend():
+    args = parse_arguments(
+        [
+            "--stt",
+            "openai",
+            "--openai_stt_base_url",
+            "http://localhost:8000/v1",
+            "--openai_stt_model",
+            "Qwen/Qwen3-ASR-1.7B",
+        ]
+    )
+
+    assert args.stt_backend.name == "openai"
+    assert args.stt_backend.config["base_url"] == "http://localhost:8000/v1"
+    assert args.stt_backend.config["model"] == "Qwen/Qwen3-ASR-1.7B"
+
+
 def test_parse_arguments_accepts_qwen3_tts_ggml_options():
     original_argv = sys.argv[:]
     try:

--- a/tests/test_openai_stt_handler.py
+++ b/tests/test_openai_stt_handler.py
@@ -266,12 +266,8 @@ def test_remote_progressive_hypothesis_corrections_reach_the_router(monkeypatch)
         HttpTranscriptionResult(text="hello their"),
     ]
 
-    assert _run_progressive(handler) == [
-        PartialTranscription(text="hello there", turn_id="turn-1", turn_revision=0)
-    ]
-    assert _run_progressive(handler) == [
-        PartialTranscription(text="hello their", turn_id="turn-1", turn_revision=0)
-    ]
+    assert _run_progressive(handler) == [PartialTranscription(text="hello there", turn_id="turn-1", turn_revision=0)]
+    assert _run_progressive(handler) == [PartialTranscription(text="hello their", turn_id="turn-1", turn_revision=0)]
 
 
 def test_remote_progressive_hypotheses_emit_realtime_deltas(monkeypatch):

--- a/tests/test_openai_stt_handler.py
+++ b/tests/test_openai_stt_handler.py
@@ -14,6 +14,7 @@ from openai.types.realtime import ConversationItemInputAudioTranscriptionDeltaEv
 from speech_to_speech.api.openai_realtime.service import RealtimeService
 from speech_to_speech.pipeline.events import SpeechStartedEvent
 from speech_to_speech.pipeline.messages import (
+    PIPELINE_END,
     PartialTranscription,
     Transcription,
     TranscriptionFailure,
@@ -173,6 +174,21 @@ def _audio(mode: str = "final", *, revision: int = 0) -> VADAudio:
     )
 
 
+def _run_progressive(handler: OpenAICompatibleSTTHandler) -> list[PartialTranscription]:
+    assert list(handler.process(_audio("progressive"))) == []
+    thread = handler._progressive_thread
+    assert thread is not None
+    thread.join(timeout=1)
+    assert not thread.is_alive()
+
+    outputs = []
+    while not handler.queue_out.empty():
+        output = handler.queue_out.get_nowait()
+        assert isinstance(output, PartialTranscription)
+        outputs.append(output)
+    return outputs
+
+
 def test_openai_stt_warmup_uses_configured_operation_before_readiness(monkeypatch):
     handler = _handler(
         monkeypatch,
@@ -236,8 +252,8 @@ def test_remote_progressive_hypotheses_remain_cumulative(monkeypatch):
         HttpTranscriptionResult(text="hello world"),
     ]
 
-    first = list(handler.process(_audio("progressive")))
-    second = list(handler.process(_audio("progressive")))
+    first = _run_progressive(handler)
+    second = _run_progressive(handler)
 
     assert first == [PartialTranscription(text="hello", turn_id="turn-1", turn_revision=0)]
     assert second == [PartialTranscription(text="hello world", turn_id="turn-1", turn_revision=0)]
@@ -250,10 +266,10 @@ def test_remote_progressive_hypothesis_corrections_reach_the_router(monkeypatch)
         HttpTranscriptionResult(text="hello their"),
     ]
 
-    assert list(handler.process(_audio("progressive"))) == [
+    assert _run_progressive(handler) == [
         PartialTranscription(text="hello there", turn_id="turn-1", turn_revision=0)
     ]
-    assert list(handler.process(_audio("progressive"))) == [
+    assert _run_progressive(handler) == [
         PartialTranscription(text="hello their", turn_id="turn-1", turn_revision=0)
     ]
 
@@ -278,7 +294,7 @@ def test_remote_progressive_hypotheses_emit_realtime_deltas(monkeypatch):
 
     wire_events = []
     for _ in range(4):
-        for partial in handler.process(_audio("progressive")):
+        for partial in _run_progressive(handler):
             assert list(notifier.process(partial)) == []
             wire_events.extend(service.dispatch_pipeline_event(conn_id, text_output_queue.get_nowait()))
 
@@ -303,7 +319,118 @@ def test_progressive_transport_failure_is_discarded(monkeypatch):
     handler = _handler(monkeypatch)
     _FakeOperation.error = TranscriptionRequestError("transcription request timed out")
 
+    assert _run_progressive(handler) == []
+
+
+def test_final_request_does_not_wait_for_in_flight_progressive(monkeypatch):
+    handler = _handler(monkeypatch)
+    progressive_started = Event()
+    release_progressive = Event()
+    final_started = Event()
+
+    class _BlockingProgressiveOperation:
+        def run(self):
+            progressive_started.set()
+            assert release_progressive.wait(timeout=2)
+            return HttpTranscriptionResult(text="partial")
+
+    class _FinalOperation:
+        def run(self):
+            final_started.set()
+            return HttpTranscriptionResult(text="final", language="en")
+
+    operations = iter([_BlockingProgressiveOperation(), _FinalOperation()])
+    monkeypatch.setattr(handler, "_make_operation", lambda _audio: next(operations))
+    handler_thread = Thread(target=handler.run, daemon=True)
+    handler_thread.start()
+
+    try:
+        handler.queue_in.put(_audio("progressive"))
+        assert progressive_started.wait(timeout=1)
+        handler.queue_in.put(_audio())
+
+        assert final_started.wait(timeout=1)
+        output = handler.queue_out.get(timeout=1)
+        assert isinstance(output, Transcription)
+        assert output.text == "final"
+        assert output.language_code == "en"
+        assert output.turn_id == "turn-1"
+        assert output.turn_revision == 0
+        assert not release_progressive.is_set()
+
+        release_progressive.set()
+        thread = handler._progressive_thread
+        assert thread is not None
+        thread.join(timeout=1)
+        assert not thread.is_alive()
+        assert handler.queue_out.empty()
+    finally:
+        release_progressive.set()
+        handler.stop_event.set()
+        handler.queue_in.put(PIPELINE_END)
+        handler_thread.join(timeout=1)
+    assert not handler_thread.is_alive()
+
+
+def test_additional_progressive_requests_are_dropped_while_one_is_in_flight(monkeypatch):
+    handler = _handler(monkeypatch)
+    progressive_started = Event()
+    release_progressive = Event()
+    operation_count = 0
+
+    class _BlockingProgressiveOperation:
+        def run(self):
+            progressive_started.set()
+            assert release_progressive.wait(timeout=2)
+            return HttpTranscriptionResult(text="partial")
+
+    def make_operation(_audio):
+        nonlocal operation_count
+        operation_count += 1
+        return _BlockingProgressiveOperation()
+
+    monkeypatch.setattr(handler, "_make_operation", make_operation)
+
     assert list(handler.process(_audio("progressive"))) == []
+    assert progressive_started.wait(timeout=1)
+    assert list(handler.process(_audio("progressive"))) == []
+    assert operation_count == 1
+
+    release_progressive.set()
+    thread = handler._progressive_thread
+    assert thread is not None
+    thread.join(timeout=1)
+    assert not thread.is_alive()
+    assert handler.queue_out.get_nowait() == PartialTranscription(
+        text="partial",
+        turn_id="turn-1",
+        turn_revision=0,
+    )
+
+
+def test_session_end_suppresses_in_flight_progressive_result(monkeypatch):
+    handler = _handler(monkeypatch)
+    progressive_started = Event()
+    release_progressive = Event()
+
+    class _BlockingProgressiveOperation:
+        def run(self):
+            progressive_started.set()
+            assert release_progressive.wait(timeout=2)
+            return HttpTranscriptionResult(text="old session")
+
+    monkeypatch.setattr(handler, "_make_operation", lambda _audio: _BlockingProgressiveOperation())
+
+    assert list(handler.process(_audio("progressive"))) == []
+    assert progressive_started.wait(timeout=1)
+    handler.on_session_end()
+    release_progressive.set()
+
+    thread = handler._progressive_thread
+    assert thread is not None
+    thread.join(timeout=1)
+    assert not thread.is_alive()
+    assert handler.queue_out.empty()
 
 
 def test_stale_revision_is_dropped_after_request(monkeypatch):

--- a/tests/test_openai_stt_handler.py
+++ b/tests/test_openai_stt_handler.py
@@ -104,6 +104,50 @@ def test_http_transcription_operation_can_select_model_by_language():
     assert b"en-US" in _TranscriptionServer.received_body
 
 
+def test_http_transcription_operation_uses_gpt_transcribe_language_contract():
+    server = ThreadingHTTPServer(("127.0.0.1", 0), _TranscriptionServer)
+    thread = Thread(target=server.serve_forever, daemon=True)
+    thread.start()
+    try:
+        operation = HttpTranscriptionOperation(
+            endpoint_url=f"http://127.0.0.1:{server.server_port}/v1/audio/transcriptions",
+            api_key=None,
+            model="gpt-transcribe",
+            wav_bytes=b"RIFF-test-wave",
+            language="fr",
+            response_format="json",
+            timeout_s=2,
+        )
+        operation.run()
+    finally:
+        server.shutdown()
+        server.server_close()
+        thread.join(timeout=1)
+
+    assert b'form-data; name="languages[]"' in _TranscriptionServer.received_body
+    assert b'form-data; name="language"' not in _TranscriptionServer.received_body
+    assert b"fr" in _TranscriptionServer.received_body
+
+
+def test_http_transcription_operation_parses_gpt_transcribe_languages():
+    operation = HttpTranscriptionOperation(
+        endpoint_url="http://127.0.0.1:1/v1/audio/transcriptions",
+        api_key=None,
+        model="gpt-transcribe",
+        wav_bytes=b"RIFF-test-wave",
+        language=None,
+        response_format="json",
+        timeout_s=2,
+    )
+
+    result = operation._parse_response(
+        json.dumps({"text": "bonjour", "languages": [{"code": "fr"}]}).encode(),
+        "application/json",
+    )
+
+    assert result == HttpTranscriptionResult(text="bonjour", language="fr")
+
+
 def test_http_transcription_operation_parses_plain_text():
     operation = HttpTranscriptionOperation(
         endpoint_url="http://127.0.0.1:1/v1/audio/transcriptions",

--- a/tests/test_openai_stt_handler.py
+++ b/tests/test_openai_stt_handler.py
@@ -8,6 +8,7 @@ from queue import Queue
 from threading import Event, Thread
 
 import numpy as np
+import pytest
 from openai.types.realtime import ConversationItemInputAudioTranscriptionDeltaEvent
 
 from speech_to_speech.api.openai_realtime.service import RealtimeService
@@ -21,6 +22,7 @@ from speech_to_speech.pipeline.messages import (
 from speech_to_speech.pipeline.speculative_turns import SpeculativeTurnTracker
 from speech_to_speech.STT import openai_compatible_handler as stt_module
 from speech_to_speech.STT.openai_compatible_handler import (
+    PIPELINE_SAMPLE_RATE,
     HttpTranscriptionOperation,
     HttpTranscriptionResult,
     OpenAICompatibleSTTHandler,
@@ -148,16 +150,18 @@ def _handler(
     tracker: SpeculativeTurnTracker | None = None,
     **setup_overrides,
 ) -> OpenAICompatibleSTTHandler:
-    _FakeOperation.results = []
+    _FakeOperation.results = [HttpTranscriptionResult(text="")]
     _FakeOperation.error = None
     _FakeOperation.instances = []
     monkeypatch.setattr(stt_module, "HttpTranscriptionOperation", _FakeOperation)
-    return OpenAICompatibleSTTHandler(
+    handler = OpenAICompatibleSTTHandler(
         Event(),
         queue_in=Queue(),
         queue_out=Queue(),
         setup_kwargs={"speculative_turns": tracker, **setup_overrides},
     )
+    _FakeOperation.results = []
+    return handler
 
 
 def _audio(mode: str = "final", *, revision: int = 0) -> VADAudio:
@@ -167,6 +171,48 @@ def _audio(mode: str = "final", *, revision: int = 0) -> VADAudio:
         turn_id="turn-1",
         turn_revision=revision,
     )
+
+
+def test_openai_stt_warmup_uses_configured_operation_before_readiness(monkeypatch):
+    handler = _handler(
+        monkeypatch,
+        base_url="https://transcription.example/v1/",
+        api_key="endpoint-secret",
+        model="test-model",
+        language="en",
+        response_format="json",
+        timeout=2,
+    )
+
+    assert len(_FakeOperation.instances) == 1
+    operation = _FakeOperation.instances[0].kwargs
+    assert operation["endpoint_url"] == "https://transcription.example/v1/audio/transcriptions"
+    assert operation["api_key"] == "endpoint-secret"
+    assert operation["model"] == "test-model"
+    assert operation["language"] == "en"
+    assert operation["response_format"] == "json"
+    assert operation["timeout_s"] == 2
+    with wave.open(io.BytesIO(operation["wav_bytes"]), "rb") as wav:
+        assert wav.getnchannels() == 1
+        assert wav.getsampwidth() == 2
+        assert wav.getframerate() == PIPELINE_SAMPLE_RATE
+        assert wav.getnframes() == PIPELINE_SAMPLE_RATE
+    assert handler.queue_out.empty()
+
+
+def test_openai_stt_warmup_failure_prevents_handler_construction(monkeypatch):
+    _FakeOperation.results = []
+    _FakeOperation.error = TranscriptionRequestError("transcription server returned HTTP 404")
+    _FakeOperation.instances = []
+    monkeypatch.setattr(stt_module, "HttpTranscriptionOperation", _FakeOperation)
+
+    with pytest.raises(TranscriptionRequestError, match="transcription server returned HTTP 404"):
+        OpenAICompatibleSTTHandler(
+            Event(),
+            queue_in=Queue(),
+            queue_out=Queue(),
+            setup_kwargs={"model": "missing-model"},
+        )
 
 
 def test_openai_stt_returns_final_transcription(monkeypatch):
@@ -179,8 +225,8 @@ def test_openai_stt_returns_final_transcription(monkeypatch):
     assert isinstance(outputs[0], Transcription)
     assert outputs[0].text == "hello"
     assert outputs[0].language_code == "en"
-    assert _FakeOperation.instances[0].kwargs["endpoint_url"].endswith("/v1/audio/transcriptions")
-    assert _FakeOperation.instances[0].kwargs["wav_bytes"].startswith(b"RIFF")
+    assert _FakeOperation.instances[-1].kwargs["endpoint_url"].endswith("/v1/audio/transcriptions")
+    assert _FakeOperation.instances[-1].kwargs["wav_bytes"].startswith(b"RIFF")
 
 
 def test_remote_progressive_hypotheses_remain_cumulative(monkeypatch):

--- a/tests/test_openai_stt_handler.py
+++ b/tests/test_openai_stt_handler.py
@@ -1,12 +1,17 @@
 from __future__ import annotations
 
+import io
 import json
+import wave
 from http.server import BaseHTTPRequestHandler, ThreadingHTTPServer
 from queue import Queue
 from threading import Event, Thread
 
 import numpy as np
+from openai.types.realtime import ConversationItemInputAudioTranscriptionDeltaEvent
 
+from speech_to_speech.api.openai_realtime.service import RealtimeService
+from speech_to_speech.pipeline.events import SpeechStartedEvent
 from speech_to_speech.pipeline.messages import (
     PartialTranscription,
     Transcription,
@@ -19,9 +24,9 @@ from speech_to_speech.STT.openai_compatible_handler import (
     HttpTranscriptionOperation,
     HttpTranscriptionResult,
     OpenAICompatibleSTTHandler,
-    TranscriptionRequestCancelled,
     TranscriptionRequestError,
 )
+from speech_to_speech.STT.transcription_notifier import TranscriptionNotifier
 
 
 class _TranscriptionServer(BaseHTTPRequestHandler):
@@ -49,11 +54,10 @@ def test_http_transcription_operation_uploads_wav_multipart():
     thread.start()
     try:
         operation = HttpTranscriptionOperation(
-            request_id="request-1",
             endpoint_url=f"http://127.0.0.1:{server.server_port}/v1/audio/transcriptions",
             api_key=None,
             model="test-model",
-            wav_bytes=b"RIFF-test-wave",
+            wav_bytes=OpenAICompatibleSTTHandler._encode_wav(np.zeros(160, dtype=np.float32)),
             language="en",
             response_format="json",
             timeout_s=2,
@@ -69,7 +73,7 @@ def test_http_transcription_operation_uploads_wav_multipart():
     assert b'form-data; name="model"' in _TranscriptionServer.received_body
     assert b"test-model" in _TranscriptionServer.received_body
     assert b'filename="audio.wav"' in _TranscriptionServer.received_body
-    assert b"RIFF-test-wave" in _TranscriptionServer.received_body
+    assert b"RIFF" in _TranscriptionServer.received_body
 
 
 def test_http_transcription_operation_can_select_model_by_language():
@@ -78,7 +82,6 @@ def test_http_transcription_operation_can_select_model_by_language():
     thread.start()
     try:
         operation = HttpTranscriptionOperation(
-            request_id="request-2",
             endpoint_url=f"http://127.0.0.1:{server.server_port}/v1/audio/transcriptions",
             api_key=None,
             model=None,
@@ -98,27 +101,30 @@ def test_http_transcription_operation_can_select_model_by_language():
     assert b"en-US" in _TranscriptionServer.received_body
 
 
-def test_http_transcription_operation_preserves_cancellation_context():
+def test_http_transcription_operation_parses_plain_text():
     operation = HttpTranscriptionOperation(
-        request_id="request-cancelled",
         endpoint_url="http://127.0.0.1:1/v1/audio/transcriptions",
         api_key=None,
         model="test-model",
         wav_bytes=b"RIFF-test-wave",
-        language=None,
-        response_format="json",
+        language="en",
+        response_format="text",
         timeout_s=2,
     )
 
-    operation.cancel("turn_reopened")
+    result = operation._parse_response(b" hello world\n", "text/plain; charset=utf-8")
 
-    try:
-        operation.run()
-    except TranscriptionRequestCancelled as exc:
-        assert exc.request_id == "request-cancelled"
-        assert exc.reason == "turn_reopened"
-    else:
-        raise AssertionError("cancelled operation did not raise TranscriptionRequestCancelled")
+    assert result == HttpTranscriptionResult(text="hello world", language="en")
+
+
+def test_openai_stt_encodes_mono_pcm16_16khz_wav():
+    encoded = OpenAICompatibleSTTHandler._encode_wav(np.array([-1.0, 0.0, 1.0], dtype=np.float32))
+
+    with wave.open(io.BytesIO(encoded), "rb") as wav:
+        assert wav.getnchannels() == 1
+        assert wav.getsampwidth() == 2
+        assert wav.getframerate() == 16000
+        assert wav.getnframes() == 3
 
 
 class _FakeOperation:
@@ -128,22 +134,20 @@ class _FakeOperation:
 
     def __init__(self, **kwargs) -> None:
         self.kwargs = kwargs
-        self.cancel_reason: str | None = None
         type(self).instances.append(self)
 
-    def run(self, cancel_check):
+    def run(self):
         if type(self).error is not None:
             raise type(self).error
-        if cancel_check():
-            self.cancel("stale")
-            raise TranscriptionRequestCancelled(self.kwargs["request_id"], "stale")
         return type(self).results.pop(0)
 
-    def cancel(self, reason: str) -> None:
-        self.cancel_reason = reason
 
-
-def _handler(monkeypatch, *, tracker: SpeculativeTurnTracker | None = None) -> OpenAICompatibleSTTHandler:
+def _handler(
+    monkeypatch,
+    *,
+    tracker: SpeculativeTurnTracker | None = None,
+    **setup_overrides,
+) -> OpenAICompatibleSTTHandler:
     _FakeOperation.results = []
     _FakeOperation.error = None
     _FakeOperation.instances = []
@@ -152,7 +156,7 @@ def _handler(monkeypatch, *, tracker: SpeculativeTurnTracker | None = None) -> O
         Event(),
         queue_in=Queue(),
         queue_out=Queue(),
-        setup_kwargs={"speculative_turns": tracker},
+        setup_kwargs={"speculative_turns": tracker, **setup_overrides},
     )
 
 
@@ -179,7 +183,7 @@ def test_openai_stt_returns_final_transcription(monkeypatch):
     assert _FakeOperation.instances[0].kwargs["wav_bytes"].startswith(b"RIFF")
 
 
-def test_remote_progressive_hypotheses_emit_only_extension_deltas(monkeypatch):
+def test_remote_progressive_hypotheses_remain_cumulative(monkeypatch):
     handler = _handler(monkeypatch)
     _FakeOperation.results = [
         HttpTranscriptionResult(text="hello"),
@@ -190,18 +194,51 @@ def test_remote_progressive_hypotheses_emit_only_extension_deltas(monkeypatch):
     second = list(handler.process(_audio("progressive")))
 
     assert first == [PartialTranscription(text="hello", turn_id="turn-1", turn_revision=0)]
-    assert second == [PartialTranscription(text=" world", turn_id="turn-1", turn_revision=0)]
+    assert second == [PartialTranscription(text="hello world", turn_id="turn-1", turn_revision=0)]
 
 
-def test_remote_progressive_hypothesis_corrections_are_suppressed(monkeypatch):
+def test_remote_progressive_hypothesis_corrections_reach_the_router(monkeypatch):
     handler = _handler(monkeypatch)
     _FakeOperation.results = [
         HttpTranscriptionResult(text="hello there"),
         HttpTranscriptionResult(text="hello their"),
     ]
 
-    assert list(handler.process(_audio("progressive")))
-    assert list(handler.process(_audio("progressive"))) == []
+    assert list(handler.process(_audio("progressive"))) == [
+        PartialTranscription(text="hello there", turn_id="turn-1", turn_revision=0)
+    ]
+    assert list(handler.process(_audio("progressive"))) == [
+        PartialTranscription(text="hello their", turn_id="turn-1", turn_revision=0)
+    ]
+
+
+def test_remote_progressive_hypotheses_emit_realtime_deltas(monkeypatch):
+    handler = _handler(monkeypatch)
+    _FakeOperation.results = [
+        HttpTranscriptionResult(text="hello"),
+        HttpTranscriptionResult(text="hello world"),
+        HttpTranscriptionResult(text="hello world again"),
+        HttpTranscriptionResult(text="hello world again today"),
+    ]
+    text_output_queue = Queue()
+    notifier = object.__new__(TranscriptionNotifier)
+    notifier.setup(text_output_queue=text_output_queue)
+    service = RealtimeService()
+    conn_id = service.register()
+    service.dispatch_pipeline_event(
+        conn_id,
+        SpeechStartedEvent(turn_id="turn-1", turn_revision=0),
+    )
+
+    wire_events = []
+    for _ in range(4):
+        for partial in handler.process(_audio("progressive")):
+            assert list(notifier.process(partial)) == []
+            wire_events.extend(service.dispatch_pipeline_event(conn_id, text_output_queue.get_nowait()))
+
+    assert all(isinstance(event, ConversationItemInputAudioTranscriptionDeltaEvent) for event in wire_events)
+    assert [event.delta for event in wire_events] == ["hello", " world"]
+    service.unregister(conn_id)
 
 
 def test_final_transport_failure_does_not_create_a_transcription(monkeypatch):
@@ -223,29 +260,32 @@ def test_progressive_transport_failure_is_discarded(monkeypatch):
     assert list(handler.process(_audio("progressive"))) == []
 
 
-def test_stale_revision_is_cancelled_before_publication(monkeypatch):
+def test_stale_revision_is_dropped_after_request(monkeypatch):
     tracker = SpeculativeTurnTracker()
     tracker.observe("turn-1", 0)
     handler = _handler(monkeypatch, tracker=tracker)
 
     class _ReopeningOperation(_FakeOperation):
-        def run(self, cancel_check):
+        def run(self):
             tracker.observe("turn-1", 1)
-            assert cancel_check()
-            self.cancel("stale")
-            raise TranscriptionRequestCancelled(self.kwargs["request_id"], "stale")
+            return HttpTranscriptionResult(text="stale")
 
     monkeypatch.setattr(stt_module, "HttpTranscriptionOperation", _ReopeningOperation)
 
     assert list(handler.process(_audio())) == []
-    assert _ReopeningOperation.instances[-1].cancel_reason == "stale"
 
 
-def test_session_end_cancels_active_transport(monkeypatch):
-    handler = _handler(monkeypatch)
-    operation = _FakeOperation(request_id="active")
-    handler._active_operation = operation
+def test_openai_api_key_is_not_sent_to_other_endpoints(monkeypatch):
+    monkeypatch.setenv("OPENAI_API_KEY", "official-secret")
 
-    handler.on_session_end()
+    local_handler = _handler(monkeypatch, base_url="http://localhost:8000/v1")
+    official_handler = _handler(monkeypatch, base_url="https://api.openai.com/v1/")
+    explicit_handler = _handler(
+        monkeypatch,
+        base_url="https://transcription.example/v1",
+        api_key="endpoint-secret",
+    )
 
-    assert operation.cancel_reason == "session_end"
+    assert local_handler.api_key is None
+    assert official_handler.api_key == "official-secret"
+    assert explicit_handler.api_key == "endpoint-secret"

--- a/tests/test_openai_stt_handler.py
+++ b/tests/test_openai_stt_handler.py
@@ -1,0 +1,251 @@
+from __future__ import annotations
+
+import json
+from http.server import BaseHTTPRequestHandler, ThreadingHTTPServer
+from queue import Queue
+from threading import Event, Thread
+
+import numpy as np
+
+from speech_to_speech.pipeline.messages import (
+    PartialTranscription,
+    Transcription,
+    TranscriptionFailure,
+    VADAudio,
+)
+from speech_to_speech.pipeline.speculative_turns import SpeculativeTurnTracker
+from speech_to_speech.STT import openai_compatible_handler as stt_module
+from speech_to_speech.STT.openai_compatible_handler import (
+    HttpTranscriptionOperation,
+    HttpTranscriptionResult,
+    OpenAICompatibleSTTHandler,
+    TranscriptionRequestCancelled,
+    TranscriptionRequestError,
+)
+
+
+class _TranscriptionServer(BaseHTTPRequestHandler):
+    received_path = ""
+    received_body = b""
+
+    def do_POST(self) -> None:
+        type(self).received_path = self.path
+        length = int(self.headers["content-length"])
+        type(self).received_body = self.rfile.read(length)
+        body = json.dumps({"text": "hello", "language": "en"}).encode()
+        self.send_response(200)
+        self.send_header("content-type", "application/json")
+        self.send_header("content-length", str(len(body)))
+        self.end_headers()
+        self.wfile.write(body)
+
+    def log_message(self, format: str, *args) -> None:
+        del format, args
+
+
+def test_http_transcription_operation_uploads_wav_multipart():
+    server = ThreadingHTTPServer(("127.0.0.1", 0), _TranscriptionServer)
+    thread = Thread(target=server.serve_forever, daemon=True)
+    thread.start()
+    try:
+        operation = HttpTranscriptionOperation(
+            request_id="request-1",
+            endpoint_url=f"http://127.0.0.1:{server.server_port}/v1/audio/transcriptions",
+            api_key=None,
+            model="test-model",
+            wav_bytes=b"RIFF-test-wave",
+            language="en",
+            response_format="json",
+            timeout_s=2,
+        )
+        result = operation.run()
+    finally:
+        server.shutdown()
+        server.server_close()
+        thread.join(timeout=1)
+
+    assert result == HttpTranscriptionResult(text="hello", language="en")
+    assert _TranscriptionServer.received_path == "/v1/audio/transcriptions"
+    assert b'form-data; name="model"' in _TranscriptionServer.received_body
+    assert b"test-model" in _TranscriptionServer.received_body
+    assert b'filename="audio.wav"' in _TranscriptionServer.received_body
+    assert b"RIFF-test-wave" in _TranscriptionServer.received_body
+
+
+def test_http_transcription_operation_can_select_model_by_language():
+    server = ThreadingHTTPServer(("127.0.0.1", 0), _TranscriptionServer)
+    thread = Thread(target=server.serve_forever, daemon=True)
+    thread.start()
+    try:
+        operation = HttpTranscriptionOperation(
+            request_id="request-2",
+            endpoint_url=f"http://127.0.0.1:{server.server_port}/v1/audio/transcriptions",
+            api_key=None,
+            model=None,
+            wav_bytes=b"RIFF-test-wave",
+            language="en-US",
+            response_format="json",
+            timeout_s=2,
+        )
+        operation.run()
+    finally:
+        server.shutdown()
+        server.server_close()
+        thread.join(timeout=1)
+
+    assert b'form-data; name="model"' not in _TranscriptionServer.received_body
+    assert b'form-data; name="language"' in _TranscriptionServer.received_body
+    assert b"en-US" in _TranscriptionServer.received_body
+
+
+def test_http_transcription_operation_preserves_cancellation_context():
+    operation = HttpTranscriptionOperation(
+        request_id="request-cancelled",
+        endpoint_url="http://127.0.0.1:1/v1/audio/transcriptions",
+        api_key=None,
+        model="test-model",
+        wav_bytes=b"RIFF-test-wave",
+        language=None,
+        response_format="json",
+        timeout_s=2,
+    )
+
+    operation.cancel("turn_reopened")
+
+    try:
+        operation.run()
+    except TranscriptionRequestCancelled as exc:
+        assert exc.request_id == "request-cancelled"
+        assert exc.reason == "turn_reopened"
+    else:
+        raise AssertionError("cancelled operation did not raise TranscriptionRequestCancelled")
+
+
+class _FakeOperation:
+    results: list[HttpTranscriptionResult] = []
+    error: Exception | None = None
+    instances: list[_FakeOperation] = []
+
+    def __init__(self, **kwargs) -> None:
+        self.kwargs = kwargs
+        self.cancel_reason: str | None = None
+        type(self).instances.append(self)
+
+    def run(self, cancel_check):
+        if type(self).error is not None:
+            raise type(self).error
+        if cancel_check():
+            self.cancel("stale")
+            raise TranscriptionRequestCancelled(self.kwargs["request_id"], "stale")
+        return type(self).results.pop(0)
+
+    def cancel(self, reason: str) -> None:
+        self.cancel_reason = reason
+
+
+def _handler(monkeypatch, *, tracker: SpeculativeTurnTracker | None = None) -> OpenAICompatibleSTTHandler:
+    _FakeOperation.results = []
+    _FakeOperation.error = None
+    _FakeOperation.instances = []
+    monkeypatch.setattr(stt_module, "HttpTranscriptionOperation", _FakeOperation)
+    return OpenAICompatibleSTTHandler(
+        Event(),
+        queue_in=Queue(),
+        queue_out=Queue(),
+        setup_kwargs={"speculative_turns": tracker},
+    )
+
+
+def _audio(mode: str = "final", *, revision: int = 0) -> VADAudio:
+    return VADAudio(
+        audio=np.zeros(160, dtype=np.float32),
+        mode=mode,
+        turn_id="turn-1",
+        turn_revision=revision,
+    )
+
+
+def test_openai_stt_returns_final_transcription(monkeypatch):
+    handler = _handler(monkeypatch)
+    _FakeOperation.results = [HttpTranscriptionResult(text="hello", language="en")]
+
+    outputs = list(handler.process(_audio()))
+
+    assert len(outputs) == 1
+    assert isinstance(outputs[0], Transcription)
+    assert outputs[0].text == "hello"
+    assert outputs[0].language_code == "en"
+    assert _FakeOperation.instances[0].kwargs["endpoint_url"].endswith("/v1/audio/transcriptions")
+    assert _FakeOperation.instances[0].kwargs["wav_bytes"].startswith(b"RIFF")
+
+
+def test_remote_progressive_hypotheses_emit_only_extension_deltas(monkeypatch):
+    handler = _handler(monkeypatch)
+    _FakeOperation.results = [
+        HttpTranscriptionResult(text="hello"),
+        HttpTranscriptionResult(text="hello world"),
+    ]
+
+    first = list(handler.process(_audio("progressive")))
+    second = list(handler.process(_audio("progressive")))
+
+    assert first == [PartialTranscription(text="hello", turn_id="turn-1", turn_revision=0)]
+    assert second == [PartialTranscription(text=" world", turn_id="turn-1", turn_revision=0)]
+
+
+def test_remote_progressive_hypothesis_corrections_are_suppressed(monkeypatch):
+    handler = _handler(monkeypatch)
+    _FakeOperation.results = [
+        HttpTranscriptionResult(text="hello there"),
+        HttpTranscriptionResult(text="hello their"),
+    ]
+
+    assert list(handler.process(_audio("progressive")))
+    assert list(handler.process(_audio("progressive"))) == []
+
+
+def test_final_transport_failure_does_not_create_a_transcription(monkeypatch):
+    handler = _handler(monkeypatch)
+    _FakeOperation.error = TranscriptionRequestError("transcription request timed out")
+
+    outputs = list(handler.process(_audio()))
+
+    assert len(outputs) == 1
+    assert isinstance(outputs[0], TranscriptionFailure)
+    assert outputs[0].message == "transcription request timed out"
+    assert outputs[0].turn_id == "turn-1"
+
+
+def test_progressive_transport_failure_is_discarded(monkeypatch):
+    handler = _handler(monkeypatch)
+    _FakeOperation.error = TranscriptionRequestError("transcription request timed out")
+
+    assert list(handler.process(_audio("progressive"))) == []
+
+
+def test_stale_revision_is_cancelled_before_publication(monkeypatch):
+    tracker = SpeculativeTurnTracker()
+    tracker.observe("turn-1", 0)
+    handler = _handler(monkeypatch, tracker=tracker)
+
+    class _ReopeningOperation(_FakeOperation):
+        def run(self, cancel_check):
+            tracker.observe("turn-1", 1)
+            assert cancel_check()
+            self.cancel("stale")
+            raise TranscriptionRequestCancelled(self.kwargs["request_id"], "stale")
+
+    monkeypatch.setattr(stt_module, "HttpTranscriptionOperation", _ReopeningOperation)
+
+    assert list(handler.process(_audio())) == []
+    assert _ReopeningOperation.instances[-1].cancel_reason == "stale"
+
+
+def test_session_end_cancels_active_transport(monkeypatch):
+    handler = _handler(monkeypatch)
+    operation = _FakeOperation(request_id="active")
+    handler._active_operation = operation
+
+    handler.on_session_end()
+
+    assert operation.cancel_reason == "session_end"

--- a/tests/test_transcription_notifier.py
+++ b/tests/test_transcription_notifier.py
@@ -62,7 +62,7 @@ def test_empty_final_transcription_reenables_listening_without_runtime_config():
     assert should_listen.is_set()
 
 
-def test_transcription_failure_emits_error_without_llm_work_and_reenables_listening():
+def test_transcription_failure_defers_listening_change_to_realtime_owner():
     text_output_queue = Queue()
     should_listen = Event()
     notifier = _notifier(text_output_queue=text_output_queue, should_listen=should_listen)
@@ -78,7 +78,7 @@ def test_transcription_failure_emits_error_without_llm_work_and_reenables_listen
     )
 
     assert result == []
-    assert should_listen.is_set()
+    assert not should_listen.is_set()
     event = text_output_queue.get_nowait()
     assert isinstance(event, TranscriptionFailedEvent)
     assert event.message == "transcription request timed out"

--- a/tests/test_transcription_notifier.py
+++ b/tests/test_transcription_notifier.py
@@ -2,8 +2,16 @@ import logging
 from queue import Queue
 from threading import Event
 
-from speech_to_speech.pipeline.events import PartialTranscriptionEvent, TranscriptionCompletedEvent
-from speech_to_speech.pipeline.messages import PartialTranscription, Transcription
+from speech_to_speech.pipeline.events import (
+    PartialTranscriptionEvent,
+    TranscriptionCompletedEvent,
+    TranscriptionFailedEvent,
+)
+from speech_to_speech.pipeline.messages import (
+    PartialTranscription,
+    Transcription,
+    TranscriptionFailure,
+)
 from speech_to_speech.STT.transcription_notifier import TranscriptionNotifier
 
 
@@ -52,3 +60,27 @@ def test_empty_final_transcription_reenables_listening_without_runtime_config():
     assert list(notifier.process(Transcription(text="", language_code="en"))) == []
 
     assert should_listen.is_set()
+
+
+def test_transcription_failure_emits_error_without_llm_work_and_reenables_listening():
+    text_output_queue = Queue()
+    should_listen = Event()
+    notifier = _notifier(text_output_queue=text_output_queue, should_listen=should_listen)
+
+    result = list(
+        notifier.process(
+            TranscriptionFailure(
+                message="transcription request timed out",
+                turn_id="turn-1",
+                turn_revision=2,
+            )
+        )
+    )
+
+    assert result == []
+    assert should_listen.is_set()
+    event = text_output_queue.get_nowait()
+    assert isinstance(event, TranscriptionFailedEvent)
+    assert event.message == "transcription request timed out"
+    assert event.turn_id == "turn-1"
+    assert event.turn_revision == 2


### PR DESCRIPTION
## Summary

- add a client-only `openai` STT backend for `/v1/audio/transcriptions`
- upload mono 16 kHz WAV and accept JSON or plain-text responses
- use the existing serial `BaseSTTHandler` stale-turn lifecycle
- surface sanitized final transcription failures without scheduling LLM work
- document vLLM/Qwen3-ASR and NVIDIA Speech NIM usage

This is the second focused slice of #369. It intentionally contains no TTS or endpoint-admission changes.

## Validation

- focused STT, notifier, and realtime failure tests (15 passed)
- registry construction smoke test
- `ruff check` on changed Python files
- `git diff --check`