### PR TITLE
Prevent stale browser audio worklet mismatches

### DIFF
--- a/demo/README.md
+++ b/demo/README.md
@@ -265,6 +265,12 @@ transport pick, and `s2s.audio.inputId` / `s2s.audio.outputId` for devices).
   feeds the `mic-capture` worklet at the `AudioContext` rate. The worklet
   resamples to 24 kHz (boxcar lowpass + decimation on the 48 -> 24 fast
   path, linear interpolation fallback for odd rates) and packs Int16 LE.
+- **Browser cache safety**: the entry module, realtime client, and both audio
+  worklet URLs share the `audio-24k-v1` cache key. The client also waits for
+  the capture worklet to report the same version and a 24 kHz output rate
+  before opening a session. When the browser-audio contract or sample rate
+  changes, bump the key in `index.html`, `main.js`, and
+  `AUDIO_WORKLET_VERSION` in `s2s-realtime-client.js` together.
 - **User replay**: the WebSocket client retains only a bounded copy of PCM it
   actually sends. `speech_started` / `speech_stopped` timestamps select each
   utterance, which is wrapped as an in-memory WAV and attached to the user row.

--- a/demo/index.html
+++ b/demo/index.html
@@ -404,6 +404,6 @@
     </dialog>
 
     <script src="vendor/openai-realtime-agents.umd.js"></script>
-    <script type="module" src="main.js"></script>
+    <script type="module" src="main.js?v=audio-24k-v1"></script>
   </body>
 </html>

--- a/demo/main.js
+++ b/demo/main.js
@@ -17,7 +17,7 @@
  * @typedef {S2sRealtimeClient} RealtimeClient
  */
 
-import { S2sRealtimeClient } from "./s2s-realtime-client.js";
+import { S2sRealtimeClient } from "./s2s-realtime-client.js?v=audio-24k-v1";
 import { $, truncateError, DEBUG } from "./ui/dom.js";
 import { ChatView } from "./ui/chat.js";
 import { Account } from "./ui/account.js";

--- a/demo/s2s-realtime-client.js
+++ b/demo/s2s-realtime-client.js
@@ -48,10 +48,19 @@ import { extractResponseTranscript, trimTrailingSlash } from "./ws/codec.js";
 import { OrbVisualiser, VIS_FFT_SIZE } from "./ws/orb-visualizer.js";
 import { SentAudioRecorder } from "./ws/user-audio-recorder.js";
 
-const AUDIO_SAMPLE_RATE = 24_000;
+export const AUDIO_SAMPLE_RATE = 24_000;
+export const AUDIO_WORKLET_VERSION = "audio-24k-v1";
 const MIC_CHUNK_MS = 40;
+const CAPTURE_CONFIG_TIMEOUT_MS = 2_000;
 const SPEAKING_OPEN_DB = -50;
 const SPEAKING_HANG_MS = 250;
+
+/** @param {string} name @param {URL} base */
+export function versionedAudioWorkletUrl(name, base) {
+  const url = new URL(name, base);
+  url.searchParams.set("v", AUDIO_WORKLET_VERSION);
+  return url.href;
+}
 
 /** @param {string} message @param {string} code @param {object} [extra] */
 function codedError(message, code, extra) {
@@ -273,22 +282,53 @@ export class S2sRealtimeClient extends EventTarget {
 
     if (this.options.transport === "websocket") {
       const base = new URL("./worklets/", import.meta.url);
-      await ctx.audioWorklet.addModule(new URL("mic-capture.js", base).href);
-      await ctx.audioWorklet.addModule(new URL("audio-playback.js", base).href);
+      await ctx.audioWorklet.addModule(versionedAudioWorkletUrl("mic-capture.js", base));
+      await ctx.audioWorklet.addModule(versionedAudioWorkletUrl("audio-playback.js", base));
       const capture = new AudioWorkletNode(ctx, "mic-capture", {
         numberOfInputs: 1,
         numberOfOutputs: 0,
-        processorOptions: { chunkMs: MIC_CHUNK_MS },
+        processorOptions: {
+          chunkMs: MIC_CHUNK_MS,
+          targetRate: AUDIO_SAMPLE_RATE,
+          version: AUDIO_WORKLET_VERSION,
+        },
       });
-      capture.port.onmessage = (event) => {
-        if (event.data instanceof ArrayBuffer) this._onMicChunk(event.data);
-        else if (event.data?.kind === "level") {
-          this.dispatchEvent(new CustomEvent("input-level", { detail: { rms: event.data.rms } }));
-        }
-      };
+      const captureConfigured = new Promise((resolve, reject) => {
+        const timeout = window.setTimeout(() => {
+          reject(new Error(
+            "The microphone audio processor did not report its sample rate. "
+            + "Close every tab for this demo, reopen it, and try again.",
+          ));
+        }, CAPTURE_CONFIG_TIMEOUT_MS);
+        capture.port.onmessage = (event) => {
+          if (event.data instanceof ArrayBuffer) {
+            this._onMicChunk(event.data);
+          } else if (event.data?.kind === "level") {
+            this.dispatchEvent(new CustomEvent("input-level", { detail: { rms: event.data.rms } }));
+          } else if (event.data?.kind === "capture-config") {
+            window.clearTimeout(timeout);
+            const inputRate = Number(event.data.inputRate);
+            const outputRate = Number(event.data.outputRate);
+            const version = String(event.data.version || "unknown");
+            console.info(
+              `[audio] capture worklet ${version}: ${inputRate} Hz -> ${outputRate} Hz`,
+            );
+            if (outputRate !== AUDIO_SAMPLE_RATE || version !== AUDIO_WORKLET_VERSION) {
+              reject(new Error(
+                `Microphone sample-rate mismatch: processor ${version} outputs ${outputRate} Hz; `
+                + `the client expects ${AUDIO_SAMPLE_RATE} Hz.`,
+              ));
+              return;
+            }
+            resolve(undefined);
+          }
+        };
+      });
+      capture.port.postMessage({ kind: "probe" });
       capture.port.postMessage({ kind: "gate", ...this._noiseGate });
       micSrc.connect(capture);
       this._captureNode = capture;
+      await captureConfigured;
 
       const playback = new AudioWorkletNode(ctx, "audio-playback", {
         numberOfInputs: 0,

--- a/demo/worklets/mic-capture.js
+++ b/demo/worklets/mic-capture.js
@@ -22,7 +22,7 @@
  *     mic meter can show the live level against the threshold.
  */
 
-const TARGET_RATE = 24000;
+const DEFAULT_TARGET_RATE = 24000;
 const DEFAULT_CHUNK_MS = 40;
 // Gate envelope timing (fixed; only the threshold is user-tunable).
 const GATE_ATTACK_MS = 5; // open almost instantly so word onsets survive
@@ -33,9 +33,14 @@ class MicCaptureProcessor extends AudioWorkletProcessor {
   constructor(options) {
     super();
     const chunkMs = options?.processorOptions?.chunkMs ?? DEFAULT_CHUNK_MS;
+    const requestedRate = Number(options?.processorOptions?.targetRate);
+    this._targetRate = Number.isFinite(requestedRate) && requestedRate > 0
+      ? requestedRate
+      : DEFAULT_TARGET_RATE;
+    this._version = String(options?.processorOptions?.version || "unknown");
     this._inputRate = sampleRate;
-    this._ratio = this._inputRate / TARGET_RATE;
-    this._chunkSamples = Math.round((TARGET_RATE * chunkMs) / 1000);
+    this._ratio = this._inputRate / this._targetRate;
+    this._chunkSamples = Math.round((this._targetRate * chunkMs) / 1000);
     this._scratch = new Float32Array(0);
     this._decimated = new Float32Array(this._chunkSamples);
     this._enabled = true;
@@ -45,14 +50,21 @@ class MicCaptureProcessor extends AudioWorkletProcessor {
     this._thresholdLin = 0; // linear amplitude; signal RMS must exceed this to open
     this._gateGain = 1; // smoothed gain currently applied
     this._holdRemaining = 0; // samples left before the gate may start closing
-    this._attackCoef = Math.exp(-1 / ((GATE_ATTACK_MS / 1000) * TARGET_RATE));
-    this._releaseCoef = Math.exp(-1 / ((GATE_RELEASE_MS / 1000) * TARGET_RATE));
-    this._holdSamples = Math.round((GATE_HOLD_MS / 1000) * TARGET_RATE);
+    this._attackCoef = Math.exp(-1 / ((GATE_ATTACK_MS / 1000) * this._targetRate));
+    this._releaseCoef = Math.exp(-1 / ((GATE_RELEASE_MS / 1000) * this._targetRate));
+    this._holdSamples = Math.round((GATE_HOLD_MS / 1000) * this._targetRate);
 
     this.port.onmessage = (e) => {
       const data = e.data;
       if (data?.kind === "enable") this._enabled = !!data.value;
-      else if (data?.kind === "gate") {
+      else if (data?.kind === "probe") {
+        this.port.postMessage({
+          kind: "capture-config",
+          inputRate: this._inputRate,
+          outputRate: this._targetRate,
+          version: this._version,
+        });
+      } else if (data?.kind === "gate") {
         this._gateEnabled = !!data.enabled;
         // dB -> linear amplitude. When off, threshold 0 keeps the gate open.
         this._thresholdLin = data.enabled ? Math.pow(10, data.thresholdDb / 20) : 0;

--- a/tests/test_demo_agents_adapter.py
+++ b/tests/test_demo_agents_adapter.py
@@ -135,7 +135,7 @@ async function setupAudio(captureConfig) {
         onmessage: null,
         postMessage: (message) => {
           this.messages.push(message);
-          if (name === "mic-capture" && message?.kind === "probe") {
+          if (name === "mic-capture" && message?.kind === "probe" && captureConfig !== undefined) {
             this.port.onmessage?.({ data: captureConfig });
           }
         },
@@ -182,6 +182,23 @@ try {
 }
 if (!String(mismatch?.message).includes("sample-rate mismatch")) {
   throw new Error(`stale worklet was not rejected: ${mismatch}`);
+}
+
+const realSetTimeout = window.setTimeout;
+window.setTimeout = (callback) => {
+  queueMicrotask(callback);
+  return 1;
+};
+let noConfig;
+try {
+  await setupAudio(undefined);
+} catch (error) {
+  noConfig = error;
+} finally {
+  window.setTimeout = realSetTimeout;
+}
+if (!String(noConfig?.message).includes("did not report")) {
+  throw new Error(`non-reporting stale worklet was not rejected: ${noConfig}`);
 }
 """
     )

--- a/tests/test_demo_agents_adapter.py
+++ b/tests/test_demo_agents_adapter.py
@@ -100,6 +100,93 @@ for (const [transport, url] of [
     )
 
 
+def test_websocket_audio_setup_requires_the_versioned_24khz_worklet():
+    _run_node(
+        """
+globalThis.window = globalThis;
+globalThis.requestAnimationFrame = () => 1;
+globalThis.document = { documentElement: { style: { setProperty() {}, removeProperty() {} } } };
+
+const { S2sRealtimeClient } = await import("./demo/s2s-realtime-client.js");
+
+async function setupAudio(captureConfig) {
+  const modules = [];
+  const nodes = [];
+  const analyser = () => ({
+    fftSize: 0,
+    smoothingTimeConstant: 0,
+    frequencyBinCount: 128,
+    connect() {},
+    getByteFrequencyData() {},
+  });
+  const context = {
+    state: "running",
+    destination: {},
+    audioWorklet: { async addModule(url) { modules.push(url); } },
+    createMediaStreamSource() { return { connect() {} }; },
+    createAnalyser: analyser,
+  };
+  globalThis.AudioWorkletNode = class AudioWorkletNode {
+    constructor(_context, name, options) {
+      this.name = name;
+      this.options = options;
+      this.messages = [];
+      this.port = {
+        onmessage: null,
+        postMessage: (message) => {
+          this.messages.push(message);
+          if (name === "mic-capture" && message?.kind === "probe") {
+            this.port.onmessage?.({ data: captureConfig });
+          }
+        },
+      };
+      nodes.push(this);
+    }
+    connect() {}
+  };
+
+  const client = new S2sRealtimeClient({
+    transport: "websocket",
+    directUrl: "ws://unused",
+    audioContext: context,
+    micStream: {},
+  });
+  await client._setupAudio();
+  return { modules, nodes };
+}
+
+const good = await setupAudio({
+  kind: "capture-config",
+  inputRate: 48000,
+  outputRate: 24000,
+  version: "audio-24k-v1",
+});
+if (good.modules.length !== 2 || good.modules.some((url) => !url.endsWith("?v=audio-24k-v1"))) {
+  throw new Error(`audio worklets were not versioned: ${JSON.stringify(good.modules)}`);
+}
+const capture = good.nodes.find((node) => node.name === "mic-capture");
+if (capture?.options?.processorOptions?.targetRate !== 24000) {
+  throw new Error("capture worklet was not configured for 24 kHz");
+}
+
+let mismatch;
+try {
+  await setupAudio({
+    kind: "capture-config",
+    inputRate: 48000,
+    outputRate: 16000,
+    version: "stale-16k",
+  });
+} catch (error) {
+  mismatch = error;
+}
+if (!String(mismatch?.message).includes("sample-rate mismatch")) {
+  throw new Error(`stale worklet was not rejected: ${mismatch}`);
+}
+"""
+    )
+
+
 def test_adapter_delegates_tools_to_realtime_session():
     _run_node(
         """

--- a/tests/test_demo_user_audio.py
+++ b/tests/test_demo_user_audio.py
@@ -265,3 +265,81 @@ if (spawned !== 1 || view._activeUserBubble !== bubble) {
 }
 """
     )
+
+
+def test_audio_asset_version_propagates_to_the_worklets():
+    index = (REPO_ROOT / "demo/index.html").read_text()
+    main = (REPO_ROOT / "demo/main.js").read_text()
+    client = (REPO_ROOT / "demo/s2s-realtime-client.js").read_text()
+
+    version = "audio-24k-v1"
+    assert f"main.js?v={version}" in index
+    assert f"s2s-realtime-client.js?v={version}" in main
+    assert f'AUDIO_WORKLET_VERSION = "{version}"' in client
+    assert 'versionedAudioWorkletUrl("mic-capture.js", base)' in client
+    assert 'versionedAudioWorkletUrl("audio-playback.js", base)' in client
+
+
+def test_mic_capture_reports_and_resamples_to_24khz_without_changing_pitch():
+    _run_node(
+        """
+import fs from "node:fs";
+import vm from "node:vm";
+
+const messages = [];
+const processors = {};
+class AudioWorkletProcessor {
+  constructor() {
+    this.port = {
+      onmessage: null,
+      postMessage(message) { messages.push(message); },
+    };
+  }
+}
+const source = fs.readFileSync("./demo/worklets/mic-capture.js", "utf8");
+vm.runInNewContext(source, {
+  AudioWorkletProcessor,
+  sampleRate: 48000,
+  registerProcessor(name, constructor) { processors[name] = constructor; },
+});
+
+const CaptureProcessor = processors["mic-capture"];
+if (!CaptureProcessor) throw new Error("mic-capture processor was not registered");
+const processor = new CaptureProcessor({
+  processorOptions: {
+    chunkMs: 40,
+    targetRate: 24000,
+    version: "audio-24k-v1",
+  },
+});
+processor.port.onmessage({ data: { kind: "probe" } });
+
+const config = messages.find((message) => message?.kind === "capture-config");
+if (!config) throw new Error("capture worklet did not report its configuration");
+if (config.inputRate !== 48000 || config.outputRate !== 24000) {
+  throw new Error(`unexpected sample-rate handshake: ${JSON.stringify(config)}`);
+}
+if (config.version !== "audio-24k-v1") {
+  throw new Error(`unexpected worklet version: ${config.version}`);
+}
+
+const input = new Float32Array(1920);
+for (let i = 0; i < input.length; i++) {
+  input[i] = 0.5 * Math.sin(2 * Math.PI * 1000 * i / 48000);
+}
+processor.process([[input]]);
+
+const pcmBuffer = messages.find((message) => message?.byteLength === 1920);
+if (!pcmBuffer) throw new Error("expected one 40 ms PCM16 chunk at 24 kHz");
+const pcm = new Int16Array(pcmBuffer);
+let zeroCrossings = 0;
+for (let i = 1; i < pcm.length; i++) {
+  if ((pcm[i - 1] < 0 && pcm[i] >= 0) || (pcm[i - 1] >= 0 && pcm[i] < 0)) {
+    zeroCrossings += 1;
+  }
+}
+if (zeroCrossings < 78 || zeroCrossings > 82) {
+  throw new Error(`resampling changed the 1 kHz tone pitch: ${zeroCrossings} crossings`);
+}
+"""
+    )


### PR DESCRIPTION
## Summary

- version the browser entry module, realtime client, and audio worklet URLs with one audio contract key
- require the capture worklet to report the expected version and 24 kHz output rate before opening a session
- add regression coverage for cache-key propagation, stale-worklet rejection, and 48-to-24 kHz pitch preservation
- document how to bump the browser audio cache key safely

## Context

A browser could retain the previous 16 kHz capture worklet while loading a newer client that treats the PCM as 24 kHz. That mixed asset graph makes replayed user audio sound 1.5x too high and degrades transcription quality.

## Testing

- `uv run --no-project --with pytest pytest tests/test_demo_user_audio.py tests/test_demo_agents_adapter.py -q` (14 passed)
- `npm run test:agents:adapter` (3 passed)
- `uvx ruff check tests/test_demo_user_audio.py tests/test_demo_agents_adapter.py`
- `uvx ruff format --check tests/test_demo_user_audio.py tests/test_demo_agents_adapter.py`
- `node --check demo/main.js demo/s2s-realtime-client.js demo/worklets/mic-capture.js`
- `git diff --check`