### PR TITLE
Switch Mac MLX default LLM to Qwen3-4B-4bit

### DIFF
--- a/README.md
+++ b/README.md
@@ -258,7 +258,7 @@ Optionally with a specific LLM:
 ```bash
 speech-to-speech local \
     --mac-optimal-settings \
-    --model_name mlx-community/Qwen3-4B-Instruct-2507-bf16
+    --model_name mlx-community/Qwen3-4B-Instruct-2507-4bit
 ```
 
 This setting:
@@ -557,7 +557,7 @@ speech-to-speech serve \
     --stt parakeet-tdt \
     --language auto \
     --llm_backend mlx-lm \
-    --model_name "mlx-community/Qwen3-4B-Instruct-2507-bf16"
+    --model_name "mlx-community/Qwen3-4B-Instruct-2507-4bit"
 ```
 
 A single non-English language, Chinese in this example:
@@ -568,7 +568,7 @@ speech-to-speech serve \
     --stt_model_name large-v3 \
     --language zh \
     --llm_backend mlx-lm \
-    --model_name mlx-community/Qwen3-4B-Instruct-2507-bf16
+    --model_name mlx-community/Qwen3-4B-Instruct-2507-4bit
 ```
 
 Both commands also work with `--mac-optimal-settings`; explicit `--stt` flags override the defaults it sets.

--- a/src/speech_to_speech/LLM/README.md
+++ b/src/speech_to_speech/LLM/README.md
@@ -42,7 +42,7 @@ Common options:
 ```bash
 speech-to-speech serve \
   --llm_backend mlx-lm \
-  --model_name mlx-community/Qwen3-4B-Instruct-2507-bf16 \
+  --model_name mlx-community/Qwen3-4B-Instruct-2507-4bit \
   --llm_device mps \
   --llm_gen_max_new_tokens 128
 ```
@@ -97,10 +97,10 @@ speech-to-speech serve \
 ```bash
 speech-to-speech local \
   --mac-optimal-settings \
-  --model_name mlx-community/Qwen3-4B-Instruct-2507-bf16
+  --model_name mlx-community/Qwen3-4B-Instruct-2507-4bit
 ```
 
-`--mac-optimal-settings` sets `--llm_backend mlx-lm` and defaults the model to `mlx-community/Qwen3-4B-Instruct-2507-bf16` if not overridden. The command independently selects whether to run only the server or compose it with the audio client.
+`--mac-optimal-settings` sets `--llm_backend mlx-lm` and defaults the model to `mlx-community/Qwen3-4B-Instruct-2507-4bit` if not overridden. The command independently selects whether to run only the server or compose it with the audio client.
 
 ### Realtime (OpenAI-compatible) setup
 
@@ -110,7 +110,7 @@ Run the server, then connect with the packaged audio client:
 # 1. Start the pipeline server
 speech-to-speech serve \
   --llm_backend mlx-lm \
-  --model_name mlx-community/Qwen3-4B-Instruct-2507-bf16 \
+  --model_name mlx-community/Qwen3-4B-Instruct-2507-4bit \
   --host 0.0.0.0 \
   --port 8765
 

--- a/src/speech_to_speech/s2s_pipeline.py
+++ b/src/speech_to_speech/s2s_pipeline.py
@@ -75,6 +75,7 @@ logger = logging.getLogger(__name__)
 logging.getLogger("numba").setLevel(logging.WARNING)  # quiet down numba logs
 
 MLX_DEFAULT_LM_MODEL = "mlx-community/Qwen3-4B-Instruct-2507-4bit"
+OPENAI_TTS_PLAYBACK_BUFFER_MS = 196.0
 
 
 def _mac_preset_defaults(llm_backend: str) -> dict[str, Any]:

--- a/src/speech_to_speech/s2s_pipeline.py
+++ b/src/speech_to_speech/s2s_pipeline.py
@@ -70,7 +70,7 @@ console = Console()
 logger = logging.getLogger(__name__)
 logging.getLogger("numba").setLevel(logging.WARNING)  # quiet down numba logs
 
-MLX_DEFAULT_LM_MODEL = "mlx-community/Qwen3-4B-Instruct-2507-bf16"
+MLX_DEFAULT_LM_MODEL = "mlx-community/Qwen3-4B-Instruct-2507-4bit"
 
 
 def _mac_preset_defaults(llm_backend: str) -> dict[str, Any]:

--- a/tests/test_cli_defaults.py
+++ b/tests/test_cli_defaults.py
@@ -76,7 +76,7 @@ def test_mac_optimal_settings_flag_does_not_select_a_command():
     assert args.module_kwargs.tts == "qwen3"
     assert args.llm_backend.config["device"] == "mps"
     assert args.tts_backend.config["device"] == "mps"
-    assert args.llm_backend.config["model_name"] == "mlx-community/Qwen3-4B-Instruct-2507-bf16"
+    assert args.llm_backend.config["model_name"] == "mlx-community/Qwen3-4B-Instruct-2507-4bit"
 
 
 def test_mac_optimal_settings_routes_explicit_model_to_mlx_backend():


### PR DESCRIPTION
## Summary
Switch Mac default MLX LLM from Qwen3-4B-bf16 to Qwen3-4B-4bit for `--mac-optimal-settings`.

Live E2E on Mac: ~31s → ~1.4s. 4/4 on FR and EN voice tests. Details in #516.

Closes #516.

## Test plan
- [x] `uv run pytest tests/test_cli_defaults.py -v`
- [ ] `uv run speech-to-speech local --mac-optimal-settings` (loads 4bit without `--model_name`)

## Limitations
- Live tests: short 4-turn voice script only (FR+EN); not long chat, tools, or code.
- Same model family (Qwen3-4B), 4bit for speed; bf16 still available via `--model_name`.
- README examples updated to match the new default.
- Newer MLX models (SmolLM3, Ministral, Phi-4) benchmarked live; not ready as default until the multilingual / `--enable_lang_prompt` path is solid (separate issue).