### PR TITLE
Fix(TTS): strip the -auto suffix before mapping a language

### DIFF
--- a/src/speech_to_speech/TTS/facebookmms_handler.py
+++ b/src/speech_to_speech/TTS/facebookmms_handler.py
@@ -11,6 +11,7 @@ from rich.console import Console
 from transformers import AutoTokenizer, VitsModel
 
 from speech_to_speech.baseHandler import BaseHandler
+from speech_to_speech.LLM.utils import resolve_auto_language
 from speech_to_speech.pipeline.cancel_scope import CancelScope
 from speech_to_speech.pipeline.handler_types import TTSIn, TTSOut
 from speech_to_speech.pipeline.messages import AUDIO_RESPONSE_DONE, EndOfResponse
@@ -162,7 +163,9 @@ class FacebookMMSTTSHandler(BaseHandler[TTSIn, TTSOut]):
             speculative_turns.commit(tts_input.turn_id, tts_input.turn_revision)
 
         gen = self.cancel_scope.generation if self.cancel_scope else None
-        language_code = tts_input.language_code
+        # STT reports "de-auto" in auto-detect mode; WHISPER_LANGUAGE_TO_FACEBOOK_LANGUAGE is
+        # keyed on bare codes, so the suffix has to go before the lookup and the comparisons.
+        language_code, _ = resolve_auto_language(tts_input.language_code)
         text = tts_input.text
 
         console.print(f"[green]ASSISTANT: {text}")

--- a/src/speech_to_speech/TTS/kokoro_handler.py
+++ b/src/speech_to_speech/TTS/kokoro_handler.py
@@ -19,6 +19,7 @@ import numpy as np
 from rich.console import Console
 
 from speech_to_speech.baseHandler import BaseHandler
+from speech_to_speech.LLM.utils import resolve_auto_language
 from speech_to_speech.pipeline.cancel_scope import CancelScope
 from speech_to_speech.pipeline.handler_types import TTSIn, TTSOut
 from speech_to_speech.pipeline.messages import AUDIO_RESPONSE_DONE, EndOfResponse
@@ -261,7 +262,9 @@ class KokoroTTSHandler(BaseHandler[TTSIn, TTSOut]):
 
         runtime_config = tts_input.runtime_config
         response = tts_input.response
-        language_code = tts_input.language_code
+        # STT reports "de-auto" in auto-detect mode, but the language maps below are keyed
+        # on bare codes, so the suffix has to go before any lookup.
+        language_code, _ = resolve_auto_language(tts_input.language_code)
         text = tts_input.text
 
         voice: Optional[str] = None

--- a/tests/test_tts_auto_language_suffix.py
+++ b/tests/test_tts_auto_language_suffix.py
@@ -1,0 +1,156 @@
+"""TTS backends must strip the ``-auto`` suffix before mapping a language.
+
+With ``--language auto`` the STT handlers report ``"de-auto"`` rather than ``"de"``, so
+downstream code knows the language may change between turns. The TTS language maps are keyed
+on bare Whisper codes, so passing the suffixed value straight into a lookup never matches:
+
+* ``WHISPER_LANGUAGE_TO_KOKORO_LANG.get("de-auto", self.lang_code)`` returns the fallback, so
+  Kokoro silently keeps the startup voice and never switches language -- the exact feature
+  that code exists to provide.
+* ``WHISPER_LANGUAGE_TO_FACEBOOK_LANGUAGE["de-auto"]`` raises ``KeyError``, which MMS catches
+  and reports as "Unsupported language" before falling back to English -- for a language it
+  fully supports.
+
+Neither failure is loud: Kokoro's "Language change detected" line never fires, and MMS blames
+the language.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from speech_to_speech.pipeline.messages import TTSInput
+from speech_to_speech.TTS.facebookmms_handler import (
+    WHISPER_LANGUAGE_TO_FACEBOOK_LANGUAGE,
+    FacebookMMSTTSHandler,
+)
+from speech_to_speech.TTS.kokoro_handler import WHISPER_LANGUAGE_TO_KOKORO_LANG, KokoroTTSHandler
+
+
+def tts_input(language_code: str | None) -> TTSInput:
+    return TTSInput(text="Guten Tag.", language_code=language_code, turn_id="t1", turn_revision=0)
+
+
+# --- the maps only accept bare codes ------------------------------------------------------
+
+
+@pytest.mark.parametrize("code", ["de", "fr", "en"])
+def test_kokoro_map_is_keyed_on_bare_codes(code):
+    assert WHISPER_LANGUAGE_TO_KOKORO_LANG.get(code) is not None
+    assert WHISPER_LANGUAGE_TO_KOKORO_LANG.get(f"{code}-auto") is None
+
+
+def test_facebookmms_map_is_keyed_on_bare_codes():
+    assert WHISPER_LANGUAGE_TO_FACEBOOK_LANGUAGE["de"] == "deu"
+    with pytest.raises(KeyError):
+        WHISPER_LANGUAGE_TO_FACEBOOK_LANGUAGE["de-auto"]
+
+
+# --- Kokoro -------------------------------------------------------------------------------
+
+
+def _kokoro(monkeypatch, backend="kokoro"):
+    """A handler stubbed down to the language decision."""
+    handler = object.__new__(KokoroTTSHandler)
+    handler.backend = backend
+    handler.lang_code = "b"
+    handler.voice = "bm_fable"
+    handler.speculative_turns = None
+    handler.cancel_scope = None
+    seen: list[str | None] = []
+
+    def capture(text, language_code=None):
+        seen.append(language_code)
+        return iter(())
+
+    monkeypatch.setattr(handler, "_process_kokoro", capture, raising=False)
+    monkeypatch.setattr(handler, "_process_mlx", capture, raising=False)
+    return handler, seen
+
+
+@pytest.mark.parametrize("backend", ["kokoro", "mlx"])
+def test_kokoro_receives_a_bare_language_code(monkeypatch, backend):
+    handler, seen = _kokoro(monkeypatch, backend)
+
+    list(handler.process(tts_input("de-auto")))
+
+    assert seen == ["de"]
+    assert WHISPER_LANGUAGE_TO_KOKORO_LANG.get(seen[0]) == "b"
+
+
+def test_kokoro_pinned_language_is_unchanged(monkeypatch):
+    handler, seen = _kokoro(monkeypatch)
+
+    list(handler.process(tts_input("fr")))
+
+    assert seen == ["fr"]
+
+
+def test_kokoro_absent_language_stays_none(monkeypatch):
+    """None must survive: it means "no per-turn language", not "unknown language"."""
+    handler, seen = _kokoro(monkeypatch)
+
+    list(handler.process(tts_input(None)))
+
+    assert seen == [None]
+
+
+# --- Facebook MMS -------------------------------------------------------------------------
+
+
+def _mms(monkeypatch):
+    handler = object.__new__(FacebookMMSTTSHandler)
+    handler.speculative_turns = None
+    handler.cancel_scope = None
+    handler.language = "en"
+    handler.model_name = None
+    handler._initial_language = "en"
+    handler._initial_model_name = None
+    requested: list[str] = []
+
+    def load_model(language_code, model_name=None):
+        # Mirror the real lookup so a suffixed code still fails here.
+        WHISPER_LANGUAGE_TO_FACEBOOK_LANGUAGE[language_code]
+        requested.append(language_code)
+        handler.language = language_code
+
+    monkeypatch.setattr(handler, "load_model", load_model, raising=False)
+    monkeypatch.setattr(handler, "generate_audio", lambda text: None, raising=False)
+    return handler, requested
+
+
+def test_facebookmms_loads_the_model_for_an_auto_detected_language(monkeypatch, caplog):
+    handler, requested = _mms(monkeypatch)
+
+    list(handler.process(tts_input("de-auto")))
+
+    assert requested == ["de"]
+    assert "Unsupported language" not in caplog.text
+
+
+def test_facebookmms_pinned_language_is_unchanged(monkeypatch):
+    handler, requested = _mms(monkeypatch)
+
+    list(handler.process(tts_input("fr")))
+
+    assert requested == ["fr"]
+
+
+def test_facebookmms_skips_reload_when_language_already_matches(monkeypatch):
+    """ "de-auto" must compare equal to an already-loaded "de", not force a reload."""
+    handler, requested = _mms(monkeypatch)
+    handler.language = "de"
+
+    list(handler.process(tts_input("de-auto")))
+
+    assert requested == []
+
+
+def test_facebookmms_unsupported_language_still_warns(monkeypatch, caplog):
+    """Normalizing must not swallow the genuine unsupported case."""
+    handler, requested = _mms(monkeypatch)
+
+    list(handler.process(tts_input("xx-auto")))
+
+    assert requested == []
+    assert "Unsupported language" in caplog.text


### PR DESCRIPTION
## Problem

With `--language auto` the STT handlers report `"de-auto"` rather than `"de"`, so downstream code knows the language may change between turns. Both Kokoro and Facebook MMS pass that value straight into language maps keyed on **bare** Whisper codes, so the lookup never matches:

```python
>>> WHISPER_LANGUAGE_TO_KOKORO_LANG.get("de")          # 'b'
>>> WHISPER_LANGUAGE_TO_KOKORO_LANG.get("de-auto")     # None  -> falls back
>>> WHISPER_LANGUAGE_TO_FACEBOOK_LANGUAGE["de"]        # 'deu'
>>> WHISPER_LANGUAGE_TO_FACEBOOK_LANGUAGE["de-auto"]   # KeyError
```

- **Kokoro** silently keeps its startup voice and never switches language — the feature that code exists to provide. Its `"Language change detected"` log line never fires, so there's no signal that anything went wrong.
- **Facebook MMS** catches the `KeyError` and reports `"Unsupported language: de-auto"` before falling back to English — for a language it fully supports. The message blames the language rather than the suffix.

So `--language auto` with either backend speaks every language in the startup voice. `tests/test_facebookmms_language_map.py` (added in #420) already documents this failure mode — *"Wrong keys silently fall back to English in `load_model`"* — but only checks the map's keys, not the suffixed input.

## Fix

Both handlers normalize once where they read `tts_input.language_code`, via the existing `resolve_auto_language()` — the canonical implementation of this convention — so every comparison and lookup downstream sees a bare code.

Normalizing at the **read site** rather than at each lookup also fixes a second MMS bug: the reload guard compared `self.language != language_code`, so an already-loaded `"de"` looked different from an incoming `"de-auto"` and forced a redundant model reload every turn.

`None` is preserved, since it means "no per-turn language" rather than an unknown one.

Source diff is 8 lines across 2 files.

## Scope

`SupertonicTTSHandler` already strips the suffix in its own `_normalize_language_code`, so it's unaffected and I left it alone — it could adopt the shared helper later if you'd prefer one implementation. Also worth noting: this imports `resolve_auto_language` from `LLM/utils` into `TTS/`, which is a slightly odd direction. I reused it rather than duplicating a third normalizer, but I'm happy to move the helper somewhere neutral (e.g. alongside the pipeline messages that carry the convention) if you'd rather not have that import.

## Tests

`tests/test_tts_auto_language_suffix.py` drives both handlers' `process()` with a suffixed code and asserts the bare code reaches the language decision, that a pinned code and `None` pass through unchanged, that MMS no longer reloads when the language already matches, and that a genuinely unsupported language still warns (normalizing mustn't swallow the real case).

Three fail against current code. The MMS one fails with the symptom itself:

```
assert requested == ["de"]
E   AssertionError: assert [] == ['de']
WARNING  facebookmms_handler.py:186 Unsupported language: de-auto
```

Full suite: **1264 passed, 1 skipped**. `ruff check`, `ruff format --check`, `mypy src/` clean.
