### PR TITLE
Clarify local tool-module commands

### DIFF
--- a/src/speech_to_speech/api/openai_realtime/README.md
+++ b/src/speech_to_speech/api/openai_realtime/README.md
@@ -222,8 +222,8 @@ async def execute_tool(name, arguments):
 Make the module importable, then opt in from either packaged CLI:
 
 ```bash
-speech-to-speech talk --tool-module my_voice_tools --url ws://127.0.0.1:8765/v1/realtime
-speech-to-speech local --tool-module my_voice_tools
+uv run python -m speech_to_speech.cli talk --tool-module my_voice_tools --url ws://127.0.0.1:8765/v1/realtime
+uv run python -m speech_to_speech.cli local --tool-module my_voice_tools
 ```
 
 For the included Google search example, get an API key from [serper.dev](https://serper.dev/) and export it:


### PR DESCRIPTION
## Summary

- invoke both packaged `my_voice_tools` examples through `python -m speech_to_speech.cli`
- keep current-directory tool modules importable without changing runtime module discovery

Closes #520

## Verification

- reproduced the console-entry-point `ModuleNotFoundError` and confirmed the module invocation imports the same current-directory module
- `uv run --no-sync pytest -q tests/test_cli_defaults.py -k tool_module` (4 passed)
- `uv run --no-sync pytest tests/ -x -q` (1252 passed, 1 skipped)
- `uv run --no-sync ruff check src/ tests/`
- `uv run --no-sync ruff format --check src/ tests/`
- `uv run --no-sync mypy src/`
- `uv build` and `twine check --strict`