### PR TITLE
Resolve OmniVoice and Qwen3 dependency conflict

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -96,6 +96,30 @@ jobs:
           name: dist
           path: dist/*
 
+  omnivoice-resolver:
+    name: OmniVoice resolver (${{ matrix.label }})
+    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - label: linux
+            platform: x86_64-manylinux_2_39
+          - label: windows
+            platform: x86_64-pc-windows-msvc
+    steps:
+      - uses: actions/checkout@v7
+      - uses: astral-sh/setup-uv@v10.0.1
+        with:
+          version: "latest"
+      - name: Resolve speech-to-speech[omnivoice]
+        run: >-
+          uv pip compile pyproject.toml
+          --extra omnivoice
+          --python-version 3.11
+          --python-platform ${{ matrix.platform }}
+          --output-file ${{ runner.temp }}/omnivoice-${{ matrix.label }}.txt
+
   install-smoke:
     name: Install smoke (${{ matrix.label }})
     needs: package
@@ -107,8 +131,12 @@ jobs:
         include:
           - label: linux
             os: ubuntu-latest
+            extra: "[omnivoice]"
+            smoke_extra: omnivoice
           - label: macos-arm64
             os: macos-14
+            extra: ""
+            smoke_extra: ""
     steps:
       - uses: actions/checkout@v7
       - uses: actions/setup-python@v7.0.0
@@ -124,10 +152,13 @@ jobs:
           python -m venv .venv-smoke
           source .venv-smoke/bin/activate
           python -m pip install --upgrade pip
-          python -m pip install dist/speech_to_speech-*.whl
+          wheel=$(find dist -name 'speech_to_speech-*.whl' -print -quit)
+          python -m pip install "${wheel}${{ matrix.extra }}"
           python -m pip check
       - name: Run installed CLI smoke test
         shell: bash
+        env:
+          SPEECH_TO_SPEECH_SMOKE_EXTRA: ${{ matrix.smoke_extra }}
         run: |
           source .venv-smoke/bin/activate
           unset OPENAI_API_KEY

--- a/README.md
+++ b/README.md
@@ -112,7 +112,7 @@ macOS and non-macOS dependencies are resolved automatically via platform markers
 
 ### CUDA Note for Qwen3-TTS
 
-On Linux, the Qwen3-TTS GGML backend comes from `faster-qwen3-tts[ggml]`. Its default `qwentts-cpp-python` wheel on PyPI targets CUDA 12.8. If your machine does not have the CUDA 12 runtime that wheel expects, install the matching wheel from the Hugging Face wheelhouse before installing `speech-to-speech`:
+On Linux, the Qwen3-TTS GGML backend comes from `faster-qwen3-tts[ggml]`. Its default `qwentts-cpp-python` wheel on PyPI targets CUDA 12.8 and `manylinux_2_39` (for example, Ubuntu 24.04). If your CUDA runtime or glibc is older, install the matching wheel from the Hugging Face wheelhouse before installing `speech-to-speech`:
 
 ```bash
 # CUDA 13.x
@@ -140,7 +140,7 @@ Optional components are installed with pip extras:
 pip install "speech-to-speech[kokoro]"          # Kokoro-82M TTS on non-macOS
 pip install "speech-to-speech[pocket]"          # Pocket TTS
 pip install "speech-to-speech[chattts]"         # ChatTTS
-pip install "speech-to-speech[omnivoice]"       # OmniVoice TTS (Apple Silicon; see dependency note below)
+pip install "speech-to-speech[omnivoice]"       # OmniVoice TTS (CUDA, Intel XPU, or Apple Silicon)
 pip install "speech-to-speech[faster-whisper]"  # Faster Whisper STT
 pip install "speech-to-speech[whisper-mlx]"     # Lightning Whisper MLX STT on macOS
 pip install "speech-to-speech[paraformer]"      # Paraformer STT through FunASR
@@ -180,7 +180,7 @@ This installs the package in editable mode and makes the `speech-to-speech` CLI 
 | TTS | [Kokoro-82M](https://huggingface.co/hexgrad/Kokoro-82M) | CUDA / CPU, Apple Silicon | `kokoro` on non-macOS; built-in on macOS |
 | TTS | [Pocket TTS](https://github.com/kyutai-labs/pocket-tts) | CPU / CUDA | `pocket` |
 | TTS | [ChatTTS](https://github.com/2noise/ChatTTS) | CUDA / CPU | `chattts` |
-| TTS | [OmniVoice](https://huggingface.co/k2-fsa/OmniVoice) | Apple Silicon / MPS; upstream also supports CUDA and Intel XPU | `omnivoice` |
+| TTS | [OmniVoice](https://huggingface.co/k2-fsa/OmniVoice) | CUDA / Intel XPU / Apple Silicon | `omnivoice` |
 | TTS | [MMS TTS](https://huggingface.co/docs/transformers/model_doc/mms) | CUDA / CPU | built-in |
 
 Select implementations with `--stt`, `--llm_backend`, and `--tts`. The CLI constructs configuration only for the selected backends; known options for inactive backends remain accepted for compatibility but are ignored with a warning. JSON configuration may likewise include extra inactive-backend keys, which are ignored. Run `speech-to-speech serve -h` for the defaults, or pass selectors before `-h` to see another combination's backend-specific flags (for example, `speech-to-speech serve --stt mlx-audio-whisper -h`).
@@ -562,20 +562,20 @@ Both commands also work with `--mac-optimal-settings`; explicit `--stt` flags ov
 
 ## OmniVoice
 
-OmniVoice provides voice cloning, voice design, and automatic voice selection across 600+ languages. Install its opt-in dependencies and provide a reference clip plus its transcript for voice cloning:
+OmniVoice provides voice cloning, voice design, and automatic voice selection across 600+ languages. Install its opt-in dependencies and provide a reference clip plus its transcript for voice cloning. This example uses CUDA on Linux or Windows; use `--omnivoice_device mps` on Apple Silicon or `--omnivoice_device xpu` with an Intel XPU-enabled PyTorch installation:
 
 ```bash
 pip install "speech-to-speech[omnivoice]"
 speech-to-speech serve \
     --tts omnivoice \
-    --omnivoice_device mps \
+    --omnivoice_device cuda \
     --omnivoice_ref_audio /path/to/reference.wav \
     --omnivoice_ref_text "Transcript of the reference clip."
 ```
 
 The handler converts OmniVoice's completed 24 kHz float output into the pipeline's 16 kHz `int16` blocks. OmniVoice does not currently expose incremental audio through `generate()`, so the first block is available only after the full utterance has been synthesized. See the [TTS component guide](./src/speech_to_speech/TTS/README.md#6-omnivoice---tts-omnivoice) for saved prompts, voice design, devices, latency, and all backend flags.
 
-The `omnivoice` extra currently resolves with this project's pinned dependencies on macOS. On Linux and Windows, OmniVoice requires Transformers 5 while the built-in Qwen3 dependency still requires Transformers 4; the combined extra is therefore not currently installable there. CUDA and Intel XPU remain upstream OmniVoice capabilities pending resolution of that dependency conflict.
+The `omnivoice` extra is supported on Linux, Windows, and macOS. On non-macOS platforms, both OmniVoice and the built-in Qwen3 backend share Transformers 5 through `faster-qwen3-tts>=0.4.0`, so installing this extra keeps the default Qwen3 path available. Linux uses Qwen3's GGML extra by default; see the [CUDA note](#cuda-note-for-qwen3-tts) if its CUDA 12.8 / `manylinux_2_39` native wheel does not match your host.
 
 > [!WARNING]
 > OmniVoice's code is Apache-2.0, but its pretrained weights are CC-BY-NC and are not licensed for commercial use. Use voice cloning only with authorization and consent; do not use it for impersonation, fraud, scams, or other illegal or unethical activity.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -46,12 +46,12 @@ dependencies = [
     "torchaudio==2.11.0; platform_system == 'Darwin'",
     "torchaudio>=2.4.0; platform_system != 'Darwin'",
     "transformers==5.14.1; platform_system == 'Darwin'",
-    "transformers>=4.57.0; platform_system != 'Darwin'",
+    "transformers>=5.15.1,<6; platform_system != 'Darwin'",
     "uvicorn>=0.30.0",
     "websockets>=12.0",
     "nano-parakeet>=0.2.0; platform_system != 'Darwin'",
-    "faster-qwen3-tts[ggml]>=0.3.2; platform_system != 'Darwin' and platform_system != 'Windows'",
-    "faster-qwen3-tts>=0.3.2; platform_system == 'Windows'",
+    "faster-qwen3-tts[ggml]>=0.4.0; platform_system != 'Darwin' and platform_system != 'Windows'",
+    "faster-qwen3-tts>=0.4.0; platform_system == 'Windows'",
     "librosa==0.11.0",
     "lingua-language-detector>=2.0.2",
     "miniaudio==1.61; platform_system == 'Darwin'",
@@ -80,7 +80,7 @@ mlx-lm = [
     "mlx-vlm==0.4.1; platform_system == 'Darwin'",
 ]
 omnivoice = [
-    "omnivoice>=0.2.1; platform_system == 'Darwin'",
+    "omnivoice>=0.2.1",
 ]
 paraformer = [
     "funasr>=1.1.6",

--- a/src/speech_to_speech/TTS/README.md
+++ b/src/speech_to_speech/TTS/README.md
@@ -100,8 +100,8 @@ Behavior:
 - Defaults to the CustomVoice model with speaker `Aiden`, so no reference audio is required. Voice-clone/base models can still use `--qwen3_tts_ref_audio`.
 
 Install notes for Linux GGML:
-- The default PyPI `qwentts-cpp-python` wheel targets CUDA 12.8.
-- If that wheel does not match your CUDA runtime, install one of the Hugging Face wheelhouse builds before installing `speech-to-speech`.
+- The default PyPI `qwentts-cpp-python` wheel targets CUDA 12.8 and `manylinux_2_39` (for example, Ubuntu 24.04).
+- If that wheel does not match your CUDA runtime or glibc, install one of the Hugging Face wheelhouse builds before installing `speech-to-speech`.
 
 ```bash
 pip install "qwentts-cpp-python==0.3.1+cu130" \
@@ -194,14 +194,14 @@ This will run separate benchmark entries for `qwen3[bf16]`, `qwen3[4bit]`, `qwen
 
 Primary args prefix: `--omnivoice_*`
 
-Install the optional dependency and select a device supported by your PyTorch installation:
+Install the optional dependency and select a device supported by your PyTorch installation. This example uses CUDA on Linux or Windows; use `mps` on Apple Silicon or `xpu` with an Intel XPU-enabled PyTorch installation:
 
 ```bash
 pip install "speech-to-speech[omnivoice]"
 speech-to-speech serve \
   --tts omnivoice \
   --omnivoice_model_name k2-fsa/OmniVoice \
-  --omnivoice_device mps \
+  --omnivoice_device cuda \
   --omnivoice_dtype float16 \
   --omnivoice_ref_audio /voices/reference.wav \
   --omnivoice_ref_text "Transcript of the reference clip."
@@ -226,7 +226,7 @@ For auto voice, omit `--omnivoice_ref_audio`, `--omnivoice_voice_clone_prompt`, 
 
 Supported upstream device values include CUDA (`cuda` or `cuda:0`), Apple Silicon (`mps`), and Intel GPU (`xpu`). Choose `float16`, `bfloat16`, or `float32` with `--omnivoice_dtype` according to device support.
 
-The `speech-to-speech[omnivoice]` dependency set currently resolves on macOS, where this project already pins Transformers 5. On Linux and Windows, the default `faster-qwen3-tts` dependency requires Transformers `<5` while OmniVoice 0.2.1 requires Transformers `>=5.3`; the combined extra is therefore not currently installable on those platforms. CUDA and Intel XPU are upstream OmniVoice capabilities but require that packaging conflict to be resolved before they can be supported by this extra. Intel XPU also requires the matching Intel PyTorch build.
+The `speech-to-speech[omnivoice]` dependency set is supported on Linux, Windows, and macOS. On non-macOS platforms, `faster-qwen3-tts>=0.4.0` and OmniVoice share Transformers 5, so the extra can be installed alongside the built-in Qwen3 backend. Linux uses Qwen3's GGML extra by default; install a matching `qwentts-cpp-python` wheel as described above when the default CUDA 12.8 / `manylinux_2_39` wheel does not match the host. Intel XPU requires the matching Intel PyTorch build.
 
 OmniVoice returns complete 24 kHz float arrays. This handler downsamples them to 16 kHz, clips to `int16`, and then emits fixed-size blocks. It is playback chunking rather than model streaming: upstream `generate()` is blocking, so time to first audio includes synthesis of the entire utterance, and an interruption during generation discards the result after the blocking call returns. Upstream reports real-time factors as low as 0.025 in its accelerated benchmarks, but actual latency depends on the device, dtype, diffusion-step count, and text length.
 

--- a/tests/install_smoke.py
+++ b/tests/install_smoke.py
@@ -184,6 +184,15 @@ def _validate_default_handler_imports() -> None:
         importlib.import_module(module_name)
 
 
+def _validate_runtime_dependency_imports() -> None:
+    if sys.platform != "darwin":
+        importlib.import_module("faster_qwen3_tts")
+    if os.environ.get("SPEECH_TO_SPEECH_SMOKE_EXTRA") == "omnivoice":
+        omnivoice = importlib.import_module("omnivoice")
+        assert omnivoice.OmniVoice is not None
+        assert omnivoice.VoiceClonePrompt is not None
+
+
 def _validate_realtime_websocket_support() -> None:
     importlib.import_module("uvicorn.protocols.websockets.websockets_impl")
 
@@ -234,6 +243,8 @@ def main() -> None:
         required_modules.extend(["miniaudio", "mlx", "mlx_audio", "mlx_lm", "misaki", "soundfile", "spacy"])
     else:
         required_modules.extend(["faster_qwen3_tts", "nano_parakeet"])
+    if os.environ.get("SPEECH_TO_SPEECH_SMOKE_EXTRA") == "omnivoice":
+        required_modules.append("omnivoice")
 
     _require_modules(required_modules)
     if sys.platform == "darwin":
@@ -243,6 +254,7 @@ def main() -> None:
     _validate_empty_qwen_ref_audio_arg()
     _validate_realtime_engine_imports()
     _validate_default_handler_imports()
+    _validate_runtime_dependency_imports()
     _validate_realtime_websocket_support()
     print("speech-to-speech installed package smoke test passed")
 


### PR DESCRIPTION
## Summary

- require `faster-qwen3-tts>=0.4.0` and Transformers 5.15.1+ on non-macOS platforms
- restore the `omnivoice` extra on Linux and Windows while preserving the default Qwen3 path
- add Linux/Windows resolver regression checks and import both upstream TTS packages in the installed-wheel smoke test
- document supported OmniVoice devices and the Linux GGML wheel's CUDA/glibc constraints

Closes #526

## Testing

- `pytest tests/ -x -q` (1293 passed, 1 skipped)
- `ruff check src/ tests/`
- `ruff format --check src/ tests/`
- `mypy src/`
- Linux `x86_64-manylinux_2_39` OmniVoice resolver check
- Windows `x86_64-pc-windows-msvc` OmniVoice resolver check
- built-wheel metadata and strict Twine validation
- real imports of FasterQwen3TTS 0.4.0 and OmniVoice 0.2.1 with Transformers 5.15.1
