### PR TITLE
Add OmniVoice TTS backend

### DIFF
--- a/README.md
+++ b/README.md
@@ -75,6 +75,7 @@ Clients using the implemented core Realtime event set can connect. The official 
 * [Realtime API](#realtime-api)
 * [LLM backends](#llm-backends)
 * [Multi-language support](#multi-language-support)
+* [OmniVoice](#omnivoice)
 * [Pocket TTS](#pocket-tts)
 * [CLI reference](#cli-reference)
 * [Contributing](#contributing)
@@ -139,6 +140,7 @@ Optional components are installed with pip extras:
 pip install "speech-to-speech[kokoro]"          # Kokoro-82M TTS on non-macOS
 pip install "speech-to-speech[pocket]"          # Pocket TTS
 pip install "speech-to-speech[chattts]"         # ChatTTS
+pip install "speech-to-speech[omnivoice]"       # OmniVoice TTS (Apple Silicon; see dependency note below)
 pip install "speech-to-speech[faster-whisper]"  # Faster Whisper STT
 pip install "speech-to-speech[whisper-mlx]"     # Lightning Whisper MLX STT on macOS
 pip install "speech-to-speech[paraformer]"      # Paraformer STT through FunASR
@@ -178,6 +180,7 @@ This installs the package in editable mode and makes the `speech-to-speech` CLI 
 | TTS | [Kokoro-82M](https://huggingface.co/hexgrad/Kokoro-82M) | CUDA / CPU, Apple Silicon | `kokoro` on non-macOS; built-in on macOS |
 | TTS | [Pocket TTS](https://github.com/kyutai-labs/pocket-tts) | CPU / CUDA | `pocket` |
 | TTS | [ChatTTS](https://github.com/2noise/ChatTTS) | CUDA / CPU | `chattts` |
+| TTS | [OmniVoice](https://huggingface.co/k2-fsa/OmniVoice) | Apple Silicon / MPS; upstream also supports CUDA and Intel XPU | `omnivoice` |
 | TTS | [MMS TTS](https://huggingface.co/docs/transformers/model_doc/mms) | CUDA / CPU | built-in |
 
 Select implementations with `--stt`, `--llm_backend`, and `--tts`. The CLI constructs configuration only for the selected backends; known options for inactive backends remain accepted for compatibility but are ignored with a warning. JSON configuration may likewise include extra inactive-backend keys, which are ignored. Run `speech-to-speech serve -h` for the defaults, or pass selectors before `-h` to see another combination's backend-specific flags (for example, `speech-to-speech serve --stt mlx-audio-whisper -h`).
@@ -254,7 +257,7 @@ This setting:
 
 The preset supplies these as defaults only: explicit `--device`, component-device flags such as `--qwen3_tts_device`, and `--stt`, `--llm_backend`, `--model_name`, and `--tts` all win. Use it with `serve` instead of `local` when you want to expose the server without starting the microphone/speaker client.
 
-`--tts pocket` and `--tts kokoro` are also valid on macOS.
+`--tts pocket`, `--tts kokoro`, and `--tts omnivoice` are also valid on macOS.
 
 To compare the MLX quantization variants locally:
 
@@ -556,6 +559,26 @@ speech-to-speech serve \
 ```
 
 Both commands also work with `--mac-optimal-settings`; explicit `--stt` flags override the defaults it sets.
+
+## OmniVoice
+
+OmniVoice provides voice cloning, voice design, and automatic voice selection across 600+ languages. Install its opt-in dependencies and provide a reference clip plus its transcript for voice cloning:
+
+```bash
+pip install "speech-to-speech[omnivoice]"
+speech-to-speech serve \
+    --tts omnivoice \
+    --omnivoice_device mps \
+    --omnivoice_ref_audio /path/to/reference.wav \
+    --omnivoice_ref_text "Transcript of the reference clip."
+```
+
+The handler converts OmniVoice's completed 24 kHz float output into the pipeline's 16 kHz `int16` blocks. OmniVoice does not currently expose incremental audio through `generate()`, so the first block is available only after the full utterance has been synthesized. See the [TTS component guide](./src/speech_to_speech/TTS/README.md#6-omnivoice---tts-omnivoice) for saved prompts, voice design, devices, latency, and all backend flags.
+
+The `omnivoice` extra currently resolves with this project's pinned dependencies on macOS. On Linux and Windows, OmniVoice requires Transformers 5 while the built-in Qwen3 dependency still requires Transformers 4; the combined extra is therefore not currently installable there. CUDA and Intel XPU remain upstream OmniVoice capabilities pending resolution of that dependency conflict.
+
+> [!WARNING]
+> OmniVoice's code is Apache-2.0, but its pretrained weights are CC-BY-NC and are not licensed for commercial use. Use voice cloning only with authorization and consent; do not use it for impersonation, fraud, scams, or other illegal or unethical activity.
 
 ## Pocket TTS
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -80,7 +80,7 @@ mlx-lm = [
     "mlx-vlm==0.4.1; platform_system == 'Darwin'",
 ]
 omnivoice = [
-    "omnivoice>=0.2.1",
+    "omnivoice>=0.2.1; platform_system == 'Darwin'",
 ]
 paraformer = [
     "funasr>=1.1.6",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -79,6 +79,9 @@ mlx-lm = [
     "mlx-lm==0.31.3; platform_system == 'Darwin'",
     "mlx-vlm==0.4.1; platform_system == 'Darwin'",
 ]
+omnivoice = [
+    "omnivoice>=0.2.1",
+]
 paraformer = [
     "funasr>=1.1.6",
     "modelscope>=1.17.1",

--- a/src/speech_to_speech/TTS/README.md
+++ b/src/speech_to_speech/TTS/README.md
@@ -8,6 +8,7 @@ Runtime-supported values in `s2s_pipeline.py`:
 - `facebookMMS` → `facebookmms_handler.py`
 - `pocket` → `pocket_tts_handler.py`
 - `kokoro` → `kokoro_handler.py`
+- `omnivoice` → `omnivoice_handler.py`
 - `qwen3` → `qwen3_tts_handler.py`
 - `supertonic` → `supertonic_tts_handler.py`
 
@@ -189,7 +190,50 @@ To benchmark the Apple Silicon MLX variants side by side:
 
 This will run separate benchmark entries for `qwen3[bf16]`, `qwen3[4bit]`, `qwen3[6bit]`, and `qwen3[8bit]`.
 
-### 6) Supertonic (`--tts supertonic`)
+### 6) OmniVoice (`--tts omnivoice`)
+
+Primary args prefix: `--omnivoice_*`
+
+Install the optional dependency and select a device supported by your PyTorch installation:
+
+```bash
+pip install "speech-to-speech[omnivoice]"
+speech-to-speech serve \
+  --tts omnivoice \
+  --omnivoice_model_name k2-fsa/OmniVoice \
+  --omnivoice_device mps \
+  --omnivoice_dtype float16 \
+  --omnivoice_ref_audio /voices/reference.wav \
+  --omnivoice_ref_text "Transcript of the reference clip."
+```
+
+The reference is encoded once during handler setup and the resulting voice-clone prompt is reused for every text chunk. To reuse an upstream `VoiceClonePrompt.save(...)` file without re-encoding the reference, replace the two reference flags with:
+
+```bash
+--omnivoice_voice_clone_prompt /voices/saved-prompt.pt
+```
+
+Voice design omits the cloning flags and supplies an instruction:
+
+```bash
+speech-to-speech serve \
+  --tts omnivoice \
+  --omnivoice_device mps \
+  --omnivoice_instruct "female, low pitch, British accent"
+```
+
+For auto voice, omit `--omnivoice_ref_audio`, `--omnivoice_voice_clone_prompt`, and `--omnivoice_instruct`. `--omnivoice_language` pins a language name or code; when it is unset, the handler forwards the language code carried by each pipeline utterance. `--omnivoice_num_steps` controls diffusion steps (32 by default), and `--omnivoice_speed` controls speaking rate.
+
+Supported upstream device values include CUDA (`cuda` or `cuda:0`), Apple Silicon (`mps`), and Intel GPU (`xpu`). Choose `float16`, `bfloat16`, or `float32` with `--omnivoice_dtype` according to device support.
+
+The `speech-to-speech[omnivoice]` dependency set currently resolves on macOS, where this project already pins Transformers 5. On Linux and Windows, the default `faster-qwen3-tts` dependency requires Transformers `<5` while OmniVoice 0.2.1 requires Transformers `>=5.3`; the combined extra is therefore not currently installable on those platforms. CUDA and Intel XPU are upstream OmniVoice capabilities but require that packaging conflict to be resolved before they can be supported by this extra. Intel XPU also requires the matching Intel PyTorch build.
+
+OmniVoice returns complete 24 kHz float arrays. This handler downsamples them to 16 kHz, clips to `int16`, and then emits fixed-size blocks. It is playback chunking rather than model streaming: upstream `generate()` is blocking, so time to first audio includes synthesis of the entire utterance, and an interruption during generation discards the result after the blocking call returns. Upstream reports real-time factors as low as 0.025 in its accelerated benchmarks, but actual latency depends on the device, dtype, diffusion-step count, and text length.
+
+> [!WARNING]
+> The [OmniVoice code](https://github.com/k2-fsa/OmniVoice) is Apache-2.0, but the [`k2-fsa/OmniVoice` pretrained weights](https://huggingface.co/k2-fsa/OmniVoice) are CC-BY-NC because of training-data constraints and are not licensed for commercial use. Voice cloning requires authorization and consent. Unauthorized cloning, impersonation, fraud, scams, and other illegal or unethical use are prohibited by the upstream model's safety notice.
+
+### 7) Supertonic (`--tts supertonic`)
 
 Primary args prefix: `--supertonic_tts_*`
 
@@ -230,4 +274,4 @@ speech-to-speech local \
   --mac-optimal-settings
 ```
 
-`--tts pocket` and `--tts kokoro` are also valid options on macOS.
+`--tts pocket`, `--tts kokoro`, and `--tts omnivoice` are also valid options on macOS.

--- a/src/speech_to_speech/TTS/omnivoice_handler.py
+++ b/src/speech_to_speech/TTS/omnivoice_handler.py
@@ -1,0 +1,178 @@
+from __future__ import annotations
+
+import logging
+from math import gcd
+from threading import Event
+from typing import Any, Iterator
+
+import numpy as np
+import scipy.signal
+from rich.console import Console
+
+from speech_to_speech.baseHandler import BaseHandler
+from speech_to_speech.pipeline.cancel_scope import CancelScope
+from speech_to_speech.pipeline.handler_types import TTSIn, TTSOut
+from speech_to_speech.pipeline.messages import AUDIO_RESPONSE_DONE, EndOfResponse
+from speech_to_speech.pipeline.speculative_turns import SpeculativeTurnTracker
+
+logger = logging.getLogger(__name__)
+console = Console()
+
+PIPELINE_SAMPLE_RATE = 16000
+
+
+class OmniVoiceTTSHandler(BaseHandler[TTSIn, TTSOut]):
+    def setup(
+        self,
+        should_listen: Event,
+        model_name: str = "k2-fsa/OmniVoice",
+        device: str = "auto",
+        dtype: str = "float16",
+        ref_audio: str | None = None,
+        ref_text: str | None = None,
+        voice_clone_prompt: str | None = None,
+        instruct: str | None = None,
+        language: str | None = None,
+        num_steps: int = 32,
+        speed: float = 1.0,
+        blocksize: int = 512,
+        gen_kwargs: dict[str, Any] | None = None,
+        cancel_scope: CancelScope | None = None,
+        speculative_turns: SpeculativeTurnTracker | None = None,
+    ) -> None:
+        if blocksize <= 0:
+            raise ValueError(f"blocksize must be positive, got {blocksize}")
+        if num_steps <= 0:
+            raise ValueError(f"num_steps must be positive, got {num_steps}")
+        if speed <= 0:
+            raise ValueError(f"speed must be positive, got {speed}")
+        if ref_audio is not None and not ref_text:
+            raise ValueError("ref_text is required when ref_audio is configured")
+        if ref_text is not None and ref_audio is None:
+            raise ValueError("ref_audio is required when ref_text is configured")
+        if voice_clone_prompt is not None and ref_audio is not None:
+            raise ValueError("voice_clone_prompt and ref_audio are mutually exclusive")
+        if instruct is not None and (voice_clone_prompt is not None or ref_audio is not None):
+            raise ValueError("instruct cannot be combined with voice-cloning configuration")
+
+        import torch
+        from omnivoice import OmniVoice, VoiceClonePrompt
+
+        torch_dtype = {
+            "float16": torch.float16,
+            "bfloat16": torch.bfloat16,
+            "float32": torch.float32,
+        }.get(dtype)
+        if torch_dtype is None:
+            raise ValueError(f"Unsupported OmniVoice dtype {dtype!r}; choose float16, bfloat16, or float32")
+
+        self.should_listen = should_listen
+        self.cancel_scope = cancel_scope
+        self.speculative_turns = speculative_turns
+        self.instruct = instruct
+        self.language = language
+        self.num_steps = num_steps
+        self.speed = speed
+        self.blocksize = blocksize
+
+        if device == "auto":
+            if torch.cuda.is_available():
+                device = "cuda"
+            elif hasattr(torch, "xpu") and torch.xpu.is_available():
+                device = "xpu"
+            elif torch.backends.mps.is_available():
+                device = "mps"
+            else:
+                device = "cpu"
+
+        logger.info("Loading OmniVoice model %r on %s", model_name, device)
+        self.model = OmniVoice.from_pretrained(model_name, device_map=device, dtype=torch_dtype)
+
+        self.voice_clone_prompt = None
+        if voice_clone_prompt is not None:
+            self.voice_clone_prompt = VoiceClonePrompt.load(voice_clone_prompt)
+            logger.info("Loaded OmniVoice clone prompt from %r", voice_clone_prompt)
+        elif ref_audio is not None:
+            self.voice_clone_prompt = self.model.create_voice_clone_prompt(ref_audio=ref_audio, ref_text=ref_text)
+            logger.info("Prepared OmniVoice clone prompt from %r", ref_audio)
+
+    def _is_cancelled(self, generation: int | None) -> bool:
+        return generation is not None and self.cancel_scope is not None and self.cancel_scope.is_stale(generation)
+
+    def process(self, tts_input: TTSIn) -> Iterator[TTSOut]:
+        speculative_turns = getattr(self, "speculative_turns", None)
+        if isinstance(tts_input, EndOfResponse):
+            if speculative_turns and not speculative_turns.is_latest_after_reopen_grace(
+                tts_input.turn_id, tts_input.turn_revision
+            ):
+                if tts_input.response_key is None:
+                    return
+                tts_input.cleanup_only = True
+            yield AUDIO_RESPONSE_DONE
+            return
+
+        if speculative_turns and not speculative_turns.is_latest_after_reopen_grace(
+            tts_input.turn_id, tts_input.turn_revision
+        ):
+            logger.debug(
+                "Dropping stale TTS input for turn=%s rev=%s",
+                tts_input.turn_id,
+                tts_input.turn_revision,
+            )
+            return
+        if speculative_turns:
+            speculative_turns.commit(tts_input.turn_id, tts_input.turn_revision)
+
+        text = tts_input.text
+        if not text.strip():
+            return
+
+        cancel_generation = self.cancel_scope.generation if self.cancel_scope else None
+        generation_kwargs: dict[str, Any] = {
+            "text": text,
+            "num_step": self.num_steps,
+            "speed": self.speed,
+        }
+        language = self.language or tts_input.language_code
+        if language:
+            generation_kwargs["language"] = language
+        if self.voice_clone_prompt is not None:
+            generation_kwargs["voice_clone_prompt"] = self.voice_clone_prompt
+        elif self.instruct is not None:
+            generation_kwargs["instruct"] = self.instruct
+
+        console.print(f"[green]ASSISTANT: {text}")
+        audios = self.model.generate(**generation_kwargs)
+
+        # OmniVoice generation is blocking. If the user interrupted while it ran,
+        # discard the completed buffer before it reaches the output client.
+        if self._is_cancelled(cancel_generation):
+            logger.info("OmniVoice TTS output cancelled (interruption)")
+            return
+        if not audios:
+            return
+
+        audio = np.asarray(audios[0], dtype=np.float32).reshape(-1)
+        source_sample_rate = int(getattr(self.model, "sampling_rate", 24000))
+        if source_sample_rate != PIPELINE_SAMPLE_RATE:
+            divisor = gcd(source_sample_rate, PIPELINE_SAMPLE_RATE)
+            audio = scipy.signal.resample_poly(
+                audio,
+                PIPELINE_SAMPLE_RATE // divisor,
+                source_sample_rate // divisor,
+            )
+
+        audio_int16 = np.clip(audio * 32768, -32768, 32767).astype(np.int16)
+        full_block_samples = (len(audio_int16) // self.blocksize) * self.blocksize
+        for offset in range(0, full_block_samples, self.blocksize):
+            if self._is_cancelled(cancel_generation):
+                logger.info("OmniVoice TTS output cancelled (interruption)")
+                return
+            yield audio_int16[offset : offset + self.blocksize]
+
+        if full_block_samples < len(audio_int16):
+            if self._is_cancelled(cancel_generation):
+                logger.info("OmniVoice TTS output cancelled (interruption)")
+                return
+            tail = audio_int16[full_block_samples:]
+            yield np.pad(tail, (0, self.blocksize - len(tail)))

--- a/src/speech_to_speech/arguments_classes/omnivoice_tts_arguments.py
+++ b/src/speech_to_speech/arguments_classes/omnivoice_tts_arguments.py
@@ -1,0 +1,58 @@
+from dataclasses import dataclass, field
+from typing import Literal, Optional
+
+
+@dataclass
+class OmniVoiceTTSHandlerArguments:
+    omnivoice_model_name: str = field(
+        default="k2-fsa/OmniVoice",
+        metadata={"help": "OmniVoice Hugging Face model ID or local path. Default is 'k2-fsa/OmniVoice'."},
+    )
+    omnivoice_device: str = field(
+        default="auto",
+        metadata={
+            "help": "Device passed to OmniVoice: 'auto', 'cuda', 'cuda:0', 'mps', 'xpu', or 'cpu'. Default is 'auto'."
+        },
+    )
+    omnivoice_dtype: Literal["float16", "bfloat16", "float32"] = field(
+        default="float16",
+        metadata={
+            "help": "Torch dtype for OmniVoice inference: 'float16', 'bfloat16', or 'float32'. Default is 'float16'."
+        },
+    )
+    omnivoice_ref_audio: Optional[str] = field(
+        default=None,
+        metadata={"help": "Reference audio path for voice cloning. Requires --omnivoice_ref_text."},
+    )
+    omnivoice_ref_text: Optional[str] = field(
+        default=None,
+        metadata={"help": "Transcript of --omnivoice_ref_audio for voice cloning."},
+    )
+    omnivoice_voice_clone_prompt: Optional[str] = field(
+        default=None,
+        metadata={
+            "help": "Saved OmniVoice VoiceClonePrompt path. Replaces --omnivoice_ref_audio and --omnivoice_ref_text."
+        },
+    )
+    omnivoice_instruct: Optional[str] = field(
+        default=None,
+        metadata={"help": "Voice-design instruction. Leave unset for auto voice or voice cloning."},
+    )
+    omnivoice_language: Optional[str] = field(
+        default=None,
+        metadata={
+            "help": "Optional target language name or code. When unset, the per-utterance pipeline language is used."
+        },
+    )
+    omnivoice_num_steps: int = field(
+        default=32,
+        metadata={"help": "Number of OmniVoice diffusion decoding steps. Default is 32."},
+    )
+    omnivoice_speed: float = field(
+        default=1.0,
+        metadata={"help": "Speaking-speed factor (>1 faster, <1 slower). Default is 1.0."},
+    )
+    omnivoice_blocksize: int = field(
+        default=512,
+        metadata={"help": "Audio output block size in 16 kHz samples. Default is 512."},
+    )

--- a/src/speech_to_speech/backend_registry.py
+++ b/src/speech_to_speech/backend_registry.py
@@ -22,6 +22,7 @@ from speech_to_speech.arguments_classes.language_model_arguments import Language
 from speech_to_speech.arguments_classes.mlx_audio_whisper_arguments import (
     MLXAudioWhisperSTTHandlerArguments,
 )
+from speech_to_speech.arguments_classes.omnivoice_tts_arguments import OmniVoiceTTSHandlerArguments
 from speech_to_speech.arguments_classes.openai_stt_arguments import OpenAICompatibleSTTHandlerArguments
 from speech_to_speech.arguments_classes.paraformer_stt_arguments import ParaformerSTTHandlerArguments
 from speech_to_speech.arguments_classes.parakeet_tdt_arguments import (
@@ -447,6 +448,19 @@ TTS_BACKENDS = build_backend_registry(
                 context_kwargs=True,
             ),
             normalize_config=_normalize_facebook_mms_config,
+        ),
+        BackendSpec(
+            "omnivoice",
+            "tts",
+            OmniVoiceTTSHandlerArguments,
+            _simple_handler_factory(
+                "speech_to_speech.TTS.omnivoice_handler",
+                "OmniVoiceTTSHandler",
+                setup_should_listen=True,
+                context_kwargs=True,
+            ),
+            config_prefix="omnivoice",
+            required_extra="omnivoice",
         ),
         BackendSpec(
             "pocket",

--- a/src/speech_to_speech/s2s_pipeline.py
+++ b/src/speech_to_speech/s2s_pipeline.py
@@ -309,9 +309,10 @@ def check_mac_settings(module_kwargs: ModuleArguments) -> None:
             logger.warning(
                 "For macOS users, it is recommended to use mlx-lm. You can activate it by passing --llm_backend mlx-lm."
             )
-        if module_kwargs.tts not in ("pocket", "kokoro", "qwen3"):
+        if module_kwargs.tts not in ("pocket", "kokoro", "omnivoice", "qwen3"):
             logger.warning(
-                "For macOS users, it is recommended to use qwen3 for TTS (pocket and kokoro are also valid options)."
+                "For macOS users, it is recommended to use qwen3 for TTS "
+                "(pocket, kokoro, and omnivoice are also valid options)."
             )
 
 

--- a/tests/test_backend_registry.py
+++ b/tests/test_backend_registry.py
@@ -75,6 +75,54 @@ def test_builtin_registry_lookup_and_cli_choices_share_one_catalog():
     assert not STT_BACKENDS["whisper"].capabilities.bypasses_transcription_notifier
 
 
+def test_omnivoice_tts_backend_is_registered_as_optional():
+    spec = TTS_BACKENDS["omnivoice"]
+
+    assert spec.kind == "tts"
+    assert spec.required_extra == "omnivoice"
+
+
+def test_omnivoice_cli_config_is_normalized_for_the_handler():
+    args = parse_arguments(
+        [
+            "--tts",
+            "omnivoice",
+            "--omnivoice_model_name",
+            "local/omnivoice",
+            "--omnivoice_device",
+            "xpu",
+            "--omnivoice_dtype",
+            "bfloat16",
+            "--omnivoice_ref_audio",
+            "voice.wav",
+            "--omnivoice_ref_text",
+            "Reference transcript.",
+            "--omnivoice_num_steps",
+            "16",
+            "--omnivoice_speed",
+            "1.25",
+            "--omnivoice_blocksize",
+            "256",
+        ]
+    )
+
+    assert args.tts_backend.name == "omnivoice"
+    assert args.tts_backend.config == {
+        "model_name": "local/omnivoice",
+        "device": "xpu",
+        "dtype": "bfloat16",
+        "ref_audio": "voice.wav",
+        "ref_text": "Reference transcript.",
+        "voice_clone_prompt": None,
+        "instruct": None,
+        "language": None,
+        "num_steps": 16,
+        "speed": 1.25,
+        "blocksize": 256,
+        "gen_kwargs": {},
+    }
+
+
 def test_registry_rejects_duplicate_names_and_wrong_kinds():
     spec = BackendSpec("fake", "stt", FakeArguments, _factory)
 
@@ -470,6 +518,7 @@ def test_factories_keep_backend_modules_lazy():
         "speech_to_speech.STT.whisper_stt_handler",
         "speech_to_speech.LLM.language_model",
         "speech_to_speech.TTS.chatTTS_handler",
+        "speech_to_speech.TTS.omnivoice_handler",
     ]
     for module_name in module_names:
         sys.modules.pop(module_name, None)

--- a/tests/test_omnivoice_tts_handler.py
+++ b/tests/test_omnivoice_tts_handler.py
@@ -1,0 +1,226 @@
+from __future__ import annotations
+
+import sys
+from collections.abc import Callable
+from threading import Event
+from types import SimpleNamespace
+from typing import Any
+
+import numpy as np
+import pytest
+import torch
+
+from speech_to_speech.pipeline.cancel_scope import CancelScope
+from speech_to_speech.pipeline.messages import AUDIO_RESPONSE_DONE, AudioOutput, EndOfResponse, TTSInput
+from speech_to_speech.pipeline.speculative_turns import SpeculativeTurnTracker
+from speech_to_speech.TTS import omnivoice_handler as omnivoice_module
+from speech_to_speech.TTS.omnivoice_handler import OmniVoiceTTSHandler
+
+
+class FakeModel:
+    sampling_rate = 24000
+
+    def __init__(
+        self,
+        generate: Callable[..., list[np.ndarray]] | None = None,
+    ) -> None:
+        self.generate_calls: list[dict[str, Any]] = []
+        self.create_prompt_calls: list[dict[str, Any]] = []
+        self._generate = generate or (lambda **_kwargs: [np.zeros(768, dtype=np.float32)])
+
+    def create_voice_clone_prompt(self, **kwargs: Any) -> object:
+        self.create_prompt_calls.append(kwargs)
+        return object()
+
+    def generate(self, **kwargs: Any) -> list[np.ndarray]:
+        self.generate_calls.append(kwargs)
+        return self._generate(**kwargs)
+
+
+def make_handler(
+    model: FakeModel,
+    *,
+    voice_clone_prompt: object | None = None,
+    instruct: str | None = None,
+    language: str | None = None,
+    blocksize: int = 512,
+    cancel_scope: CancelScope | None = None,
+) -> OmniVoiceTTSHandler:
+    handler = OmniVoiceTTSHandler.__new__(OmniVoiceTTSHandler)
+    handler.model = model
+    handler.voice_clone_prompt = voice_clone_prompt
+    handler.instruct = instruct
+    handler.language = language
+    handler.num_steps = 32
+    handler.speed = 1.0
+    handler.blocksize = blocksize
+    handler.cancel_scope = cancel_scope
+    handler.speculative_turns = None
+    return handler
+
+
+def test_setup_precomputes_and_reuses_raw_voice_clone_prompt(monkeypatch: pytest.MonkeyPatch) -> None:
+    model = FakeModel()
+    load_calls = []
+
+    class FakeOmniVoice:
+        @classmethod
+        def from_pretrained(cls, *args: Any, **kwargs: Any) -> FakeModel:
+            load_calls.append((args, kwargs))
+            return model
+
+    monkeypatch.setitem(
+        sys.modules,
+        "omnivoice",
+        SimpleNamespace(OmniVoice=FakeOmniVoice, VoiceClonePrompt=SimpleNamespace(load=lambda _path: object())),
+    )
+    handler = OmniVoiceTTSHandler.__new__(OmniVoiceTTSHandler)
+
+    handler.setup(
+        Event(),
+        model_name="local/omnivoice",
+        device="mps",
+        dtype="bfloat16",
+        ref_audio="voice.wav",
+        ref_text="Reference transcript.",
+    )
+    list(handler.process(TTSInput(text="First chunk.", language_code="en")))
+    list(handler.process(TTSInput(text="Second chunk.", language_code="en")))
+
+    assert load_calls == [
+        (("local/omnivoice",), {"device_map": "mps", "dtype": torch.bfloat16}),
+    ]
+    assert model.create_prompt_calls == [{"ref_audio": "voice.wav", "ref_text": "Reference transcript."}]
+    assert [call["voice_clone_prompt"] for call in model.generate_calls] == [
+        handler.voice_clone_prompt,
+        handler.voice_clone_prompt,
+    ]
+
+
+def test_setup_loads_saved_voice_clone_prompt_once(monkeypatch: pytest.MonkeyPatch) -> None:
+    model = FakeModel()
+    saved_prompt = object()
+    prompt_loads = []
+
+    class FakeOmniVoice:
+        @classmethod
+        def from_pretrained(cls, *_args: Any, **_kwargs: Any) -> FakeModel:
+            return model
+
+    class FakeVoiceClonePrompt:
+        @classmethod
+        def load(cls, path: str) -> object:
+            prompt_loads.append(path)
+            return saved_prompt
+
+    monkeypatch.setitem(
+        sys.modules,
+        "omnivoice",
+        SimpleNamespace(OmniVoice=FakeOmniVoice, VoiceClonePrompt=FakeVoiceClonePrompt),
+    )
+    handler = OmniVoiceTTSHandler.__new__(OmniVoiceTTSHandler)
+
+    handler.setup(Event(), voice_clone_prompt="saved-voice.pt")
+    list(handler.process(TTSInput(text="Hello.")))
+
+    assert prompt_loads == ["saved-voice.pt"]
+    assert model.create_prompt_calls == []
+    assert model.generate_calls[0]["voice_clone_prompt"] is saved_prompt
+
+
+@pytest.mark.parametrize(
+    ("voice_clone_prompt", "instruct", "expected_key"),
+    [
+        (object(), None, "voice_clone_prompt"),
+        (None, "female, low pitch", "instruct"),
+        (None, None, None),
+    ],
+)
+def test_process_selects_clone_design_or_auto_mode(
+    voice_clone_prompt: object | None,
+    instruct: str | None,
+    expected_key: str | None,
+) -> None:
+    model = FakeModel()
+    handler = make_handler(model, voice_clone_prompt=voice_clone_prompt, instruct=instruct)
+
+    list(handler.process(TTSInput(text="Hello.", language_code="fr")))
+
+    call = model.generate_calls[0]
+    assert call["text"] == "Hello."
+    assert call["language"] == "fr"
+    assert call["num_step"] == 32
+    assert call["speed"] == 1.0
+    assert ("voice_clone_prompt" in call, "instruct" in call) == {
+        "voice_clone_prompt": (True, False),
+        "instruct": (False, True),
+        None: (False, False),
+    }[expected_key]
+
+
+def test_process_resamples_clips_and_pads_16khz_blocks(monkeypatch: pytest.MonkeyPatch) -> None:
+    model = FakeModel(lambda **_kwargs: [np.zeros(8, dtype=np.float32)])
+    resample_calls = []
+
+    def fake_resample(audio: np.ndarray, up: int, down: int) -> np.ndarray:
+        resample_calls.append((audio, up, down))
+        return np.array([2.0, -2.0, 0.5], dtype=np.float32)
+
+    monkeypatch.setattr(omnivoice_module.scipy.signal, "resample_poly", fake_resample)
+    handler = make_handler(model, blocksize=4)
+
+    chunks = list(handler.process(TTSInput(text="Hello.")))
+
+    assert (resample_calls[0][1], resample_calls[0][2]) == (2, 3)
+    assert len(chunks) == 1
+    assert chunks[0].dtype == np.int16
+    np.testing.assert_array_equal(chunks[0], np.array([32767, -32768, 16384, 0], dtype=np.int16))
+
+
+def test_process_drops_audio_when_cancelled_during_blocking_generation() -> None:
+    cancel_scope = CancelScope()
+
+    def generate(**_kwargs: Any) -> list[np.ndarray]:
+        cancel_scope.cancel()
+        return [np.zeros(768, dtype=np.float32)]
+
+    handler = make_handler(FakeModel(generate), cancel_scope=cancel_scope)
+
+    assert list(handler.process(TTSInput(text="Hello."))) == []
+
+
+def test_process_stops_emitting_blocks_after_cancellation() -> None:
+    cancel_scope = CancelScope()
+    model = FakeModel(lambda **_kwargs: [np.zeros(5, dtype=np.float32)])
+    model.sampling_rate = 16000
+    handler = make_handler(model, blocksize=4, cancel_scope=cancel_scope)
+    chunks = handler.process(TTSInput(text="Hello."))
+
+    assert len(next(chunks)) == 4
+    cancel_scope.cancel()
+    with pytest.raises(StopIteration):
+        next(chunks)
+
+
+def test_stale_keyed_terminal_becomes_cleanup_after_lm_tts_handoff() -> None:
+    tracker = SpeculativeTurnTracker()
+    tracker.observe("turn_1", 0)
+    handler = OmniVoiceTTSHandler.__new__(OmniVoiceTTSHandler)
+    handler.speculative_turns = tracker
+    terminal = EndOfResponse(
+        response_key="response_1",
+        turn_id="turn_1",
+        turn_revision=0,
+        cancel_generation=7,
+    )
+    tracker.observe("turn_1", 1)
+
+    outputs = list(handler.process(terminal))
+    queued = handler.output_for_queue(outputs[0], terminal)
+
+    assert outputs == [AUDIO_RESPONSE_DONE]
+    assert terminal.cleanup_only is True
+    assert isinstance(queued, AudioOutput)
+    assert queued.response_key == "response_1"
+    assert queued.cancel_generation == 7
+    assert queued.cleanup_only is True


### PR DESCRIPTION
## Summary

- add an opt-in OmniVoice TTS backend with clone, design, and automatic modes
- precompute or load reusable voice-clone prompts and adapt blocking 24 kHz float output to the pipeline 16 kHz int16 block contract
- preserve cancellation, stale-turn, and end-of-response behavior used by existing TTS handlers
- document setup, devices, latency and streaming limits, model licensing, safety considerations, and the current platform dependency boundary

## Testing

- focused OmniVoice and registry tests: 12 passed
- full suite: 1264 passed, 1 skipped
- ruff check and format check
- mypy: 98 source files
- wheel and sdist build plus strict twine checks
- macOS optional-extra resolution: OmniVoice 0.2.1 with the project dependency set

Closes #525

Follow-up dependency work for Linux and Windows is tracked in #526.