### PR TITLE
Document --log_transcripts and the content-free logging default

### DIFF
--- a/README.md
+++ b/README.md
@@ -620,7 +620,15 @@ See [ModuleArguments](./src/speech_to_speech/arguments_classes/module_arguments.
 - LLM backend (`--llm_backend`: `transformers`, `mlx-lm`, `responses-api`, or `chat-completions`)
 - TTS implementation (`--tts`)
 - logging level
+- transcript logging (`--log_transcripts`)
 - realtime pipeline pool size (`--num_pipelines`)
+
+Logs are content-free by default: transcript-bearing records report a character count rather
+than the text, because logs are commonly retained by service managers, containers and hosted
+log aggregators. Pass `--log_transcripts` to include full user and assistant transcripts when
+debugging STT, LLM, TTS or Realtime behaviour; it logs a warning at startup because enabling
+it writes conversation content wherever those logs are collected. The `talk` client takes the
+same flag, as `--log-transcripts` or `--log_transcripts`.
 
 ### VAD Parameters
 


### PR DESCRIPTION
Follow-up to #517, which you merged. That PR made application logs content-free by default and added `--log_transcripts` to opt back in — but neither is mentioned in the README.

Two gaps, and the second is the one that matters:

1. The flag itself is undiscoverable.
2. So is the **behaviour change**. An operator debugging STT now sees `chars=42` where the transcript used to be, with nothing in the docs explaining why or how to get it back. That's a support question my own merged change created.

Adds the flag to the module-level parameter list plus a short note covering the default and the startup warning, since enabling it writes conversation content wherever logs are collected.

Every claim is verified against the merged implementation rather than written from memory:

```
flag exists, default = False
default gate       = False
default rendering  = chars=10
startup warns      = True
```

README-only, 7 lines. Full suite 1368 passed, 1 skipped (unchanged — no code touched).
