### PR TITLE
Preserve chat turn order during non-interrupting back-to-back speech

### DIFF
--- a/src/speech_to_speech/LLM/base_openai_compatible_language_model.py
+++ b/src/speech_to_speech/LLM/base_openai_compatible_language_model.py
@@ -121,6 +121,9 @@ class _Turn(BaseModel):
     wants_audio: bool
     response_key: str
     prefetch_transaction: ResponsePrefetchTransaction | None = None
+    # End of the conversation when this turn started; keeps its output ahead of
+    # user messages appended while the model was still running.
+    history_anchor_id: str | None = None
 
 
 class _GenState(BaseModel):
@@ -563,6 +566,7 @@ class BaseOpenAICompatibleHandler(BaseHandler[LLMIn, LLMOut], ABC):
             recorded_items = chat.add_provisional_generation_items(
                 turn.response_key,
                 [*state.pending, fc_item],
+                after_item_id=turn.history_anchor_id,
             )
             state.pending.clear()
             if recorded_items is None:
@@ -848,6 +852,7 @@ class BaseOpenAICompatibleHandler(BaseHandler[LLMIn, LLMOut], ABC):
                             committed_item_ids=(
                                 {transactional_user_message_id} if transactional_user_message_id is not None else None
                             ),
+                            after_item_id=turn.history_anchor_id,
                         )
                         if recorded_items is None:
                             can_commit = False
@@ -930,6 +935,7 @@ class BaseOpenAICompatibleHandler(BaseHandler[LLMIn, LLMOut], ABC):
             return
 
         original_chat = runtime_config.chat
+        history_anchor_id: str | None = None
         if not is_out_of_band(response) and original_chat.has_pending_tool_calls():
             yield EndOfResponse(
                 turn_id=turn_id,
@@ -996,6 +1002,9 @@ class BaseOpenAICompatibleHandler(BaseHandler[LLMIn, LLMOut], ABC):
                 return
             assert provisional_message.id is not None
             transactional_user_message_id = provisional_message.id
+            # This turn writes its own user message, so anchor its output after
+            # that message: speech arriving later must not overtake it.
+            history_anchor_id = transactional_user_message_id
 
             def commit_audio_history() -> None:
                 original_chat.compact_audio_history(self.audio_history_turns)
@@ -1016,6 +1025,7 @@ class BaseOpenAICompatibleHandler(BaseHandler[LLMIn, LLMOut], ABC):
             wants_audio=wants_audio,
             response_key=request.response_key,
             prefetch_transaction=request.prefetch_transaction,
+            history_anchor_id=history_anchor_id,
         )
         yield from self._generate(
             active_chat,
@@ -1052,6 +1062,7 @@ class BaseOpenAICompatibleHandler(BaseHandler[LLMIn, LLMOut], ABC):
             return
 
         original_chat = runtime_config.chat
+        history_anchor_id = original_chat.history_anchor_id()
         if not is_out_of_band(response) and original_chat.has_pending_tool_calls():
             yield EndOfResponse(
                 turn_id=turn_id,
@@ -1110,6 +1121,7 @@ class BaseOpenAICompatibleHandler(BaseHandler[LLMIn, LLMOut], ABC):
             wants_audio=wants_audio,
             response_key=request.response_key,
             prefetch_transaction=request.prefetch_transaction,
+            history_anchor_id=history_anchor_id,
         )
         yield from self._generate(active_chat, original_chat, turn, optional_kwargs)
 

--- a/src/speech_to_speech/LLM/chat.py
+++ b/src/speech_to_speech/LLM/chat.py
@@ -45,6 +45,11 @@ logger = logging.getLogger(__name__)
 
 AUDIO_INPUT_HISTORY_PLACEHOLDER = "[User audio input]"
 
+# Anchor returned by :meth:`Chat.history_anchor_id` for an empty conversation,
+# so a generation that starts from empty history is still written before user
+# messages that arrive while it runs.
+HISTORY_START_ANCHOR = "__history_start__"
+
 
 class ChatItemError(Exception):
     """Raised when a conversation item fails validation in :meth:`Chat.add_item`."""
@@ -213,7 +218,58 @@ class Chat:
         with self._lock:
             self.init_chat_message = message
 
-    def _add_item_locked(self, item: SupportedItem, *, ordered_function_call: bool = False) -> SupportedItem:
+    def history_anchor_id(self) -> str | None:
+        """Anchor identifying the current end of the conversation.
+
+        A generation captures this before it starts so its output can later be
+        written back at its own turn position instead of after user messages
+        that arrived while it was still running. ``None`` means the tail cannot
+        be anchored, in which case callers fall back to appending.
+        """
+
+        with self._lock:
+            if not self.buffer:
+                return HISTORY_START_ANCHOR
+            return self.buffer[-1].id
+
+    def _turn_insertion_index_locked(self, after_item_id: str | None) -> int | None:
+        """Buffer index just past the turn anchored at *after_item_id*.
+
+        ``None`` means "append at the end": either the caller passed no anchor,
+        or the anchor is gone (evicted, compacted, or rolled back) and its turn
+        position can no longer be recovered.
+        """
+
+        if after_item_id is None:
+            return None
+        if after_item_id == HISTORY_START_ANCHOR:
+            cursor = 0
+        else:
+            anchor = next((index for index, item in enumerate(self.buffer) if item.id == after_item_id), None)
+            if anchor is None:
+                return None
+            cursor = anchor + 1
+        # Items already written for this same turn stay before the next user
+        # message, which by definition opens a later turn.
+        while cursor < len(self.buffer) and not isinstance(self.buffer[cursor], RealtimeConversationItemUserMessage):
+            cursor += 1
+        return cursor
+
+    def _place_locked(self, item: SupportedItem, insert_at: int | None) -> None:
+        """Append *item*, or splice it back into its own turn at *insert_at*."""
+
+        if insert_at is None:
+            self.buffer.append(item)
+        else:
+            self.buffer.insert(insert_at, item)
+
+    def _add_item_locked(
+        self,
+        item: SupportedItem,
+        *,
+        ordered_function_call: bool = False,
+        insert_at: int | None = None,
+    ) -> SupportedItem:
         """Body of :meth:`add_item`; caller holds ``_lock``."""
 
         if isinstance(item, RealtimeConversationItemSystemMessage):
@@ -234,7 +290,7 @@ class Chat:
                 raise ChatItemError(
                     "Message has no supported content. Supported modalities: input_text, input_image, input_audio."
                 )
-            self.buffer.append(item)
+            self._place_locked(item, insert_at)
             self._user_turn_count += 1
             logger.debug("Added user message to chat (%d parts)", len(item.content))
 
@@ -243,14 +299,14 @@ class Chat:
             item.content = [part for part in item.content if part.type == "output_text" and part.text]
             if not item.content:
                 return item
-            self.buffer.append(item)
+            self._place_locked(item, insert_at)
             logger.debug("Added assistant message to chat (%d parts)", len(item.content))
 
         elif isinstance(item, RealtimeConversationItemFunctionCall):
             item.id = _ensure_id(item.id, "fc")
             item.call_id = _ensure_id(item.call_id, "call")
             if ordered_function_call:
-                self.buffer.append(item)
+                self._place_locked(item, insert_at)
                 self._ordered_pending_call_ids.add(item.call_id)
             self._pending_tool_calls[item.call_id] = item
             logger.debug("Added function_call to chat (call_id=%s)", item.call_id)
@@ -274,8 +330,12 @@ class Chat:
 
         return item
 
-    def add_item(self, item: SupportedItem) -> SupportedItem:
+    def add_item(self, item: SupportedItem, *, after_item_id: str | None = None) -> SupportedItem:
         """Validate and route a conversation item into the chat buffer.
+
+        ``after_item_id`` is a :meth:`history_anchor_id` anchor: the item is
+        spliced back into that turn instead of being appended after user
+        messages that arrived in the meantime.
 
         Does not enforce the soft size limit — call :meth:`trim_if_needed`
         explicitly after each successful generation to evict or compact old
@@ -286,14 +346,18 @@ class Chat:
         Raises :class:`ChatItemError` if the item fails validation.
         """
         with self._lock:
-            return self._add_item_locked(item)
+            return self._add_item_locked(item, insert_at=self._turn_insertion_index_locked(after_item_id))
 
     def add_ordered_function_call(
-        self, item: RealtimeConversationItemFunctionCall
+        self, item: RealtimeConversationItemFunctionCall, *, after_item_id: str | None = None
     ) -> RealtimeConversationItemFunctionCall:
         """Stage a local-model call at its emitted position until its output arrives."""
         with self._lock:
-            recorded = self._add_item_locked(item, ordered_function_call=True)
+            recorded = self._add_item_locked(
+                item,
+                ordered_function_call=True,
+                insert_at=self._turn_insertion_index_locked(after_item_id),
+            )
             assert isinstance(recorded, RealtimeConversationItemFunctionCall)
             return recorded
 
@@ -382,6 +446,7 @@ class Chat:
         items: Sequence[SupportedItem],
         *,
         committed_item_ids: set[str] | None = None,
+        after_item_id: str | None = None,
     ) -> list[SupportedItem] | None:
         """Atomically write and track items exposed by an active response.
 
@@ -401,6 +466,7 @@ class Chat:
             recorded_items: list[SupportedItem] = []
             item_ids: set[str] = set()
             call_ids: set[str] = set()
+            anchor_id = after_item_id
             try:
                 for item in items:
                     if not isinstance(
@@ -412,10 +478,17 @@ class Chat:
                         ),
                     ):
                         raise ChatItemError(f"Unsupported provisional item type: {getattr(item, 'type', None)}")
+                    buffered_before = len(self.buffer)
                     recorded = self._add_item_locked(
                         item,
                         ordered_function_call=isinstance(item, RealtimeConversationItemFunctionCall),
+                        insert_at=self._turn_insertion_index_locked(anchor_id),
                     )
+                    # Keep the batch in emission order: the next item anchors on
+                    # the one just written, re-resolved so an eviction triggered
+                    # by this write cannot leave a stale index behind.
+                    if len(self.buffer) > buffered_before and recorded.id is not None:
+                        anchor_id = recorded.id
                     if isinstance(recorded, RealtimeConversationItemAssistantMessage) and not recorded.content:
                         continue
                     recorded_items.append(recorded)
@@ -516,6 +589,32 @@ class Chat:
                         replacement_added = True
                 item.content = compacted
 
+    def _drop_unpaired_ordered_turns_locked(self, items: Sequence[SupportedItem]) -> list[SupportedItem]:
+        """Drop each unpaired ordered call and the rest of the turn it opened.
+
+        A local model can emit text after a tool call in the same response, and
+        that text is meaningless to a provider until the call has an output. So
+        everything from such a call up to the next user message is omitted --
+        but later turns, which a non-interrupting speaker may have appended
+        while the call was still unpaired, stay in the snapshot.
+
+        Runs on the output of :meth:`_with_adjacent_tool_outputs` so a result
+        that arrived after the unpaired call has already been moved next to the
+        call it completes, instead of being skipped with the unpaired turn.
+        """
+        kept: list[SupportedItem] = []
+        skipping = False
+        for item in items:
+            if isinstance(item, RealtimeConversationItemUserMessage):
+                skipping = False
+            elif isinstance(item, RealtimeConversationItemFunctionCall) and item.call_id in (
+                self._ordered_pending_call_ids
+            ):
+                skipping = True
+            if not skipping:
+                kept.append(item)
+        return kept
+
     @staticmethod
     def _with_adjacent_tool_outputs(items: Sequence[SupportedItem]) -> list[SupportedItem]:
         """Return a backend-safe snapshot without rewriting canonical chronology."""
@@ -549,7 +648,7 @@ class Chat:
 
     def _to_responses_api_chat_locked(self, items: list[SupportedItem]) -> ResponseInputParam:
         """Body of :meth:`to_responses_api_chat`. Caller must hold ``_lock``."""
-        buffer_items = self._with_adjacent_tool_outputs(items)
+        buffer_items = self._drop_unpaired_ordered_turns_locked(self._with_adjacent_tool_outputs(items))
         result: list[ResponseInputItemParam] = []
         if self.init_chat_message:
             result.append(
@@ -599,8 +698,6 @@ class Chat:
                     )
             elif isinstance(item, RealtimeConversationItemFunctionCall) and item.call_id is not None:
                 if item.call_id in self._pending_tool_calls:
-                    if item.call_id in self._ordered_pending_call_ids:
-                        break
                     continue
                 assert item.call_id is not None and item.call_id != ""
                 function_call = ResponseFunctionToolCallParam(
@@ -640,7 +737,7 @@ class Chat:
             if self.init_chat_message:
                 text = " ".join(p.text for p in self.init_chat_message.content if p.text)
                 messages.append(TransformersSystemMessage(content=text))
-            for item in self._with_adjacent_tool_outputs(self.buffer):
+            for item in self._drop_unpaired_ordered_turns_locked(self._with_adjacent_tool_outputs(self.buffer)):
                 if isinstance(item, RealtimeConversationItemUserMessage):
                     has_media = any(p.type in {"input_image", "input_audio"} for p in item.content)
                     if has_media:
@@ -655,8 +752,6 @@ class Chat:
                     messages.append(TransformersAssistantMessage(content=text))
                 elif isinstance(item, RealtimeConversationItemFunctionCall):
                     if item.call_id in self._pending_tool_calls:
-                        if item.call_id in self._ordered_pending_call_ids:
-                            break
                         continue
                     assert item.call_id is not None and item.call_id != ""
                     args: Any = item.arguments

--- a/src/speech_to_speech/LLM/language_model.py
+++ b/src/speech_to_speech/LLM/language_model.py
@@ -419,6 +419,7 @@ class BaseLanguageModelHandler(BaseHandler[LLMIn, LLMOut], ABC):
         response_key: str | None = None,
         recorded_item_ids: set[str] | None = None,
         recorded_call_ids: set[str] | None = None,
+        after_item_id: str | None = None,
     ) -> bool:
         """Persist exactly the ordered text/tool stream emitted to the client."""
         text_parts: list[str] = []
@@ -452,16 +453,16 @@ class BaseLanguageModelHandler(BaseHandler[LLMIn, LLMOut], ABC):
         flush_text()
 
         if response_key is not None:
-            recorded_items = chat.add_provisional_generation_items(response_key, items)
+            recorded_items = chat.add_provisional_generation_items(response_key, items, after_item_id=after_item_id)
             if recorded_items is None:
                 return False
         else:
             recorded_items = []
             for item in items:
                 if isinstance(item, RealtimeConversationItemFunctionCall):
-                    recorded_items.append(chat.add_ordered_function_call(item))
+                    recorded_items.append(chat.add_ordered_function_call(item, after_item_id=after_item_id))
                 else:
-                    recorded_items.append(chat.add_item(item))
+                    recorded_items.append(chat.add_item(item, after_item_id=after_item_id))
         for recorded in recorded_items:
             if recorded_item_ids is not None and recorded.id is not None:
                 recorded_item_ids.add(recorded.id)
@@ -589,6 +590,10 @@ class BaseLanguageModelHandler(BaseHandler[LLMIn, LLMOut], ABC):
         response = request.response
         original_chat = runtime_config.chat
         out_of_band = is_out_of_band(response)
+        # Snapshot the end of the conversation before generating so this turn's
+        # output is written back at its own position even when non-interrupting
+        # speech appends a newer user message while the model is still running.
+        history_anchor_id = original_chat.history_anchor_id()
         if not out_of_band and original_chat.has_pending_tool_calls():
             yield EndOfResponse(
                 turn_id=ctx.turn_id,
@@ -668,6 +673,7 @@ class BaseLanguageModelHandler(BaseHandler[LLMIn, LLMOut], ABC):
                         response_key=request.response_key,
                         recorded_item_ids=ctx.recorded_item_ids,
                         recorded_call_ids=ctx.recorded_call_ids,
+                        after_item_id=history_anchor_id,
                     )
                     if not recorded:
                         ctx.cancelled = True
@@ -706,6 +712,7 @@ class BaseLanguageModelHandler(BaseHandler[LLMIn, LLMOut], ABC):
                     response_key=request.response_key,
                     recorded_item_ids=ctx.recorded_item_ids,
                     recorded_call_ids=ctx.recorded_call_ids,
+                    after_item_id=history_anchor_id,
                 )
                 if commit_allowed:
                     ctx.history_parts_committed = len(ctx.output_parts)

--- a/tests/test_chat.py
+++ b/tests/test_chat.py
@@ -1543,3 +1543,130 @@ class TestBuildActiveChat:
 
         with pytest.raises(ChatItemError):
             build_active_chat(original, resp)
+
+
+# ===================================================================
+# Turn ordering under overlapping (non-interrupting) speech
+# ===================================================================
+
+
+def _texts(chat: Chat) -> list[str]:
+    return [part.text for item in chat.buffer for part in getattr(item, "content", []) if part.text]
+
+
+class TestTurnOrdering:
+    def test_generation_output_stays_ahead_of_speech_that_arrived_meanwhile(self):
+        chat = Chat(size=5)
+        chat.add_item(_user("A"))
+        anchor = chat.history_anchor_id()
+        chat.add_item(_user("B"))
+
+        recorded = chat.add_provisional_generation_items("response-a", [_assistant("answer A")], after_item_id=anchor)
+
+        assert recorded is not None
+        assert _texts(chat) == ["A", "answer A", "B"]
+
+    def test_multi_item_generation_keeps_its_own_emission_order(self):
+        chat = Chat(size=5)
+        chat.add_item(_user("A"))
+        anchor = chat.history_anchor_id()
+        chat.add_item(_user("B"))
+
+        chat.add_provisional_generation_items(
+            "response-a",
+            [_assistant("first"), _fc("call_a"), _assistant("second")],
+            after_item_id=anchor,
+        )
+
+        assert [item.type for item in chat.buffer] == [
+            "message",
+            "message",
+            "function_call",
+            "message",
+            "message",
+        ]
+        assert _texts(chat) == ["A", "first", "second", "B"]
+
+    def test_generation_started_on_empty_history_precedes_later_speech(self):
+        chat = Chat(size=5)
+        anchor = chat.history_anchor_id()
+        chat.add_item(_user("B"))
+
+        chat.add_item(_assistant("out of the blue"), after_item_id=anchor)
+
+        assert _texts(chat) == ["out of the blue", "B"]
+
+    def test_output_is_appended_when_its_anchor_turn_is_gone(self):
+        chat = Chat(size=5)
+        user_a = chat.add_item(_user("A"))
+        anchor = chat.history_anchor_id()
+        chat.add_item(_user("B"))
+        assert user_a.id is not None
+        assert chat.remove_user_message(user_a.id)
+
+        chat.add_item(_assistant("answer A"), after_item_id=anchor)
+
+        assert _texts(chat) == ["B", "answer A"]
+
+    def test_ordered_function_call_is_placed_in_its_own_turn(self):
+        chat = Chat(size=5)
+        chat.add_item(_user("A"))
+        anchor = chat.history_anchor_id()
+        chat.add_item(_user("B"))
+
+        chat.add_ordered_function_call(_fc("call_a"), after_item_id=anchor)
+
+        assert [item.type for item in chat.buffer] == ["message", "function_call", "message"]
+
+    def test_unpaired_ordered_call_hides_its_own_turn_but_not_later_speech(self):
+        chat = Chat(size=5)
+        chat.add_item(_user("A"))
+        anchor = chat.history_anchor_id()
+        chat.add_item(_user("B"))
+
+        chat.add_provisional_generation_items(
+            "response-a",
+            [_assistant("before the call"), _fc("call_a"), _assistant("after the call")],
+            after_item_id=anchor,
+        )
+
+        # The unpaired call and the text emitted after it are not serializable
+        # yet, but the newer user turn still has to reach the provider.
+        assert [(item["role"], item["content"][0]["text"]) for item in chat.to_responses_api_chat()] == [
+            ("user", "A"),
+            ("assistant", "before the call"),
+            ("user", "B"),
+        ]
+        assert [(item["role"], item["content"]) for item in chat.to_transformers_chat()] == [
+            ("user", "A"),
+            ("assistant", "before the call"),
+            ("user", "B"),
+        ]
+
+    def test_paired_call_is_serialized_once_its_output_arrives_after_later_speech(self):
+        chat = Chat(size=5)
+        chat.add_item(_user("A"))
+        anchor = chat.history_anchor_id()
+        chat.add_item(_user("B"))
+        chat.add_provisional_generation_items("response-a", [_fc("call_a")], after_item_id=anchor)
+
+        chat.add_item(_fco("call_a", output="result"))
+
+        assert [item["type"] for item in chat.to_responses_api_chat()] == [
+            "message",
+            "function_call",
+            "function_call_output",
+            "message",
+        ]
+
+    def test_second_commit_of_a_turn_follows_the_items_it_already_wrote(self):
+        chat = Chat(size=5)
+        chat.add_item(_user("A"))
+        anchor = chat.history_anchor_id()
+        chat.add_provisional_generation_items("response-a", [_assistant("first")], after_item_id=anchor)
+        chat.add_item(_user("B"))
+
+        # Same stale anchor: the trailing commit must land after "first", not before it.
+        chat.add_provisional_generation_items("response-a", [_assistant("second")], after_item_id=anchor)
+
+        assert _texts(chat) == ["A", "first", "second", "B"]

--- a/tests/test_chat_turn_order.py
+++ b/tests/test_chat_turn_order.py
@@ -1,0 +1,104 @@
+"""Local language-model history ordering under overlapping speech.
+
+Covers the non-interrupting overlap described in issue #454: a second
+transcription can reach ``Chat`` while the first response is still being
+generated, and the first response must still land in its own turn.
+"""
+
+from __future__ import annotations
+
+from collections.abc import Iterator
+from typing import Any, Optional
+
+from openai.types.realtime import RealtimeSessionCreateRequest
+from openai.types.realtime.realtime_response_create_params import RealtimeResponseCreateParams
+from openai.types.responses import ResponseFunctionToolCall
+
+from speech_to_speech.api.openai_realtime.runtime_config import RuntimeConfig
+from speech_to_speech.LLM.chat import Chat, make_user_message
+from speech_to_speech.LLM.language_model import BaseLanguageModelHandler, StreamContext
+from speech_to_speech.pipeline.messages import (
+    AssistantTextPart,
+    AssistantToolCallPart,
+    GenerateResponseRequest,
+    LLMResponseChunk,
+)
+
+
+class _OverlappingSpeechHandler(BaseLanguageModelHandler):
+    """Local handler whose generation is overtaken by a newer user turn."""
+
+    def _load_model(
+        self,
+        model_name: str,
+        device: str,
+        torch_dtype: str,
+        gen_kwargs: dict[str, Any],
+    ) -> None:
+        pass
+
+    def _generate(
+        self,
+        chat: Chat,
+        language_code: Optional[str],
+        gen: int | None,
+        ctx: StreamContext,
+        runtime_config: RuntimeConfig | None = None,
+        response: RealtimeResponseCreateParams | None = None,
+    ) -> Iterator[LLMResponseChunk]:
+        assert runtime_config is not None
+        runtime_config.chat.add_item(make_user_message("B"))
+        yield LLMResponseChunk(text="answer A", runtime_config=runtime_config, response=response)
+
+
+def _make_handler() -> _OverlappingSpeechHandler:
+    handler = object.__new__(_OverlappingSpeechHandler)
+    handler.cancel_scope = None
+    handler.speculative_turns = None
+    handler.enable_lang_prompt = False
+    handler.compactor = None
+    handler.tokenizer = None
+    return handler
+
+
+def test_local_response_history_precedes_speech_that_arrived_during_generation():
+    chat = Chat(10)
+    chat.add_item(make_user_message("A"))
+    request = GenerateResponseRequest(
+        runtime_config=RuntimeConfig(
+            chat=chat,
+            session=RealtimeSessionCreateRequest(type="realtime", instructions="SESSION INSTRUCTIONS"),
+        )
+    )
+
+    list(_make_handler().process(request))
+
+    assert [part.text for item in chat.buffer for part in item.content if part.text] == ["A", "answer A", "B"]
+
+
+def test_keyless_commit_places_text_and_tool_calls_in_their_own_turn():
+    """Responses committed without a response key follow the same anchor."""
+    chat = Chat(10)
+    chat.add_item(make_user_message("A"))
+    anchor = chat.history_anchor_id()
+    chat.add_item(make_user_message("B"))
+
+    committed = BaseLanguageModelHandler._commit_ordered_output(
+        chat,
+        [
+            AssistantTextPart(text="answer A"),
+            AssistantToolCallPart(
+                tool=ResponseFunctionToolCall(
+                    type="function_call",
+                    call_id="call_a",
+                    name="camera",
+                    arguments="{}",
+                )
+            ),
+        ],
+        wants_audio=False,
+        after_item_id=anchor,
+    )
+
+    assert committed
+    assert [item.type for item in chat.buffer] == ["message", "message", "function_call", "message"]

--- a/tests/test_responses_api_language_model.py
+++ b/tests/test_responses_api_language_model.py
@@ -1681,3 +1681,30 @@ def test_out_of_band_invalid_input_emits_failed_end_of_response():
     assert isinstance(outputs[0], EndOfResponse)
     assert outputs[0].error is not None
     assert outputs[0].cancel_generation == scope.generation
+
+
+def test_response_history_precedes_speech_that_arrived_during_generation():
+    """Non-interrupting speech must not overtake the response it did not interrupt."""
+    handler = _make_handler(stream=False)
+    request = _make_request("A", chat_size=5)
+    chat = request.runtime_config.chat
+
+    def create(**kwargs):
+        chat.add_item(make_user_message("B"))
+        return _make_response(
+            [
+                ResponseOutputMessage(
+                    id="msg_a",
+                    type="message",
+                    role="assistant",
+                    status="completed",
+                    content=[ResponseOutputText(type="output_text", text="answer A", annotations=[])],
+                )
+            ]
+        )
+
+    handler.client = SimpleNamespace(responses=SimpleNamespace(create=create))
+
+    list(handler.process(request))
+
+    assert [part.text for item in chat.buffer for part in item.content if part.text] == ["A", "answer A", "B"]


### PR DESCRIPTION
## Summary

Fix #454 — the base ordering race.

When `interrupt_response=False`, a response committed its assistant history by
appending to the chat buffer. A transcription that landed while the model was
still running therefore ended up *ahead* of the answer it did not interrupt:

```text
user A -> user B -> assistant A
```

Each generation now snapshots a history anchor (`Chat.history_anchor_id()`)
before it starts and writes its output back into its own turn, so later user
turns are left untouched:

```text
user A -> assistant A -> user B
```

- `Chat` gained `history_anchor_id()` plus an `after_item_id=` argument on
  `add_item`, `add_ordered_function_call` and `add_provisional_generation_items`.
  Without that argument every call behaves exactly as before (plain append).
- Both generation paths capture the anchor before generating:
  `BaseLanguageModelHandler` (local models) and `BaseOpenAICompatibleHandler`
  (text and audio turns, including the mid-stream tool-call commit). The audio
  turn anchors on the user message it writes itself.
- If the anchor is gone (evicted, compacted, rolled back) the item is appended,
  i.e. today's behaviour.

Once an unpaired ordered function call can sit mid-buffer, the two serializers
needed a matching change: they used to `break` on such a call, which was
harmless only while it was always the last item. They now omit just the turn
that call opened, so a newer user turn still reaches the provider
(`_drop_unpaired_ordered_turns_locked`). Same output as before when the call is
at the tail.

The issue's second failure mode (compaction absorbing provisional output) is
already handled on `main`: `trim_if_needed` defers the compactor and
`_snapshot_for_compaction` bails out while `_provisional_generations` is
non-empty, covered by `TestCompaction::test_cancelled_provisional_history_is_not_compacted`.
Nothing was added for it.

Not covered here: the anchor is taken when the LLM thread picks a request up.
A request that waits in the queue behind an in-flight response can still be
anchored after a newer transcript. That is never worse than today, and closing
it means carrying the anchor on `GenerateResponseRequest` — happy to do that in
a follow-up if you'd prefer it in scope.

## Test verification (RED -> GREEN)

RED — the 11 new tests on unmodified `main` (only the tests applied, `src/` untouched):

```text
E       AssertionError: assert ['A', 'B', 'answer A'] == ['A', 'answer A', 'B']
E       AssertionError: assert ['A', 'B', 'answer A'] == ['A', 'answer A', 'B']
FAILED tests/test_chat_turn_order.py::test_local_response_history_precedes_speech_that_arrived_during_generation
FAILED tests/test_chat_turn_order.py::test_keyless_commit_places_text_and_tool_calls_in_their_own_turn
FAILED tests/test_chat.py::TestTurnOrdering::test_generation_output_stays_ahead_of_speech_that_arrived_meanwhile
FAILED tests/test_chat.py::TestTurnOrdering::test_multi_item_generation_keeps_its_own_emission_order
FAILED tests/test_chat.py::TestTurnOrdering::test_generation_started_on_empty_history_precedes_later_speech
FAILED tests/test_chat.py::TestTurnOrdering::test_output_is_appended_when_its_anchor_turn_is_gone
FAILED tests/test_chat.py::TestTurnOrdering::test_ordered_function_call_is_placed_in_its_own_turn
FAILED tests/test_chat.py::TestTurnOrdering::test_unpaired_ordered_call_hides_its_own_turn_but_not_later_speech
FAILED tests/test_chat.py::TestTurnOrdering::test_paired_call_is_serialized_once_its_output_arrives_after_later_speech
FAILED tests/test_chat.py::TestTurnOrdering::test_second_commit_of_a_turn_follows_the_items_it_already_wrote
FAILED tests/test_responses_api_language_model.py::test_response_history_precedes_speech_that_arrived_during_generation
11 failed in 7.61s
```

The two end-to-end tests show the reported symptom directly:

```text
E       AssertionError: assert ['A', 'B', 'answer A'] == ['A', 'answer A', 'B']
E         At index 1 diff: 'B' != 'answer A'
```

GREEN — same tests on this branch, and the full suite:

```text
=== ruff-check ===
All checks passed!
=== ruff-format ===
155 files already formatted
=== mypy ===
Success: no issues found in 96 source files
=== pytest ===
1263 passed, 1 skipped, 4 warnings in 59.05s
```

Baseline on `main` with the same commands: `1252 passed, 1 skipped`. No test
changed state; the 11 added tests account for the difference.

## Files changed

| File | Change |
|------|--------|
| `LLM/chat.py` | `history_anchor_id()`, turn-anchored insertion, unpaired-ordered-call serialization boundary |
| `LLM/language_model.py` | capture the anchor before generating, pass it through `_commit_ordered_output` |
| `LLM/base_openai_compatible_language_model.py` | same for the text and audio turns via `_Turn.history_anchor_id` |
| `tests/test_chat.py` | `TestTurnOrdering` — ordering, anchor fallback, serializer boundary |
| `tests/test_chat_turn_order.py` | local-model handler ordering end to end |
| `tests/test_responses_api_language_model.py` | OpenAI-compatible handler ordering end to end |
