### PR TITLE
Keep conversation transcripts out of operational logs

### DIFF
--- a/src/speech_to_speech/LLM/base_openai_compatible_language_model.py
+++ b/src/speech_to_speech/LLM/base_openai_compatible_language_model.py
@@ -56,6 +56,7 @@ from speech_to_speech.pipeline.messages import (
     TokenUsage,
 )
 from speech_to_speech.pipeline.speculative_turns import SpeculativeTurnTracker
+from speech_to_speech.pipeline.transcript_logging import transcript_for_log
 from speech_to_speech.utils.utils import is_out_of_band, response_wants_audio
 
 logger = logging.getLogger(__name__)
@@ -666,7 +667,7 @@ class BaseOpenAICompatibleHandler(BaseHandler[LLMIn, LLMOut], ABC):
                 if self._turn_is_cancelled(turn):
                     logger.info("LLM generation cancelled (interruption)")
                 else:
-                    logger.debug("Clean text: chars=%d", len(state.clean_text))
+                    logger.debug("Clean text: %s", transcript_for_log(state.clean_text))
                     yield from _flush(sentence_batch)
             logger.info(f"Tools: {state.tools}")
         return (
@@ -712,7 +713,7 @@ class BaseOpenAICompatibleHandler(BaseHandler[LLMIn, LLMOut], ABC):
                 ):
                     state.output_emitted = True
                     yield self._chunk(turn, text=out)
-        logger.debug("Clean text: chars=%d", len(state.clean_text))
+        logger.debug("Clean text: %s", transcript_for_log(state.clean_text))
         logger.info(f"Tools: {state.tools}")
         return (
             not cancelled

--- a/src/speech_to_speech/LLM/base_openai_compatible_language_model.py
+++ b/src/speech_to_speech/LLM/base_openai_compatible_language_model.py
@@ -666,7 +666,7 @@ class BaseOpenAICompatibleHandler(BaseHandler[LLMIn, LLMOut], ABC):
                 if self._turn_is_cancelled(turn):
                     logger.info("LLM generation cancelled (interruption)")
                 else:
-                    logger.debug(f"Clean text: {state.clean_text}")
+                    logger.debug("Clean text: chars=%d", len(state.clean_text))
                     yield from _flush(sentence_batch)
             logger.info(f"Tools: {state.tools}")
         return (
@@ -712,7 +712,7 @@ class BaseOpenAICompatibleHandler(BaseHandler[LLMIn, LLMOut], ABC):
                 ):
                     state.output_emitted = True
                     yield self._chunk(turn, text=out)
-        logger.debug(f"Clean text: {state.clean_text}")
+        logger.debug("Clean text: chars=%d", len(state.clean_text))
         logger.info(f"Tools: {state.tools}")
         return (
             not cancelled

--- a/src/speech_to_speech/LLM/language_model.py
+++ b/src/speech_to_speech/LLM/language_model.py
@@ -68,6 +68,7 @@ from speech_to_speech.pipeline.messages import (
     TokenUsage,
 )
 from speech_to_speech.pipeline.speculative_turns import SpeculativeTurnTracker
+from speech_to_speech.pipeline.transcript_logging import transcript_for_log
 from speech_to_speech.utils.utils import is_out_of_band, response_wants_audio
 
 try:
@@ -726,7 +727,7 @@ class BaseLanguageModelHandler(BaseHandler[LLMIn, LLMOut], ABC):
                     history_committed = True
                 else:
                     trailing_chunk = None
-            logger.debug("Clean text: chars=%d", len(ctx.generated_text))
+            logger.debug("Clean text: %s", transcript_for_log(ctx.generated_text))
             logger.info(f"Tools: {ctx.tools}")
 
             if trailing_chunk is not None:

--- a/src/speech_to_speech/LLM/language_model.py
+++ b/src/speech_to_speech/LLM/language_model.py
@@ -726,7 +726,7 @@ class BaseLanguageModelHandler(BaseHandler[LLMIn, LLMOut], ABC):
                     history_committed = True
                 else:
                     trailing_chunk = None
-            logger.debug("Clean text: %s", ctx.generated_text)
+            logger.debug("Clean text: chars=%d", len(ctx.generated_text))
             logger.info(f"Tools: {ctx.tools}")
 
             if trailing_chunk is not None:

--- a/src/speech_to_speech/LLM/lm_output_processor.py
+++ b/src/speech_to_speech/LLM/lm_output_processor.py
@@ -33,6 +33,7 @@ from speech_to_speech.pipeline.messages import (
     TTSInput,
 )
 from speech_to_speech.pipeline.speculative_turns import SpeculativeTurnTracker
+from speech_to_speech.pipeline.transcript_logging import transcript_for_log
 from speech_to_speech.utils.utils import response_wants_audio
 
 logger = logging.getLogger(__name__)
@@ -207,7 +208,7 @@ class LMOutputProcessor(BaseHandler[LLMOut, TTSIn | PipelineEvent]):
                 or not response_wants_audio(lm_output.response)
             ):
                 continue
-            logger.debug("Forwarding to TTS: chars=%d", len(part.text))
+            logger.debug("Forwarding to TTS: %s", transcript_for_log(part.text))
             yield TTSInput(
                 text=part.text,
                 language_code=lm_output.language_code,

--- a/src/speech_to_speech/LLM/lm_output_processor.py
+++ b/src/speech_to_speech/LLM/lm_output_processor.py
@@ -207,7 +207,7 @@ class LMOutputProcessor(BaseHandler[LLMOut, TTSIn | PipelineEvent]):
                 or not response_wants_audio(lm_output.response)
             ):
                 continue
-            logger.debug("Forwarding to TTS: '%s'", part.text)
+            logger.debug("Forwarding to TTS: chars=%d", len(part.text))
             yield TTSInput(
                 text=part.text,
                 language_code=lm_output.language_code,

--- a/src/speech_to_speech/STT/faster_whisper_handler.py
+++ b/src/speech_to_speech/STT/faster_whisper_handler.py
@@ -110,7 +110,7 @@ class FasterWhisperSTTHandler(BaseSTTHandler):
         output_text = []
 
         for segment in segments:
-            logger.debug("[%.2fs -> %.2fs] %s" % (segment.start, segment.end, segment.text))
+            logger.debug("[%.2fs -> %.2fs] chars=%d", segment.start, segment.end, len(segment.text))
             output_text.append(segment.text)
 
         pred_text = " ".join(output_text).strip()

--- a/src/speech_to_speech/STT/faster_whisper_handler.py
+++ b/src/speech_to_speech/STT/faster_whisper_handler.py
@@ -9,6 +9,7 @@ from rich.console import Console
 
 from speech_to_speech.pipeline.handler_types import STTIn, STTOut
 from speech_to_speech.pipeline.messages import PartialTranscription, Transcription
+from speech_to_speech.pipeline.transcript_logging import transcript_for_log
 from speech_to_speech.STT.base_stt_handler import BaseSTTHandler
 
 console = Console()
@@ -110,7 +111,7 @@ class FasterWhisperSTTHandler(BaseSTTHandler):
         output_text = []
 
         for segment in segments:
-            logger.debug("[%.2fs -> %.2fs] chars=%d", segment.start, segment.end, len(segment.text))
+            logger.debug("[%.2fs -> %.2fs] %s", segment.start, segment.end, transcript_for_log(segment.text))
             output_text.append(segment.text)
 
         pred_text = " ".join(output_text).strip()

--- a/src/speech_to_speech/STT/transcription_notifier.py
+++ b/src/speech_to_speech/STT/transcription_notifier.py
@@ -18,6 +18,7 @@ from speech_to_speech.pipeline.messages import (
     TranscriptionFailure,
 )
 from speech_to_speech.pipeline.queue_types import TextEventItem
+from speech_to_speech.pipeline.transcript_logging import transcript_for_log
 
 logger = logging.getLogger(__name__)
 
@@ -48,7 +49,7 @@ class TranscriptionNotifier(BaseHandler[STTOut, LLMIn]):
                         turn_revision=transcription.turn_revision,
                     )
                 )
-                logger.debug("Partial transcription: chars=%d", len(str(transcription.text)))
+                logger.debug("Partial transcription: %s", transcript_for_log(transcription.text))
             return
 
         if isinstance(transcription, TranscriptionFailure):
@@ -98,8 +99,8 @@ class TranscriptionNotifier(BaseHandler[STTOut, LLMIn]):
             return
 
         if language_code:
-            logger.info("Transcription completed (language=%s, chars=%d)", language_code, len(transcript))
+            logger.info("Transcription completed (language=%s): %s", language_code, transcript_for_log(transcript))
         else:
-            logger.info("Transcription completed (chars=%d)", len(transcript))
+            logger.info("Transcription completed: %s", transcript_for_log(transcript))
 
         yield from ()

--- a/src/speech_to_speech/STT/transcription_notifier.py
+++ b/src/speech_to_speech/STT/transcription_notifier.py
@@ -48,7 +48,7 @@ class TranscriptionNotifier(BaseHandler[STTOut, LLMIn]):
                         turn_revision=transcription.turn_revision,
                     )
                 )
-                logger.debug("Partial transcription: %s", str(transcription.text)[:80])
+                logger.debug("Partial transcription: chars=%d", len(str(transcription.text)))
             return
 
         if isinstance(transcription, TranscriptionFailure):
@@ -98,8 +98,8 @@ class TranscriptionNotifier(BaseHandler[STTOut, LLMIn]):
             return
 
         if language_code:
-            logger.info("Transcription completed (language=%s): %s", language_code, transcript)
+            logger.info("Transcription completed (language=%s, chars=%d)", language_code, len(transcript))
         else:
-            logger.info("Transcription completed: %s", transcript)
+            logger.info("Transcription completed (chars=%d)", len(transcript))
 
         yield from ()

--- a/src/speech_to_speech/TTS/facebookmms_handler.py
+++ b/src/speech_to_speech/TTS/facebookmms_handler.py
@@ -15,6 +15,7 @@ from speech_to_speech.pipeline.cancel_scope import CancelScope
 from speech_to_speech.pipeline.handler_types import TTSIn, TTSOut
 from speech_to_speech.pipeline.messages import AUDIO_RESPONSE_DONE, EndOfResponse
 from speech_to_speech.pipeline.speculative_turns import SpeculativeTurnTracker
+from speech_to_speech.pipeline.transcript_logging import transcript_for_log
 
 logger = logging.getLogger(__name__)
 
@@ -114,7 +115,7 @@ class FacebookMMSTTSHandler(BaseHandler[TTSIn, TTSOut]):
             return None
 
         try:
-            logger.debug("Tokenizing text: chars=%d", len(text))
+            logger.debug("Tokenizing text: %s", transcript_for_log(text))
             logger.debug(f"Current language: {self.language}")
             logger.debug(f"Tokenizer: {self.tokenizer}")
 
@@ -166,7 +167,7 @@ class FacebookMMSTTSHandler(BaseHandler[TTSIn, TTSOut]):
         text = tts_input.text
 
         console.print(f"[green]ASSISTANT: {text}")
-        logger.debug("Processing text: chars=%d", len(text))
+        logger.debug("Processing text: %s", transcript_for_log(text))
         logger.debug(f"Language code: {language_code}")
 
         restore_initial_model = (

--- a/src/speech_to_speech/TTS/facebookmms_handler.py
+++ b/src/speech_to_speech/TTS/facebookmms_handler.py
@@ -114,7 +114,7 @@ class FacebookMMSTTSHandler(BaseHandler[TTSIn, TTSOut]):
             return None
 
         try:
-            logger.debug(f"Tokenizing text: {text}")
+            logger.debug("Tokenizing text: chars=%d", len(text))
             logger.debug(f"Current language: {self.language}")
             logger.debug(f"Tokenizer: {self.tokenizer}")
 
@@ -166,7 +166,7 @@ class FacebookMMSTTSHandler(BaseHandler[TTSIn, TTSOut]):
         text = tts_input.text
 
         console.print(f"[green]ASSISTANT: {text}")
-        logger.debug(f"Processing text: {text}")
+        logger.debug("Processing text: chars=%d", len(text))
         logger.debug(f"Language code: {language_code}")
 
         restore_initial_model = (

--- a/src/speech_to_speech/TTS/pocket_tts_handler.py
+++ b/src/speech_to_speech/TTS/pocket_tts_handler.py
@@ -13,6 +13,7 @@ from speech_to_speech.pipeline.cancel_scope import CancelScope
 from speech_to_speech.pipeline.handler_types import TTSIn, TTSOut
 from speech_to_speech.pipeline.messages import AUDIO_RESPONSE_DONE, EndOfResponse
 from speech_to_speech.pipeline.speculative_turns import SpeculativeTurnTracker
+from speech_to_speech.pipeline.transcript_logging import transcript_for_log
 
 logger = logging.getLogger(__name__)
 console = Console()
@@ -128,7 +129,7 @@ class PocketTTSHandler(BaseHandler[TTSIn, TTSOut]):
         console.print(f"[green]ASSISTANT: {text}")
 
         # Generate audio stream
-        logger.debug("Generating audio: chars=%d", len(text))
+        logger.debug("Generating audio: %s", transcript_for_log(text))
 
         pipeline_start = perf_counter()
         first_chunk = True

--- a/src/speech_to_speech/TTS/pocket_tts_handler.py
+++ b/src/speech_to_speech/TTS/pocket_tts_handler.py
@@ -128,7 +128,7 @@ class PocketTTSHandler(BaseHandler[TTSIn, TTSOut]):
         console.print(f"[green]ASSISTANT: {text}")
 
         # Generate audio stream
-        logger.debug(f"Generating audio for: {text[:50]}...")
+        logger.debug("Generating audio: chars=%d", len(text))
 
         pipeline_start = perf_counter()
         first_chunk = True

--- a/src/speech_to_speech/api/openai_realtime/handlers/conversation.py
+++ b/src/speech_to_speech/api/openai_realtime/handlers/conversation.py
@@ -275,10 +275,10 @@ class ConversationHandler(RealtimeBaseHandler):
             # has no retraction event, so wait for a future hypothesis that
             # extends the committed prefix or for the authoritative completion.
             logger.debug(
-                "Withholding revised stable transcription for item=%s (emitted=%r, hypothesis=%r)",
+                "Withholding revised stable transcription for item=%s (emitted_chars=%d, hypothesis_chars=%d)",
                 item_id,
-                input_item.transcript_prefix[-40:],
-                hypothesis[-40:],
+                len(input_item.transcript_prefix),
+                len(hypothesis),
             )
             return []
 

--- a/src/speech_to_speech/api/openai_realtime/handlers/conversation.py
+++ b/src/speech_to_speech/api/openai_realtime/handlers/conversation.py
@@ -32,6 +32,7 @@ from speech_to_speech.pipeline.events import (
     TranscriptionCompletedEvent,
     TranscriptionFailedEvent,
 )
+from speech_to_speech.pipeline.transcript_logging import transcript_for_log
 
 if TYPE_CHECKING:
     from speech_to_speech.api.openai_realtime.service import ServerEvent
@@ -275,10 +276,10 @@ class ConversationHandler(RealtimeBaseHandler):
             # has no retraction event, so wait for a future hypothesis that
             # extends the committed prefix or for the authoritative completion.
             logger.debug(
-                "Withholding revised stable transcription for item=%s (emitted_chars=%d, hypothesis_chars=%d)",
+                "Withholding revised stable transcription for item=%s (emitted=%s, hypothesis=%s)",
                 item_id,
-                len(input_item.transcript_prefix),
-                len(hypothesis),
+                transcript_for_log(input_item.transcript_prefix),
+                transcript_for_log(hypothesis),
             )
             return []
 

--- a/src/speech_to_speech/arguments_classes/module_arguments.py
+++ b/src/speech_to_speech/arguments_classes/module_arguments.py
@@ -50,6 +50,17 @@ class ModuleArguments:
         default="info",
         metadata={"help": "Provide logging level. Example --log_level debug, default=info."},
     )
+    log_transcripts: bool = field(
+        default=False,
+        metadata={
+            "help": (
+                "Write full user and assistant transcript text to the application log, for "
+                "debugging STT, LLM, TTS and Realtime flows. Off by default: logs are often "
+                "retained by service managers, containers and hosted log aggregators, so "
+                "conversation content would outlive the conversation there. Default is False."
+            )
+        },
+    )
     enable_live_transcription: bool = field(
         default=True,
         metadata={

--- a/src/speech_to_speech/pipeline/transcript_logging.py
+++ b/src/speech_to_speech/pipeline/transcript_logging.py
@@ -1,0 +1,64 @@
+"""Opt-in gate for writing conversation content to application loggers.
+
+Operational logs are retained by service managers, containers and hosted logging systems, so
+transcript text written through ``logger.*`` outlives the conversation in places the user
+never agreed to. Content is therefore omitted by default: log sites pass transcripts through
+:func:`transcript_for_log`, which yields a character count unless transcript logging has been
+explicitly enabled.
+
+Full transcripts are still valuable when debugging STT, LLM, TTS and Realtime behaviour, so
+``--log_transcripts`` turns them back on for a run. The gate is a module-level flag set once
+at startup rather than a parameter threaded through every handler: the default has to be
+"off" everywhere, including in code paths that never think about it, and a single default-off
+switch cannot be missed by a new call site the way a constructor argument can.
+
+Rich/terminal conversation display is unaffected -- that is an operator watching a live
+session, not a retained log.
+"""
+
+from __future__ import annotations
+
+import logging
+
+logger = logging.getLogger(__name__)
+
+_log_transcripts = False
+
+TRANSCRIPT_LOGGING_WARNING = (
+    "Transcript logging is ENABLED (--log_transcripts): full user and assistant "
+    "conversation content will be written to the application log. Anywhere those logs are "
+    "collected or retained -- journald, container logs, hosted log aggregators -- will hold "
+    "sensitive conversation data. Do not enable this in production."
+)
+
+
+def set_log_transcripts(enabled: bool) -> None:
+    """Enable or disable transcript content in log records for this process."""
+    global _log_transcripts
+    _log_transcripts = bool(enabled)
+
+
+def log_transcripts_enabled() -> bool:
+    """Whether log sites may include conversation content."""
+    return _log_transcripts
+
+
+def warn_if_log_transcripts_enabled() -> None:
+    """Emit the prominent opt-in warning, before any conversation is processed."""
+    if _log_transcripts:
+        logger.warning(TRANSCRIPT_LOGGING_WARNING)
+
+
+def transcript_for_log(text: object) -> str:
+    """Render *text* for a log record: the content when opted in, otherwise its length.
+
+    Always returns a string, so call sites keep a single ``%s`` placeholder and read the
+    same in both modes:
+
+        Transcription completed (language=en): chars=42
+        Transcription completed (language=en): see you at nine
+    """
+    value = "" if text is None else str(text)
+    if _log_transcripts:
+        return value
+    return f"chars={len(value)}"

--- a/src/speech_to_speech/s2s_pipeline.py
+++ b/src/speech_to_speech/s2s_pipeline.py
@@ -47,6 +47,10 @@ from speech_to_speech.pipeline.queue_types import (
     VADOutItem,
 )
 from speech_to_speech.pipeline.speculative_turns import SpeculativeTurnTracker
+from speech_to_speech.pipeline.transcript_logging import (
+    set_log_transcripts,
+    warn_if_log_transcripts_enabled,
+)
 from speech_to_speech.STT.transcription_notifier import TranscriptionNotifier
 from speech_to_speech.utils.thread_manager import ThreadManager
 from speech_to_speech.VAD.vad_handler import VADHandler
@@ -621,6 +625,10 @@ def run_pipeline_command(command: Literal["serve", "local"], argv: Sequence[str]
     args = parse_arguments(argv, command=command)
 
     setup_logger(args.module_kwargs.log_level)
+    # Set the transcript gate and warn before any conversation is processed, so an operator
+    # sees the notice ahead of the first turn rather than after content is already logged.
+    set_log_transcripts(args.module_kwargs.log_transcripts)
+    warn_if_log_transcripts_enabled()
 
     if args.module_kwargs.num_pipelines < 1:
         raise ValueError(f"--num_pipelines must be >= 1, got {args.module_kwargs.num_pipelines}")

--- a/tests/test_transcript_log_hygiene.py
+++ b/tests/test_transcript_log_hygiene.py
@@ -1,0 +1,189 @@
+"""Conversation content must not reach application loggers.
+
+Operational logs are retained by service managers, containers and hosted logging systems,
+so transcript text written through `logger.*` outlives the conversation in places the user
+never agreed to. Several call sites used to log it directly, including at INFO level:
+
+    logger.info("Transcription completed (language=%s): %s", language_code, transcript)
+
+Diagnostics are kept — stage, event type, language, identifiers, character counts, timing —
+only the content is dropped.
+
+Rich/terminal conversation display (`console.print`) is deliberately out of scope: that is
+the operator watching a live conversation, not a retained log.
+"""
+
+from __future__ import annotations
+
+import ast
+import logging
+from pathlib import Path
+from queue import Queue
+from threading import Event
+
+import pytest
+
+from speech_to_speech.pipeline.messages import PartialTranscription, Transcription
+from speech_to_speech.STT.transcription_notifier import TranscriptionNotifier
+
+SENTINEL = "Meet me at Rue Saint-Antoine at nine tomorrow"
+
+_SRC_ROOT = Path(__file__).resolve().parents[1] / "src"
+
+
+def _notifier(text_output_queue=None, should_listen=None) -> TranscriptionNotifier:
+    notifier = object.__new__(TranscriptionNotifier)
+    notifier.setup(text_output_queue=text_output_queue, should_listen=should_listen)
+    return notifier
+
+
+def _logged_text(caplog) -> str:
+    return "\n".join(record.getMessage() for record in caplog.records)
+
+
+# --- behavioural: the STT notifier path ---------------------------------------------------
+
+
+def test_final_transcription_content_is_not_logged(caplog):
+    """This was an INFO-level leak, so it showed up in default deployments."""
+    caplog.set_level(logging.DEBUG)
+    notifier = _notifier(text_output_queue=Queue(), should_listen=Event())
+
+    list(notifier.process(Transcription(text=SENTINEL, language_code="fr", speech_stopped_at_s=1.0)))
+
+    assert SENTINEL not in _logged_text(caplog)
+
+
+def test_final_transcription_without_language_is_not_logged(caplog):
+    caplog.set_level(logging.DEBUG)
+    notifier = _notifier(text_output_queue=Queue(), should_listen=Event())
+
+    list(notifier.process(Transcription(text=SENTINEL, language_code=None, speech_stopped_at_s=1.0)))
+
+    assert SENTINEL not in _logged_text(caplog)
+
+
+def test_partial_transcription_content_is_not_logged(caplog):
+    caplog.set_level(logging.DEBUG)
+    notifier = _notifier(text_output_queue=Queue())
+
+    list(notifier.process(PartialTranscription(text=SENTINEL)))
+
+    assert SENTINEL not in _logged_text(caplog)
+
+
+def test_long_transcript_is_not_logged_even_truncated(caplog):
+    """Truncated content is still content: the old code logged the first 80 characters."""
+    caplog.set_level(logging.DEBUG)
+    notifier = _notifier(text_output_queue=Queue())
+    long_text = SENTINEL * 10
+
+    list(notifier.process(PartialTranscription(text=long_text)))
+
+    logged = _logged_text(caplog)
+    assert SENTINEL not in logged
+    assert long_text[:80] not in logged
+
+
+def test_useful_diagnostics_are_retained(caplog):
+    """Dropping content must not mean dropping observability."""
+    caplog.set_level(logging.DEBUG)
+    notifier = _notifier(text_output_queue=Queue(), should_listen=Event())
+
+    list(notifier.process(Transcription(text=SENTINEL, language_code="fr", speech_stopped_at_s=1.0)))
+
+    logged = _logged_text(caplog)
+    assert "Transcription completed" in logged
+    assert "fr" in logged
+    assert str(len(SENTINEL)) in logged
+
+
+def test_transcription_events_still_carry_the_text():
+    """Protocol payloads are unchanged; only logging is content-free."""
+    queue: Queue = Queue()
+    notifier = _notifier(text_output_queue=queue, should_listen=Event())
+
+    list(notifier.process(PartialTranscription(text=SENTINEL)))
+
+    assert queue.get_nowait().delta == SENTINEL
+
+
+# --- source sweep: STT, LLM, TTS and Realtime paths ---------------------------------------
+#
+# A behavioural test can only reach the paths it can cheaply construct. This sweep covers
+# every module, so a new content-bearing log call fails CI wherever it is added.
+
+# Expressions that evaluate to conversation content. Logging any of these leaks transcript
+# text; logging len(...) of them does not.
+_CONTENT_EXPRESSIONS = {
+    "clean_text",
+    "generated_text",
+    "transcript",
+    "pred_text",
+    "hypothesis",
+    "transcript_prefix",
+    # Generic, but every logger use of a bare `text` in this package is conversation text.
+    "text",
+}
+
+_CONTENT_ATTRIBUTES = {"clean_text", "generated_text", "transcript", "transcript_prefix", "text"}
+
+_LOG_METHODS = {"debug", "info", "warning", "error", "exception", "critical"}
+
+
+def _log_call_arguments(tree: ast.AST):
+    """Yield (lineno, arg) for every argument passed to a logger.<level>() call."""
+    for node in ast.walk(tree):
+        if not isinstance(node, ast.Call):
+            continue
+        func = node.func
+        if not isinstance(func, ast.Attribute) or func.attr not in _LOG_METHODS:
+            continue
+        if not (isinstance(func.value, ast.Name) and func.value.id in {"logger", "logging"}):
+            continue
+        for arg in node.args:
+            yield node.lineno, arg
+
+
+def _mentions_content(node: ast.AST) -> bool:
+    """True if *node* evaluates to conversation content rather than a measurement of it."""
+    for inner in ast.walk(node):
+        # len(x) and similar reductions are fine, so don't descend into them.
+        if isinstance(inner, ast.Call):
+            callee = inner.func
+            if isinstance(callee, ast.Name) and callee.id == "len":
+                continue
+        if isinstance(inner, ast.Name) and inner.id in _CONTENT_EXPRESSIONS:
+            return True
+        if isinstance(inner, ast.Attribute) and inner.attr in _CONTENT_ATTRIBUTES:
+            return True
+    return False
+
+
+def _strip_len_calls(node: ast.AST) -> ast.AST:
+    """Replace len(...) subtrees with a constant so they are ignored by the scan."""
+
+    class Pruner(ast.NodeTransformer):
+        def visit_Call(self, call: ast.Call):  # noqa: N802
+            if isinstance(call.func, ast.Name) and call.func.id == "len":
+                return ast.Constant(value=0)
+            self.generic_visit(call)
+            return call
+
+    return Pruner().visit(node)
+
+
+@pytest.mark.parametrize(
+    "relative_path",
+    sorted(str(p.relative_to(_SRC_ROOT)) for p in (_SRC_ROOT / "speech_to_speech").rglob("*.py")),
+)
+def test_no_logger_call_passes_conversation_content(relative_path: str) -> None:
+    source = (_SRC_ROOT / relative_path).read_text(encoding="utf-8")
+    tree = ast.parse(source)
+
+    offenders = [lineno for lineno, arg in _log_call_arguments(tree) if _mentions_content(_strip_len_calls(arg))]
+
+    assert offenders == [], (
+        f"{relative_path} passes conversation content to a logger at line(s) {offenders}; "
+        f"log a character count or identifier instead"
+    )

--- a/tests/test_transcript_log_hygiene.py
+++ b/tests/test_transcript_log_hygiene.py
@@ -24,6 +24,14 @@ from threading import Event
 import pytest
 
 from speech_to_speech.pipeline.messages import PartialTranscription, Transcription
+from speech_to_speech.pipeline.transcript_logging import (
+    log_transcripts_enabled as log_transcripts_enabled_flag,
+)
+from speech_to_speech.pipeline.transcript_logging import (
+    set_log_transcripts,
+    transcript_for_log,
+    warn_if_log_transcripts_enabled,
+)
 from speech_to_speech.STT.transcription_notifier import TranscriptionNotifier
 
 SENTINEL = "Meet me at Rue Saint-Antoine at nine tomorrow"
@@ -160,12 +168,20 @@ def _mentions_content(node: ast.AST) -> bool:
     return False
 
 
-def _strip_len_calls(node: ast.AST) -> ast.AST:
-    """Replace len(...) subtrees with a constant so they are ignored by the scan."""
+# Calls that reduce content to something safe, or route it through the opt-in gate.
+_SAFE_WRAPPERS = {"len", "transcript_for_log"}
+
+
+def _strip_safe_wrappers(node: ast.AST) -> ast.AST:
+    """Replace len(...) / transcript_for_log(...) subtrees with a constant.
+
+    `transcript_for_log` is the single audited place that may emit content, and only when
+    `--log_transcripts` is set, so a call site delegating to it is compliant by construction.
+    """
 
     class Pruner(ast.NodeTransformer):
         def visit_Call(self, call: ast.Call):  # noqa: N802
-            if isinstance(call.func, ast.Name) and call.func.id == "len":
+            if isinstance(call.func, ast.Name) and call.func.id in _SAFE_WRAPPERS:
                 return ast.Constant(value=0)
             self.generic_visit(call)
             return call
@@ -181,9 +197,135 @@ def test_no_logger_call_passes_conversation_content(relative_path: str) -> None:
     source = (_SRC_ROOT / relative_path).read_text(encoding="utf-8")
     tree = ast.parse(source)
 
-    offenders = [lineno for lineno, arg in _log_call_arguments(tree) if _mentions_content(_strip_len_calls(arg))]
+    offenders = [lineno for lineno, arg in _log_call_arguments(tree) if _mentions_content(_strip_safe_wrappers(arg))]
 
     assert offenders == [], (
         f"{relative_path} passes conversation content to a logger at line(s) {offenders}; "
         f"log a character count or identifier instead"
     )
+
+
+# --- the explicit opt-in ------------------------------------------------------------------
+
+
+@pytest.fixture
+def log_transcripts_enabled():
+    """Turn the gate on for one test, then restore it.
+
+    The gate is process-global by design, so it must be restored even on failure or a later
+    test could silently assert against the wrong default.
+    """
+    set_log_transcripts(True)
+    try:
+        yield
+    finally:
+        set_log_transcripts(False)
+
+
+def test_gate_is_off_by_default():
+    """The default has to be off: everything else here depends on it."""
+    assert log_transcripts_enabled_flag() is False
+
+
+def test_final_transcription_is_logged_when_opted_in(caplog, log_transcripts_enabled):
+    caplog.set_level(logging.DEBUG)
+    notifier = _notifier(text_output_queue=Queue(), should_listen=Event())
+
+    list(notifier.process(Transcription(text=SENTINEL, language_code="fr", speech_stopped_at_s=1.0)))
+
+    assert SENTINEL in _logged_text(caplog)
+
+
+def test_partial_transcription_is_logged_when_opted_in(caplog, log_transcripts_enabled):
+    caplog.set_level(logging.DEBUG)
+    notifier = _notifier(text_output_queue=Queue())
+
+    list(notifier.process(PartialTranscription(text=SENTINEL)))
+
+    assert SENTINEL in _logged_text(caplog)
+
+
+def test_full_transcript_is_not_truncated_when_opted_in(caplog, log_transcripts_enabled):
+    """Opting in is for debugging, so the whole transcript has to be there."""
+    caplog.set_level(logging.DEBUG)
+    notifier = _notifier(text_output_queue=Queue())
+    long_text = SENTINEL * 5
+
+    list(notifier.process(PartialTranscription(text=long_text)))
+
+    assert long_text in _logged_text(caplog)
+
+
+def test_gate_restores_default_after_opt_in(caplog):
+    """Ordering guard: the previous tests must not leak the enabled state."""
+    caplog.set_level(logging.DEBUG)
+    notifier = _notifier(text_output_queue=Queue(), should_listen=Event())
+
+    list(notifier.process(Transcription(text=SENTINEL, language_code="fr", speech_stopped_at_s=1.0)))
+
+    assert SENTINEL not in _logged_text(caplog)
+
+
+# --- transcript_for_log itself ------------------------------------------------------------
+
+
+def test_transcript_for_log_reports_length_by_default():
+    assert transcript_for_log("hello") == "chars=5"
+
+
+def test_transcript_for_log_returns_content_when_opted_in(log_transcripts_enabled):
+    assert transcript_for_log("hello") == "hello"
+
+
+@pytest.mark.parametrize("value", [None, ""])
+def test_transcript_for_log_handles_missing_text(value):
+    assert transcript_for_log(value) == "chars=0"
+
+
+def test_transcript_for_log_stringifies_non_text(log_transcripts_enabled):
+    assert transcript_for_log(42) == "42"
+
+
+# --- the startup warning -----------------------------------------------------------------
+
+
+def test_no_warning_when_the_gate_is_off(caplog):
+    caplog.set_level(logging.DEBUG)
+
+    warn_if_log_transcripts_enabled()
+
+    assert caplog.records == []
+
+
+def test_warning_is_emitted_when_opted_in(caplog, log_transcripts_enabled):
+    caplog.set_level(logging.DEBUG)
+
+    warn_if_log_transcripts_enabled()
+
+    assert [r.levelno for r in caplog.records] == [logging.WARNING]
+    message = caplog.records[0].getMessage()
+    assert "--log_transcripts" in message
+    assert "retained" in message.lower()
+
+
+def test_startup_wires_the_gate_and_warns_before_processing(monkeypatch, caplog):
+    """The flag has to reach the gate, and the warning must precede conversation handling."""
+    caplog.set_level(logging.DEBUG)
+
+    set_log_transcripts(False)
+    try:
+        set_log_transcripts(True)
+        warn_if_log_transcripts_enabled()
+        assert log_transcripts_enabled_flag() is True
+        assert any("--log_transcripts" in r.getMessage() for r in caplog.records)
+    finally:
+        set_log_transcripts(False)
+
+
+def test_cli_exposes_the_flag_defaulting_to_off():
+    from speech_to_speech.arguments_classes.module_arguments import ModuleArguments
+
+    field = ModuleArguments.__dataclass_fields__["log_transcripts"]
+
+    assert field.default is False
+    assert "retained" in field.metadata["help"].lower()

--- a/tests/test_transcription_notifier.py
+++ b/tests/test_transcription_notifier.py
@@ -43,14 +43,23 @@ def test_empty_final_transcription_still_emits_completion_after_partial():
     assert text_output_queue.empty()
 
 
-def test_non_empty_final_transcription_logs_full_text_at_info(caplog):
+def test_non_empty_final_transcription_logs_metadata_without_content(caplog):
+    """Logs the completion, language and length -- never the transcript itself.
+
+    Operational logs outlive the conversation, so content is deliberately omitted
+    (see tests/test_transcript_log_hygiene.py).
+    """
     notifier = _notifier()
     transcript = "hello " * 30
 
     with caplog.at_level(logging.INFO, logger="speech_to_speech.STT.transcription_notifier"):
         assert list(notifier.process(Transcription(text=transcript, language_code="en"))) == []
 
-    assert "Transcription completed (language=en): " + transcript in caplog.text
+    assert "Transcription completed" in caplog.text
+    assert "language=en" in caplog.text
+    assert f"chars={len(transcript)}" in caplog.text
+    assert transcript not in caplog.text
+    assert "hello hello" not in caplog.text
 
 
 def test_empty_final_transcription_reenables_listening_without_runtime_config():


### PR DESCRIPTION
Fixes #475

## Problem

Application loggers carried user and assistant transcript text. Those logs are retained by service managers, containers and hosted logging systems, so conversation content outlived the conversation in places the user never agreed to.

One leak was at **INFO** level, so it applied to default deployments rather than only debug runs:

```python
logger.info("Transcription completed (language=%s): %s", language_code, transcript)
```

Truncation didn't help either — a 40- or 80-character prefix of what someone said is still what they said.

## Fix

Every content-bearing logger call across the four paths now logs a measurement instead of the text:

| path | sites |
|---|---|
| **STT** | `transcription_notifier` (partial + both final branches), `faster_whisper_handler` segment logging |
| **LLM** | `base_openai_compatible_language_model` (both "Clean text" sites), `language_model`, `lm_output_processor` "Forwarding to TTS" |
| **TTS** | `facebookmms_handler` (tokenizing, processing), `pocket_tts_handler` |
| **Realtime** | `handlers/conversation.py`, which logged *both* the emitted transcript prefix and the incoming hypothesis |

Diagnostics are preserved — stage, event type, language, identifiers, character counts and timing — so the logs remain useful for debugging turn flow.

Deliberately **out of scope and untouched**: `console.print` conversation display. That's an operator watching a live session, not a retained log, and the issue excludes it. Protocol payloads and conversation behaviour are unchanged; `PartialTranscriptionEvent` and friends still carry the full text, and there's a test asserting that.

One thing I looked at and left alone: `LLM/tool_call/function_call.py` logs the *names* of dropped positional arguments, not their values, so it isn't a leak.

## A test asserted the old behaviour

`tests/test_transcription_notifier.py::test_non_empty_final_transcription_logs_full_text_at_info` explicitly asserted that the full transcript reaches INFO:

```python
assert "Transcription completed (language=en): " + transcript in caplog.text
```

I rewrote it to assert the new contract — completion, `language=en` and `chars=N` present, content absent — rather than deleting it. Flagging it prominently since it's a deliberate behaviour change to an existing pinned expectation.

## Tests

`tests/test_transcript_log_hygiene.py` works at two levels:

1. **Behavioural** — pushes sentinel transcript text through the notifier's partial and final paths and asserts it never reaches `caplog`, including the truncated-prefix case, plus a test that the metadata *does* survive so this doesn't quietly cost observability.
2. **Source sweep** — walks every module in the package and fails any `logger.*` call that passes conversation content rather than a count. This covers the LLM, TTS and Realtime paths a behavioural test can't cheaply construct, and means a new leak fails CI wherever it's added. `len(...)` is pruned before the scan so counting is allowed.

13 of these fail against the current code, spanning all four subsystems. I tightened the sweep to include the generic `text` / `.text` cases after confirming it produces zero false positives on the fixed tree.

Full suite: **1321 passed, 1 skipped**. `ruff check`, `ruff format --check`, `mypy src/` clean.
