### PR TITLE
Highlight GitHub Trending badge

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,10 +4,13 @@
 
 # Speech To Speech: Build voice agents with open-source models
 
+<p>
+  <a href="https://trendshift.io/repositories/20645"><img src="https://img.shields.io/badge/GitHub%20Trending-%231%20Repository%20of%20the%20Day-7B2CBF?logo=github&amp;logoColor=white&amp;style=for-the-badge" alt="GitHub Trending: #1 Repository of the Day"></a>
+</p>
+
 [![PyPI](https://img.shields.io/pypi/v/speech-to-speech)](https://pypi.org/project/speech-to-speech/)
 [![Python](https://img.shields.io/pypi/pyversions/speech-to-speech)](https://pypi.org/project/speech-to-speech/)
 [![License](https://img.shields.io/badge/license-Apache%202.0-blue)](./LICENSE)
-[![GitHub Trending: #1 Repository of the Day](https://img.shields.io/badge/GitHub%20Trending-%231%20Repository%20of%20the%20Day-7B2CBF?logo=github&logoColor=white)](https://trendshift.io/repositories/20645)
 
 </div>
 


### PR DESCRIPTION
## Summary

- move the GitHub Trending badge ahead of the package badges
- give it a dedicated row
- use Shields.io's larger `for-the-badge` style

## Why

The trending recognition is easier to notice when it has stronger visual priority in the README header.

## Impact

Documentation-only change; package behavior is unchanged.

## Validation

- `git diff --check`
