### PR TITLE
Log per-turn STT/LLM/TTS latency at `response.done`

### DIFF
--- a/src/speech_to_speech/LLM/language_model.py
+++ b/src/speech_to_speech/LLM/language_model.py
@@ -69,8 +69,8 @@ from speech_to_speech.pipeline.messages import (
     TokenUsage,
 )
 from speech_to_speech.pipeline.speculative_turns import SpeculativeTurnTracker
-from speech_to_speech.pipeline.turn_latency import bind_active_turn_latency_tracker
 from speech_to_speech.pipeline.transcript_logging import log_exception, transcript_for_log
+from speech_to_speech.pipeline.turn_latency import bind_active_turn_latency_tracker
 from speech_to_speech.utils.utils import is_out_of_band, response_wants_audio
 
 try:
@@ -671,7 +671,15 @@ class BaseLanguageModelHandler(BaseHandler[LLMIn, LLMOut], ABC):
 
         try:
             store = getattr(self, "turn_latency_store", None)
-            tracker = store.get_or_create(ctx.turn_id, ctx.turn_revision) if store else None
+            tracker = (
+                store.get_or_create_response(
+                    request.response_key,
+                    turn_id=ctx.turn_id,
+                    turn_revision=ctx.turn_revision,
+                )
+                if store
+                else None
+            )
             llm_start_s = perf_counter()
             with bind_active_turn_latency_tracker(tracker):
                 for chunk in self._generate(active_chat, language_code, gen, ctx, runtime_config, response):

--- a/src/speech_to_speech/LLM/language_model.py
+++ b/src/speech_to_speech/LLM/language_model.py
@@ -5,6 +5,7 @@ from abc import ABC, abstractmethod
 from collections.abc import Iterable, Iterator, Sized
 from queue import Empty
 from threading import Lock, Thread
+from time import perf_counter
 from typing import Any, Literal, Optional, Protocol, runtime_checkable
 
 import torch
@@ -68,6 +69,7 @@ from speech_to_speech.pipeline.messages import (
     TokenUsage,
 )
 from speech_to_speech.pipeline.speculative_turns import SpeculativeTurnTracker
+from speech_to_speech.pipeline.turn_latency import bind_active_turn_latency_tracker
 from speech_to_speech.pipeline.transcript_logging import log_exception, transcript_for_log
 from speech_to_speech.utils.utils import is_out_of_band, response_wants_audio
 
@@ -668,26 +670,32 @@ class BaseLanguageModelHandler(BaseHandler[LLMIn, LLMOut], ABC):
             history_rolled_back = True
 
         try:
-            for chunk in self._generate(active_chat, language_code, gen, ctx, runtime_config, response):
-                chunk.response_key = request.response_key
-                chunk.prefetch_transaction = request.prefetch_transaction
-                new_parts = [part.model_copy(deep=True) for part in chunk.parts]
-                ctx.output_parts.extend(new_parts)
-                if not out_of_band and any(isinstance(part, AssistantToolCallPart) for part in new_parts):
-                    recorded = self._commit_ordered_output(
-                        original_chat,
-                        ctx.output_parts[ctx.history_parts_committed :],
-                        wants_audio=response_wants_audio(response),
-                        response_key=request.response_key,
-                        recorded_item_ids=ctx.recorded_item_ids,
-                        recorded_call_ids=ctx.recorded_call_ids,
-                        after_item_id=history_anchor_id,
-                    )
-                    if not recorded:
-                        ctx.cancelled = True
-                        break
-                    ctx.history_parts_committed = len(ctx.output_parts)
-                yield chunk
+            store = getattr(self, "turn_latency_store", None)
+            tracker = store.get_or_create(ctx.turn_id, ctx.turn_revision) if store else None
+            llm_start_s = perf_counter()
+            with bind_active_turn_latency_tracker(tracker):
+                for chunk in self._generate(active_chat, language_code, gen, ctx, runtime_config, response):
+                    chunk.response_key = request.response_key
+                    chunk.prefetch_transaction = request.prefetch_transaction
+                    new_parts = [part.model_copy(deep=True) for part in chunk.parts]
+                    ctx.output_parts.extend(new_parts)
+                    if not out_of_band and any(isinstance(part, AssistantToolCallPart) for part in new_parts):
+                        recorded = self._commit_ordered_output(
+                            original_chat,
+                            ctx.output_parts[ctx.history_parts_committed :],
+                            wants_audio=response_wants_audio(response),
+                            response_key=request.response_key,
+                            recorded_item_ids=ctx.recorded_item_ids,
+                            recorded_call_ids=ctx.recorded_call_ids,
+                            after_item_id=history_anchor_id,
+                        )
+                        if not recorded:
+                            ctx.cancelled = True
+                            break
+                        ctx.history_parts_committed = len(ctx.output_parts)
+                    yield chunk
+            if tracker is not None:
+                tracker.record_llm(perf_counter() - llm_start_s)
 
             if ctx.stopped:
                 return

--- a/src/speech_to_speech/STT/parakeet_tdt_handler.py
+++ b/src/speech_to_speech/STT/parakeet_tdt_handler.py
@@ -23,6 +23,7 @@ from rich.text import Text
 
 from speech_to_speech.pipeline.handler_types import STTIn, STTOut
 from speech_to_speech.pipeline.messages import PartialTranscription, Transcription
+from speech_to_speech.pipeline.turn_latency import bind_active_turn_latency_tracker
 from speech_to_speech.STT.base_stt_handler import BaseSTTHandler
 from speech_to_speech.STT.smart_progressive_streaming import PartialTranscription as ProgressiveStreamPartial
 from speech_to_speech.utils.mlx_lock import MLXLockContext
@@ -295,71 +296,76 @@ class ParakeetTDTSTTHandler(BaseSTTHandler):
             return
 
         # Handle final transcription (send to LLM)
-        logger.info(
-            "Parakeet final STT start turn=%s rev=%s audio=%.3fs age=%.3fs",
-            vad_audio.turn_id,
-            vad_audio.turn_revision,
-            audio_duration_s,
-            item_age_s,
-        )
-        inference_s = 0.0
-        lock_scope_s = 0.0
-        try:
-            if self.enable_live_transcription:
-                # Mark that we're processing final audio (ignore stale progressive updates)
-                self.processing_final = True
+        store = getattr(self, "turn_latency_store", None)
+        tracker = store.get_or_create(vad_audio.turn_id, vad_audio.turn_revision) if store else None
+        with bind_active_turn_latency_tracker(tracker):
+            logger.info(
+                "Parakeet final STT start turn=%s rev=%s audio=%.3fs age=%.3fs",
+                vad_audio.turn_id,
+                vad_audio.turn_revision,
+                audio_duration_s,
+                item_age_s,
+            )
+            inference_s = 0.0
+            lock_scope_s = 0.0
+            try:
+                if self.enable_live_transcription:
+                    # Mark that we're processing final audio (ignore stale progressive updates)
+                    self.processing_final = True
 
-            # Acquire lock with longer timeout for final transcription
-            lock_scope_start_s = perf_counter()
-            with self._compute_lock_context(handler_name="ParakeetSTT-Final", timeout=5.0) as acquired:
-                lock_scope_s = perf_counter() - lock_scope_start_s
-                if not acquired:
-                    logger.error("Failed to acquire compute lock for final transcription")
-                    pred_text = ""
-                    language_code = self.last_language
-                else:
-                    inference_start_s = perf_counter()
-                    if self.backend == "mlx":
-                        pred_text, language_code = self._process_mlx_final(audio_input)
-                    else:
-                        pred_text, language_code = self._process_nano_parakeet(audio_input)
-                    inference_s = perf_counter() - inference_start_s
+                # Acquire lock with longer timeout for final transcription
+                lock_scope_start_s = perf_counter()
+                with self._compute_lock_context(handler_name="ParakeetSTT-Final", timeout=5.0) as acquired:
                     lock_scope_s = perf_counter() - lock_scope_start_s
+                    if not acquired:
+                        logger.error("Failed to acquire compute lock for final transcription")
+                        pred_text = ""
+                        language_code = self.last_language
+                    else:
+                        inference_start_s = perf_counter()
+                        if self.backend == "mlx":
+                            pred_text, language_code = self._process_mlx_final(audio_input)
+                        else:
+                            pred_text, language_code = self._process_nano_parakeet(audio_input)
+                        inference_s = perf_counter() - inference_start_s
+                        lock_scope_s = perf_counter() - lock_scope_start_s
 
-            # Validate and update language
-            if language_code and language_code in SUPPORTED_LANGUAGES:
-                self.last_language = language_code
-            else:
+                # Validate and update language
+                if language_code and language_code in SUPPORTED_LANGUAGES:
+                    self.last_language = language_code
+                else:
+                    language_code = self.last_language
+
+            except Exception as e:
+                logger.error(f"Parakeet TDT inference failed: {e}")
+                pred_text = ""
                 language_code = self.last_language
 
-        except Exception as e:
-            logger.error(f"Parakeet TDT inference failed: {e}")
-            pred_text = ""
-            language_code = self.last_language
+            total_s = perf_counter() - process_start_s
+            if tracker is not None:
+                tracker.record_stt(total_s)
+            logger.info(
+                "Parakeet final STT done turn=%s rev=%s total=%.3fs lock_scope=%.3fs inference=%.3fs chars=%d",
+                vad_audio.turn_id,
+                vad_audio.turn_revision,
+                total_s,
+                lock_scope_s,
+                inference_s,
+                len(pred_text),
+            )
+            logger.debug("Finished Parakeet TDT inference")
+            self._clear_live_transcription_line()
+            if pred_text.strip():
+                console.print(f"[yellow]USER: {pred_text.strip()}")
+                if language_code:
+                    console.print(f"[dim]Language: {language_code}[/dim]")
 
-        total_s = perf_counter() - process_start_s
-        logger.info(
-            "Parakeet final STT done turn=%s rev=%s total=%.3fs lock_scope=%.3fs inference=%.3fs chars=%d",
-            vad_audio.turn_id,
-            vad_audio.turn_revision,
-            total_s,
-            lock_scope_s,
-            inference_s,
-            len(pred_text),
-        )
-        logger.debug("Finished Parakeet TDT inference")
-        self._clear_live_transcription_line()
-        if pred_text.strip():
-            console.print(f"[yellow]USER: {pred_text.strip()}")
-            if language_code:
-                console.print(f"[dim]Language: {language_code}[/dim]")
-
-        # Reset per-utterance live transcription state only after final STT
-        # completes. The streaming handler carries fixed sentence timing within
-        # an utterance, and stale timing must not leak into the next turn.
-        if self.enable_live_transcription:
-            self.processing_final = False
-            self._reset_live_transcription_state(clear_turn=True)
+            # Reset per-utterance live transcription state only after final STT
+            # completes. The streaming handler carries fixed sentence timing within
+            # an utterance, and stale timing must not leak into the next turn.
+            if self.enable_live_transcription:
+                self.processing_final = False
+                self._reset_live_transcription_state(clear_turn=True)
 
         yield Transcription(
             text=pred_text,

--- a/src/speech_to_speech/STT/parakeet_tdt_handler.py
+++ b/src/speech_to_speech/STT/parakeet_tdt_handler.py
@@ -297,7 +297,7 @@ class ParakeetTDTSTTHandler(BaseSTTHandler):
 
         # Handle final transcription (send to LLM)
         store = getattr(self, "turn_latency_store", None)
-        tracker = store.get_or_create(vad_audio.turn_id, vad_audio.turn_revision) if store else None
+        tracker = store.get_or_create_for_turn(vad_audio.turn_id, vad_audio.turn_revision) if store else None
         with bind_active_turn_latency_tracker(tracker):
             logger.info(
                 "Parakeet final STT start turn=%s rev=%s audio=%.3fs age=%.3fs",

--- a/src/speech_to_speech/TTS/qwen3_tts_handler.py
+++ b/src/speech_to_speech/TTS/qwen3_tts_handler.py
@@ -38,8 +38,8 @@ from speech_to_speech.pipeline.messages import (
     TTSInput,
 )
 from speech_to_speech.pipeline.speculative_turns import SpeculativeTurnTracker
-from speech_to_speech.pipeline.turn_latency import active_turn_latency_tracker, bind_active_turn_latency_tracker
 from speech_to_speech.pipeline.transcript_logging import log_exception
+from speech_to_speech.pipeline.turn_latency import active_turn_latency_tracker, bind_active_turn_latency_tracker
 from speech_to_speech.utils.mlx_lock import MLXLockContext
 
 logger = logging.getLogger(__name__)
@@ -850,7 +850,15 @@ class Qwen3TTSHandler(BaseHandler[TTSIn, TTSOut]):
         console.print(f"[green]ASSISTANT: {text}")
 
         store = getattr(self, "turn_latency_store", None)
-        tracker = store.get_or_create(tts_input.turn_id, tts_input.turn_revision) if store else None
+        tracker = (
+            store.get_or_create_response(
+                tts_input.response_key,
+                turn_id=tts_input.turn_id,
+                turn_revision=tts_input.turn_revision,
+            )
+            if store and tts_input.response_key is not None
+            else None
+        )
         try:
             with bind_active_turn_latency_tracker(tracker):
                 if self._has_voice_clone_reference():

--- a/src/speech_to_speech/TTS/qwen3_tts_handler.py
+++ b/src/speech_to_speech/TTS/qwen3_tts_handler.py
@@ -38,6 +38,7 @@ from speech_to_speech.pipeline.messages import (
     TTSInput,
 )
 from speech_to_speech.pipeline.speculative_turns import SpeculativeTurnTracker
+from speech_to_speech.pipeline.turn_latency import active_turn_latency_tracker, bind_active_turn_latency_tracker
 from speech_to_speech.pipeline.transcript_logging import log_exception
 from speech_to_speech.utils.mlx_lock import MLXLockContext
 
@@ -712,7 +713,11 @@ class Qwen3TTSHandler(BaseHandler[TTSIn, TTSOut]):
                 continue
 
             if first_chunk:
-                logger.info(f"Qwen3-TTS TTFA: {perf_counter() - start:.2f}s ({label})")
+                ttfa_s = perf_counter() - start
+                logger.info(f"Qwen3-TTS TTFA: {ttfa_s:.2f}s ({label})")
+                tracker = active_turn_latency_tracker()
+                if tracker is not None:
+                    tracker.record_tts_ttfa(ttfa_s)
                 first_chunk = False
 
             audio_chunk = self._resample_to_pipeline_sr(audio_chunk, sr)
@@ -844,24 +849,27 @@ class Qwen3TTSHandler(BaseHandler[TTSIn, TTSOut]):
 
         console.print(f"[green]ASSISTANT: {text}")
 
+        store = getattr(self, "turn_latency_store", None)
+        tracker = store.get_or_create(tts_input.turn_id, tts_input.turn_revision) if store else None
         try:
-            if self._has_voice_clone_reference():
-                audio_iter = self._process_voice_clone(text)
-            elif model_type == "custom_voice":
-                audio_iter = self._process_custom_voice(text)
-            elif model_type == "voice_design":
-                audio_iter = self._process_voice_design(text)
-            else:
-                raise ValueError(
-                    "Qwen3-TTS Base model requires a voice-clone reference. "
-                    "Provide qwen3_tts_ref_audio or qwen3_tts_ref_spk, or use a CustomVoice/VoiceDesign model."
-                )
-            first_audio = True
-            for audio_chunk in audio_iter:
-                if first_audio:
-                    self._log_first_audio_latency(tts_input)
-                    first_audio = False
-                yield audio_chunk
+            with bind_active_turn_latency_tracker(tracker):
+                if self._has_voice_clone_reference():
+                    audio_iter = self._process_voice_clone(text)
+                elif model_type == "custom_voice":
+                    audio_iter = self._process_custom_voice(text)
+                elif model_type == "voice_design":
+                    audio_iter = self._process_voice_design(text)
+                else:
+                    raise ValueError(
+                        "Qwen3-TTS Base model requires a voice-clone reference. "
+                        "Provide qwen3_tts_ref_audio or qwen3_tts_ref_spk, or use a CustomVoice/VoiceDesign model."
+                    )
+                first_audio = True
+                for audio_chunk in audio_iter:
+                    if first_audio:
+                        self._log_first_audio_latency(tts_input)
+                        first_audio = False
+                    yield audio_chunk
         except Exception as exc:
             log_exception(logger, "Error during Qwen3-TTS generation", exc)
 
@@ -871,6 +879,9 @@ class Qwen3TTSHandler(BaseHandler[TTSIn, TTSOut]):
         latency_s = perf_counter() - tts_input.speech_stopped_at_s
         if latency_s < 0:
             return
+        tracker = active_turn_latency_tracker()
+        if tracker is not None:
+            tracker.record_e2e(latency_s)
         logger.info(
             "Last speech detected to first speech out: %.3fs (turn=%s rev=%s)",
             latency_s,

--- a/src/speech_to_speech/api/openai_realtime/handlers/response.py
+++ b/src/speech_to_speech/api/openai_realtime/handlers/response.py
@@ -44,7 +44,7 @@ from speech_to_speech.pipeline.transcript_logging import log_exception
 from speech_to_speech.utils.utils import _generate_id, is_out_of_band, response_wants_audio
 
 if TYPE_CHECKING:
-    from speech_to_speech.api.openai_realtime.service import ServerEvent, _ResponseStatus, _StatusReason
+    from speech_to_speech.api.openai_realtime.service import ConnState, ServerEvent, _ResponseStatus, _StatusReason
 
 logger = logging.getLogger(__name__)
 
@@ -75,29 +75,24 @@ class ResponseHandler(RealtimeBaseHandler):
         st.clear_pending_response(effective_response_key)
         return st.current_response_id, self._current_item_id(conn_id)
 
-    def _log_turn_latency(self, st: ConnState, status: _ResponseStatus) -> None:
-        tracker = self._service.turn_latency_store.pop(
-            st.speculative_user_turn_id,
-            st.speculative_user_turn_revision,
-        )
-        if tracker is None and st.turn_latency.turn_id is not None:
-            tracker = st.turn_latency
+    def _log_turn_latency(self, st: ConnState, status: _ResponseStatus, response_key: str | None) -> None:
+        tracker = self._service.turn_latency_store.pop(response_key, session_id=st.session_id)
         if tracker is None or tracker.turn_id is None:
             return
         tracker.status = status
         line = tracker.format_log_line()
         if line:
             logger.info(line)
-        st.turn_latency.reset()
 
     def _end_response(self, conn_id: str, status: _ResponseStatus = "completed") -> None:
         st = self._state(conn_id)
+        completed_response_key = st.current_response_key
         if status == "cancelled":
             st.response_usage.responses_cancelled += 1
         else:
             st.response_usage.responses_completed += 1
         self._service.total_usage += st.response_usage
-        self._log_turn_latency(st, status)
+        self._log_turn_latency(st, status, completed_response_key)
         logger.info(
             "Response done (status=%s) — this response: input_tokens=%d, output_tokens=%d, audio=%.2fs"
             " | cumulative: input_tokens=%d, output_tokens=%d, audio=%.2fs",
@@ -110,7 +105,6 @@ class ResponseHandler(RealtimeBaseHandler):
             self._service.total_usage.audio_duration_s,
         )
         st.response_usage.reset()
-        completed_response_key = st.current_response_key
         completed_with_tools = bool(st.pending_function_calls)
         if (
             status == "completed"
@@ -202,6 +196,12 @@ class ResponseHandler(RealtimeBaseHandler):
             speech_stopped_at_s=st.speculative_user_speech_stopped_at_s,
             prefetch_transaction=ResponsePrefetchTransaction(),
         )
+        self._service.bind_response_latency_tracker(
+            conn_id,
+            request.response_key,
+            turn_id=request.turn_id,
+            turn_revision=request.turn_revision,
+        )
         st.tool_followup_prefetch_request = request
         st.tool_followup_prefetch_origin_response_key = origin_response_key
         st.mark_response_pending(request.response_key)
@@ -242,6 +242,10 @@ class ResponseHandler(RealtimeBaseHandler):
                     queue.not_full.notify()
         if request.prefetch_transaction is not None:
             request.prefetch_transaction.discard()
+        self._service.turn_latency_store.discard_response(
+            request.response_key,
+            session_id=st.session_id,
+        )
         st.runtime_config.chat.rollback_provisional_generation(request.response_key)
         self._service.close_response_key(conn_id, request.response_key)
         st.generation_done_tool_calls.pop(request.response_key, None)
@@ -616,6 +620,13 @@ class ResponseHandler(RealtimeBaseHandler):
             turn_revision=None if out_of_band else st.speculative_user_turn_revision,
             speech_stopped_at_s=None if out_of_band else st.speculative_user_speech_stopped_at_s,
         )
+        if not out_of_band:
+            self._service.bind_response_latency_tracker(
+                conn_id,
+                request.response_key,
+                turn_id=request.turn_id,
+                turn_revision=request.turn_revision,
+            )
         st.in_response = True
         st.clear_pending_response(request.response_key)
         st.current_response_params = event.response

--- a/src/speech_to_speech/api/openai_realtime/handlers/response.py
+++ b/src/speech_to_speech/api/openai_realtime/handlers/response.py
@@ -75,6 +75,21 @@ class ResponseHandler(RealtimeBaseHandler):
         st.clear_pending_response(effective_response_key)
         return st.current_response_id, self._current_item_id(conn_id)
 
+    def _log_turn_latency(self, st: ConnState, status: _ResponseStatus) -> None:
+        tracker = self._service.turn_latency_store.pop(
+            st.speculative_user_turn_id,
+            st.speculative_user_turn_revision,
+        )
+        if tracker is None and st.turn_latency.turn_id is not None:
+            tracker = st.turn_latency
+        if tracker is None or tracker.turn_id is None:
+            return
+        tracker.status = status
+        line = tracker.format_log_line()
+        if line:
+            logger.info(line)
+        st.turn_latency.reset()
+
     def _end_response(self, conn_id: str, status: _ResponseStatus = "completed") -> None:
         st = self._state(conn_id)
         if status == "cancelled":
@@ -82,6 +97,7 @@ class ResponseHandler(RealtimeBaseHandler):
         else:
             st.response_usage.responses_completed += 1
         self._service.total_usage += st.response_usage
+        self._log_turn_latency(st, status)
         logger.info(
             "Response done (status=%s) — this response: input_tokens=%d, output_tokens=%d, audio=%.2fs"
             " | cumulative: input_tokens=%d, output_tokens=%d, audio=%.2fs",

--- a/src/speech_to_speech/api/openai_realtime/service.py
+++ b/src/speech_to_speech/api/openai_realtime/service.py
@@ -71,8 +71,8 @@ from speech_to_speech.pipeline.events import (
 from speech_to_speech.pipeline.messages import GenerateResponseRequest
 from speech_to_speech.pipeline.queue_types import TextPromptItem
 from speech_to_speech.pipeline.speculative_turns import SpeculativeTurnTracker
-from speech_to_speech.pipeline.turn_latency import TurnLatencyStore, TurnLatencyTracker
 from speech_to_speech.pipeline.transcript_logging import log_exception, transcript_for_log
+from speech_to_speech.pipeline.turn_latency import TurnLatencyStore
 from speech_to_speech.utils.utils import _generate_id
 
 logger = logging.getLogger(__name__)
@@ -236,7 +236,6 @@ class ConnState(BaseModel):
     speculative_user_speech_stopped_at_s: Optional[float] = None
     speculative_user_item_id: Optional[str] = None
     speculative_audio_duration_s: float = 0.0
-    turn_latency: TurnLatencyTracker = Field(default_factory=TurnLatencyTracker)
     # Client conversation.item.create items that arrived while a response was
     # generating. Applying them mid-generation races the LLM handler's chat
     # write-back (cross-thread), so they are buffered here and flushed in order
@@ -359,6 +358,7 @@ class RealtimeService:
                 st.response_usage.input_tokens += input_tokens
                 st.response_usage.output_tokens += output_tokens
             self.total_usage += st.response_usage
+            self.turn_latency_store.clear_session(conn_id)
             logger.info(
                 "Session %s unregistered — cumulative: input_tokens=%d, output_tokens=%d, audio=%.2fs",
                 conn_id,
@@ -369,6 +369,21 @@ class RealtimeService:
 
     def _state(self, conn_id: str) -> ConnState:
         return self._conns[conn_id]
+
+    def bind_response_latency_tracker(
+        self,
+        conn_id: str,
+        response_key: str,
+        *,
+        turn_id: str | None = None,
+        turn_revision: int | None = None,
+    ) -> None:
+        self.turn_latency_store.get_or_create_response(
+            response_key,
+            turn_id=turn_id,
+            turn_revision=turn_revision,
+            session_id=conn_id,
+        )
 
     @property
     def connection_ids(self) -> list[str]:
@@ -670,9 +685,6 @@ class RealtimeService:
             st.speculative_user_turn_id = event.turn_id
             st.speculative_user_turn_revision = event.turn_revision
             st.speculative_user_speech_stopped_at_s = event.speech_stopped_at_s
-            tracker = self.turn_latency_store.get_or_create(event.turn_id, event.turn_revision)
-            if tracker is not None:
-                st.turn_latency = tracker
 
         queue = self.text_prompt_queue
         if queue and transcript:
@@ -682,6 +694,12 @@ class RealtimeService:
                 turn_id=event.turn_id,
                 turn_revision=event.turn_revision,
                 speech_stopped_at_s=event.speech_stopped_at_s,
+            )
+            self.bind_response_latency_tracker(
+                conn_id,
+                request.response_key,
+                turn_id=event.turn_id,
+                turn_revision=event.turn_revision,
             )
             st.mark_response_pending(request.response_key)
             queue.put(request)
@@ -718,9 +736,6 @@ class RealtimeService:
             st.speculative_user_turn_id = event.turn_id
             st.speculative_user_turn_revision = event.turn_revision
             st.speculative_user_speech_stopped_at_s = event.speech_stopped_at_s
-            tracker = self.turn_latency_store.get_or_create(event.turn_id, event.turn_revision)
-            if tracker is not None:
-                st.turn_latency = tracker
 
         queue = self.text_prompt_queue
         if queue:
@@ -731,6 +746,12 @@ class RealtimeService:
                 turn_id=event.turn_id,
                 turn_revision=event.turn_revision,
                 speech_stopped_at_s=event.speech_stopped_at_s,
+            )
+            self.bind_response_latency_tracker(
+                conn_id,
+                request.response_key,
+                turn_id=event.turn_id,
+                turn_revision=event.turn_revision,
             )
             st.mark_response_pending(request.response_key)
             queue.put(request)

--- a/src/speech_to_speech/api/openai_realtime/service.py
+++ b/src/speech_to_speech/api/openai_realtime/service.py
@@ -71,6 +71,7 @@ from speech_to_speech.pipeline.events import (
 from speech_to_speech.pipeline.messages import GenerateResponseRequest
 from speech_to_speech.pipeline.queue_types import TextPromptItem
 from speech_to_speech.pipeline.speculative_turns import SpeculativeTurnTracker
+from speech_to_speech.pipeline.turn_latency import TurnLatencyStore, TurnLatencyTracker
 from speech_to_speech.pipeline.transcript_logging import log_exception, transcript_for_log
 from speech_to_speech.utils.utils import _generate_id
 
@@ -235,6 +236,7 @@ class ConnState(BaseModel):
     speculative_user_speech_stopped_at_s: Optional[float] = None
     speculative_user_item_id: Optional[str] = None
     speculative_audio_duration_s: float = 0.0
+    turn_latency: TurnLatencyTracker = Field(default_factory=TurnLatencyTracker)
     # Client conversation.item.create items that arrived while a response was
     # generating. Applying them mid-generation races the LLM handler's chat
     # write-back (cross-thread), so they are buffered here and flushed in order
@@ -298,12 +300,14 @@ class RealtimeService:
         should_listen: ThreadingEvent | None = None,
         chat_size: int = 10,
         speculative_turns: SpeculativeTurnTracker | None = None,
+        turn_latency_store: TurnLatencyStore | None = None,
         default_instructions: str | None = None,
     ) -> None:
         self.text_prompt_queue = text_prompt_queue
         self.should_listen = should_listen
         self._chat_size = chat_size
         self.speculative_turns = speculative_turns
+        self.turn_latency_store = turn_latency_store or TurnLatencyStore()
         self._default_instructions = default_instructions
         self._conns: dict[str, ConnState] = {}
         self.total_usage = GlobalUsageMetrics()
@@ -666,6 +670,9 @@ class RealtimeService:
             st.speculative_user_turn_id = event.turn_id
             st.speculative_user_turn_revision = event.turn_revision
             st.speculative_user_speech_stopped_at_s = event.speech_stopped_at_s
+            tracker = self.turn_latency_store.get_or_create(event.turn_id, event.turn_revision)
+            if tracker is not None:
+                st.turn_latency = tracker
 
         queue = self.text_prompt_queue
         if queue and transcript:
@@ -711,6 +718,9 @@ class RealtimeService:
             st.speculative_user_turn_id = event.turn_id
             st.speculative_user_turn_revision = event.turn_revision
             st.speculative_user_speech_stopped_at_s = event.speech_stopped_at_s
+            tracker = self.turn_latency_store.get_or_create(event.turn_id, event.turn_revision)
+            if tracker is not None:
+                st.turn_latency = tracker
 
         queue = self.text_prompt_queue
         if queue:

--- a/src/speech_to_speech/pipeline/turn_latency.py
+++ b/src/speech_to_speech/pipeline/turn_latency.py
@@ -1,0 +1,124 @@
+from __future__ import annotations
+
+from contextlib import contextmanager
+from contextvars import ContextVar
+from dataclasses import dataclass, field
+from threading import Lock
+from typing import Literal
+
+TurnLatencyStatus = Literal["completed", "cancelled", "failed", "incomplete"]
+
+_active_tracker: ContextVar[TurnLatencyTracker | None] = ContextVar(
+    "active_turn_latency_tracker",
+    default=None,
+)
+
+
+def active_turn_latency_tracker() -> TurnLatencyTracker | None:
+    return _active_tracker.get()
+
+
+@contextmanager
+def bind_active_turn_latency_tracker(tracker: TurnLatencyTracker | None):
+    token = _active_tracker.set(tracker)
+    try:
+        yield tracker
+    finally:
+        _active_tracker.reset(token)
+
+
+@dataclass
+class TurnLatencyTracker:
+    turn_id: str | None = None
+    turn_revision: int | None = None
+    stt_s: float | None = None
+    llm_s: float | None = None
+    tts_ttfa_s: float | None = None
+    e2e_s: float | None = None
+    mlx_lock_wait_s: float = 0.0
+    status: TurnLatencyStatus = "completed"
+
+    def reset(
+        self,
+        turn_id: str | None = None,
+        turn_revision: int | None = None,
+    ) -> None:
+        self.turn_id = turn_id
+        self.turn_revision = turn_revision
+        self.stt_s = None
+        self.llm_s = None
+        self.tts_ttfa_s = None
+        self.e2e_s = None
+        self.mlx_lock_wait_s = 0.0
+        self.status = "completed"
+
+    def record_stt(self, seconds: float) -> None:
+        self.stt_s = max(0.0, seconds)
+
+    def record_llm(self, seconds: float) -> None:
+        self.llm_s = max(0.0, seconds)
+
+    def record_tts_ttfa(self, seconds: float) -> None:
+        self.tts_ttfa_s = max(0.0, seconds)
+
+    def record_e2e(self, seconds: float) -> None:
+        self.e2e_s = max(0.0, seconds)
+
+    def record_mlx_lock_wait(self, seconds: float) -> None:
+        if seconds > 0.0:
+            self.mlx_lock_wait_s += max(0.0, seconds)
+
+    @staticmethod
+    def _fmt(seconds: float | None) -> str:
+        if seconds is None:
+            return "n/a"
+        return f"{seconds:.2f}s"
+
+    def format_log_line(self) -> str | None:
+        if self.turn_id is None:
+            return None
+        revision = 0 if self.turn_revision is None else self.turn_revision
+        return (
+            f"Turn {self.turn_id} rev={revision} latency: "
+            f"stt={self._fmt(self.stt_s)} llm={self._fmt(self.llm_s)} "
+            f"tts_ttfa={self._fmt(self.tts_ttfa_s)} e2e={self._fmt(self.e2e_s)} "
+            f"mlx_lock_wait={self.mlx_lock_wait_s:.2f}s status={self.status}"
+        )
+
+
+class TurnLatencyStore:
+    """Thread-safe latency trackers keyed by (turn_id, turn_revision)."""
+
+    def __init__(self) -> None:
+        self._lock = Lock()
+        self._trackers: dict[tuple[str, int], TurnLatencyTracker] = {}
+
+    @staticmethod
+    def _key(turn_id: str, turn_revision: int | None) -> tuple[str, int]:
+        return turn_id, 0 if turn_revision is None else turn_revision
+
+    def get_or_create(
+        self,
+        turn_id: str | None,
+        turn_revision: int | None,
+    ) -> TurnLatencyTracker | None:
+        if turn_id is None:
+            return None
+        key = self._key(turn_id, turn_revision)
+        with self._lock:
+            tracker = self._trackers.get(key)
+            if tracker is None:
+                tracker = TurnLatencyTracker(turn_id=turn_id, turn_revision=key[1])
+                self._trackers[key] = tracker
+            return tracker
+
+    def pop(
+        self,
+        turn_id: str | None,
+        turn_revision: int | None,
+    ) -> TurnLatencyTracker | None:
+        if turn_id is None:
+            return None
+        key = self._key(turn_id, turn_revision)
+        with self._lock:
+            return self._trackers.pop(key, None)

--- a/src/speech_to_speech/pipeline/turn_latency.py
+++ b/src/speech_to_speech/pipeline/turn_latency.py
@@ -1,8 +1,9 @@
 from __future__ import annotations
 
+from collections import defaultdict
 from contextlib import contextmanager
 from contextvars import ContextVar
-from dataclasses import dataclass, field
+from dataclasses import dataclass
 from threading import Lock
 from typing import Literal
 
@@ -59,14 +60,21 @@ class TurnLatencyTracker:
         self.llm_s = max(0.0, seconds)
 
     def record_tts_ttfa(self, seconds: float) -> None:
-        self.tts_ttfa_s = max(0.0, seconds)
+        if self.tts_ttfa_s is None:
+            self.tts_ttfa_s = max(0.0, seconds)
 
     def record_e2e(self, seconds: float) -> None:
-        self.e2e_s = max(0.0, seconds)
+        if self.e2e_s is None:
+            self.e2e_s = max(0.0, seconds)
 
     def record_mlx_lock_wait(self, seconds: float) -> None:
         if seconds > 0.0:
             self.mlx_lock_wait_s += max(0.0, seconds)
+
+    def absorb_pending(self, pending: TurnLatencyTracker) -> None:
+        if pending.stt_s is not None:
+            self.stt_s = pending.stt_s
+        self.mlx_lock_wait_s += pending.mlx_lock_wait_s
 
     @staticmethod
     def _fmt(seconds: float | None) -> str:
@@ -87,38 +95,100 @@ class TurnLatencyTracker:
 
 
 class TurnLatencyStore:
-    """Thread-safe latency trackers keyed by (turn_id, turn_revision)."""
+    """Thread-safe latency trackers keyed by response_key.
+
+    STT runs before a response_key exists, so interim measurements are held on
+    a per-turn pending slot and merged when the response tracker is created.
+
+    Session cleanup: response trackers are indexed by ``session_id`` so
+    ``unregister`` can drop only that session's in-flight measurements.
+    Pending turn slots are not session-tagged (STT runs on the shared pipeline
+    without conn context), so they are cleared only once the last tracked
+    session has been removed — which matches the one-active-session-per-pipeline
+    unit model used by the realtime server.
+    """
 
     def __init__(self) -> None:
         self._lock = Lock()
-        self._trackers: dict[tuple[str, int], TurnLatencyTracker] = {}
+        self._trackers: dict[str, TurnLatencyTracker] = {}
+        self._pending_turn: dict[tuple[str, int], TurnLatencyTracker] = {}
+        self._session_keys: dict[str, set[str]] = defaultdict(set)
+
+    @property
+    def active_session_count(self) -> int:
+        with self._lock:
+            return len(self._session_keys)
 
     @staticmethod
-    def _key(turn_id: str, turn_revision: int | None) -> tuple[str, int]:
+    def _turn_key(turn_id: str, turn_revision: int | None) -> tuple[str, int]:
         return turn_id, 0 if turn_revision is None else turn_revision
 
-    def get_or_create(
+    def _detach_response_from_session(self, session_id: str, response_key: str) -> None:
+        keys = self._session_keys.get(session_id)
+        if keys is None:
+            return
+        keys.discard(response_key)
+        if not keys:
+            self._session_keys.pop(session_id, None)
+
+    def get_or_create_for_turn(
         self,
         turn_id: str | None,
         turn_revision: int | None,
     ) -> TurnLatencyTracker | None:
         if turn_id is None:
             return None
-        key = self._key(turn_id, turn_revision)
+        key = self._turn_key(turn_id, turn_revision)
         with self._lock:
-            tracker = self._trackers.get(key)
+            tracker = self._pending_turn.get(key)
             if tracker is None:
                 tracker = TurnLatencyTracker(turn_id=turn_id, turn_revision=key[1])
-                self._trackers[key] = tracker
+                self._pending_turn[key] = tracker
             return tracker
 
-    def pop(
+    def get_or_create_response(
         self,
-        turn_id: str | None,
-        turn_revision: int | None,
-    ) -> TurnLatencyTracker | None:
-        if turn_id is None:
-            return None
-        key = self._key(turn_id, turn_revision)
+        response_key: str,
+        *,
+        turn_id: str | None = None,
+        turn_revision: int | None = None,
+        session_id: str | None = None,
+    ) -> TurnLatencyTracker:
         with self._lock:
-            return self._trackers.pop(key, None)
+            tracker = self._trackers.get(response_key)
+            if tracker is None:
+                revision = None if turn_revision is None else turn_revision
+                tracker = TurnLatencyTracker(turn_id=turn_id, turn_revision=revision)
+                self._trackers[response_key] = tracker
+                if session_id is not None:
+                    self._session_keys[session_id].add(response_key)
+                if turn_id is not None:
+                    pending = self._pending_turn.pop(self._turn_key(turn_id, turn_revision), None)
+                    if pending is not None:
+                        tracker.absorb_pending(pending)
+                        if tracker.turn_id is None:
+                            tracker.turn_id = pending.turn_id
+                            tracker.turn_revision = pending.turn_revision
+            elif turn_id is not None and tracker.turn_id is None:
+                tracker.turn_id = turn_id
+                tracker.turn_revision = turn_revision
+            return tracker
+
+    def pop(self, response_key: str | None, *, session_id: str | None = None) -> TurnLatencyTracker | None:
+        if response_key is None:
+            return None
+        with self._lock:
+            tracker = self._trackers.pop(response_key, None)
+            if session_id is not None:
+                self._detach_response_from_session(session_id, response_key)
+            return tracker
+
+    def discard_response(self, response_key: str, *, session_id: str | None = None) -> None:
+        self.pop(response_key, session_id=session_id)
+
+    def clear_session(self, session_id: str) -> None:
+        with self._lock:
+            for response_key in self._session_keys.pop(session_id, set()):
+                self._trackers.pop(response_key, None)
+            if not self._session_keys:
+                self._pending_turn.clear()

--- a/src/speech_to_speech/s2s_pipeline.py
+++ b/src/speech_to_speech/s2s_pipeline.py
@@ -47,6 +47,7 @@ from speech_to_speech.pipeline.queue_types import (
     VADOutItem,
 )
 from speech_to_speech.pipeline.speculative_turns import SpeculativeTurnTracker
+from speech_to_speech.pipeline.turn_latency import TurnLatencyStore
 from speech_to_speech.pipeline.transcript_logging import (
     set_log_transcripts,
     warn_if_log_transcripts_enabled,
@@ -486,6 +487,7 @@ def _build_pipeline_unit(
     response_playing = Event()
     cancel_scope = CancelScope()
     speculative_turns = SpeculativeTurnTracker()
+    turn_latency_store = TurnLatencyStore()
     recv_audio_chunks_queue: Queue[AudioInItem] = Queue()
     send_audio_chunks_queue: Queue[AudioOutItem] = Queue()
     spoken_prompt_queue: Queue[VADOutItem] = Queue()
@@ -503,6 +505,7 @@ def _build_pipeline_unit(
         should_listen=should_listen,
         chat_size=chat_size,
         speculative_turns=speculative_turns,
+        turn_latency_store=turn_latency_store,
         default_instructions=default_instructions,
     )
 
@@ -532,6 +535,7 @@ def _build_pipeline_unit(
     )
     for h in handlers:
         h.pipeline_index = index
+        h.turn_latency_store = turn_latency_store
 
     return PipelineUnit(
         index=index,

--- a/src/speech_to_speech/utils/mlx_lock.py
+++ b/src/speech_to_speech/utils/mlx_lock.py
@@ -20,6 +20,8 @@ from threading import Lock, RLock, current_thread, get_ident
 from time import perf_counter
 from typing import Literal
 
+from speech_to_speech.pipeline.turn_latency import active_turn_latency_tracker
+
 logger = logging.getLogger(__name__)
 
 # Global reentrant lock for MLX model access
@@ -104,6 +106,9 @@ def acquire_mlx_lock(timeout: float | None = None, handler_name: str = "Unknown"
 
     if acquired:
         depth = _record_lock_acquired(handler_name)
+        tracker = active_turn_latency_tracker()
+        if tracker is not None and wait_s > 0.0:
+            tracker.record_mlx_lock_wait(wait_s)
         if wait_s >= 0.25:
             logger.info(
                 "%s: MLX lock acquired after %.2fs (previous_owner=%s, depth=%d)",

--- a/tests/test_turn_latency.py
+++ b/tests/test_turn_latency.py
@@ -1,0 +1,119 @@
+from __future__ import annotations
+
+import logging
+
+import pytest
+
+from speech_to_speech.pipeline.turn_latency import TurnLatencyStore, TurnLatencyTracker
+
+
+def test_turn_latency_tracker_format_log_line() -> None:
+    tracker = TurnLatencyTracker(
+        turn_id="turn_1",
+        turn_revision=0,
+        stt_s=0.14,
+        llm_s=1.28,
+        tts_ttfa_s=0.16,
+        e2e_s=1.61,
+        mlx_lock_wait_s=0.0,
+        status="completed",
+    )
+    assert (
+        tracker.format_log_line()
+        == "Turn turn_1 rev=0 latency: stt=0.14s llm=1.28s tts_ttfa=0.16s e2e=1.61s mlx_lock_wait=0.00s status=completed"
+    )
+
+
+def test_turn_latency_tracker_record_and_reset() -> None:
+    tracker = TurnLatencyTracker()
+    tracker.reset("turn_2", 1)
+    tracker.record_stt(0.5)
+    tracker.record_llm(2.0)
+    tracker.record_tts_ttfa(0.2)
+    tracker.record_e2e(3.0)
+    tracker.record_mlx_lock_wait(0.1)
+    tracker.record_mlx_lock_wait(0.05)
+    tracker.status = "cancelled"
+
+    line = tracker.format_log_line()
+    assert line is not None
+    assert "turn_2 rev=1" in line
+    assert "stt=0.50s" in line
+    assert "llm=2.00s" in line
+    assert "tts_ttfa=0.20s" in line
+    assert "e2e=3.00s" in line
+    assert "mlx_lock_wait=0.15s" in line
+    assert "status=cancelled" in line
+
+    tracker.reset()
+    assert tracker.turn_id is None
+    assert tracker.format_log_line() is None
+
+
+def test_turn_latency_store_get_or_create_and_pop() -> None:
+    store = TurnLatencyStore()
+    first = store.get_or_create("turn_3", 0)
+    second = store.get_or_create("turn_3", 0)
+    assert first is second
+    first.record_stt(0.1)
+
+    popped = store.pop("turn_3", 0)
+    assert popped is first
+    assert popped.stt_s == 0.1
+    assert store.pop("turn_3", 0) is None
+
+
+def test_turn_latency_log_emission(caplog: pytest.LogCaptureFixture) -> None:
+    """Simulates _log_turn_latency without importing the full realtime stack."""
+    logger = logging.getLogger("speech_to_speech.api.openai_realtime.handlers.response")
+    store = TurnLatencyStore()
+    tracker = store.get_or_create("turn_1", 0)
+    tracker.record_stt(0.14)
+    tracker.record_llm(1.28)
+    tracker.record_tts_ttfa(0.16)
+    tracker.record_e2e(1.61)
+
+    with caplog.at_level(logging.INFO, logger="speech_to_speech.api.openai_realtime.handlers.response"):
+        popped = store.pop("turn_1", 0)
+        assert popped is tracker
+        line = popped.format_log_line()
+        assert line is not None
+        logger.info(line)
+
+    assert len(caplog.records) == 1
+    assert (
+        caplog.records[0].message
+        == "Turn turn_1 rev=0 latency: stt=0.14s llm=1.28s tts_ttfa=0.16s e2e=1.61s mlx_lock_wait=0.00s status=completed"
+    )
+
+
+def test_end_response_logs_turn_latency(caplog: pytest.LogCaptureFixture) -> None:
+    pytest.importorskip("speech_to_speech.utils.utils")
+
+    from speech_to_speech.api.openai_realtime.handlers.response import ResponseHandler
+    from speech_to_speech.api.openai_realtime.service import RealtimeService
+
+    store = TurnLatencyStore()
+    service = RealtimeService(turn_latency_store=store)
+    conn_id = service.register()
+    st = service._state(conn_id)
+    st.speculative_user_turn_id = "turn_1"
+    st.speculative_user_turn_revision = 0
+
+    tracker = store.get_or_create("turn_1", 0)
+    st.turn_latency = tracker
+    tracker.record_stt(0.14)
+    tracker.record_llm(1.28)
+    tracker.record_tts_ttfa(0.16)
+    tracker.record_e2e(1.61)
+
+    handler = ResponseHandler(service)
+    with caplog.at_level(logging.INFO):
+        handler._end_response(conn_id, "completed")
+
+    latency_logs = [record.message for record in caplog.records if "Turn turn_1 rev=0 latency:" in record.message]
+    assert len(latency_logs) == 1
+    assert (
+        latency_logs[0]
+        == "Turn turn_1 rev=0 latency: stt=0.14s llm=1.28s tts_ttfa=0.16s e2e=1.61s mlx_lock_wait=0.00s status=completed"
+    )

--- a/tests/test_turn_latency.py
+++ b/tests/test_turn_latency.py
@@ -50,31 +50,77 @@ def test_turn_latency_tracker_record_and_reset() -> None:
     assert tracker.format_log_line() is None
 
 
-def test_turn_latency_store_get_or_create_and_pop() -> None:
-    store = TurnLatencyStore()
-    first = store.get_or_create("turn_3", 0)
-    second = store.get_or_create("turn_3", 0)
-    assert first is second
-    first.record_stt(0.1)
+def test_turn_latency_tracker_first_write_wins_for_ttfa_and_e2e() -> None:
+    tracker = TurnLatencyTracker(turn_id="turn_1", turn_revision=0)
+    tracker.record_tts_ttfa(0.2)
+    tracker.record_tts_ttfa(1.5)
+    tracker.record_e2e(1.0)
+    tracker.record_e2e(4.0)
+    assert tracker.tts_ttfa_s == 0.2
+    assert tracker.e2e_s == 1.0
 
-    popped = store.pop("turn_3", 0)
-    assert popped is first
-    assert popped.stt_s == 0.1
-    assert store.pop("turn_3", 0) is None
+
+def test_turn_latency_store_pending_turn_merges_into_response() -> None:
+    store = TurnLatencyStore()
+    pending = store.get_or_create_for_turn("turn_3", 0)
+    pending.record_stt(0.12)
+    pending.record_mlx_lock_wait(0.03)
+
+    tracker = store.get_or_create_response("resp_a", turn_id="turn_3", turn_revision=0, session_id="sess_1")
+    assert tracker.stt_s == 0.12
+    assert tracker.mlx_lock_wait_s == 0.03
+    assert store.get_or_create_for_turn("turn_3", 0) is not pending
+
+
+def test_turn_latency_store_pop_and_clear_session() -> None:
+    store = TurnLatencyStore()
+    tracker = store.get_or_create_response("resp_a", turn_id="turn_1", turn_revision=0, session_id="sess_1")
+    tracker.record_llm(1.0)
+
+    popped = store.pop("resp_a", session_id="sess_1")
+    assert popped is tracker
+    assert store.pop("resp_a", session_id="sess_1") is None
+
+    store.get_or_create_response("resp_b", turn_id="turn_2", turn_revision=0, session_id="sess_1")
+    store.get_or_create_for_turn("turn_9", 0).record_stt(0.1)
+    store.clear_session("sess_1")
+    assert store.pop("resp_b", session_id="sess_1") is None
+    assert store.get_or_create_for_turn("turn_9", 0).stt_s is None
+    assert store.active_session_count == 0
+
+
+def test_clear_session_keeps_pending_while_other_sessions_active() -> None:
+    store = TurnLatencyStore()
+    store.get_or_create_response("resp_a", turn_id="turn_1", turn_revision=0, session_id="sess_1")
+    pending = store.get_or_create_for_turn("turn_9", 0)
+    pending.record_stt(0.1)
+
+    store.get_or_create_response("resp_b", turn_id="turn_1", turn_revision=0, session_id="sess_2")
+    store.clear_session("sess_1")
+
+    assert store.pop("resp_a", session_id="sess_1") is None
+    assert store.get_or_create_for_turn("turn_9", 0).stt_s == 0.1
+    assert store.active_session_count == 1
+
+    assert store.pop("resp_b", session_id="sess_2") is not None
+    assert store.active_session_count == 0
+
+    store.clear_session("sess_2")
+    assert store.get_or_create_for_turn("turn_9", 0).stt_s is None
 
 
 def test_turn_latency_log_emission(caplog: pytest.LogCaptureFixture) -> None:
     """Simulates _log_turn_latency without importing the full realtime stack."""
     logger = logging.getLogger("speech_to_speech.api.openai_realtime.handlers.response")
     store = TurnLatencyStore()
-    tracker = store.get_or_create("turn_1", 0)
+    tracker = store.get_or_create_response("resp_a", turn_id="turn_1", turn_revision=0)
     tracker.record_stt(0.14)
     tracker.record_llm(1.28)
     tracker.record_tts_ttfa(0.16)
     tracker.record_e2e(1.61)
 
     with caplog.at_level(logging.INFO, logger="speech_to_speech.api.openai_realtime.handlers.response"):
-        popped = store.pop("turn_1", 0)
+        popped = store.pop("resp_a")
         assert popped is tracker
         line = popped.format_log_line()
         assert line is not None
@@ -83,37 +129,5 @@ def test_turn_latency_log_emission(caplog: pytest.LogCaptureFixture) -> None:
     assert len(caplog.records) == 1
     assert (
         caplog.records[0].message
-        == "Turn turn_1 rev=0 latency: stt=0.14s llm=1.28s tts_ttfa=0.16s e2e=1.61s mlx_lock_wait=0.00s status=completed"
-    )
-
-
-def test_end_response_logs_turn_latency(caplog: pytest.LogCaptureFixture) -> None:
-    pytest.importorskip("speech_to_speech.utils.utils")
-
-    from speech_to_speech.api.openai_realtime.handlers.response import ResponseHandler
-    from speech_to_speech.api.openai_realtime.service import RealtimeService
-
-    store = TurnLatencyStore()
-    service = RealtimeService(turn_latency_store=store)
-    conn_id = service.register()
-    st = service._state(conn_id)
-    st.speculative_user_turn_id = "turn_1"
-    st.speculative_user_turn_revision = 0
-
-    tracker = store.get_or_create("turn_1", 0)
-    st.turn_latency = tracker
-    tracker.record_stt(0.14)
-    tracker.record_llm(1.28)
-    tracker.record_tts_ttfa(0.16)
-    tracker.record_e2e(1.61)
-
-    handler = ResponseHandler(service)
-    with caplog.at_level(logging.INFO):
-        handler._end_response(conn_id, "completed")
-
-    latency_logs = [record.message for record in caplog.records if "Turn turn_1 rev=0 latency:" in record.message]
-    assert len(latency_logs) == 1
-    assert (
-        latency_logs[0]
         == "Turn turn_1 rev=0 latency: stt=0.14s llm=1.28s tts_ttfa=0.16s e2e=1.61s mlx_lock_wait=0.00s status=completed"
     )


### PR DESCRIPTION
hey again (:

Not sure this is useful *right now*, or if it's even on your priority list — happy to close if the timing is off.

After #516 / #533 I was trying to explain Mac turn latency and kept scraping four separate logs (Parakeet STT, MLX-LLM hold, Qwen3 TTFA, speech-stopped → first audio). That works once. It doesn't scale when you're comparing configs.

So this PR adds a small structure: one INFO line when the response actually finishes (`_end_response`), keyed by `turn_id` / revision:

```
Turn turn_3 rev=0 latency: stt=0.08s llm=1.83s tts_ttfa=0.16s e2e=2.09s mlx_lock_wait=0.00s status=completed
```

Instrumenting the Mac default path only (Parakeet + Qwen3 + MLX lock). Other backends stay `n/a`. Existing logs are unchanged.

I found it relevant for *improving* latency, not just staring at it: once you can attribute a slow turn, the next default/model change is a decision instead of a guess. Same motion as bf16 → 4bit, just with a cleaner signal.

## Test plan
- [x] `uv run pytest tests/test_turn_latency.py -v`
- [x] `speech-to-speech local --mac-optimal-settings` — completed turns emit the line; a failed turn still logs `status=failed`

No rush either way.


Made with [Cursor](https://cursor.com)