### PR TITLE
Fix `enable_lang_prompt` for strict chat templates

### DIFF
--- a/src/speech_to_speech/LLM/base_openai_compatible_language_model.py
+++ b/src/speech_to_speech/LLM/base_openai_compatible_language_model.py
@@ -41,6 +41,7 @@ from speech_to_speech.LLM.chat import (
 from speech_to_speech.LLM.compaction_prompt import CompactGenerateFn, build_compactor
 from speech_to_speech.LLM.text_prompt import build_text_system_prompt
 from speech_to_speech.LLM.utils import (
+    language_name_for_prompt,
     remove_markdown,
     remove_unspeechable,
     resolve_auto_language,
@@ -500,11 +501,14 @@ class BaseOpenAICompatibleHandler(BaseHandler[LLMIn, LLMOut], ABC):
         chat: Chat,
         instructions: Optional[str],
         wants_audio: bool = True,
+        *,
+        language_name: str | None = None,
     ) -> None:
-        if instructions:
-            builder = build_voice_system_prompt if wants_audio else build_text_system_prompt
-            full_instructions = builder(instructions)
-            chat.add_item(make_system_message(full_instructions))
+        if not instructions and not language_name:
+            return
+        builder = build_voice_system_prompt if wants_audio else build_text_system_prompt
+        full_instructions = builder(instructions or "", language_name=language_name)
+        chat.add_item(make_system_message(full_instructions))
 
     # ── output helpers ──────────────────────────────────────────────────────--
 
@@ -957,6 +961,8 @@ class BaseOpenAICompatibleHandler(BaseHandler[LLMIn, LLMOut], ABC):
             active_chat = original_chat.copy()
 
         language_code = request.language_code
+        language_code, _ = resolve_auto_language(language_code)
+        lang_name = language_name_for_prompt(language_code, enable=self.enable_lang_prompt)
         instructions = (
             response.instructions
             if response is not None and response.instructions is not None
@@ -969,10 +975,7 @@ class BaseOpenAICompatibleHandler(BaseHandler[LLMIn, LLMOut], ABC):
             response.tool_choice if response and response.tool_choice else runtime_config.session.tool_choice
         )
         wants_audio = response_wants_audio(response)
-        self._apply_config(active_chat, instructions, wants_audio)
-        language_code, lang_name = resolve_auto_language(language_code)
-        if lang_name and self.enable_lang_prompt:
-            active_chat.add_item(make_user_message(f"Please reply to my message in {lang_name}."))
+        self._apply_config(active_chat, instructions, wants_audio, language_name=lang_name)
 
         audio_b64 = self._audio_to_wav_base64(request.audio, request.audio_sample_rate)
         audio_message = active_chat.add_item(make_user_audio_message(audio_b64))
@@ -1078,6 +1081,8 @@ class BaseOpenAICompatibleHandler(BaseHandler[LLMIn, LLMOut], ABC):
         else:
             active_chat = original_chat.copy()
         language_code = request.language_code
+        language_code, _ = resolve_auto_language(language_code)
+        lang_name = language_name_for_prompt(language_code, enable=self.enable_lang_prompt)
         instructions = (
             response.instructions
             if response is not None and response.instructions is not None
@@ -1090,10 +1095,7 @@ class BaseOpenAICompatibleHandler(BaseHandler[LLMIn, LLMOut], ABC):
             response.tool_choice if response and response.tool_choice else runtime_config.session.tool_choice
         )
         wants_audio = response_wants_audio(response)
-        self._apply_config(active_chat, instructions, wants_audio)
-        language_code, lang_name = resolve_auto_language(language_code)
-        if lang_name and self.enable_lang_prompt:
-            active_chat.add_item(make_user_message(f"Please reply to my message in {lang_name}."))
+        self._apply_config(active_chat, instructions, wants_audio, language_name=lang_name)
 
         optional_kwargs = self._build_optional_kwargs(req_tools, req_tool_choice)
 

--- a/src/speech_to_speech/LLM/base_openai_compatible_language_model.py
+++ b/src/speech_to_speech/LLM/base_openai_compatible_language_model.py
@@ -36,7 +36,6 @@ from speech_to_speech.LLM.chat import (
     build_active_chat,
     make_system_message,
     make_user_audio_message,
-    make_user_message,
 )
 from speech_to_speech.LLM.compaction_prompt import CompactGenerateFn, build_compactor
 from speech_to_speech.LLM.text_prompt import build_text_system_prompt

--- a/src/speech_to_speech/LLM/language_model.py
+++ b/src/speech_to_speech/LLM/language_model.py
@@ -49,6 +49,7 @@ from speech_to_speech.LLM.tool_call.function_tool import FunctionTool
 from speech_to_speech.LLM.tool_call.tool_prompt import END_CODE, ENTER_CODE, build_block_regex, build_tool_system_prompt
 from speech_to_speech.LLM.utils import (
     image_url_to_pil,
+    language_name_for_prompt,
     remove_markdown,
     remove_unspeechable,
     resolve_auto_language,
@@ -277,8 +278,10 @@ class BaseLanguageModelHandler(BaseHandler[LLMIn, LLMOut], ABC):
         tool_choice: Optional[str],
         ctx: StreamContext | None = None,
         wants_audio: bool = True,
+        *,
+        language_name: str | None = None,
     ) -> None:
-        if not instructions:
+        if not instructions and not language_name:
             return
 
         raw_tools = raw_tools or []
@@ -289,12 +292,16 @@ class BaseLanguageModelHandler(BaseHandler[LLMIn, LLMOut], ABC):
 
         if function_tools and tool_choice != "none":
             tool_section = build_tool_system_prompt(function_tools, text_only=not wants_audio)
-            full_instructions = build_system_prompt(instructions, tool_section=tool_section)
+            full_instructions = build_system_prompt(
+                instructions or "",
+                tool_section=tool_section,
+                language_name=language_name,
+            )
             block_regex = build_block_regex()
             enter_code = ENTER_CODE
             end_code = END_CODE
         else:
-            full_instructions = build_system_prompt(instructions)
+            full_instructions = build_system_prompt(instructions or "", language_name=language_name)
             block_regex = None
             enter_code = None
             end_code = None
@@ -616,6 +623,8 @@ class BaseLanguageModelHandler(BaseHandler[LLMIn, LLMOut], ABC):
         else:
             active_chat = original_chat.copy()
         language_code = request.language_code
+        language_code, _ = resolve_auto_language(language_code)
+        lang_name = language_name_for_prompt(language_code, enable=self.enable_lang_prompt)
         instructions = (
             response.instructions
             if response is not None and response.instructions is not None
@@ -630,10 +639,8 @@ class BaseLanguageModelHandler(BaseHandler[LLMIn, LLMOut], ABC):
             str(tool_choice) if tool_choice else None,
             ctx,
             response_wants_audio(response),
+            language_name=lang_name,
         )
-        language_code, lang_name = resolve_auto_language(language_code)
-        if lang_name and self.enable_lang_prompt:
-            active_chat.add_item(make_user_message(f"Please reply to my message in {lang_name}."))
 
         # Images the model sees this turn; only these are stripped on write-back,
         # so an image a fast client injects mid-generation for the next turn

--- a/src/speech_to_speech/LLM/language_model.py
+++ b/src/speech_to_speech/LLM/language_model.py
@@ -40,7 +40,6 @@ from speech_to_speech.LLM.chat import (
     build_active_chat,
     make_assistant_message,
     make_system_message,
-    make_user_message,
 )
 from speech_to_speech.LLM.compaction_prompt import CompactGenerateFn, build_compactor
 from speech_to_speech.LLM.text_prompt import build_text_system_prompt

--- a/src/speech_to_speech/LLM/text_prompt.py
+++ b/src/speech_to_speech/LLM/text_prompt.py
@@ -1,5 +1,7 @@
 """Text-channel system prompt: lead + session prompt + tail (strongest constraints last)."""
 
+from speech_to_speech.LLM.utils import format_language_instruction
+
 TEXT_SYSTEM_PROMPT_LEAD = """\
 You are a helpful assistant in a text conversation.
 """
@@ -19,20 +21,29 @@ _TEXT_SYSTEM_PROMPT_FULL = """\
 {lead}
 
 Session Prompt:
-{session_prompt}{optional_tools}
+{session_prompt}{optional_tools}{optional_language}
 
 {tail}
 """
 
 
-def build_text_system_prompt(session_prompt: str, *, tool_section: str = "") -> str:
-    """Context → session prompt → optional tool block → strongest text rules last."""
+def build_text_system_prompt(
+    session_prompt: str,
+    *,
+    tool_section: str = "",
+    language_name: str | None = None,
+) -> str:
+    """Context → session prompt → optional tool block → optional language hint → text rules."""
     tools = tool_section.strip()
     optional_tools = f"\n\n{tools}" if tools else ""
+    optional_language = ""
+    if language_name:
+        optional_language = f"\n\n{format_language_instruction(language_name)}"
     return _TEXT_SYSTEM_PROMPT_FULL.format(
         lead=TEXT_SYSTEM_PROMPT_LEAD.rstrip(),
         session_prompt=session_prompt.strip(),
         optional_tools=optional_tools,
+        optional_language=optional_language,
         tail=TEXT_SYSTEM_PROMPT_TAIL.rstrip(),
     )
 

--- a/src/speech_to_speech/LLM/utils.py
+++ b/src/speech_to_speech/LLM/utils.py
@@ -251,6 +251,19 @@ WHISPER_LANGUAGE_TO_LLM_LANGUAGE = {
 }
 
 
+def format_language_instruction(lang_name: str) -> str:
+    """Build the opt-in language instruction for ``--enable_lang_prompt``."""
+    return f"Please reply to my message in {lang_name}."
+
+
+def language_name_for_prompt(language_code: Optional[str], *, enable: bool) -> Optional[str]:
+    """Resolve the language name injected into the system prompt when enabled."""
+    if not enable:
+        return None
+    _, lang_name = resolve_auto_language(language_code)
+    return lang_name
+
+
 def resolve_auto_language(language_code: Optional[str]) -> tuple[Optional[str], Optional[str]]:
     """Strip the ``-auto`` suffix and resolve the human-readable language name.
 

--- a/src/speech_to_speech/LLM/voice_prompt.py
+++ b/src/speech_to_speech/LLM/voice_prompt.py
@@ -1,5 +1,7 @@
 """Voice-channel system prompt: lead + session prompt + tail (strongest constraints last)."""
 
+from speech_to_speech.LLM.utils import format_language_instruction
+
 VOICE_SYSTEM_PROMPT_LEAD = """\
 You are in a spoken conversation. The user speaks and hears you.
 The session prompt defines persona, facts, goals, and tool descriptions. These channel rules only control spoken output and tool-use behavior.
@@ -24,20 +26,29 @@ _VOICE_SYSTEM_PROMPT_FULL = """\
 {lead}
 
 Session Prompt:
-{session_prompt}{optional_tools}
+{session_prompt}{optional_tools}{optional_language}
 
 {tail}
 """
 
 
-def build_voice_system_prompt(session_prompt: str, *, tool_section: str = "") -> str:
-    """Context → session prompt → optional tool block → strongest voice rules last."""
+def build_voice_system_prompt(
+    session_prompt: str,
+    *,
+    tool_section: str = "",
+    language_name: str | None = None,
+) -> str:
+    """Context → session prompt → optional tool block → optional language hint → voice rules."""
     tools = tool_section.strip()
     optional_tools = f"\n\n{tools}" if tools else ""
+    optional_language = ""
+    if language_name:
+        optional_language = f"\n\n{format_language_instruction(language_name)}"
     return _VOICE_SYSTEM_PROMPT_FULL.format(
         lead=VOICE_SYSTEM_PROMPT_LEAD.rstrip(),
         session_prompt=session_prompt.strip(),
         optional_tools=optional_tools,
+        optional_language=optional_language,
         tail=VOICE_SYSTEM_PROMPT_TAIL.rstrip(),
     )
 

--- a/src/speech_to_speech/arguments_classes/language_model_base_arguments.py
+++ b/src/speech_to_speech/arguments_classes/language_model_base_arguments.py
@@ -33,8 +33,8 @@ class LanguageModelBaseArguments:
     enable_lang_prompt: bool = field(
         default=False,
         metadata={
-            "help": "When True, append a user message instructing the model to reply in the detected/selected "
-            "language (e.g. 'Please reply to my message in French.'). Default is False."
+            "help": "When True, add a language instruction to the system prompt for the current turn "
+            "(e.g. 'Please reply to my message in French.'). Default is False."
         },
     )
     compact_history: bool = field(

--- a/tests/test_language_prompt.py
+++ b/tests/test_language_prompt.py
@@ -1,12 +1,11 @@
 """End-to-end coverage for the ``--enable_lang_prompt`` language instruction.
 
-The instruction is gated on a language *name*, not on the language code:
+When enabled, the resolved language name is passed into the system-prompt
+builders (``build_voice_system_prompt`` / ``build_text_system_prompt``) for the
+current turn. It never adds a second consecutive user message, which would break
+strict chat templates (e.g. Ministral).
 
-    language_code, lang_name = resolve_auto_language(language_code)
-    if lang_name and self.enable_lang_prompt:
-        active_chat.add_item(make_user_message(f"Please reply to my message in {lang_name}."))
-
-so any code missing from ``WHISPER_LANGUAGE_TO_LLM_LANGUAGE`` silently produces no
+Any code missing from ``WHISPER_LANGUAGE_TO_LLM_LANGUAGE`` silently produces no
 instruction at all. Parakeet TDT is the default STT and reports 25 languages, so this
 asserts the instruction actually reaches the outgoing request for the ones it detects --
 not merely that the mapping dict has keys.
@@ -29,6 +28,8 @@ from speech_to_speech.LLM.chat import Chat, make_user_message
 from speech_to_speech.LLM.chat_completions_language_model import ChatCompletionsApiModelHandler
 from speech_to_speech.pipeline.messages import GenerateResponseRequest
 from speech_to_speech.STT.parakeet_tdt_handler import SUPPORTED_LANGUAGES as PARAKEET_LANGUAGES
+
+LANGUAGE_INSTRUCTION_PREFIX = "Please reply to my message in "
 
 
 class _FakeCompletions:
@@ -74,8 +75,8 @@ def _make_handler(*, enable_lang_prompt):
         base_mod.OpenAI = orig_openai
 
 
-def _sent_messages(handler, language_code, *, enable_lang_prompt=True):
-    """Drive one request and return the messages the backend actually sent."""
+def _sent_system_messages(handler, language_code, *, enable_lang_prompt=True):
+    """Drive one request and return system message contents the backend sent."""
     chat = Chat(10)
     chat.add_item(make_user_message("Hej, hur mar du?"))
     session = RealtimeSessionCreateRequest(type="realtime", instructions="You are a robot.")
@@ -86,16 +87,18 @@ def _sent_messages(handler, language_code, *, enable_lang_prompt=True):
 
     calls = handler.client.chat.completions.calls
     assert calls, "the backend never issued a request"
-    return [m.get("content") for m in calls[-1]["messages"] if m.get("role") == "user"]
+    return [m.get("content") for m in calls[-1]["messages"] if m.get("role") == "system"]
 
 
 def test_swedish_gets_a_language_instruction():
     """Swedish is one of the 17 Parakeet languages that previously got nothing."""
     handler = _make_handler(enable_lang_prompt=True)
 
-    contents = _sent_messages(handler, "sv-auto")
+    contents = _sent_system_messages(handler, "sv-auto")
 
-    assert "Please reply to my message in swedish." in contents
+    assert any(
+        isinstance(c, str) and f"{LANGUAGE_INSTRUCTION_PREFIX}swedish." in c for c in contents
+    )
 
 
 @pytest.mark.parametrize("code", sorted(PARAKEET_LANGUAGES))
@@ -103,9 +106,11 @@ def test_every_parakeet_language_produces_an_instruction(code):
     """No language the default STT can report may silently skip the instruction."""
     handler = _make_handler(enable_lang_prompt=True)
 
-    contents = _sent_messages(handler, f"{code}-auto")
+    contents = _sent_system_messages(handler, f"{code}-auto")
 
-    instructions = [c for c in contents if isinstance(c, str) and c.startswith("Please reply to my message in ")]
+    instructions = [
+        c for c in contents if isinstance(c, str) and LANGUAGE_INSTRUCTION_PREFIX in c
+    ]
     assert len(instructions) == 1, f"no language instruction emitted for {code!r}"
 
 
@@ -113,15 +118,15 @@ def test_no_instruction_when_the_flag_is_disabled():
     """The flag still gates the instruction; this is the default configuration."""
     handler = _make_handler(enable_lang_prompt=False)
 
-    contents = _sent_messages(handler, "sv-auto")
+    contents = _sent_system_messages(handler, "sv-auto")
 
-    assert not [c for c in contents if isinstance(c, str) and c.startswith("Please reply to my message in ")]
+    assert not [c for c in contents if isinstance(c, str) and LANGUAGE_INSTRUCTION_PREFIX in c]
 
 
 def test_unknown_language_code_still_emits_no_instruction():
     """An unnameable code must not produce 'reply in None.' -- absent is correct here."""
     handler = _make_handler(enable_lang_prompt=True)
 
-    contents = _sent_messages(handler, "xx-auto")
+    contents = _sent_system_messages(handler, "xx-auto")
 
-    assert not [c for c in contents if isinstance(c, str) and c.startswith("Please reply to my message in ")]
+    assert not [c for c in contents if isinstance(c, str) and LANGUAGE_INSTRUCTION_PREFIX in c]

--- a/tests/test_language_prompt.py
+++ b/tests/test_language_prompt.py
@@ -96,9 +96,7 @@ def test_swedish_gets_a_language_instruction():
 
     contents = _sent_system_messages(handler, "sv-auto")
 
-    assert any(
-        isinstance(c, str) and f"{LANGUAGE_INSTRUCTION_PREFIX}swedish." in c for c in contents
-    )
+    assert any(isinstance(c, str) and f"{LANGUAGE_INSTRUCTION_PREFIX}swedish." in c for c in contents)
 
 
 @pytest.mark.parametrize("code", sorted(PARAKEET_LANGUAGES))
@@ -108,9 +106,7 @@ def test_every_parakeet_language_produces_an_instruction(code):
 
     contents = _sent_system_messages(handler, f"{code}-auto")
 
-    instructions = [
-        c for c in contents if isinstance(c, str) and LANGUAGE_INSTRUCTION_PREFIX in c
-    ]
+    instructions = [c for c in contents if isinstance(c, str) and LANGUAGE_INSTRUCTION_PREFIX in c]
     assert len(instructions) == 1, f"no language instruction emitted for {code!r}"
 
 

--- a/tests/test_text_prompt.py
+++ b/tests/test_text_prompt.py
@@ -11,6 +11,12 @@ def test_text_prompt_keeps_persona_in_session_prompt():
     assert "You are a helpful assistant in a text conversation." in TEXT_SYSTEM_PROMPT
 
 
+def test_text_prompt_can_include_language_hint():
+    prompt = build_text_system_prompt("Be helpful.", language_name="swedish")
+
+    assert "Please reply to my message in swedish." in prompt
+
+
 def test_text_prompt_allows_markdown_and_drops_voice_rules():
     prompt = build_text_system_prompt("Be helpful.")
 

--- a/tests/test_voice_prompt.py
+++ b/tests/test_voice_prompt.py
@@ -62,6 +62,13 @@ def test_voice_prompt_is_short_and_keeps_persona_in_session_prompt():
     assert "Match the user's intent" not in prompt
 
 
+def test_voice_prompt_can_include_language_hint():
+    prompt = build_voice_system_prompt("Be concise.", language_name="french")
+
+    assert "Please reply to my message in french." in prompt
+    assert "Be concise." in prompt
+
+
 def test_voice_prompt_makes_speech_the_default_and_handles_noisy_stt():
     prompt = build_voice_system_prompt("Be concise.")
 


### PR DESCRIPTION
## Summary

Fixes #534.

With `--enable_lang_prompt`, the pipeline used to append a second consecutive `user` message after the STT transcription:

```
user: <STT transcription>
user: Please reply to my message in {language}.
```

Strict chat templates (e.g. Ministral) reject that layout and raise:

```
TemplateError: conversation roles must alternate user and assistant roles
```

This change injects the language hint into the existing system-prompt builders (`build_voice_system_prompt` / `build_text_system_prompt`) for the current turn, so user/assistant roles keep alternating.

## Approach

- Add `language_name_for_prompt()` in `LLM/utils.py` to resolve the language name when the flag is enabled.
- Extend the voice/text system-prompt builders with an optional `language_name` parameter.
- Pass that value from `_apply_instructions` / `_apply_config` in the MLX and OpenAI-compatible handlers.
- Remove the extra `make_user_message(...)` call that caused the crash.

## Verification

**Before (main):** Ministral + `--enable_lang_prompt` fails every turn with `TemplateError`; `input_tokens=0`.

**After (this branch):** same command completes successfully (`response completed`, French answers, ~1.2s E2E).

```bash
uv run pytest tests/test_language_prompt.py tests/test_voice_prompt.py tests/test_text_prompt.py -v
```

Manual repro:

```bash
uv run speech-to-speech local --mac-optimal-settings \
  --model_name mlx-community/Ministral-3-3B-Instruct-2512-4bit \
  --enable_lang_prompt \
  --qwen3_tts_language french \
  --local_audio_block_mic_during_playback
```

## Notes

- The instruction text is unchanged: `Please reply to my message in {language}.`
- `--enable_lang_prompt` still follows STT language detection; a wrong STT language tag can still steer the model (separate from this template bug).