### PR TITLE
Preserve trailing whitespace when buffering the local LLM stream remainder

### DIFF
--- a/src/speech_to_speech/LLM/language_model.py
+++ b/src/speech_to_speech/LLM/language_model.py
@@ -399,6 +399,7 @@ class BaseLanguageModelHandler(BaseHandler[LLMIn, LLMOut], ABC):
             return chunks, tools, pending_marker
 
         if printable_text:
+            trailing_whitespace = printable_text[len(printable_text.rstrip()) :]
             sentences = sent_tokenize_preserving_markdown_code(printable_text, sent_tokenize)
             if len(sentences) > 1:
                 for s in sentences[:-1]:
@@ -406,7 +407,7 @@ class BaseLanguageModelHandler(BaseHandler[LLMIn, LLMOut], ABC):
                     if len(ctx.sentence_batch) >= self.stream_batch_sentences:
                         chunks.append(text_chunk(" ".join(ctx.sentence_batch)))
                         ctx.sentence_batch = []
-                printable_text = sentences[-1]
+                printable_text = sentences[-1] + trailing_whitespace
 
         return chunks, tools, printable_text
 

--- a/tests/test_voice_prompt.py
+++ b/tests/test_voice_prompt.py
@@ -308,6 +308,29 @@ def test_local_audio_strips_markdown_after_reassembling_streamed_deltas():
     assert ctx.printable_text.strip() == "Second sentence."
 
 
+def test_local_audio_streaming_preserves_whitespace_across_chunks():
+    handler = object.__new__(LanguageModelHandler)
+    handler.cancel_scope = None
+    handler.speculative_turns = None
+    handler.stop_event = Event()
+    handler.stream_batch_sentences = 1
+    ctx = StreamContext()
+
+    chunks = list(
+        handler._stream_tokens(
+            iter(["It is sunny. What is ", "the weather like?"]),
+            None,
+            None,
+            ctx,
+        )
+    )
+
+    text = "".join(chunk.text for chunk in chunks) + ctx.printable_text
+    assert [chunk.text for chunk in chunks] == ["It is sunny."]
+    assert "isthe" not in text
+    assert ctx.printable_text == "What is the weather like?"
+
+
 def test_local_text_only_tool_marker_can_span_tokens_without_losing_whitespace():
     handler = object.__new__(LanguageModelHandler)
     ctx = _stream_context("dance")


### PR DESCRIPTION
The local transformers and MLX backends stream through `TextIteratorStreamer`, whose chunks end at word boundaries with a trailing space. In `_process_printable_text` (src/speech_to_speech/LLM/language_model.py:402), nltk's `sent_tokenize` strips that space, and line 409 keeps the stripped `sentences[-1]` as the remainder. The next chunk from `_stream_tokens` (line 526) is appended directly onto the truncated word: buffered "It is sunny. What is " followed by "the weather like?" becomes "What isthe weather like?", which is batched and sent to TTS, so the assistant audibly speaks the fused word and it lands in the transcript.

This is the same defect #481 fixed (closes #480) in base_openai_compatible_language_model.py:646/660, but the local-model sibling was never touched; #497 patched both files as siblings in one change. This PR mirrors the #481 fix exactly: capture `trailing_whitespace` before tokenizing and re-append it to the kept remainder.

The regression test drives `_stream_tokens` with split deltas in the style of #481's `test_audio_streaming_preserves_provider_whitespace_across_chunks` and fails on main with the fused "What isthe weather like?".

Verification: full suite green (1253 passed, 1 skipped; main baseline 1252/1), ruff check, ruff format --check, and mypy all clean.

Deliberately not done here: consolidating the duplicated sentence-buffering logic shared by language_model.py and base_openai_compatible_language_model.py. That divergence is what let #481 miss this file, but deduplicating it is a refactor beyond a minimal bug fix.
