### PR TITLE
Fix OpenAI-compatible TTS regressions

### DIFF
--- a/README.md
+++ b/README.md
@@ -203,13 +203,14 @@ or another compatible server, see
 
 `serve` binds to `127.0.0.1` by default; pass `--host 0.0.0.0` explicitly for network exposure. `local` always binds to loopback and connects the same packaged client at `ws://127.0.0.1:<port>/v1/realtime`.
 
-The packaged `local` and `talk` client buffers 196 ms of received audio before
-starting playback. This absorbs short delivery gaps from either local or remote
-backends. Use `--playback-buffer-ms <milliseconds>` to tune the tradeoff: a
-larger value resists stuttering but delays the start of each response, while a
-smaller value starts sooner but is more sensitive to jitter. This setting only
-controls the packaged Python client's speakers; browser and other Realtime
-clients manage their own playback buffers.
+The packaged `local` client buffers 196 ms of received audio when using the
+OpenAI-compatible TTS backend, which absorbs short delivery gaps from HTTP
+speech inference. Other `local` backends and `talk` start playback immediately
+by default. Use `--playback-buffer-ms <milliseconds>` to override either
+default: a larger value resists stuttering but delays the start of each
+response, while a smaller value starts sooner but is more sensitive to jitter.
+This setting only controls the packaged Python client's speakers; browser and
+other Realtime clients manage their own playback buffers.
 
 The packaged client can opt in to local Python tools with `talk --tool-module <module>` or `local --tool-module <module>`. The module contract, programmatic API, and a Serper web-search example are documented in [Tool calling design](./src/speech_to_speech/api/openai_realtime/README.md#packaged-python-client-tools).
 

--- a/docs/openai-compatible-tts.md
+++ b/docs/openai-compatible-tts.md
@@ -73,21 +73,22 @@ the HTTP response body incrementally. It does not send the non-standard
 
 ## Playback buffering
 
-The packaged Python audio client used by `speech-to-speech local` and
-`speech-to-speech talk` waits for 196 ms of audio before starting playback. If
-playback runs out of audio while a response is still arriving, it uses the same
-cushion before restarting. This small client-side delay absorbs uneven network
-or synthesis delivery so the speaker is less likely to underrun and stutter.
+When `speech-to-speech local` uses `--tts openai`, its packaged Python audio
+client waits for 196 ms of audio before starting playback. If playback runs out
+of audio while a response is still arriving, it uses the same cushion before
+restarting. This small client-side delay absorbs uneven HTTP synthesis delivery
+so the speaker is less likely to underrun and stutter.
 
-The buffer is downstream of TTS and therefore applies to both PCM and WAV and
-to every backend, including hosted OpenAI and a local vLLM deployment. A local
-server may need less buffering because its chunks usually arrive more evenly.
-It does not alter the TTS request, synthesis, resampling, or server deployment.
+Other local TTS backends and `speech-to-speech talk` default to no playback
+buffer. The `talk` client connects to a Realtime endpoint and cannot determine
+which TTS backend produced its audio. The buffer is downstream of TTS and does
+not alter the TTS request, synthesis, resampling, or server deployment.
 
-Override the default for either command with `--playback-buffer-ms`. Higher
-values improve tolerance for delivery jitter at the cost of a later start to
-each response; lower values reduce that startup delay but increase underrun
-risk. For example:
+Override the default for either command with `--playback-buffer-ms`. An
+explicit `0` disables buffering even for `local --tts openai`. Higher values
+improve tolerance for delivery jitter at the cost of a later start to each
+response; lower values reduce that startup delay but increase underrun risk.
+For example:
 
 ```bash
 speech-to-speech local \

--- a/docs/openai-compatible-tts.md
+++ b/docs/openai-compatible-tts.md
@@ -73,16 +73,27 @@ the HTTP response body incrementally. It does not send the non-standard
 
 ## Playback buffering
 
-When `speech-to-speech local` uses `--tts openai`, its packaged Python audio
-client waits for 196 ms of audio before starting playback. If playback runs out
-of audio while a response is still arriving, it uses the same cushion before
-restarting. This small client-side delay absorbs uneven HTTP synthesis delivery
-so the speaker is less likely to underrun and stutter.
+Sometimes the first audio chunks arrive unevenly: an initial burst can be
+followed by a short gap before delivery settles into a steady stream. Starting
+playback immediately can then empty the speaker queue and cause a brief stutter.
+A startup buffer holds a small amount of audio before playback begins so it can
+absorb that early jitter. If playback later catches up with the incoming stream,
+the client uses the same buffer before restarting.
 
-Other local TTS backends and `speech-to-speech talk` default to no playback
-buffer. The `talk` client connects to a Realtime endpoint and cannot determine
-which TTS backend produced its audio. The buffer is downstream of TTS and does
-not alter the TTS request, synthesis, resampling, or server deployment.
+The buffer is generally 0 ms, so other local TTS backends and
+`speech-to-speech talk` start playback as soon as audio arrives. This keeps
+latency to a minimum when chunks are delivered evenly. The `talk` client cannot
+choose a backend-specific default because it connects to a Realtime endpoint
+without knowing which TTS backend produced the audio.
+
+For `speech-to-speech local --tts openai`, the default changes to 196 ms. The
+OpenAI-compatible backend receives synthesized audio over a separate HTTP
+connection to the `/audio/speech` endpoint, where the first chunks can have more
+substantial delivery jitter than in-process TTS. The extra cushion trades a
+small startup delay for smoother playback.
+
+The buffer is downstream of TTS and does not alter the TTS request, synthesis,
+resampling, or server deployment.
 
 Override the default for either command with `--playback-buffer-ms`. An
 explicit `0` disables buffering even for `local --tts openai`. Higher values

--- a/src/speech_to_speech/TTS/openai_compatible_handler.py
+++ b/src/speech_to_speech/TTS/openai_compatible_handler.py
@@ -482,6 +482,7 @@ class OpenAICompatibleTTSHandler(BaseHandler[TTSIn, TTSOut]):
         text = tts_input.text.strip()
         if not text:
             return
+
         def cancel_check() -> bool:
             cancelled = self.stop_event.is_set() or (
                 cancel_generation is not None

--- a/src/speech_to_speech/TTS/openai_compatible_handler.py
+++ b/src/speech_to_speech/TTS/openai_compatible_handler.py
@@ -39,6 +39,14 @@ class SpeechRequestError(RuntimeError):
 _SPEECH_STREAM_DONE = object()
 _SPEECH_STREAM_QUEUE_MAXSIZE = 2
 _SPEECH_STREAM_POLL_INTERVAL_S = 0.025
+_AUDIO_MEDIA_TYPES_BY_FORMAT = {
+    "pcm": frozenset({"audio/pcm", "audio/l16", "audio/x-pcm"}),
+    "wav": frozenset({"application/x-wav", "audio/vnd.wave", "audio/wav", "audio/wave", "audio/x-wav"}),
+    "mp3": frozenset({"audio/mp3", "audio/mpeg"}),
+    "opus": frozenset({"audio/ogg", "audio/opus"}),
+    "aac": frozenset({"audio/aac"}),
+    "flac": frozenset({"audio/flac", "audio/x-flac"}),
+}
 
 
 class HttpSpeechOperation:
@@ -51,11 +59,13 @@ class HttpSpeechOperation:
         api_key: str | None,
         payload: dict[str, Any],
         timeout_s: float,
+        response_format: str | None = None,
     ) -> None:
         self.endpoint_url = endpoint_url
         self.api_key = api_key
         self.payload = payload
         self.timeout_s = timeout_s
+        self.response_format = response_format if response_format is not None else payload.get("response_format")
         self._cancelled = Event()
         self._transport_lock = Lock()
         self._worker_loop: asyncio.AbstractEventLoop | None = None
@@ -174,14 +184,24 @@ class HttpSpeechOperation:
             return True
         return False
 
-    @staticmethod
-    def _validate_content_type(response: httpx.Response) -> None:
+    def _validate_content_type(self, response: httpx.Response) -> None:
         headers = getattr(response, "headers", None)
         if headers is None:
             return
         media_type = headers.get("content-type", "").partition(";")[0].strip().lower()
         if media_type.startswith("text/") or media_type == "application/json" or media_type.endswith("+json"):
             raise SpeechRequestError("speech endpoint returned a non-audio response")
+        response_format = self.response_format
+        if response_format not in {"pcm", "wav"}:
+            return
+        for actual_format, media_types in _AUDIO_MEDIA_TYPES_BY_FORMAT.items():
+            if media_type not in media_types:
+                continue
+            if actual_format != response_format:
+                raise SpeechRequestError(
+                    f"speech endpoint returned {actual_format} audio for requested {response_format} format"
+                )
+            return
 
     def _normalize_error(self, exc: Exception) -> BaseException:
         if isinstance(exc, (SpeechRequestCancelled, SpeechRequestError)):
@@ -462,11 +482,6 @@ class OpenAICompatibleTTSHandler(BaseHandler[TTSIn, TTSOut]):
         text = tts_input.text.strip()
         if not text:
             return
-        voice = self._resolve_voice(tts_input.runtime_config, tts_input.response)
-        operation = self._make_operation(text=text, voice=voice)
-        with self._operation_lock:
-            self._active_operation = operation
-
         def cancel_check() -> bool:
             cancelled = self.stop_event.is_set() or (
                 cancel_generation is not None
@@ -482,7 +497,12 @@ class OpenAICompatibleTTSHandler(BaseHandler[TTSIn, TTSOut]):
 
         first_audio = True
         started_at_s = perf_counter()
+        operation: HttpSpeechOperation | None = None
         try:
+            voice = self._resolve_voice(tts_input.runtime_config, tts_input.response)
+            operation = self._make_operation(text=text, voice=voice)
+            with self._operation_lock:
+                self._active_operation = operation
             source_chunks = operation.iter_bytes(cancel_check)
             decoded_chunks = (
                 self._decode_pcm_stream(source_chunks)
@@ -523,9 +543,10 @@ class OpenAICompatibleTTSHandler(BaseHandler[TTSIn, TTSOut]):
                     )
                 )
         finally:
-            with self._operation_lock:
-                if self._active_operation is operation:
-                    self._active_operation = None
+            if operation is not None:
+                with self._operation_lock:
+                    if self._active_operation is operation:
+                        self._active_operation = None
 
     def _commit_first_audio(self, tts_input: TTSInput) -> bool:
         tracker = self.speculative_turns
@@ -556,6 +577,7 @@ class OpenAICompatibleTTSHandler(BaseHandler[TTSIn, TTSOut]):
             api_key=self.api_key,
             payload=self._request_payload(text=text, voice=voice),
             timeout_s=self.timeout,
+            response_format=self.response_format,
         )
 
     def _request_payload(

--- a/src/speech_to_speech/api/openai_realtime/audio_client.py
+++ b/src/speech_to_speech/api/openai_realtime/audio_client.py
@@ -34,7 +34,7 @@ logger = logging.getLogger(__name__)
 _AssistantTranscriptStream = tuple[str | None, str | None, int | None, int | None]
 ToolExecutor = Callable[[str, dict[str, Any]], Awaitable[Any]]
 _TOOL_CREATE_ID_METADATA_KEY = "s2s_local_tool_create_id"
-_PLAYBACK_START_BUFFER_MS = 196.0
+_PLAYBACK_START_BUFFER_MS = 0.0
 
 
 @dataclass(frozen=True)

--- a/src/speech_to_speech/arguments_classes/local_audio_arguments.py
+++ b/src/speech_to_speech/arguments_classes/local_audio_arguments.py
@@ -23,10 +23,13 @@ class LocalAudioArguments:
         default=1024,
         metadata={"help": "Microphone and speaker callback block size in samples. Default is 1024."},
     )
-    local_audio_playback_buffer_ms: float = field(
-        default=196.0,
+    local_audio_playback_buffer_ms: Optional[float] = field(
+        default=None,
         metadata={
-            "help": "Audio to buffer before local playback starts, in milliseconds. Default is 196.",
+            "help": (
+                "Audio to buffer before local playback starts, in milliseconds. "
+                "Defaults to 196 for OpenAI-compatible TTS and 0 otherwise."
+            ),
             "aliases": ["--playback-buffer-ms"],
         },
     )

--- a/src/speech_to_speech/s2s_pipeline.py
+++ b/src/speech_to_speech/s2s_pipeline.py
@@ -75,6 +75,7 @@ logger = logging.getLogger(__name__)
 logging.getLogger("numba").setLevel(logging.WARNING)  # quiet down numba logs
 
 MLX_DEFAULT_LM_MODEL = "mlx-community/Qwen3-4B-Instruct-2507-bf16"
+OPENAI_TTS_PLAYBACK_BUFFER_MS = 196.0
 
 
 def _mac_preset_defaults(llm_backend: str) -> dict[str, Any]:
@@ -596,6 +597,9 @@ def build_local_pipeline(args: ParsedArguments, stop_event: Event) -> ThreadMana
     )
 
     local_audio = args.local_audio_kwargs
+    playback_buffer_ms = local_audio.local_audio_playback_buffer_ms
+    if playback_buffer_ms is None:
+        playback_buffer_ms = OPENAI_TTS_PLAYBACK_BUFFER_MS if args.tts_backend.name == "openai" else 0.0
     tools: list[dict[str, Any]] = []
     tool_executor = None
     tool_response_create = True
@@ -608,7 +612,7 @@ def build_local_pipeline(args: ParsedArguments, stop_event: Event) -> ThreadMana
             url=f"ws://127.0.0.1:{args.realtime_server_kwargs.port}/v1/realtime",
             api_key="local",
             chunk_size=local_audio.local_audio_chunk_size,
-            playback_buffer_ms=local_audio.local_audio_playback_buffer_ms,
+            playback_buffer_ms=playback_buffer_ms,
             input_device=local_audio.local_audio_input_device,
             output_device=local_audio.local_audio_output_device,
             print_json=local_audio.local_audio_print_json,

--- a/tests/openai_realtime/test_audio_client.py
+++ b/tests/openai_realtime/test_audio_client.py
@@ -255,6 +255,17 @@ def test_playback_buffer_flushes_completed_audio_shorter_than_startup_buffer():
     assert playback.buffered_bytes == 0
 
 
+def test_playback_buffer_starts_immediately_by_default():
+    playback = PlaybackBuffer(1000)
+    playback.append(b"\x04" * 100)
+    callback = bytearray(100)
+
+    playback.write(callback)
+
+    assert callback == b"\x04" * 100
+    assert playback.buffered_bytes == 0
+
+
 @pytest.mark.parametrize("buffer_ms", [-1, float("inf"), float("nan")])
 def test_audio_client_rejects_invalid_playback_buffer(buffer_ms):
     with pytest.raises(ValueError, match="playback_buffer_ms"):

--- a/tests/openai_realtime/test_pipeline_builder.py
+++ b/tests/openai_realtime/test_pipeline_builder.py
@@ -61,3 +61,22 @@ def test_local_composes_loopback_client_with_same_server_builder(monkeypatch):
     assert client.config.url == f"ws://127.0.0.1:{server.port}/v1/realtime"
     assert client.config.api_key == "local"
     assert client.config.playback_buffer_ms == 240
+
+
+def test_local_resolves_backend_specific_playback_buffer_defaults(monkeypatch):
+    unit = SimpleNamespace(handlers=[object()])
+    monkeypatch.setattr("speech_to_speech.s2s_pipeline._build_pipeline_unit", lambda **_kwargs: unit)
+
+    cases = [
+        (["--tts", "qwen3"], 0),
+        (["--tts", "openai"], 196),
+        (["--tts", "openai", "--playback-buffer-ms", "0"], 0),
+        (["--tts", "openai", "--playback-buffer-ms", "240"], 240),
+    ]
+    for argv, expected_buffer_ms in cases:
+        args = parse_arguments(argv, command="local")
+        manager = build_local_pipeline(args, Event())
+        client = manager.handlers[-1]
+
+        assert isinstance(client, RealtimeAudioClient)
+        assert client.config.playback_buffer_ms == expected_buffer_ms

--- a/tests/test_cli_defaults.py
+++ b/tests/test_cli_defaults.py
@@ -386,9 +386,9 @@ def test_talk_accepts_custom_playback_buffer():
     assert config.playback_buffer_ms == 240
 
 
-def test_packaged_audio_clients_default_to_196_ms_playback_buffer():
-    assert parse_talk_arguments([]).playback_buffer_ms == 196
-    assert LocalAudioArguments().local_audio_playback_buffer_ms == 196
+def test_packaged_audio_clients_have_no_general_playback_buffer_default():
+    assert parse_talk_arguments([]).playback_buffer_ms == 0
+    assert LocalAudioArguments().local_audio_playback_buffer_ms is None
 
 
 @pytest.mark.parametrize("flag", ["--log-transcripts", "--log_transcripts"])

--- a/tests/test_openai_tts_handler.py
+++ b/tests/test_openai_tts_handler.py
@@ -254,6 +254,20 @@ def test_openai_tts_preserves_per_response_custom_voice_id(monkeypatch):
     assert _FakeSpeechOperation.instances[0].payload["voice"] == {"id": "voice_response"}
 
 
+def test_openai_tts_invalid_custom_voice_emits_failure(monkeypatch):
+    handler = _openai_tts_handler(monkeypatch)
+    response = RealtimeResponseCreateParams(
+        audio={"output": {"voice": {"id": ""}}},
+    )
+
+    assert list(handler.process(TTSInput(text="Hello", response=response, response_key="response-1"))) == []
+    assert _FakeSpeechOperation.instances == []
+    failure = handler.queue_out.get_nowait()
+    assert isinstance(failure, ResponseFailedEvent)
+    assert failure.message == "speech request failed"
+    assert failure.response_key == "response-1"
+
+
 def test_openai_tts_standard_request_yields_audio_before_response_eof(monkeypatch):
     release_response = Event()
     response_finished = Event()
@@ -880,6 +894,96 @@ def test_openai_tts_rejects_non_audio_success_responses(monkeypatch, content_typ
     failure = handler.queue_out.get_nowait()
     assert isinstance(failure, ResponseFailedEvent)
     assert failure.message == "speech endpoint returned a non-audio response"
+    assert failure.response_key == "response-1"
+
+
+@pytest.mark.parametrize(
+    ("response_format", "content_type"),
+    [
+        ("pcm", "audio/pcm; rate=24000"),
+        ("pcm", "audio/L16"),
+        ("wav", "audio/wav"),
+        ("wav", "application/x-wav"),
+        ("pcm", None),
+        ("wav", "application/octet-stream"),
+    ],
+)
+def test_http_speech_accepts_matching_or_ambiguous_content_types(response_format, content_type):
+    headers = {} if content_type is None else {"Content-Type": content_type}
+    operation = HttpSpeechOperation(
+        endpoint_url="http://localhost:8000/v1/audio/speech",
+        api_key=None,
+        payload={"input": "hello", "response_format": response_format},
+        timeout_s=1,
+    )
+
+    operation._validate_content_type(tts_module.httpx.Response(200, headers=headers))
+
+
+@pytest.mark.parametrize(
+    ("response_format", "content_type", "actual_format"),
+    [
+        ("pcm", "audio/mpeg", "mp3"),
+        ("pcm", "audio/wav", "wav"),
+        ("wav", "audio/pcm", "pcm"),
+        ("wav", "audio/flac", "flac"),
+    ],
+)
+def test_http_speech_rejects_known_audio_format_mismatches(response_format, content_type, actual_format):
+    operation = HttpSpeechOperation(
+        endpoint_url="http://localhost:8000/v1/audio/speech",
+        api_key=None,
+        payload={"input": "hello", "response_format": response_format},
+        timeout_s=1,
+    )
+
+    with pytest.raises(
+        tts_module.SpeechRequestError,
+        match=f"speech endpoint returned {actual_format} audio for requested {response_format} format",
+    ):
+        operation._validate_content_type(tts_module.httpx.Response(200, headers={"Content-Type": content_type}))
+
+
+def test_http_speech_validates_against_decoder_format_when_payload_is_overridden():
+    operation = HttpSpeechOperation(
+        endpoint_url="http://localhost:8000/v1/audio/speech",
+        api_key=None,
+        payload={"input": "hello", "response_format": "mp3"},
+        timeout_s=1,
+        response_format="pcm",
+    )
+
+    with pytest.raises(
+        tts_module.SpeechRequestError,
+        match="speech endpoint returned mp3 audio for requested pcm format",
+    ):
+        operation._validate_content_type(tts_module.httpx.Response(200, headers={"Content-Type": "audio/mpeg"}))
+
+
+def test_openai_tts_audio_format_mismatch_emits_failure_without_audio(monkeypatch):
+    transport = tts_module.httpx.MockTransport(
+        lambda request: tts_module.httpx.Response(
+            200,
+            headers={"Content-Type": "audio/mpeg"},
+            content=b"ID3 invalid for raw PCM",
+            request=request,
+        )
+    )
+    client = tts_module.httpx.AsyncClient(transport=transport)
+    monkeypatch.setattr(tts_module.httpx, "AsyncClient", lambda **kwargs: client)
+    monkeypatch.setattr(OpenAICompatibleTTSHandler, "warmup", lambda self: None)
+    handler = OpenAICompatibleTTSHandler(
+        Event(),
+        queue_in=Queue(),
+        queue_out=Queue(),
+        setup_args=(Event(),),
+        setup_kwargs={"sample_rate": 24000, "blocksize": 512},
+    )
+
+    assert list(handler.process(TTSInput(text="Hello", response_key="response-1"))) == []
+    failure = handler.queue_out.get_nowait()
+    assert isinstance(failure, ResponseFailedEvent)
+    assert failure.message == "speech endpoint returned mp3 audio for requested pcm format"
     assert failure.response_key == "response-1"
 
 


### PR DESCRIPTION
## Summary

- restore zero-delay playback as the general packaged-client default while retaining the 196 ms cushion for `local --tts openai` when no override is provided
- reject known audio MIME types that conflict with the configured PCM or WAV decoder while allowing missing and generic binary content types for third-party compatibility
- route invalid voice overrides and other request-preparation errors through the existing deterministic response-failure path
- update playback documentation and add focused regression coverage

The MIME checks follow the documented distinction between raw 24 kHz signed 16-bit little-endian PCM and the other supported speech output formats: https://developers.openai.com/api/docs/guides/text-to-speech#supported-output-formats

## Validation

- `pytest -q` — 1355 passed, 1 skipped
- `ruff check .`
- `ruff format --check .`
- `mypy src/speech_to_speech` — 101 source files

Closes #531
