### PR TITLE
Fix(STT): Guard `torch.mps.empty_cache()`  when not on MPS.

### DIFF
--- a/src/speech_to_speech/STT/lightning_whisper_mlx_handler.py
+++ b/src/speech_to_speech/STT/lightning_whisper_mlx_handler.py
@@ -85,7 +85,9 @@ class LightningWhisperSTTHandler(BaseSTTHandler):
 
         pred_text = transcription_dict["text"].strip()
         language_code = transcription_dict["language"]
-        torch.mps.empty_cache()
+        # Same idea as ChatTTSHandler: MPS cache clear only on Apple Silicon.
+        if getattr(self, "device", None) == "mps":
+            torch.mps.empty_cache()
 
         logger.debug("finished whisper inference")
         console.print(f"[yellow]USER: {pred_text}")

--- a/src/speech_to_speech/STT/lightning_whisper_mlx_handler.py
+++ b/src/speech_to_speech/STT/lightning_whisper_mlx_handler.py
@@ -86,7 +86,7 @@ class LightningWhisperSTTHandler(BaseSTTHandler):
         pred_text = transcription_dict["text"].strip()
         language_code = transcription_dict["language"]
         # Same idea as ChatTTSHandler: MPS cache clear only on Apple Silicon.
-        if getattr(self, "device", None) == "mps":
+        if self.device == "mps":
             torch.mps.empty_cache()
 
         logger.debug("finished whisper inference")

--- a/src/speech_to_speech/STT/paraformer_handler.py
+++ b/src/speech_to_speech/STT/paraformer_handler.py
@@ -57,7 +57,9 @@ class ParaformerSTTHandler(BaseSTTHandler):
         logger.debug("infering paraformer...")
 
         pred_text = self.model.generate(vad_audio.audio)[0]["text"].strip().replace(" ", "")
-        torch.mps.empty_cache()
+        # Same idea as ChatTTSHandler: MPS cache clear only on Apple Silicon.
+        if self.device == "mps":
+            torch.mps.empty_cache()
 
         logger.debug("finished paraformer inference")
         console.print(f"[yellow]USER: {pred_text}")

--- a/tests/test_paraformer_transcription_events.py
+++ b/tests/test_paraformer_transcription_events.py
@@ -14,10 +14,11 @@ class _FakeParaformerModel:
         return [{"text": " 今 天 天 气 不 错 "}]
 
 
-def _handler(*, language: str = "zh"):
+def _handler(*, language: str = "zh", device: str = "cpu"):
     handler = object.__new__(ParaformerSTTHandler)
     handler.model = _FakeParaformerModel()
     handler.language = language
+    handler.device = device
     return handler
 
 
@@ -107,3 +108,24 @@ def test_final_paraformer_transcription_uses_english_checkpoint_language(monkeyp
     )
 
     assert result[0].language_code == "en"
+
+
+def test_paraformer_skips_mps_cache_clear_on_cpu(monkeypatch):
+    monkeypatch.setattr(paraformer_handler.console, "print", lambda *args, **kwargs: None)
+
+    def fail_if_called():
+        raise AssertionError("torch.mps.empty_cache should not run on cpu")
+
+    monkeypatch.setattr(paraformer_handler.torch.mps, "empty_cache", fail_if_called)
+
+    result = list(
+        _handler(device="cpu").process(
+            VADAudio(
+                audio=np.zeros(16000, dtype=np.float32),
+                mode="final",
+            )
+        )
+    )
+
+    assert len(result) == 1
+    assert isinstance(result[0], Transcription)

--- a/tests/test_whisper_progressive_transcription.py
+++ b/tests/test_whisper_progressive_transcription.py
@@ -108,10 +108,10 @@ def build_lightning_whisper_mlx(monkeypatch):
     from speech_to_speech.STT.lightning_whisper_mlx_handler import LightningWhisperSTTHandler
 
     monkeypatch.setattr(lightning_whisper_mlx_handler.console, "print", lambda *a, **k: None)
-    # torch.mps.empty_cache() is unguarded and is a no-op only where Metal exists.
     monkeypatch.setattr(lightning_whisper_mlx_handler.torch.mps, "empty_cache", lambda: None)
 
     handler = object.__new__(LightningWhisperSTTHandler)
+    handler.device = "mps"
     handler.start_language = "en"
     handler.last_language = "en"
     handler.model = SimpleNamespace(transcribe=lambda audio, **kw: {"text": TRANSCRIPTS[len(audio)], "language": "en"})


### PR DESCRIPTION
hey again, (:

Paraformer and LightningWhisper called `torch.mps.empty_cache()` after every inference. On Linux/CUDA this can fail because MPS is not available.

Same pattern as `ChatTTSHandler` in `src/speech_to_speech/TTS/chatTTS_handler.py`: only clear MPS cache when `device == "mps"`.

## Test plan
- [x] `uv run pytest tests/test_paraformer_transcription_events.py -v`