### PR TITLE
Complete transcript log hygiene coverage

### DIFF
--- a/src/speech_to_speech/LLM/base_openai_compatible_language_model.py
+++ b/src/speech_to_speech/LLM/base_openai_compatible_language_model.py
@@ -56,6 +56,7 @@ from speech_to_speech.pipeline.messages import (
     TokenUsage,
 )
 from speech_to_speech.pipeline.speculative_turns import SpeculativeTurnTracker
+from speech_to_speech.pipeline.transcript_logging import transcript_for_log
 from speech_to_speech.utils.utils import is_out_of_band, response_wants_audio
 
 logger = logging.getLogger(__name__)
@@ -666,7 +667,7 @@ class BaseOpenAICompatibleHandler(BaseHandler[LLMIn, LLMOut], ABC):
                 if self._turn_is_cancelled(turn):
                     logger.info("LLM generation cancelled (interruption)")
                 else:
-                    logger.debug("Clean text: chars=%d", len(state.clean_text))
+                    logger.debug("Clean text: %s", transcript_for_log(state.clean_text))
                     yield from _flush(sentence_batch)
             logger.info(f"Tools: {state.tools}")
         return (
@@ -712,7 +713,7 @@ class BaseOpenAICompatibleHandler(BaseHandler[LLMIn, LLMOut], ABC):
                 ):
                     state.output_emitted = True
                     yield self._chunk(turn, text=out)
-        logger.debug("Clean text: chars=%d", len(state.clean_text))
+        logger.debug("Clean text: %s", transcript_for_log(state.clean_text))
         logger.info(f"Tools: {state.tools}")
         return (
             not cancelled

--- a/src/speech_to_speech/LLM/base_openai_compatible_language_model.py
+++ b/src/speech_to_speech/LLM/base_openai_compatible_language_model.py
@@ -56,7 +56,7 @@ from speech_to_speech.pipeline.messages import (
     TokenUsage,
 )
 from speech_to_speech.pipeline.speculative_turns import SpeculativeTurnTracker
-from speech_to_speech.pipeline.transcript_logging import transcript_for_log
+from speech_to_speech.pipeline.transcript_logging import log_exception, transcript_for_log
 from speech_to_speech.utils.utils import is_out_of_band, response_wants_audio
 
 logger = logging.getLogger(__name__)
@@ -669,7 +669,7 @@ class BaseOpenAICompatibleHandler(BaseHandler[LLMIn, LLMOut], ABC):
                 else:
                     logger.debug("Clean text: %s", transcript_for_log(state.clean_text))
                     yield from _flush(sentence_batch)
-            logger.info(f"Tools: {state.tools}")
+            logger.info("Tools: %s", transcript_for_log(state.tools))
         return (
             not cancelled
             and not self._turn_is_cancelled(turn)
@@ -714,7 +714,7 @@ class BaseOpenAICompatibleHandler(BaseHandler[LLMIn, LLMOut], ABC):
                     state.output_emitted = True
                     yield self._chunk(turn, text=out)
         logger.debug("Clean text: %s", transcript_for_log(state.clean_text))
-        logger.info(f"Tools: {state.tools}")
+        logger.info("Tools: %s", transcript_for_log(state.tools))
         return (
             not cancelled
             and not self._turn_is_cancelled(turn)
@@ -804,7 +804,7 @@ class BaseOpenAICompatibleHandler(BaseHandler[LLMIn, LLMOut], ABC):
                 # the error and fall through to the EndOfResponse below. Without this the
                 # exception would escape process() and no EndOfResponse would be emitted,
                 # leaving st.in_response stuck and locking every subsequent response.
-                logger.exception("LLM generation failed; ending the current response")
+                log_exception(logger, "LLM generation failed; ending the current response", exc)
                 if error_message is None:
                     error_message = f"Language model generation failed: {exc}"
 
@@ -874,7 +874,7 @@ class BaseOpenAICompatibleHandler(BaseHandler[LLMIn, LLMOut], ABC):
                                 cleanup_history()
                     history_committed = can_commit
                 except Exception as exc:
-                    logger.exception("LLM history commit failed; rolling back the current response")
+                    log_exception(logger, "LLM history commit failed; rolling back the current response", exc)
                     error_message = f"Language model history commit failed: {exc}"
 
             rollback_transaction()
@@ -944,7 +944,7 @@ class BaseOpenAICompatibleHandler(BaseHandler[LLMIn, LLMOut], ABC):
             try:
                 active_chat = build_active_chat(original_chat, response)
             except ChatItemError as exc:
-                logger.info("Out-of-band response rejected: %s", exc)
+                log_exception(logger, "Out-of-band response rejected", exc, level=logging.INFO)
                 yield EndOfResponse(
                     turn_id=turn_id,
                     turn_revision=turn_revision,
@@ -1066,7 +1066,7 @@ class BaseOpenAICompatibleHandler(BaseHandler[LLMIn, LLMOut], ABC):
             try:
                 active_chat = build_active_chat(original_chat, response)
             except ChatItemError as exc:
-                logger.info("Out-of-band response rejected: %s", exc)
+                log_exception(logger, "Out-of-band response rejected", exc, level=logging.INFO)
                 yield EndOfResponse(
                     turn_id=turn_id,
                     turn_revision=turn_revision,

--- a/src/speech_to_speech/LLM/base_openai_compatible_language_model.py
+++ b/src/speech_to_speech/LLM/base_openai_compatible_language_model.py
@@ -666,7 +666,7 @@ class BaseOpenAICompatibleHandler(BaseHandler[LLMIn, LLMOut], ABC):
                 if self._turn_is_cancelled(turn):
                     logger.info("LLM generation cancelled (interruption)")
                 else:
-                    logger.debug(f"Clean text: {state.clean_text}")
+                    logger.debug("Clean text: chars=%d", len(state.clean_text))
                     yield from _flush(sentence_batch)
             logger.info(f"Tools: {state.tools}")
         return (
@@ -712,7 +712,7 @@ class BaseOpenAICompatibleHandler(BaseHandler[LLMIn, LLMOut], ABC):
                 ):
                     state.output_emitted = True
                     yield self._chunk(turn, text=out)
-        logger.debug(f"Clean text: {state.clean_text}")
+        logger.debug("Clean text: chars=%d", len(state.clean_text))
         logger.info(f"Tools: {state.tools}")
         return (
             not cancelled

--- a/src/speech_to_speech/LLM/chat.py
+++ b/src/speech_to_speech/LLM/chat.py
@@ -943,8 +943,12 @@ class Chat:
                 return
             try:
                 result = compactor(snapshot)
-            except Exception:
-                logger.exception("Chat compaction failed; chat unchanged")
+            except Exception as exc:
+                # Import lazily: importing pipeline modules while RuntimeConfig imports Chat
+                # creates a RuntimeConfig -> Chat -> pipeline.messages cycle at startup.
+                from speech_to_speech.pipeline.transcript_logging import log_exception
+
+                log_exception(logger, "Chat compaction failed; chat unchanged", exc)
                 return
             if not isinstance(result, CompactionResult):
                 logger.error("Compactor must return a CompactionResult, got %r", type(result).__name__)

--- a/src/speech_to_speech/LLM/language_model.py
+++ b/src/speech_to_speech/LLM/language_model.py
@@ -68,7 +68,7 @@ from speech_to_speech.pipeline.messages import (
     TokenUsage,
 )
 from speech_to_speech.pipeline.speculative_turns import SpeculativeTurnTracker
-from speech_to_speech.pipeline.transcript_logging import transcript_for_log
+from speech_to_speech.pipeline.transcript_logging import log_exception, transcript_for_log
 from speech_to_speech.utils.utils import is_out_of_band, response_wants_audio
 
 try:
@@ -603,7 +603,7 @@ class BaseLanguageModelHandler(BaseHandler[LLMIn, LLMOut], ABC):
             try:
                 active_chat = build_active_chat(original_chat, response)
             except ChatItemError as exc:
-                logger.info("Out-of-band response rejected: %s", exc)
+                log_exception(logger, "Out-of-band response rejected", exc, level=logging.INFO)
                 yield EndOfResponse(
                     turn_id=ctx.turn_id,
                     turn_revision=ctx.turn_revision,
@@ -728,7 +728,7 @@ class BaseLanguageModelHandler(BaseHandler[LLMIn, LLMOut], ABC):
                 else:
                     trailing_chunk = None
             logger.debug("Clean text: %s", transcript_for_log(ctx.generated_text))
-            logger.info(f"Tools: {ctx.tools}")
+            logger.info("Tools: %s", transcript_for_log(ctx.tools))
 
             if trailing_chunk is not None:
                 yield trailing_chunk
@@ -747,7 +747,7 @@ class BaseLanguageModelHandler(BaseHandler[LLMIn, LLMOut], ABC):
             # Any generation failure must still terminate the response. Without this
             # the exception would escape process() and no EndOfResponse would be
             # emitted, leaving st.in_response stuck and locking every later response.
-            logger.exception("LLM generation failed; ending the current response")
+            log_exception(logger, "LLM generation failed; ending the current response", exc)
             rollback_history()
             if request.prefetch_transaction is not None:
                 # The terminal is queued before this generator resumes into its

--- a/src/speech_to_speech/LLM/language_model.py
+++ b/src/speech_to_speech/LLM/language_model.py
@@ -68,6 +68,7 @@ from speech_to_speech.pipeline.messages import (
     TokenUsage,
 )
 from speech_to_speech.pipeline.speculative_turns import SpeculativeTurnTracker
+from speech_to_speech.pipeline.transcript_logging import transcript_for_log
 from speech_to_speech.utils.utils import is_out_of_band, response_wants_audio
 
 try:
@@ -726,7 +727,7 @@ class BaseLanguageModelHandler(BaseHandler[LLMIn, LLMOut], ABC):
                     history_committed = True
                 else:
                     trailing_chunk = None
-            logger.debug("Clean text: chars=%d", len(ctx.generated_text))
+            logger.debug("Clean text: %s", transcript_for_log(ctx.generated_text))
             logger.info(f"Tools: {ctx.tools}")
 
             if trailing_chunk is not None:

--- a/src/speech_to_speech/LLM/language_model.py
+++ b/src/speech_to_speech/LLM/language_model.py
@@ -726,7 +726,7 @@ class BaseLanguageModelHandler(BaseHandler[LLMIn, LLMOut], ABC):
                     history_committed = True
                 else:
                     trailing_chunk = None
-            logger.debug("Clean text: %s", ctx.generated_text)
+            logger.debug("Clean text: chars=%d", len(ctx.generated_text))
             logger.info(f"Tools: {ctx.tools}")
 
             if trailing_chunk is not None:

--- a/src/speech_to_speech/LLM/lm_output_processor.py
+++ b/src/speech_to_speech/LLM/lm_output_processor.py
@@ -33,6 +33,7 @@ from speech_to_speech.pipeline.messages import (
     TTSInput,
 )
 from speech_to_speech.pipeline.speculative_turns import SpeculativeTurnTracker
+from speech_to_speech.pipeline.transcript_logging import transcript_for_log
 from speech_to_speech.utils.utils import response_wants_audio
 
 logger = logging.getLogger(__name__)
@@ -207,7 +208,7 @@ class LMOutputProcessor(BaseHandler[LLMOut, TTSIn | PipelineEvent]):
                 or not response_wants_audio(lm_output.response)
             ):
                 continue
-            logger.debug("Forwarding to TTS: chars=%d", len(part.text))
+            logger.debug("Forwarding to TTS: %s", transcript_for_log(part.text))
             yield TTSInput(
                 text=part.text,
                 language_code=lm_output.language_code,

--- a/src/speech_to_speech/LLM/lm_output_processor.py
+++ b/src/speech_to_speech/LLM/lm_output_processor.py
@@ -173,7 +173,7 @@ class LMOutputProcessor(BaseHandler[LLMOut, TTSIn | PipelineEvent]):
             logger.debug("Dropping stale LLM chunk for turn=%s rev=%s", lm_output.turn_id, lm_output.turn_revision)
             return
 
-        logger.debug("LM processor: parts=%s", lm_output.parts)
+        logger.debug("LM processor: parts=%s", transcript_for_log(lm_output.parts))
 
         response_key = self._start_response(lm_output.response_key)
 

--- a/src/speech_to_speech/LLM/lm_output_processor.py
+++ b/src/speech_to_speech/LLM/lm_output_processor.py
@@ -207,7 +207,7 @@ class LMOutputProcessor(BaseHandler[LLMOut, TTSIn | PipelineEvent]):
                 or not response_wants_audio(lm_output.response)
             ):
                 continue
-            logger.debug("Forwarding to TTS: '%s'", part.text)
+            logger.debug("Forwarding to TTS: chars=%d", len(part.text))
             yield TTSInput(
                 text=part.text,
                 language_code=lm_output.language_code,

--- a/src/speech_to_speech/STT/faster_whisper_handler.py
+++ b/src/speech_to_speech/STT/faster_whisper_handler.py
@@ -110,7 +110,7 @@ class FasterWhisperSTTHandler(BaseSTTHandler):
         output_text = []
 
         for segment in segments:
-            logger.debug("[%.2fs -> %.2fs] %s" % (segment.start, segment.end, segment.text))
+            logger.debug("[%.2fs -> %.2fs] chars=%d", segment.start, segment.end, len(segment.text))
             output_text.append(segment.text)
 
         pred_text = " ".join(output_text).strip()

--- a/src/speech_to_speech/STT/faster_whisper_handler.py
+++ b/src/speech_to_speech/STT/faster_whisper_handler.py
@@ -9,6 +9,7 @@ from rich.console import Console
 
 from speech_to_speech.pipeline.handler_types import STTIn, STTOut
 from speech_to_speech.pipeline.messages import PartialTranscription, Transcription
+from speech_to_speech.pipeline.transcript_logging import transcript_for_log
 from speech_to_speech.STT.base_stt_handler import BaseSTTHandler
 
 console = Console()
@@ -110,7 +111,7 @@ class FasterWhisperSTTHandler(BaseSTTHandler):
         output_text = []
 
         for segment in segments:
-            logger.debug("[%.2fs -> %.2fs] chars=%d", segment.start, segment.end, len(segment.text))
+            logger.debug("[%.2fs -> %.2fs] %s", segment.start, segment.end, transcript_for_log(segment.text))
             output_text.append(segment.text)
 
         pred_text = " ".join(output_text).strip()

--- a/src/speech_to_speech/STT/transcription_notifier.py
+++ b/src/speech_to_speech/STT/transcription_notifier.py
@@ -18,6 +18,7 @@ from speech_to_speech.pipeline.messages import (
     TranscriptionFailure,
 )
 from speech_to_speech.pipeline.queue_types import TextEventItem
+from speech_to_speech.pipeline.transcript_logging import transcript_for_log
 
 logger = logging.getLogger(__name__)
 
@@ -48,7 +49,7 @@ class TranscriptionNotifier(BaseHandler[STTOut, LLMIn]):
                         turn_revision=transcription.turn_revision,
                     )
                 )
-                logger.debug("Partial transcription: chars=%d", len(str(transcription.text)))
+                logger.debug("Partial transcription: %s", transcript_for_log(transcription.text))
             return
 
         if isinstance(transcription, TranscriptionFailure):
@@ -98,8 +99,8 @@ class TranscriptionNotifier(BaseHandler[STTOut, LLMIn]):
             return
 
         if language_code:
-            logger.info("Transcription completed (language=%s, chars=%d)", language_code, len(transcript))
+            logger.info("Transcription completed (language=%s): %s", language_code, transcript_for_log(transcript))
         else:
-            logger.info("Transcription completed (chars=%d)", len(transcript))
+            logger.info("Transcription completed: %s", transcript_for_log(transcript))
 
         yield from ()

--- a/src/speech_to_speech/STT/transcription_notifier.py
+++ b/src/speech_to_speech/STT/transcription_notifier.py
@@ -48,7 +48,7 @@ class TranscriptionNotifier(BaseHandler[STTOut, LLMIn]):
                         turn_revision=transcription.turn_revision,
                     )
                 )
-                logger.debug("Partial transcription: %s", str(transcription.text)[:80])
+                logger.debug("Partial transcription: chars=%d", len(str(transcription.text)))
             return
 
         if isinstance(transcription, TranscriptionFailure):
@@ -98,8 +98,8 @@ class TranscriptionNotifier(BaseHandler[STTOut, LLMIn]):
             return
 
         if language_code:
-            logger.info("Transcription completed (language=%s): %s", language_code, transcript)
+            logger.info("Transcription completed (language=%s, chars=%d)", language_code, len(transcript))
         else:
-            logger.info("Transcription completed: %s", transcript)
+            logger.info("Transcription completed (chars=%d)", len(transcript))
 
         yield from ()

--- a/src/speech_to_speech/TTS/facebookmms_handler.py
+++ b/src/speech_to_speech/TTS/facebookmms_handler.py
@@ -15,6 +15,7 @@ from speech_to_speech.pipeline.cancel_scope import CancelScope
 from speech_to_speech.pipeline.handler_types import TTSIn, TTSOut
 from speech_to_speech.pipeline.messages import AUDIO_RESPONSE_DONE, EndOfResponse
 from speech_to_speech.pipeline.speculative_turns import SpeculativeTurnTracker
+from speech_to_speech.pipeline.transcript_logging import transcript_for_log
 
 logger = logging.getLogger(__name__)
 
@@ -114,7 +115,7 @@ class FacebookMMSTTSHandler(BaseHandler[TTSIn, TTSOut]):
             return None
 
         try:
-            logger.debug("Tokenizing text: chars=%d", len(text))
+            logger.debug("Tokenizing text: %s", transcript_for_log(text))
             logger.debug(f"Current language: {self.language}")
             logger.debug(f"Tokenizer: {self.tokenizer}")
 
@@ -166,7 +167,7 @@ class FacebookMMSTTSHandler(BaseHandler[TTSIn, TTSOut]):
         text = tts_input.text
 
         console.print(f"[green]ASSISTANT: {text}")
-        logger.debug("Processing text: chars=%d", len(text))
+        logger.debug("Processing text: %s", transcript_for_log(text))
         logger.debug(f"Language code: {language_code}")
 
         restore_initial_model = (

--- a/src/speech_to_speech/TTS/facebookmms_handler.py
+++ b/src/speech_to_speech/TTS/facebookmms_handler.py
@@ -114,7 +114,7 @@ class FacebookMMSTTSHandler(BaseHandler[TTSIn, TTSOut]):
             return None
 
         try:
-            logger.debug(f"Tokenizing text: {text}")
+            logger.debug("Tokenizing text: chars=%d", len(text))
             logger.debug(f"Current language: {self.language}")
             logger.debug(f"Tokenizer: {self.tokenizer}")
 
@@ -166,7 +166,7 @@ class FacebookMMSTTSHandler(BaseHandler[TTSIn, TTSOut]):
         text = tts_input.text
 
         console.print(f"[green]ASSISTANT: {text}")
-        logger.debug(f"Processing text: {text}")
+        logger.debug("Processing text: chars=%d", len(text))
         logger.debug(f"Language code: {language_code}")
 
         restore_initial_model = (

--- a/src/speech_to_speech/TTS/facebookmms_handler.py
+++ b/src/speech_to_speech/TTS/facebookmms_handler.py
@@ -15,7 +15,7 @@ from speech_to_speech.pipeline.cancel_scope import CancelScope
 from speech_to_speech.pipeline.handler_types import TTSIn, TTSOut
 from speech_to_speech.pipeline.messages import AUDIO_RESPONSE_DONE, EndOfResponse
 from speech_to_speech.pipeline.speculative_turns import SpeculativeTurnTracker
-from speech_to_speech.pipeline.transcript_logging import transcript_for_log
+from speech_to_speech.pipeline.transcript_logging import log_exception, transcript_for_log
 
 logger = logging.getLogger(__name__)
 
@@ -124,7 +124,7 @@ class FacebookMMSTTSHandler(BaseHandler[TTSIn, TTSOut]):
             attention_mask = inputs.attention_mask.to(self.device)
 
             logger.debug(f"Input IDs shape: {input_ids.shape}, dtype: {input_ids.dtype}")
-            logger.debug(f"Input IDs: {input_ids}")
+            logger.debug("Input IDs: %s", transcript_for_log(input_ids))
 
             if input_ids.numel() == 0:
                 logger.error("Input IDs tensor is empty")
@@ -135,9 +135,8 @@ class FacebookMMSTTSHandler(BaseHandler[TTSIn, TTSOut]):
 
             logger.debug(f"Output waveform shape: {output.waveform.shape}")
             return output.waveform
-        except Exception as e:
-            logger.error(f"Error in generate_audio: {str(e)}")
-            logger.exception("Full traceback:")
+        except Exception as exc:
+            log_exception(logger, "Error in generate_audio", exc)
             return None
 
     def process(self, tts_input: TTSIn) -> Iterator[TTSOut]:

--- a/src/speech_to_speech/TTS/pocket_tts_handler.py
+++ b/src/speech_to_speech/TTS/pocket_tts_handler.py
@@ -13,6 +13,7 @@ from speech_to_speech.pipeline.cancel_scope import CancelScope
 from speech_to_speech.pipeline.handler_types import TTSIn, TTSOut
 from speech_to_speech.pipeline.messages import AUDIO_RESPONSE_DONE, EndOfResponse
 from speech_to_speech.pipeline.speculative_turns import SpeculativeTurnTracker
+from speech_to_speech.pipeline.transcript_logging import transcript_for_log
 
 logger = logging.getLogger(__name__)
 console = Console()
@@ -128,7 +129,7 @@ class PocketTTSHandler(BaseHandler[TTSIn, TTSOut]):
         console.print(f"[green]ASSISTANT: {text}")
 
         # Generate audio stream
-        logger.debug("Generating audio: chars=%d", len(text))
+        logger.debug("Generating audio: %s", transcript_for_log(text))
 
         pipeline_start = perf_counter()
         first_chunk = True

--- a/src/speech_to_speech/TTS/pocket_tts_handler.py
+++ b/src/speech_to_speech/TTS/pocket_tts_handler.py
@@ -128,7 +128,7 @@ class PocketTTSHandler(BaseHandler[TTSIn, TTSOut]):
         console.print(f"[green]ASSISTANT: {text}")
 
         # Generate audio stream
-        logger.debug(f"Generating audio for: {text[:50]}...")
+        logger.debug("Generating audio: chars=%d", len(text))
 
         pipeline_start = perf_counter()
         first_chunk = True

--- a/src/speech_to_speech/TTS/qwen3_tts_handler.py
+++ b/src/speech_to_speech/TTS/qwen3_tts_handler.py
@@ -38,6 +38,7 @@ from speech_to_speech.pipeline.messages import (
     TTSInput,
 )
 from speech_to_speech.pipeline.speculative_turns import SpeculativeTurnTracker
+from speech_to_speech.pipeline.transcript_logging import log_exception
 from speech_to_speech.utils.mlx_lock import MLXLockContext
 
 logger = logging.getLogger(__name__)
@@ -861,8 +862,8 @@ class Qwen3TTSHandler(BaseHandler[TTSIn, TTSOut]):
                     self._log_first_audio_latency(tts_input)
                     first_audio = False
                 yield audio_chunk
-        except Exception as e:
-            logger.error(f"Error during Qwen3-TTS generation: {e}", exc_info=True)
+        except Exception as exc:
+            log_exception(logger, "Error during Qwen3-TTS generation", exc)
 
     def _log_first_audio_latency(self, tts_input: TTSInput) -> None:
         if tts_input.speech_stopped_at_s is None:

--- a/src/speech_to_speech/api/openai_realtime/audio_client.py
+++ b/src/speech_to_speech/api/openai_realtime/audio_client.py
@@ -27,6 +27,8 @@ from jsonschema import SchemaError, ValidationError
 from jsonschema.validators import validator_for
 from openai import AsyncOpenAI
 
+from speech_to_speech.pipeline.transcript_logging import log_exception
+
 logger = logging.getLogger(__name__)
 
 _AssistantTranscriptStream = tuple[str | None, str | None, int | None, int | None]
@@ -528,7 +530,7 @@ class _ToolCallCoordinator:
             raise
         except Exception as exc:
             message = f"{type(exc).__name__}: {exc}"
-            logger.debug("Local tool %s failed", display_name, exc_info=True)
+            log_exception(logger, f"Local tool {display_name} failed", exc, level=logging.DEBUG)
             print(f"TOOL ERROR: {display_name} call_id={call_id}: {message}", flush=True)
             output = json.dumps({"error": message})
             create_response = True

--- a/src/speech_to_speech/api/openai_realtime/audio_client.py
+++ b/src/speech_to_speech/api/openai_realtime/audio_client.py
@@ -60,6 +60,7 @@ class RealtimeAudioClientConfig:
     voice: Optional[str] = None
     print_json: bool = False
     block_mic_during_playback: bool = False
+    log_transcripts: bool = False
     connection_retry_timeout_s: float = 30.0
     tools: list[dict[str, Any]] = field(default_factory=list)
     tool_executor: ToolExecutor | None = None

--- a/src/speech_to_speech/api/openai_realtime/handlers/conversation.py
+++ b/src/speech_to_speech/api/openai_realtime/handlers/conversation.py
@@ -275,10 +275,10 @@ class ConversationHandler(RealtimeBaseHandler):
             # has no retraction event, so wait for a future hypothesis that
             # extends the committed prefix or for the authoritative completion.
             logger.debug(
-                "Withholding revised stable transcription for item=%s (emitted=%r, hypothesis=%r)",
+                "Withholding revised stable transcription for item=%s (emitted_chars=%d, hypothesis_chars=%d)",
                 item_id,
-                input_item.transcript_prefix[-40:],
-                hypothesis[-40:],
+                len(input_item.transcript_prefix),
+                len(hypothesis),
             )
             return []
 

--- a/src/speech_to_speech/api/openai_realtime/handlers/conversation.py
+++ b/src/speech_to_speech/api/openai_realtime/handlers/conversation.py
@@ -32,6 +32,7 @@ from speech_to_speech.pipeline.events import (
     TranscriptionCompletedEvent,
     TranscriptionFailedEvent,
 )
+from speech_to_speech.pipeline.transcript_logging import transcript_for_log
 
 if TYPE_CHECKING:
     from speech_to_speech.api.openai_realtime.service import ServerEvent
@@ -275,10 +276,10 @@ class ConversationHandler(RealtimeBaseHandler):
             # has no retraction event, so wait for a future hypothesis that
             # extends the committed prefix or for the authoritative completion.
             logger.debug(
-                "Withholding revised stable transcription for item=%s (emitted_chars=%d, hypothesis_chars=%d)",
+                "Withholding revised stable transcription for item=%s (emitted=%s, hypothesis=%s)",
                 item_id,
-                len(input_item.transcript_prefix),
-                len(hypothesis),
+                transcript_for_log(input_item.transcript_prefix),
+                transcript_for_log(hypothesis),
             )
             return []
 

--- a/src/speech_to_speech/api/openai_realtime/handlers/response.py
+++ b/src/speech_to_speech/api/openai_realtime/handlers/response.py
@@ -40,6 +40,7 @@ from speech_to_speech.pipeline.messages import (
     GenerateResponseRequest,
     ResponsePrefetchTransaction,
 )
+from speech_to_speech.pipeline.transcript_logging import log_exception
 from speech_to_speech.utils.utils import _generate_id, is_out_of_band, response_wants_audio
 
 if TYPE_CHECKING:
@@ -247,11 +248,11 @@ class ResponseHandler(RealtimeBaseHandler):
         if request.prefetch_transaction is not None:
             try:
                 claim_succeeded = request.prefetch_transaction.claim()
-            except Exception:
+            except Exception as exc:
                 # Deferred image/history cleanup runs at the standard create
                 # boundary. A failure must not escape the transport or leave
                 # the hidden response occupying the session indefinitely.
-                logger.exception("Failed to commit tool follow-up prefetch history")
+                log_exception(logger, "Failed to commit tool follow-up prefetch history", exc)
                 self.discard_tool_followup_prefetch(
                     conn_id,
                     origin_response_key=st.tool_followup_prefetch_origin_response_key,

--- a/src/speech_to_speech/api/openai_realtime/service.py
+++ b/src/speech_to_speech/api/openai_realtime/service.py
@@ -71,6 +71,7 @@ from speech_to_speech.pipeline.events import (
 from speech_to_speech.pipeline.messages import GenerateResponseRequest
 from speech_to_speech.pipeline.queue_types import TextPromptItem
 from speech_to_speech.pipeline.speculative_turns import SpeculativeTurnTracker
+from speech_to_speech.pipeline.transcript_logging import log_exception, transcript_for_log
 from speech_to_speech.utils.utils import _generate_id
 
 logger = logging.getLogger(__name__)
@@ -387,8 +388,8 @@ class RealtimeService:
             return None
         try:
             return model_cls.model_validate(raw)  # type: ignore[return-value]
-        except ValidationError as e:
-            logger.error(f"Invalid {event_type} payload: {e}")
+        except ValidationError as exc:
+            log_exception(logger, f"Invalid {event_type} payload", exc)
             return None
 
     # ── Client event handlers ────────────────────
@@ -769,7 +770,7 @@ class RealtimeService:
         response; stale generations are discarded by the router. Unkeyed late
         failures remain gated on active/pending state for compatibility.
         """
-        logger.info("Response failed: %s", event.message)
+        logger.info("Response failed: %s", transcript_for_log(event.message))
         st = self._state(conn_id)
         if event.response_key is None and not (st.in_response or st.response_pending):
             return []

--- a/src/speech_to_speech/api/openai_realtime/webrtc_session.py
+++ b/src/speech_to_speech/api/openai_realtime/webrtc_session.py
@@ -30,6 +30,7 @@ from aiortc.mediastreams import MediaStreamError, MediaStreamTrack
 
 from speech_to_speech.api.openai_realtime.service import PIPELINE_SAMPLE_RATE
 from speech_to_speech.api.openai_realtime.transports import SessionTransport
+from speech_to_speech.pipeline.transcript_logging import log_exception, transcript_for_log
 
 if TYPE_CHECKING:
     from speech_to_speech.api.openai_realtime.service import RealtimeService, ServerEvent
@@ -403,15 +404,15 @@ class WebRTCSession(SessionTransport):
             try:
                 raw = json.loads(msg)
             except json.JSONDecodeError:
-                logger.error(f"[WebRTC] Invalid JSON on data channel: {msg!r}")
+                logger.error("[WebRTC] Invalid JSON on data channel: %s", transcript_for_log(msg))
                 continue
             if not isinstance(raw, dict):
-                logger.error(f"[WebRTC] Non-object event on data channel: {msg!r}")
+                logger.error("[WebRTC] Non-object event on data channel: %s", transcript_for_log(msg))
                 continue
             try:
                 await self._on_client_event(raw)
-            except Exception:  # noqa: BLE001
-                logger.exception("[WebRTC] Error handling client event")
+            except Exception as exc:  # noqa: BLE001
+                log_exception(logger, "[WebRTC] Error handling client event", exc)
 
     async def _consume_inbound_audio(self, track) -> None:
         while not self._closed:

--- a/src/speech_to_speech/api/openai_realtime/websocket_router.py
+++ b/src/speech_to_speech/api/openai_realtime/websocket_router.py
@@ -48,6 +48,7 @@ from speech_to_speech.pipeline.events import (
 )
 from speech_to_speech.pipeline.log_context import pipeline_log_ctx
 from speech_to_speech.pipeline.messages import AUDIO_RESPONSE_DONE, PIPELINE_END, AudioOutput
+from speech_to_speech.pipeline.transcript_logging import log_exception
 
 # aiortc (the 'webrtc' extra) is optional. Import it here, at module load,
 # rather than lazily in the calls endpoint: the av/cryptography C extensions
@@ -586,8 +587,8 @@ def create_app(
 
         except WebSocketDisconnect:
             logger.info(f"Client {session_id} disconnected from pipeline {unit.index}")
-        except Exception as e:
-            logger.error(f"Client {session_id} on pipeline {unit.index} error: {type(e).__name__}: {e}", exc_info=True)
+        except Exception as exc:
+            log_exception(logger, f"Client {session_id} on pipeline {unit.index} error", exc)
         finally:
             # Hold the session reference: the send loop's snapshot will still resolve
             # to this object until we clear unit.session, so any handler output that

--- a/src/speech_to_speech/arguments_classes/module_arguments.py
+++ b/src/speech_to_speech/arguments_classes/module_arguments.py
@@ -50,6 +50,17 @@ class ModuleArguments:
         default="info",
         metadata={"help": "Provide logging level. Example --log_level debug, default=info."},
     )
+    log_transcripts: bool = field(
+        default=False,
+        metadata={
+            "help": (
+                "Write full user and assistant transcript text to the application log, for "
+                "debugging STT, LLM, TTS and Realtime flows. Off by default: logs are often "
+                "retained by service managers, containers and hosted log aggregators, so "
+                "conversation content would outlive the conversation there. Default is False."
+            )
+        },
+    )
     enable_live_transcription: bool = field(
         default=True,
         metadata={

--- a/src/speech_to_speech/baseHandler.py
+++ b/src/speech_to_speech/baseHandler.py
@@ -14,6 +14,7 @@ from speech_to_speech.pipeline.control import PipelineControlMessage, is_control
 from speech_to_speech.pipeline.events import PipelineEvent, TokenUsageEvent
 from speech_to_speech.pipeline.log_context import pipeline_log_ctx
 from speech_to_speech.pipeline.messages import PIPELINE_END, AudioOutput, EndOfResponse, TTSInput
+from speech_to_speech.pipeline.transcript_logging import log_exception
 
 logger = logging.getLogger(__name__)
 
@@ -116,11 +117,8 @@ class BaseHandler(Generic[InT, OutT]):
                 logger.debug(f"{self.__class__.__name__}: session end received")
                 try:
                     self.on_session_end()
-                except Exception as e:
-                    logger.error(
-                        f"{self.__class__.__name__}: Error in on_session_end(): {type(e).__name__}: {e}",
-                        exc_info=True,
-                    )
+                except Exception as exc:
+                    log_exception(logger, f"{self.__class__.__name__}: Error in on_session_end()", exc)
                 self.queue_out.put(item)
                 continue
 
@@ -159,8 +157,8 @@ class BaseHandler(Generic[InT, OutT]):
                     )
                     self.queue_out.put(queued_output)
                     start_time = perf_counter()
-            except Exception as e:
-                logger.error(f"{self.__class__.__name__}: Error in process(): {type(e).__name__}: {e}", exc_info=True)
+            except Exception as exc:
+                log_exception(logger, f"{self.__class__.__name__}: Error in process()", exc)
 
         self.cleanup()
         self.queue_out.put(PIPELINE_END)

--- a/src/speech_to_speech/cli.py
+++ b/src/speech_to_speech/cli.py
@@ -10,6 +10,10 @@ from speech_to_speech.api.openai_realtime.audio_client import (
     load_realtime_tool_module,
     run_realtime_audio_client,
 )
+from speech_to_speech.pipeline.transcript_logging import (
+    set_log_transcripts,
+    warn_if_log_transcripts_enabled,
+)
 
 Command = Literal["serve", "talk", "local"]
 
@@ -135,6 +139,14 @@ def parse_talk_arguments(argv: Sequence[str]) -> RealtimeAudioClientConfig:
         default=defaults.block_mic_during_playback,
     )
     parser.add_argument(
+        "--log-transcripts",
+        "--log_transcripts",
+        dest="log_transcripts",
+        action="store_true",
+        default=defaults.log_transcripts,
+        help="Write full Realtime transcript and tool error details to application logs.",
+    )
+    parser.add_argument(
         "--connection-retry-timeout",
         type=float,
         default=defaults.connection_retry_timeout_s,
@@ -159,6 +171,7 @@ def parse_talk_arguments(argv: Sequence[str]) -> RealtimeAudioClientConfig:
         voice=namespace.voice,
         print_json=namespace.print_json,
         block_mic_during_playback=namespace.block_mic_during_playback,
+        log_transcripts=namespace.log_transcripts,
         connection_retry_timeout_s=namespace.connection_retry_timeout,
         tools=tools,
         tool_executor=tool_executor,
@@ -169,7 +182,10 @@ def parse_talk_arguments(argv: Sequence[str]) -> RealtimeAudioClientConfig:
 def main() -> None:
     command, command_args = parse_command()
     if command == "talk":
-        run_realtime_audio_client(parse_talk_arguments(command_args))
+        config = parse_talk_arguments(command_args)
+        set_log_transcripts(config.log_transcripts)
+        warn_if_log_transcripts_enabled()
+        run_realtime_audio_client(config)
         return
 
     from speech_to_speech.s2s_pipeline import run_pipeline_command

--- a/src/speech_to_speech/pipeline/messages.py
+++ b/src/speech_to_speech/pipeline/messages.py
@@ -21,6 +21,7 @@ from openai.types.responses.response_function_tool_call import ResponseFunctionT
 from pydantic import BaseModel, ConfigDict, Field, model_validator
 
 from speech_to_speech.api.openai_realtime.runtime_config import RuntimeConfig
+from speech_to_speech.pipeline.transcript_logging import log_exception
 
 logger = logging.getLogger(__name__)
 
@@ -258,10 +259,10 @@ class ResponsePrefetchTransaction:
     def _run_abort(abort: Callable[[], None]) -> None:
         try:
             abort()
-        except Exception:
+        except Exception as exc:
             # Cancellation must still reach response rollback and tombstoning
             # when a provider or backend raises while releasing its stream.
-            logger.exception("Failed to abort discarded response prefetch")
+            log_exception(logger, "Failed to abort discarded response prefetch", exc)
 
     @property
     def discarded(self) -> bool:

--- a/src/speech_to_speech/pipeline/transcript_logging.py
+++ b/src/speech_to_speech/pipeline/transcript_logging.py
@@ -62,3 +62,24 @@ def transcript_for_log(text: object) -> str:
     if _log_transcripts:
         return value
     return f"chars={len(value)}"
+
+
+def log_exception(
+    target: logging.Logger,
+    message: str,
+    exc: BaseException,
+    *,
+    level: int = logging.ERROR,
+) -> None:
+    """Log an exception without exposing its message or traceback by default."""
+    if _log_transcripts:
+        target.log(
+            level,
+            "%s (%s): %s",
+            message,
+            type(exc).__name__,
+            exc,
+            exc_info=(type(exc), exc, exc.__traceback__),
+        )
+        return
+    target.log(level, "%s (%s)", message, type(exc).__name__)

--- a/src/speech_to_speech/pipeline/transcript_logging.py
+++ b/src/speech_to_speech/pipeline/transcript_logging.py
@@ -1,0 +1,64 @@
+"""Opt-in gate for writing conversation content to application loggers.
+
+Operational logs are retained by service managers, containers and hosted logging systems, so
+transcript text written through ``logger.*`` outlives the conversation in places the user
+never agreed to. Content is therefore omitted by default: log sites pass transcripts through
+:func:`transcript_for_log`, which yields a character count unless transcript logging has been
+explicitly enabled.
+
+Full transcripts are still valuable when debugging STT, LLM, TTS and Realtime behaviour, so
+``--log_transcripts`` turns them back on for a run. The gate is a module-level flag set once
+at startup rather than a parameter threaded through every handler: the default has to be
+"off" everywhere, including in code paths that never think about it, and a single default-off
+switch cannot be missed by a new call site the way a constructor argument can.
+
+Rich/terminal conversation display is unaffected -- that is an operator watching a live
+session, not a retained log.
+"""
+
+from __future__ import annotations
+
+import logging
+
+logger = logging.getLogger(__name__)
+
+_log_transcripts = False
+
+TRANSCRIPT_LOGGING_WARNING = (
+    "Transcript logging is ENABLED (--log_transcripts): full user and assistant "
+    "conversation content will be written to the application log. Anywhere those logs are "
+    "collected or retained -- journald, container logs, hosted log aggregators -- will hold "
+    "sensitive conversation data. Do not enable this in production."
+)
+
+
+def set_log_transcripts(enabled: bool) -> None:
+    """Enable or disable transcript content in log records for this process."""
+    global _log_transcripts
+    _log_transcripts = bool(enabled)
+
+
+def log_transcripts_enabled() -> bool:
+    """Whether log sites may include conversation content."""
+    return _log_transcripts
+
+
+def warn_if_log_transcripts_enabled() -> None:
+    """Emit the prominent opt-in warning, before any conversation is processed."""
+    if _log_transcripts:
+        logger.warning(TRANSCRIPT_LOGGING_WARNING)
+
+
+def transcript_for_log(text: object) -> str:
+    """Render *text* for a log record: the content when opted in, otherwise its length.
+
+    Always returns a string, so call sites keep a single ``%s`` placeholder and read the
+    same in both modes:
+
+        Transcription completed (language=en): chars=42
+        Transcription completed (language=en): see you at nine
+    """
+    value = "" if text is None else str(text)
+    if _log_transcripts:
+        return value
+    return f"chars={len(value)}"

--- a/src/speech_to_speech/s2s_pipeline.py
+++ b/src/speech_to_speech/s2s_pipeline.py
@@ -47,6 +47,10 @@ from speech_to_speech.pipeline.queue_types import (
     VADOutItem,
 )
 from speech_to_speech.pipeline.speculative_turns import SpeculativeTurnTracker
+from speech_to_speech.pipeline.transcript_logging import (
+    set_log_transcripts,
+    warn_if_log_transcripts_enabled,
+)
 from speech_to_speech.STT.transcription_notifier import TranscriptionNotifier
 from speech_to_speech.utils.thread_manager import ThreadManager
 from speech_to_speech.VAD.vad_handler import VADHandler
@@ -621,6 +625,10 @@ def run_pipeline_command(command: Literal["serve", "local"], argv: Sequence[str]
     args = parse_arguments(argv, command=command)
 
     setup_logger(args.module_kwargs.log_level)
+    # Set the transcript gate and warn before any conversation is processed, so an operator
+    # sees the notice ahead of the first turn rather than after content is already logged.
+    set_log_transcripts(args.module_kwargs.log_transcripts)
+    warn_if_log_transcripts_enabled()
 
     if args.module_kwargs.num_pipelines < 1:
         raise ValueError(f"--num_pipelines must be >= 1, got {args.module_kwargs.num_pipelines}")

--- a/tests/openai_realtime/test_audio_client.py
+++ b/tests/openai_realtime/test_audio_client.py
@@ -1,5 +1,6 @@
 import asyncio
 import json
+import logging
 import signal
 import sys
 from threading import Event
@@ -819,12 +820,13 @@ async def test_audio_client_returns_error_when_executor_result_is_not_awaitable(
     await coordinator.close()
 
 
-async def test_audio_client_returns_unknown_malformed_and_handler_failures_and_forces_recovery(capsys):
+async def test_audio_client_returns_unknown_malformed_and_handler_failures_and_forces_recovery(capsys, caplog):
+    caplog.set_level(logging.DEBUG)
     calls = []
 
     async def executor(name, arguments):
         calls.append((name, arguments))
-        raise RuntimeError("lookup failed")
+        raise RuntimeError("executor-secret-8675309")
 
     conn = RecordingConnection()
     coordinator = _ToolCallCoordinator(
@@ -854,7 +856,8 @@ async def test_audio_client_returns_unknown_malformed_and_handler_failures_and_f
     errors = capsys.readouterr().out
     assert "unknown tool" in errors
     assert "not valid JSON" in errors
-    assert "lookup failed" in errors
+    assert "executor-secret-8675309" in errors
+    assert "executor-secret-8675309" not in "\n".join(record.getMessage() for record in caplog.records)
     await coordinator.close()
 
 

--- a/tests/test_cli_defaults.py
+++ b/tests/test_cli_defaults.py
@@ -18,6 +18,7 @@ from speech_to_speech.arguments_classes.responses_api_language_model_arguments i
 from speech_to_speech.arguments_classes.vad_arguments import VADHandlerArguments
 from speech_to_speech.backend_registry import BackendSelection
 from speech_to_speech.cli import main, parse_command, parse_talk_arguments
+from speech_to_speech.pipeline.transcript_logging import log_transcripts_enabled, set_log_transcripts
 from speech_to_speech.s2s_pipeline import ParsedArguments, parse_arguments, prepare_all_args, prepare_module_args
 
 
@@ -353,6 +354,35 @@ def test_talk_accepts_one_full_url_connection_option():
 def test_talk_leaves_api_key_unset_for_sdk_environment_authentication():
     assert parse_talk_arguments([]).api_key is None
     assert parse_talk_arguments(["--api-key", "explicit-secret"]).api_key == "explicit-secret"
+
+
+@pytest.mark.parametrize("flag", ["--log-transcripts", "--log_transcripts"])
+def test_talk_accepts_transcript_logging_opt_in(flag):
+    assert parse_talk_arguments([]).log_transcripts is False
+    assert parse_talk_arguments([flag]).log_transcripts is True
+
+
+def test_main_wires_talk_transcript_logging_before_client_start(monkeypatch):
+    events = []
+    monkeypatch.setattr(sys, "argv", ["speech-to-speech", "talk", "--log-transcripts"])
+
+    def warning():
+        assert log_transcripts_enabled() is True
+        events.append("warning")
+
+    def run_client(config):
+        assert log_transcripts_enabled() is True
+        events.append(("client", config.log_transcripts))
+
+    monkeypatch.setattr("speech_to_speech.cli.warn_if_log_transcripts_enabled", warning)
+    monkeypatch.setattr("speech_to_speech.cli.run_realtime_audio_client", run_client)
+
+    try:
+        main()
+    finally:
+        set_log_transcripts(False)
+
+    assert events == ["warning", ("client", True)]
 
 
 def test_talk_loads_opt_in_tool_module(monkeypatch):

--- a/tests/test_transcript_log_hygiene.py
+++ b/tests/test_transcript_log_hygiene.py
@@ -1,0 +1,189 @@
+"""Conversation content must not reach application loggers.
+
+Operational logs are retained by service managers, containers and hosted logging systems,
+so transcript text written through `logger.*` outlives the conversation in places the user
+never agreed to. Several call sites used to log it directly, including at INFO level:
+
+    logger.info("Transcription completed (language=%s): %s", language_code, transcript)
+
+Diagnostics are kept — stage, event type, language, identifiers, character counts, timing —
+only the content is dropped.
+
+Rich/terminal conversation display (`console.print`) is deliberately out of scope: that is
+the operator watching a live conversation, not a retained log.
+"""
+
+from __future__ import annotations
+
+import ast
+import logging
+from pathlib import Path
+from queue import Queue
+from threading import Event
+
+import pytest
+
+from speech_to_speech.pipeline.messages import PartialTranscription, Transcription
+from speech_to_speech.STT.transcription_notifier import TranscriptionNotifier
+
+SENTINEL = "Meet me at Rue Saint-Antoine at nine tomorrow"
+
+_SRC_ROOT = Path(__file__).resolve().parents[1] / "src"
+
+
+def _notifier(text_output_queue=None, should_listen=None) -> TranscriptionNotifier:
+    notifier = object.__new__(TranscriptionNotifier)
+    notifier.setup(text_output_queue=text_output_queue, should_listen=should_listen)
+    return notifier
+
+
+def _logged_text(caplog) -> str:
+    return "\n".join(record.getMessage() for record in caplog.records)
+
+
+# --- behavioural: the STT notifier path ---------------------------------------------------
+
+
+def test_final_transcription_content_is_not_logged(caplog):
+    """This was an INFO-level leak, so it showed up in default deployments."""
+    caplog.set_level(logging.DEBUG)
+    notifier = _notifier(text_output_queue=Queue(), should_listen=Event())
+
+    list(notifier.process(Transcription(text=SENTINEL, language_code="fr", speech_stopped_at_s=1.0)))
+
+    assert SENTINEL not in _logged_text(caplog)
+
+
+def test_final_transcription_without_language_is_not_logged(caplog):
+    caplog.set_level(logging.DEBUG)
+    notifier = _notifier(text_output_queue=Queue(), should_listen=Event())
+
+    list(notifier.process(Transcription(text=SENTINEL, language_code=None, speech_stopped_at_s=1.0)))
+
+    assert SENTINEL not in _logged_text(caplog)
+
+
+def test_partial_transcription_content_is_not_logged(caplog):
+    caplog.set_level(logging.DEBUG)
+    notifier = _notifier(text_output_queue=Queue())
+
+    list(notifier.process(PartialTranscription(text=SENTINEL)))
+
+    assert SENTINEL not in _logged_text(caplog)
+
+
+def test_long_transcript_is_not_logged_even_truncated(caplog):
+    """Truncated content is still content: the old code logged the first 80 characters."""
+    caplog.set_level(logging.DEBUG)
+    notifier = _notifier(text_output_queue=Queue())
+    long_text = SENTINEL * 10
+
+    list(notifier.process(PartialTranscription(text=long_text)))
+
+    logged = _logged_text(caplog)
+    assert SENTINEL not in logged
+    assert long_text[:80] not in logged
+
+
+def test_useful_diagnostics_are_retained(caplog):
+    """Dropping content must not mean dropping observability."""
+    caplog.set_level(logging.DEBUG)
+    notifier = _notifier(text_output_queue=Queue(), should_listen=Event())
+
+    list(notifier.process(Transcription(text=SENTINEL, language_code="fr", speech_stopped_at_s=1.0)))
+
+    logged = _logged_text(caplog)
+    assert "Transcription completed" in logged
+    assert "fr" in logged
+    assert str(len(SENTINEL)) in logged
+
+
+def test_transcription_events_still_carry_the_text():
+    """Protocol payloads are unchanged; only logging is content-free."""
+    queue: Queue = Queue()
+    notifier = _notifier(text_output_queue=queue, should_listen=Event())
+
+    list(notifier.process(PartialTranscription(text=SENTINEL)))
+
+    assert queue.get_nowait().delta == SENTINEL
+
+
+# --- source sweep: STT, LLM, TTS and Realtime paths ---------------------------------------
+#
+# A behavioural test can only reach the paths it can cheaply construct. This sweep covers
+# every module, so a new content-bearing log call fails CI wherever it is added.
+
+# Expressions that evaluate to conversation content. Logging any of these leaks transcript
+# text; logging len(...) of them does not.
+_CONTENT_EXPRESSIONS = {
+    "clean_text",
+    "generated_text",
+    "transcript",
+    "pred_text",
+    "hypothesis",
+    "transcript_prefix",
+    # Generic, but every logger use of a bare `text` in this package is conversation text.
+    "text",
+}
+
+_CONTENT_ATTRIBUTES = {"clean_text", "generated_text", "transcript", "transcript_prefix", "text"}
+
+_LOG_METHODS = {"debug", "info", "warning", "error", "exception", "critical"}
+
+
+def _log_call_arguments(tree: ast.AST):
+    """Yield (lineno, arg) for every argument passed to a logger.<level>() call."""
+    for node in ast.walk(tree):
+        if not isinstance(node, ast.Call):
+            continue
+        func = node.func
+        if not isinstance(func, ast.Attribute) or func.attr not in _LOG_METHODS:
+            continue
+        if not (isinstance(func.value, ast.Name) and func.value.id in {"logger", "logging"}):
+            continue
+        for arg in node.args:
+            yield node.lineno, arg
+
+
+def _mentions_content(node: ast.AST) -> bool:
+    """True if *node* evaluates to conversation content rather than a measurement of it."""
+    for inner in ast.walk(node):
+        # len(x) and similar reductions are fine, so don't descend into them.
+        if isinstance(inner, ast.Call):
+            callee = inner.func
+            if isinstance(callee, ast.Name) and callee.id == "len":
+                continue
+        if isinstance(inner, ast.Name) and inner.id in _CONTENT_EXPRESSIONS:
+            return True
+        if isinstance(inner, ast.Attribute) and inner.attr in _CONTENT_ATTRIBUTES:
+            return True
+    return False
+
+
+def _strip_len_calls(node: ast.AST) -> ast.AST:
+    """Replace len(...) subtrees with a constant so they are ignored by the scan."""
+
+    class Pruner(ast.NodeTransformer):
+        def visit_Call(self, call: ast.Call):  # noqa: N802
+            if isinstance(call.func, ast.Name) and call.func.id == "len":
+                return ast.Constant(value=0)
+            self.generic_visit(call)
+            return call
+
+    return Pruner().visit(node)
+
+
+@pytest.mark.parametrize(
+    "relative_path",
+    sorted(str(p.relative_to(_SRC_ROOT)) for p in (_SRC_ROOT / "speech_to_speech").rglob("*.py")),
+)
+def test_no_logger_call_passes_conversation_content(relative_path: str) -> None:
+    source = (_SRC_ROOT / relative_path).read_text(encoding="utf-8")
+    tree = ast.parse(source)
+
+    offenders = [lineno for lineno, arg in _log_call_arguments(tree) if _mentions_content(_strip_len_calls(arg))]
+
+    assert offenders == [], (
+        f"{relative_path} passes conversation content to a logger at line(s) {offenders}; "
+        f"log a character count or identifier instead"
+    )

--- a/tests/test_transcript_log_hygiene.py
+++ b/tests/test_transcript_log_hygiene.py
@@ -24,6 +24,14 @@ from threading import Event
 import pytest
 
 from speech_to_speech.pipeline.messages import PartialTranscription, Transcription
+from speech_to_speech.pipeline.transcript_logging import (
+    log_transcripts_enabled as log_transcripts_enabled_flag,
+)
+from speech_to_speech.pipeline.transcript_logging import (
+    set_log_transcripts,
+    transcript_for_log,
+    warn_if_log_transcripts_enabled,
+)
 from speech_to_speech.STT.transcription_notifier import TranscriptionNotifier
 
 SENTINEL = "Meet me at Rue Saint-Antoine at nine tomorrow"
@@ -160,12 +168,20 @@ def _mentions_content(node: ast.AST) -> bool:
     return False
 
 
-def _strip_len_calls(node: ast.AST) -> ast.AST:
-    """Replace len(...) subtrees with a constant so they are ignored by the scan."""
+# Calls that reduce content to something safe, or route it through the opt-in gate.
+_SAFE_WRAPPERS = {"len", "transcript_for_log"}
+
+
+def _strip_safe_wrappers(node: ast.AST) -> ast.AST:
+    """Replace len(...) / transcript_for_log(...) subtrees with a constant.
+
+    `transcript_for_log` is the single audited place that may emit content, and only when
+    `--log_transcripts` is set, so a call site delegating to it is compliant by construction.
+    """
 
     class Pruner(ast.NodeTransformer):
         def visit_Call(self, call: ast.Call):  # noqa: N802
-            if isinstance(call.func, ast.Name) and call.func.id == "len":
+            if isinstance(call.func, ast.Name) and call.func.id in _SAFE_WRAPPERS:
                 return ast.Constant(value=0)
             self.generic_visit(call)
             return call
@@ -181,9 +197,135 @@ def test_no_logger_call_passes_conversation_content(relative_path: str) -> None:
     source = (_SRC_ROOT / relative_path).read_text(encoding="utf-8")
     tree = ast.parse(source)
 
-    offenders = [lineno for lineno, arg in _log_call_arguments(tree) if _mentions_content(_strip_len_calls(arg))]
+    offenders = [lineno for lineno, arg in _log_call_arguments(tree) if _mentions_content(_strip_safe_wrappers(arg))]
 
     assert offenders == [], (
         f"{relative_path} passes conversation content to a logger at line(s) {offenders}; "
         f"log a character count or identifier instead"
     )
+
+
+# --- the explicit opt-in ------------------------------------------------------------------
+
+
+@pytest.fixture
+def log_transcripts_enabled():
+    """Turn the gate on for one test, then restore it.
+
+    The gate is process-global by design, so it must be restored even on failure or a later
+    test could silently assert against the wrong default.
+    """
+    set_log_transcripts(True)
+    try:
+        yield
+    finally:
+        set_log_transcripts(False)
+
+
+def test_gate_is_off_by_default():
+    """The default has to be off: everything else here depends on it."""
+    assert log_transcripts_enabled_flag() is False
+
+
+def test_final_transcription_is_logged_when_opted_in(caplog, log_transcripts_enabled):
+    caplog.set_level(logging.DEBUG)
+    notifier = _notifier(text_output_queue=Queue(), should_listen=Event())
+
+    list(notifier.process(Transcription(text=SENTINEL, language_code="fr", speech_stopped_at_s=1.0)))
+
+    assert SENTINEL in _logged_text(caplog)
+
+
+def test_partial_transcription_is_logged_when_opted_in(caplog, log_transcripts_enabled):
+    caplog.set_level(logging.DEBUG)
+    notifier = _notifier(text_output_queue=Queue())
+
+    list(notifier.process(PartialTranscription(text=SENTINEL)))
+
+    assert SENTINEL in _logged_text(caplog)
+
+
+def test_full_transcript_is_not_truncated_when_opted_in(caplog, log_transcripts_enabled):
+    """Opting in is for debugging, so the whole transcript has to be there."""
+    caplog.set_level(logging.DEBUG)
+    notifier = _notifier(text_output_queue=Queue())
+    long_text = SENTINEL * 5
+
+    list(notifier.process(PartialTranscription(text=long_text)))
+
+    assert long_text in _logged_text(caplog)
+
+
+def test_gate_restores_default_after_opt_in(caplog):
+    """Ordering guard: the previous tests must not leak the enabled state."""
+    caplog.set_level(logging.DEBUG)
+    notifier = _notifier(text_output_queue=Queue(), should_listen=Event())
+
+    list(notifier.process(Transcription(text=SENTINEL, language_code="fr", speech_stopped_at_s=1.0)))
+
+    assert SENTINEL not in _logged_text(caplog)
+
+
+# --- transcript_for_log itself ------------------------------------------------------------
+
+
+def test_transcript_for_log_reports_length_by_default():
+    assert transcript_for_log("hello") == "chars=5"
+
+
+def test_transcript_for_log_returns_content_when_opted_in(log_transcripts_enabled):
+    assert transcript_for_log("hello") == "hello"
+
+
+@pytest.mark.parametrize("value", [None, ""])
+def test_transcript_for_log_handles_missing_text(value):
+    assert transcript_for_log(value) == "chars=0"
+
+
+def test_transcript_for_log_stringifies_non_text(log_transcripts_enabled):
+    assert transcript_for_log(42) == "42"
+
+
+# --- the startup warning -----------------------------------------------------------------
+
+
+def test_no_warning_when_the_gate_is_off(caplog):
+    caplog.set_level(logging.DEBUG)
+
+    warn_if_log_transcripts_enabled()
+
+    assert caplog.records == []
+
+
+def test_warning_is_emitted_when_opted_in(caplog, log_transcripts_enabled):
+    caplog.set_level(logging.DEBUG)
+
+    warn_if_log_transcripts_enabled()
+
+    assert [r.levelno for r in caplog.records] == [logging.WARNING]
+    message = caplog.records[0].getMessage()
+    assert "--log_transcripts" in message
+    assert "retained" in message.lower()
+
+
+def test_startup_wires_the_gate_and_warns_before_processing(monkeypatch, caplog):
+    """The flag has to reach the gate, and the warning must precede conversation handling."""
+    caplog.set_level(logging.DEBUG)
+
+    set_log_transcripts(False)
+    try:
+        set_log_transcripts(True)
+        warn_if_log_transcripts_enabled()
+        assert log_transcripts_enabled_flag() is True
+        assert any("--log_transcripts" in r.getMessage() for r in caplog.records)
+    finally:
+        set_log_transcripts(False)
+
+
+def test_cli_exposes_the_flag_defaulting_to_off():
+    from speech_to_speech.arguments_classes.module_arguments import ModuleArguments
+
+    field = ModuleArguments.__dataclass_fields__["log_transcripts"]
+
+    assert field.default is False
+    assert "retained" in field.metadata["help"].lower()

--- a/tests/test_transcript_log_hygiene.py
+++ b/tests/test_transcript_log_hygiene.py
@@ -1,47 +1,48 @@
-"""Conversation content must not reach application loggers.
-
-Operational logs are retained by service managers, containers and hosted logging systems,
-so transcript text written through `logger.*` outlives the conversation in places the user
-never agreed to. Several call sites used to log it directly, including at INFO level:
-
-    logger.info("Transcription completed (language=%s): %s", language_code, transcript)
-
-Diagnostics are kept — stage, event type, language, identifiers, character counts, timing —
-only the content is dropped.
-
-Rich/terminal conversation display (`console.print`) is deliberately out of scope: that is
-the operator watching a live conversation, not a retained log.
-"""
+"""Conversation content is retained in protocol events, but omitted from logs by default."""
 
 from __future__ import annotations
 
-import ast
 import logging
-from pathlib import Path
 from queue import Queue
 from threading import Event
+from types import SimpleNamespace
 
 import pytest
+from openai.types.responses import ResponseFunctionToolCall
 
-from speech_to_speech.pipeline.messages import PartialTranscription, Transcription
-from speech_to_speech.pipeline.transcript_logging import (
-    log_transcripts_enabled as log_transcripts_enabled_flag,
+from speech_to_speech.api.openai_realtime.service import RealtimeService
+from speech_to_speech.LLM.lm_output_processor import LMOutputProcessor
+from speech_to_speech.pipeline.messages import (
+    AssistantTextPart,
+    AssistantToolCallPart,
+    LLMResponseChunk,
+    PartialTranscription,
+    Transcription,
 )
 from speech_to_speech.pipeline.transcript_logging import (
+    log_transcripts_enabled,
     set_log_transcripts,
     transcript_for_log,
     warn_if_log_transcripts_enabled,
 )
 from speech_to_speech.STT.transcription_notifier import TranscriptionNotifier
+from speech_to_speech.TTS.facebookmms_handler import FacebookMMSTTSHandler
 
 SENTINEL = "Meet me at Rue Saint-Antoine at nine tomorrow"
+TOOL_SENTINEL = "account-number-8675309"
+ERROR_SENTINEL = "tts-error-8675309"
 
-_SRC_ROOT = Path(__file__).resolve().parents[1] / "src"
+
+@pytest.fixture(autouse=True)
+def reset_transcript_gate():
+    set_log_transcripts(False)
+    yield
+    set_log_transcripts(False)
 
 
-def _notifier(text_output_queue=None, should_listen=None) -> TranscriptionNotifier:
+def _notifier() -> TranscriptionNotifier:
     notifier = object.__new__(TranscriptionNotifier)
-    notifier.setup(text_output_queue=text_output_queue, should_listen=should_listen)
+    notifier.setup(text_output_queue=Queue(), should_listen=Event())
     return notifier
 
 
@@ -49,56 +50,32 @@ def _logged_text(caplog) -> str:
     return "\n".join(record.getMessage() for record in caplog.records)
 
 
-# --- behavioural: the STT notifier path ---------------------------------------------------
+def _assert_content_visibility(logged: str, enabled: bool, *values: str) -> None:
+    for value in values:
+        assert (value in logged) is enabled
 
 
-def test_final_transcription_content_is_not_logged(caplog):
-    """This was an INFO-level leak, so it showed up in default deployments."""
+@pytest.mark.parametrize(
+    "message",
+    [
+        Transcription(text=SENTINEL, language_code="fr", speech_stopped_at_s=1.0),
+        Transcription(text=SENTINEL, language_code=None, speech_stopped_at_s=1.0),
+        PartialTranscription(text=SENTINEL),
+        PartialTranscription(text=SENTINEL * 10),
+    ],
+)
+def test_stt_content_is_not_logged_by_default(caplog, message):
     caplog.set_level(logging.DEBUG)
-    notifier = _notifier(text_output_queue=Queue(), should_listen=Event())
 
-    list(notifier.process(Transcription(text=SENTINEL, language_code="fr", speech_stopped_at_s=1.0)))
+    list(_notifier().process(message))
 
     assert SENTINEL not in _logged_text(caplog)
 
 
-def test_final_transcription_without_language_is_not_logged(caplog):
+def test_stt_metadata_is_retained(caplog):
     caplog.set_level(logging.DEBUG)
-    notifier = _notifier(text_output_queue=Queue(), should_listen=Event())
 
-    list(notifier.process(Transcription(text=SENTINEL, language_code=None, speech_stopped_at_s=1.0)))
-
-    assert SENTINEL not in _logged_text(caplog)
-
-
-def test_partial_transcription_content_is_not_logged(caplog):
-    caplog.set_level(logging.DEBUG)
-    notifier = _notifier(text_output_queue=Queue())
-
-    list(notifier.process(PartialTranscription(text=SENTINEL)))
-
-    assert SENTINEL not in _logged_text(caplog)
-
-
-def test_long_transcript_is_not_logged_even_truncated(caplog):
-    """Truncated content is still content: the old code logged the first 80 characters."""
-    caplog.set_level(logging.DEBUG)
-    notifier = _notifier(text_output_queue=Queue())
-    long_text = SENTINEL * 10
-
-    list(notifier.process(PartialTranscription(text=long_text)))
-
-    logged = _logged_text(caplog)
-    assert SENTINEL not in logged
-    assert long_text[:80] not in logged
-
-
-def test_useful_diagnostics_are_retained(caplog):
-    """Dropping content must not mean dropping observability."""
-    caplog.set_level(logging.DEBUG)
-    notifier = _notifier(text_output_queue=Queue(), should_listen=Event())
-
-    list(notifier.process(Transcription(text=SENTINEL, language_code="fr", speech_stopped_at_s=1.0)))
+    list(_notifier().process(Transcription(text=SENTINEL, language_code="fr", speech_stopped_at_s=1.0)))
 
     logged = _logged_text(caplog)
     assert "Transcription completed" in logged
@@ -106,187 +83,103 @@ def test_useful_diagnostics_are_retained(caplog):
     assert str(len(SENTINEL)) in logged
 
 
-def test_transcription_events_still_carry_the_text():
-    """Protocol payloads are unchanged; only logging is content-free."""
+def test_transcription_protocol_event_still_carries_text():
     queue: Queue = Queue()
-    notifier = _notifier(text_output_queue=queue, should_listen=Event())
+    notifier = object.__new__(TranscriptionNotifier)
+    notifier.setup(text_output_queue=queue, should_listen=Event())
 
     list(notifier.process(PartialTranscription(text=SENTINEL)))
 
     assert queue.get_nowait().delta == SENTINEL
 
 
-# --- source sweep: STT, LLM, TTS and Realtime paths ---------------------------------------
-#
-# A behavioural test can only reach the paths it can cheaply construct. This sweep covers
-# every module, so a new content-bearing log call fails CI wherever it is added.
-
-# Expressions that evaluate to conversation content. Logging any of these leaks transcript
-# text; logging len(...) of them does not.
-_CONTENT_EXPRESSIONS = {
-    "clean_text",
-    "generated_text",
-    "transcript",
-    "pred_text",
-    "hypothesis",
-    "transcript_prefix",
-    # Generic, but every logger use of a bare `text` in this package is conversation text.
-    "text",
-}
-
-_CONTENT_ATTRIBUTES = {"clean_text", "generated_text", "transcript", "transcript_prefix", "text"}
-
-_LOG_METHODS = {"debug", "info", "warning", "error", "exception", "critical"}
-
-
-def _log_call_arguments(tree: ast.AST):
-    """Yield (lineno, arg) for every argument passed to a logger.<level>() call."""
-    for node in ast.walk(tree):
-        if not isinstance(node, ast.Call):
-            continue
-        func = node.func
-        if not isinstance(func, ast.Attribute) or func.attr not in _LOG_METHODS:
-            continue
-        if not (isinstance(func.value, ast.Name) and func.value.id in {"logger", "logging"}):
-            continue
-        for arg in node.args:
-            yield node.lineno, arg
-
-
-def _mentions_content(node: ast.AST) -> bool:
-    """True if *node* evaluates to conversation content rather than a measurement of it."""
-    for inner in ast.walk(node):
-        # len(x) and similar reductions are fine, so don't descend into them.
-        if isinstance(inner, ast.Call):
-            callee = inner.func
-            if isinstance(callee, ast.Name) and callee.id == "len":
-                continue
-        if isinstance(inner, ast.Name) and inner.id in _CONTENT_EXPRESSIONS:
-            return True
-        if isinstance(inner, ast.Attribute) and inner.attr in _CONTENT_ATTRIBUTES:
-            return True
-    return False
-
-
-# Calls that reduce content to something safe, or route it through the opt-in gate.
-_SAFE_WRAPPERS = {"len", "transcript_for_log"}
-
-
-def _strip_safe_wrappers(node: ast.AST) -> ast.AST:
-    """Replace len(...) / transcript_for_log(...) subtrees with a constant.
-
-    `transcript_for_log` is the single audited place that may emit content, and only when
-    `--log_transcripts` is set, so a call site delegating to it is compliant by construction.
-    """
-
-    class Pruner(ast.NodeTransformer):
-        def visit_Call(self, call: ast.Call):  # noqa: N802
-            if isinstance(call.func, ast.Name) and call.func.id in _SAFE_WRAPPERS:
-                return ast.Constant(value=0)
-            self.generic_visit(call)
-            return call
-
-    return Pruner().visit(node)
-
-
 @pytest.mark.parametrize(
-    "relative_path",
-    sorted(str(p.relative_to(_SRC_ROOT)) for p in (_SRC_ROOT / "speech_to_speech").rglob("*.py")),
+    "message",
+    [
+        Transcription(text=SENTINEL, language_code="fr", speech_stopped_at_s=1.0),
+        PartialTranscription(text=SENTINEL * 5),
+    ],
 )
-def test_no_logger_call_passes_conversation_content(relative_path: str) -> None:
-    source = (_SRC_ROOT / relative_path).read_text(encoding="utf-8")
-    tree = ast.parse(source)
-
-    offenders = [lineno for lineno, arg in _log_call_arguments(tree) if _mentions_content(_strip_safe_wrappers(arg))]
-
-    assert offenders == [], (
-        f"{relative_path} passes conversation content to a logger at line(s) {offenders}; "
-        f"log a character count or identifier instead"
-    )
-
-
-# --- the explicit opt-in ------------------------------------------------------------------
-
-
-@pytest.fixture
-def log_transcripts_enabled():
-    """Turn the gate on for one test, then restore it.
-
-    The gate is process-global by design, so it must be restored even on failure or a later
-    test could silently assert against the wrong default.
-    """
+def test_stt_content_is_logged_in_full_when_opted_in(caplog, message):
+    caplog.set_level(logging.DEBUG)
     set_log_transcripts(True)
-    try:
-        yield
-    finally:
-        set_log_transcripts(False)
+
+    list(_notifier().process(message))
+
+    assert message.text in _logged_text(caplog)
+
+
+@pytest.mark.parametrize("enabled", [False, True])
+def test_llm_text_and_tool_arguments_follow_the_gate(caplog, enabled):
+    caplog.set_level(logging.DEBUG)
+    tool = ResponseFunctionToolCall(
+        type="function_call",
+        id="fc_test",
+        call_id="call_test",
+        name="remember",
+        arguments=f'{{"note": "{TOOL_SENTINEL}"}}',
+        status="completed",
+    )
+    chunk = LLMResponseChunk(parts=[AssistantTextPart(text=SENTINEL), AssistantToolCallPart(tool=tool)])
+    processor = object.__new__(LMOutputProcessor)
+    processor.setup()
+    set_log_transcripts(enabled)
+
+    list(processor.process(chunk))
+
+    _assert_content_visibility(_logged_text(caplog), enabled, SENTINEL, TOOL_SENTINEL)
+
+
+@pytest.mark.parametrize("enabled", [False, True])
+def test_realtime_validation_errors_follow_the_gate(caplog, enabled):
+    caplog.set_level(logging.DEBUG)
+    raw = {
+        "type": "conversation.item.create",
+        "item": {"type": "function_call", "arguments": TOOL_SENTINEL},
+    }
+    set_log_transcripts(enabled)
+
+    assert RealtimeService().parse_client_event(raw) is None
+
+    _assert_content_visibility(_logged_text(caplog), enabled, TOOL_SENTINEL)
+
+
+@pytest.mark.parametrize("enabled", [False, True])
+def test_tts_exceptions_follow_the_gate(caplog, enabled):
+    class FailingTokenizer:
+        def __call__(self, *_args, **_kwargs):
+            raise ValueError(ERROR_SENTINEL)
+
+    caplog.set_level(logging.DEBUG)
+    handler = object.__new__(FacebookMMSTTSHandler)
+    handler.language = "en"
+    handler.tokenizer = FailingTokenizer()
+    set_log_transcripts(enabled)
+
+    assert handler.generate_audio("harmless input") is None
+
+    logged = _logged_text(caplog)
+    _assert_content_visibility(logged, enabled, ERROR_SENTINEL)
+    assert "ValueError" in logged
 
 
 def test_gate_is_off_by_default():
-    """The default has to be off: everything else here depends on it."""
-    assert log_transcripts_enabled_flag() is False
+    assert log_transcripts_enabled() is False
 
 
-def test_final_transcription_is_logged_when_opted_in(caplog, log_transcripts_enabled):
-    caplog.set_level(logging.DEBUG)
-    notifier = _notifier(text_output_queue=Queue(), should_listen=Event())
-
-    list(notifier.process(Transcription(text=SENTINEL, language_code="fr", speech_stopped_at_s=1.0)))
-
-    assert SENTINEL in _logged_text(caplog)
-
-
-def test_partial_transcription_is_logged_when_opted_in(caplog, log_transcripts_enabled):
-    caplog.set_level(logging.DEBUG)
-    notifier = _notifier(text_output_queue=Queue())
-
-    list(notifier.process(PartialTranscription(text=SENTINEL)))
-
-    assert SENTINEL in _logged_text(caplog)
+@pytest.mark.parametrize(
+    ("value", "expected"),
+    [("hello", "chars=5"), (None, "chars=0"), ("", "chars=0")],
+)
+def test_transcript_for_log_reports_length_by_default(value, expected):
+    assert transcript_for_log(value) == expected
 
 
-def test_full_transcript_is_not_truncated_when_opted_in(caplog, log_transcripts_enabled):
-    """Opting in is for debugging, so the whole transcript has to be there."""
-    caplog.set_level(logging.DEBUG)
-    notifier = _notifier(text_output_queue=Queue())
-    long_text = SENTINEL * 5
+def test_transcript_for_log_returns_stringified_content_when_opted_in():
+    set_log_transcripts(True)
 
-    list(notifier.process(PartialTranscription(text=long_text)))
-
-    assert long_text in _logged_text(caplog)
-
-
-def test_gate_restores_default_after_opt_in(caplog):
-    """Ordering guard: the previous tests must not leak the enabled state."""
-    caplog.set_level(logging.DEBUG)
-    notifier = _notifier(text_output_queue=Queue(), should_listen=Event())
-
-    list(notifier.process(Transcription(text=SENTINEL, language_code="fr", speech_stopped_at_s=1.0)))
-
-    assert SENTINEL not in _logged_text(caplog)
-
-
-# --- transcript_for_log itself ------------------------------------------------------------
-
-
-def test_transcript_for_log_reports_length_by_default():
-    assert transcript_for_log("hello") == "chars=5"
-
-
-def test_transcript_for_log_returns_content_when_opted_in(log_transcripts_enabled):
     assert transcript_for_log("hello") == "hello"
-
-
-@pytest.mark.parametrize("value", [None, ""])
-def test_transcript_for_log_handles_missing_text(value):
-    assert transcript_for_log(value) == "chars=0"
-
-
-def test_transcript_for_log_stringifies_non_text(log_transcripts_enabled):
     assert transcript_for_log(42) == "42"
-
-
-# --- the startup warning -----------------------------------------------------------------
 
 
 def test_no_warning_when_the_gate_is_off(caplog):
@@ -297,29 +190,57 @@ def test_no_warning_when_the_gate_is_off(caplog):
     assert caplog.records == []
 
 
-def test_warning_is_emitted_when_opted_in(caplog, log_transcripts_enabled):
+def test_warning_is_emitted_when_opted_in(caplog):
     caplog.set_level(logging.DEBUG)
+    set_log_transcripts(True)
 
     warn_if_log_transcripts_enabled()
 
-    assert [r.levelno for r in caplog.records] == [logging.WARNING]
+    assert [record.levelno for record in caplog.records] == [logging.WARNING]
     message = caplog.records[0].getMessage()
     assert "--log_transcripts" in message
     assert "retained" in message.lower()
 
 
-def test_startup_wires_the_gate_and_warns_before_processing(monkeypatch, caplog):
-    """The flag has to reach the gate, and the warning must precede conversation handling."""
-    caplog.set_level(logging.DEBUG)
+def test_startup_wires_the_gate_and_warns_before_processing(monkeypatch):
+    from speech_to_speech import s2s_pipeline
 
-    set_log_transcripts(False)
-    try:
-        set_log_transcripts(True)
-        warn_if_log_transcripts_enabled()
-        assert log_transcripts_enabled_flag() is True
-        assert any("--log_transcripts" in r.getMessage() for r in caplog.records)
-    finally:
-        set_log_transcripts(False)
+    events: list[str] = []
+    args = SimpleNamespace(
+        module_kwargs=SimpleNamespace(
+            log_level="debug",
+            log_transcripts=True,
+            num_pipelines=1,
+            enable_live_transcription=False,
+        )
+    )
+    manager = SimpleNamespace(
+        start=lambda: events.append("start"),
+        wait=lambda: events.append("wait"),
+        stop=lambda: events.append("stop"),
+    )
+
+    monkeypatch.setattr(s2s_pipeline, "parse_arguments", lambda *_args, **_kwargs: args)
+    monkeypatch.setattr(s2s_pipeline, "setup_logger", lambda _level: events.append("logger"))
+    monkeypatch.setattr(s2s_pipeline, "prepare_all_args", lambda _args: events.append("prepare"))
+    monkeypatch.setattr(
+        s2s_pipeline,
+        "build_pipeline",
+        lambda _args, _stop_event: events.append("build") or manager,
+    )
+    monkeypatch.setattr(s2s_pipeline.signal, "signal", lambda *_args: None)
+    original_warning = s2s_pipeline.warn_if_log_transcripts_enabled
+
+    def record_warning():
+        assert log_transcripts_enabled() is True
+        events.append("warning")
+        original_warning()
+
+    monkeypatch.setattr(s2s_pipeline, "warn_if_log_transcripts_enabled", record_warning)
+
+    s2s_pipeline.run_pipeline_command("serve", [])
+
+    assert events == ["logger", "warning", "prepare", "build", "start", "wait"]
 
 
 def test_cli_exposes_the_flag_defaulting_to_off():

--- a/tests/test_transcript_log_hygiene.py
+++ b/tests/test_transcript_log_hygiene.py
@@ -12,6 +12,7 @@ from openai.types.responses import ResponseFunctionToolCall
 
 from speech_to_speech.api.openai_realtime.service import RealtimeService
 from speech_to_speech.LLM.lm_output_processor import LMOutputProcessor
+from speech_to_speech.pipeline.events import PartialTranscriptionEvent, SpeechStartedEvent
 from speech_to_speech.pipeline.messages import (
     AssistantTextPart,
     AssistantToolCallPart,
@@ -145,6 +146,27 @@ def test_realtime_validation_errors_follow_the_gate(caplog, enabled):
 
 
 @pytest.mark.parametrize("enabled", [False, True])
+def test_realtime_transcript_hypotheses_follow_the_gate(caplog, enabled):
+    caplog.set_level(logging.DEBUG)
+    service = RealtimeService()
+    conn_id = service.register()
+    set_log_transcripts(enabled)
+
+    service.dispatch_pipeline_event(conn_id, SpeechStartedEvent())
+    service.dispatch_pipeline_event(conn_id, PartialTranscriptionEvent(delta=SENTINEL))
+    service.dispatch_pipeline_event(conn_id, PartialTranscriptionEvent(delta=f"{SENTINEL} please"))
+    service.dispatch_pipeline_event(conn_id, PartialTranscriptionEvent(delta=f"{SENTINEL} please now"))
+    revised = service.dispatch_pipeline_event(
+        conn_id,
+        PartialTranscriptionEvent(delta="Call me at Rue Saint-Antoine at nine tomorrow please now"),
+    )
+
+    assert revised == []
+    _assert_content_visibility(_logged_text(caplog), enabled, SENTINEL)
+    service.unregister(conn_id)
+
+
+@pytest.mark.parametrize("enabled", [False, True])
 def test_tts_exceptions_follow_the_gate(caplog, enabled):
     class FailingTokenizer:
         def __call__(self, *_args, **_kwargs):
@@ -156,10 +178,10 @@ def test_tts_exceptions_follow_the_gate(caplog, enabled):
     handler.tokenizer = FailingTokenizer()
     set_log_transcripts(enabled)
 
-    assert handler.generate_audio("harmless input") is None
+    assert handler.generate_audio(SENTINEL) is None
 
     logged = _logged_text(caplog)
-    _assert_content_visibility(logged, enabled, ERROR_SENTINEL)
+    _assert_content_visibility(logged, enabled, SENTINEL, ERROR_SENTINEL)
     assert "ValueError" in logged
 
 

--- a/tests/test_transcription_notifier.py
+++ b/tests/test_transcription_notifier.py
@@ -43,14 +43,23 @@ def test_empty_final_transcription_still_emits_completion_after_partial():
     assert text_output_queue.empty()
 
 
-def test_non_empty_final_transcription_logs_full_text_at_info(caplog):
+def test_non_empty_final_transcription_logs_metadata_without_content(caplog):
+    """Logs the completion, language and length -- never the transcript itself.
+
+    Operational logs outlive the conversation, so content is deliberately omitted
+    (see tests/test_transcript_log_hygiene.py).
+    """
     notifier = _notifier()
     transcript = "hello " * 30
 
     with caplog.at_level(logging.INFO, logger="speech_to_speech.STT.transcription_notifier"):
         assert list(notifier.process(Transcription(text=transcript, language_code="en"))) == []
 
-    assert "Transcription completed (language=en): " + transcript in caplog.text
+    assert "Transcription completed" in caplog.text
+    assert "language=en" in caplog.text
+    assert f"chars={len(transcript)}" in caplog.text
+    assert transcript not in caplog.text
+    assert "hello hello" not in caplog.text
 
 
 def test_empty_final_transcription_reenables_listening_without_runtime_config():


### PR DESCRIPTION
## Summary

- preserve the contributor commits from #517 through a regular merge
- gate remaining transcript-bearing LLM parts, tool arguments, payloads, and exception paths
- replace the broad AST source scan with focused behavioral coverage across STT, LLM/tools, TTS, Realtime, startup, and errors
- keep OpenAI Realtime protocol events and terminal conversation display unchanged

Closes #475.

## Verification

- 1,287 tests passed, 1 skipped
- Ruff checks and formatting passed
- mypy passed