### PR TITLE
Update default model to GPT-5.6 Terra

### DIFF
--- a/README.md
+++ b/README.md
@@ -229,7 +229,7 @@ speech-to-speech serve \
     --enable_live_transcription
 ```
 
-The default model is `gpt-5.6-terra` through the OpenAI Responses API. Override it with `--model_name`, and set `--responses_api_base_url` for another OpenAI-compatible provider or server.
+The default model is `gpt-5.6-terra` through the OpenAI Responses API with reasoning effort `none`, preserving the previous default model's latency-oriented reasoning behavior. Override the model with `--model_name`, the effort with `--responses_api_reasoning_effort`, and set `--responses_api_base_url` for another OpenAI-compatible provider or server.
 
 ### Local Mac
 

--- a/README.md
+++ b/README.md
@@ -223,13 +223,13 @@ speech-to-speech serve \
     --qwen3_tts_backend ggml \
     --qwen3_tts_non_streaming_mode True \
     --qwen3_tts_mlx_quantization 6bit \
-    --model_name gpt-5.4-mini \
+    --model_name gpt-5.6-terra \
     --chat_size 30 \
     --responses_api_stream \
     --enable_live_transcription
 ```
 
-The default model is `gpt-5.4-mini` through the OpenAI Responses API. Override it with `--model_name`, and set `--responses_api_base_url` for another OpenAI-compatible provider or server.
+The default model is `gpt-5.6-terra` through the OpenAI Responses API. Override it with `--model_name`, and set `--responses_api_base_url` for another OpenAI-compatible provider or server.
 
 ### Local Mac
 
@@ -356,10 +356,10 @@ supported with `--llm_backend responses-api`: a model may accept audio through
 [`gpt-audio-1.5`](https://developers.openai.com/api/docs/models/gpt-audio-1.5).
 
 You must explicitly set `--model_name` to a model that accepts audio: the
-default `gpt-5.4-mini` accepts text and image input, but not audio. Check the
+default `gpt-5.6-terra` accepts text and image input, but not audio. Check the
 provider's model documentation and endpoint support before enabling this mode.
 For OpenAI, see the
-[GPT-5.4 mini model card](https://developers.openai.com/api/docs/models/gpt-5.4-mini)
+[GPT-5.6 Terra model card](https://developers.openai.com/api/docs/models/gpt-5.6-terra)
 and [audio-input guide](https://developers.openai.com/api/docs/guides/audio#add-audio-to-your-existing-application).
 
 ```bash

--- a/src/speech_to_speech/LLM/README.md
+++ b/src/speech_to_speech/LLM/README.md
@@ -63,7 +63,7 @@ Common options:
 ```bash
 speech-to-speech serve \
   --llm_backend responses-api \
-  --model_name gpt-5.4-mini \
+  --model_name gpt-5.6-terra \
   --responses_api_api_key YOUR_API_KEY \
   --responses_api_base_url https://api.example.com/v1 \
   --responses_api_stream true
@@ -132,6 +132,6 @@ speech-to-speech serve \
 ```bash
 speech-to-speech serve \
   --llm_backend responses-api \
-  --model_name gpt-5.4-mini \
+  --model_name gpt-5.6-terra \
   --responses_api_api_key YOUR_API_KEY
 ```

--- a/src/speech_to_speech/LLM/base_openai_compatible_language_model.py
+++ b/src/speech_to_speech/LLM/base_openai_compatible_language_model.py
@@ -188,6 +188,7 @@ class BaseOpenAICompatibleHandler(BaseHandler[LLMIn, LLMOut], ABC):
             raise ValueError("audio_content_type must be either 'input_audio' or 'audio_url'.")
         self.audio_content_type = audio_content_type
         self.audio_history_turns = max(0, audio_history_turns)
+        self.reasoning_effort = reasoning_effort
         self.request_timeout_s = float(request_timeout_s)
         self.request_timeout = httpx.Timeout(
             self.request_timeout_s,

--- a/src/speech_to_speech/LLM/base_openai_compatible_language_model.py
+++ b/src/speech_to_speech/LLM/base_openai_compatible_language_model.py
@@ -154,7 +154,7 @@ class BaseOpenAICompatibleHandler(BaseHandler[LLMIn, LLMOut], ABC):
 
     def setup(
         self,
-        model_name: str = "gpt-5.4-mini",
+        model_name: str = "gpt-5.6-terra",
         device: str = "cuda",
         gen_kwargs: dict[str, Any] = {},
         base_url: Optional[str] = None,

--- a/src/speech_to_speech/LLM/responses_api_language_model.py
+++ b/src/speech_to_speech/LLM/responses_api_language_model.py
@@ -43,6 +43,25 @@ logger = logging.getLogger(__name__)
 class ResponsesApiModelHandler(BaseOpenAICompatibleHandler):
     """LLM handler that talks to an OpenAI ``/v1/responses`` server."""
 
+    @classmethod
+    def _build_extra_body(
+        cls,
+        base_url: str | None,
+        disable_thinking: bool,
+        reasoning_effort: str | None,
+    ) -> dict[str, Any] | None:
+        """Keep Responses reasoning out of the Chat-Completions-shaped extra body."""
+        return super()._build_extra_body(
+            base_url,
+            disable_thinking=disable_thinking and reasoning_effort is None,
+            reasoning_effort=None,
+        )
+
+    def _reasoning_kwargs(self) -> dict[str, Any]:
+        if self.reasoning_effort is None:
+            return {}
+        return {"reasoning": {"effort": self.reasoning_effort}}
+
     def warmup(self) -> None:
         logger.info(f"Warming up {self.__class__.__name__}")
         start = time.time()
@@ -57,6 +76,7 @@ class ResponsesApiModelHandler(BaseOpenAICompatibleHandler):
                 {"type": "message", "role": "user", "content": [{"type": "input_text", "text": "Hello"}]},
             ],
             timeout=self.request_timeout,
+            **self._reasoning_kwargs(),
         )
         end = time.time()
         logger.info(f"{self.__class__.__name__}:  warmed up! time: {(end - start):.3f} s")
@@ -66,6 +86,7 @@ class ResponsesApiModelHandler(BaseOpenAICompatibleHandler):
         client = self.client
         model_name = self.model_name
         timeout = self.request_timeout
+        reasoning_kwargs = self._reasoning_kwargs()
 
         def generate(system: str, user: str) -> str:
             response = client.responses.create(
@@ -83,6 +104,7 @@ class ResponsesApiModelHandler(BaseOpenAICompatibleHandler):
                     },
                 ],
                 timeout=timeout,
+                **reasoning_kwargs,
             )
             return response.output_text
 
@@ -130,7 +152,7 @@ class ResponsesApiModelHandler(BaseOpenAICompatibleHandler):
         return active_chat.to_responses_api_chat()
 
     def _build_optional_kwargs(self, req_tools: Any, req_tool_choice: Any) -> dict[str, Any]:
-        optional_kwargs: dict[str, Any] = {}
+        optional_kwargs = self._reasoning_kwargs()
         if req_tools is not None:
             optional_kwargs["tools"] = req_tools
         if req_tool_choice is not None:

--- a/src/speech_to_speech/arguments_classes/chat_completions_language_model_arguments.py
+++ b/src/speech_to_speech/arguments_classes/chat_completions_language_model_arguments.py
@@ -13,8 +13,9 @@ class ChatCompletionsLanguageModelHandlerArguments(ResponsesApiLanguageModelHand
     Inherits the OpenAI-compatible connection fields from the Responses-API
     arguments (``responses_api_base_url`` / ``responses_api_api_key`` /
     ``responses_api_stream`` / ``responses_api_disable_thinking``) so the same
-    CLI flags and launcher env vars drive both backends, and adds the
-    Chat-Completions-only ``reasoning_effort`` knob.
+    CLI flags and launcher env vars drive both backends. Chat Completions keeps
+    the reasoning-effort default unset so provider-specific disable-thinking
+    behavior remains unchanged.
     """
 
     responses_api_reasoning_effort: Optional[str] = field(

--- a/src/speech_to_speech/arguments_classes/responses_api_language_model_arguments.py
+++ b/src/speech_to_speech/arguments_classes/responses_api_language_model_arguments.py
@@ -35,6 +35,14 @@ class ResponsesApiLanguageModelHandlerArguments(LanguageModelBaseArguments):
             "For Together Qwen3.5 models this sends chat_template_kwargs.enable_thinking=false."
         },
     )
+    responses_api_reasoning_effort: Optional[str] = field(
+        default="none",
+        metadata={
+            "help": "Reasoning effort for the OpenAI-compatible API. The Responses backend sends "
+            "reasoning={'effort': <value>}; Chat Completions sends reasoning_effort. Default is 'none', "
+            "preserving the previous gpt-5.4-mini reasoning behavior."
+        },
+    )
     responses_api_audio_max_tokens: int = field(
         default=256,
         metadata={"help": "Maximum chat completion tokens for audio-input LLM requests. Default is 256."},

--- a/src/speech_to_speech/arguments_classes/responses_api_language_model_arguments.py
+++ b/src/speech_to_speech/arguments_classes/responses_api_language_model_arguments.py
@@ -7,9 +7,9 @@ from speech_to_speech.arguments_classes.language_model_base_arguments import Lan
 @dataclass
 class ResponsesApiLanguageModelHandlerArguments(LanguageModelBaseArguments):
     model_name: str = field(
-        default="gpt-5.4-mini",
+        default="gpt-5.6-terra",
         metadata={
-            "help": "The model to use with the OpenAI-compatible API. Default is 'gpt-5.4-mini', "
+            "help": "The model to use with the OpenAI-compatible API. Default is 'gpt-5.6-terra', "
             "which is not audio-capable; --stt none requires an explicitly selected audio-input model."
         },
     )

--- a/tests/install_smoke.py
+++ b/tests/install_smoke.py
@@ -121,7 +121,7 @@ def _validate_package_defaults() -> None:
     assert module_args.log_level == "info"
     assert module_args.enable_live_transcription is True
     assert module_args.live_transcription_update_interval == 0.5
-    assert responses_api_args.model_name == "gpt-5.4-mini"
+    assert responses_api_args.model_name == "gpt-5.6-terra"
     assert responses_api_args.responses_api_stream is True
     assert qwen3_args.qwen3_tts_model_name == "Qwen/Qwen3-TTS-12Hz-1.7B-CustomVoice"
     assert qwen3_args.qwen3_tts_speaker == "Aiden"

--- a/tests/install_smoke.py
+++ b/tests/install_smoke.py
@@ -123,6 +123,7 @@ def _validate_package_defaults() -> None:
     assert module_args.live_transcription_update_interval == 0.5
     assert responses_api_args.model_name == "gpt-5.6-terra"
     assert responses_api_args.responses_api_stream is True
+    assert responses_api_args.responses_api_reasoning_effort == "none"
     assert qwen3_args.qwen3_tts_model_name == "Qwen/Qwen3-TTS-12Hz-1.7B-CustomVoice"
     assert qwen3_args.qwen3_tts_speaker == "Aiden"
     assert qwen3_args.qwen3_tts_language == "auto"

--- a/tests/test_cli_defaults.py
+++ b/tests/test_cli_defaults.py
@@ -44,6 +44,7 @@ def test_release_defaults_match_responses_api_parakeet_qwen3_profile():
     assert responses_api_args.model_name == "gpt-5.6-terra"
     assert responses_api_args.chat_size == 30
     assert responses_api_args.responses_api_stream is True
+    assert responses_api_args.responses_api_reasoning_effort == "none"
     assert responses_api_args.responses_api_audio_content_type == "input_audio"
     assert responses_api_args.responses_api_audio_history_turns == 1
     assert qwen3_args.qwen3_tts_model_name == "Qwen/Qwen3-TTS-12Hz-1.7B-CustomVoice"
@@ -166,6 +167,7 @@ def test_parse_arguments_default_backend_returns_openai_api():
     assert args.llm_backend.name == "responses-api"
     assert args.llm_backend.spec.config_type is ResponsesApiLanguageModelHandlerArguments
     assert args.llm_backend.config["model_name"] == "gpt-5.6-terra"
+    assert args.llm_backend.config["reasoning_effort"] == "none"
     assert args.module_kwargs.llm_backend == "responses-api"
     assert args.vad_handler_kwargs.smart_turn is True
     assert args.vad_handler_kwargs.smart_turn_model_path is None

--- a/tests/test_cli_defaults.py
+++ b/tests/test_cli_defaults.py
@@ -41,7 +41,7 @@ def test_release_defaults_match_responses_api_parakeet_qwen3_profile():
     assert vad_args.min_speech_continuation_ms == 192
     assert vad_args.realtime_processing_pause == 0.5
     assert vad_args.smart_turn is True
-    assert responses_api_args.model_name == "gpt-5.4-mini"
+    assert responses_api_args.model_name == "gpt-5.6-terra"
     assert responses_api_args.chat_size == 30
     assert responses_api_args.responses_api_stream is True
     assert responses_api_args.responses_api_audio_content_type == "input_audio"
@@ -165,7 +165,7 @@ def test_parse_arguments_default_backend_returns_openai_api():
     assert isinstance(args.module_kwargs, ModuleArguments)
     assert args.llm_backend.name == "responses-api"
     assert args.llm_backend.spec.config_type is ResponsesApiLanguageModelHandlerArguments
-    assert args.llm_backend.config["model_name"] == "gpt-5.4-mini"
+    assert args.llm_backend.config["model_name"] == "gpt-5.6-terra"
     assert args.module_kwargs.llm_backend == "responses-api"
     assert args.vad_handler_kwargs.smart_turn is True
     assert args.vad_handler_kwargs.smart_turn_model_path is None

--- a/tests/test_responses_api_language_model.py
+++ b/tests/test_responses_api_language_model.py
@@ -137,7 +137,7 @@ def _chat_tool_delta(index, *, tool_id=None, name=None, arguments=None):
     )
 
 
-def _make_handler(*, disable_thinking=False, stream=True, cancel_scope=None):
+def _make_handler(*, disable_thinking=False, stream=True, cancel_scope=None, reasoning_effort="none"):
     handler = object.__new__(ResponsesApiModelHandler)
     handler.model_name = "test-model"
     handler.stream = stream
@@ -146,7 +146,12 @@ def _make_handler(*, disable_thinking=False, stream=True, cancel_scope=None):
     handler.request_timeout_s = 20.0
     handler.request_timeout = 20.0
     handler.disable_thinking = disable_thinking
-    handler._extra_body = {"chat_template_kwargs": {"enable_thinking": False}} if disable_thinking else None
+    handler.reasoning_effort = reasoning_effort
+    handler._extra_body = ResponsesApiModelHandler._build_extra_body(
+        "http://fake/v1",
+        disable_thinking,
+        reasoning_effort,
+    )
     handler.user_role = "user"
     handler.cancel_scope = cancel_scope
     handler.speculative_turns = None
@@ -470,6 +475,21 @@ def test_warmup_uses_request_scoped_sdk_retries():
 
     handler.client.with_options.assert_called_once_with(max_retries=WARMUP_MAX_RETRIES)
     handler.client.responses.create.assert_called_once()
+    assert handler.client.responses.create.call_args.kwargs["reasoning"] == {"effort": "none"}
+
+
+def test_compaction_uses_responses_reasoning_shape():
+    handler = _make_handler()
+    captured = {}
+
+    def fake_create(**kwargs):
+        captured.update(kwargs)
+        return SimpleNamespace(output_text="summary")
+
+    handler.client = SimpleNamespace(responses=SimpleNamespace(create=fake_create))
+
+    assert handler._build_compaction_generate_fn()("system", "user") == "summary"
+    assert captured["reasoning"] == {"effort": "none"}
 
 
 def test_warmup_failure_propagates_and_prevents_readiness():
@@ -1098,7 +1118,7 @@ def test_empty_context_fails_with_clear_message_without_calling_provider():
 
 
 def test_disable_thinking_passes_extra_body():
-    handler = _make_handler(disable_thinking=True)
+    handler = _make_handler(disable_thinking=True, reasoning_effort=None)
     captured = {}
 
     def fake_create(**kwargs):
@@ -1135,6 +1155,36 @@ def test_no_disable_thinking_omits_extra_body():
     list(handler.process(_make_request("Hi")))
 
     assert captured.get("extra_body") is None
+    assert captured["reasoning"] == {"effort": "none"}
+
+
+def test_responses_reasoning_omitted_when_unset():
+    handler = _make_handler(reasoning_effort=None)
+    captured = {}
+
+    def fake_create(**kwargs):
+        captured.update(kwargs)
+        return _make_stream(
+            [
+                _make_text_delta_event("Ok"),
+                _make_output_item_done_event(content="Ok"),
+            ]
+        )
+
+    handler.client = SimpleNamespace(responses=SimpleNamespace(create=fake_create))
+
+    list(handler.process(_make_request("Hi")))
+
+    assert "reasoning" not in captured
+
+
+def test_responses_extra_body_uses_provider_fallback_only_without_reasoning_effort():
+    build_extra_body = ResponsesApiModelHandler._build_extra_body
+
+    assert build_extra_body(None, True, "none") is None
+    assert build_extra_body("https://api.openai.com/v1", True, "none") is None
+    assert build_extra_body("http://provider/v1", True, "none") is None
+    assert build_extra_body("http://provider/v1", True, None) == {"chat_template_kwargs": {"enable_thinking": False}}
 
 
 def test_second_turn_flattens_assistant_history_for_responses():


### PR DESCRIPTION
## Summary

- change the default OpenAI model from `gpt-5.4-mini` to `gpt-5.6-terra`
- keep the Responses API as the default backend
- explicitly send Responses reasoning as `reasoning: {effort: "none"}` to preserve the previous default latency behavior
- leave Chat Completions reasoning defaults unchanged for compatible providers
- update CLI defaults, smoke assertions, examples, and model documentation links
- track reasoning-item preservation during tool continuations separately in #519

## Testing

- `uv run pytest tests/ -x -q` (1,224 passed, 1 skipped)
- `uv run mypy src/`
- `uv run ruff check src/ tests/`
- `uv run ruff format --check src/ tests/`