### PR TITLE
Add Qwen3-ASR STT backend

### DIFF
--- a/README.md
+++ b/README.md
@@ -172,6 +172,7 @@ This installs the package in editable mode and makes the `speech-to-speech` CLI 
 | STT | [Lightning Whisper MLX](https://github.com/mustafaaljadery/lightning-whisper-mlx) | Apple Silicon | `whisper-mlx` |
 | STT | [MLX Audio Whisper](https://github.com/huggingface/mlx-audio) | Apple Silicon | built-in on macOS |
 | STT | [Paraformer](https://github.com/modelscope/FunASR) | CUDA / CPU | `paraformer` |
+| STT | [Qwen3-ASR](https://huggingface.co/Qwen/Qwen3-ASR-0.6B-hf) through Transformers | CUDA / CPU, Apple Silicon | built-in |
 | STT | OpenAI-compatible `/v1/audio/transcriptions` endpoint | local or remote HTTP server | built-in |
 | LLM | OpenAI-compatible API (`responses-api`, `chat-completions`) | hosted providers or self-hosted servers | built-in |
 | LLM | [Transformers](https://huggingface.co/models?pipeline_tag=text-generation&sort=trending) | CUDA / CPU | built-in |

--- a/src/speech_to_speech/LLM/utils.py
+++ b/src/speech_to_speech/LLM/utils.py
@@ -208,6 +208,8 @@ WHISPER_LANGUAGE_TO_LLM_LANGUAGE = {
     "kk": "kazakh",
     "sq": "albanian",
     "sw": "swahili",
+    # Qwen3-ASR reports Filipino as "fil"; Whisper only knows "tl" (Tagalog) above.
+    "fil": "filipino",
     "gl": "galician",
     "mr": "marathi",
     "pa": "punjabi",

--- a/src/speech_to_speech/STT/README.md
+++ b/src/speech_to_speech/STT/README.md
@@ -89,7 +89,7 @@ This document summarizes the Speech-to-Text (STT) implementations in the `STT/` 
   - With `auto`, the model identifies the language of each final turn and reports it with the `-auto` suffix
   - Progressive (partial) windows are short and fool the language ID, so they reuse the language of the last final turn
   - A forced language is passed on every request and reported as is
-- Needs `transformers>=5.13.0`, which `pyproject.toml` already requires
+- Transformers versions: `pyproject.toml` already requires a version that knows `qwen3_asr`. The prompt and true language forcing need `transformers>=5.15.1` (the Linux pin); with 5.14.1 (the macOS pin) the language is a hint and the prompt is ignored with a warning
 
 ### 8) OpenAI-compatible endpoint (`--stt openai`)
 

--- a/src/speech_to_speech/STT/README.md
+++ b/src/speech_to_speech/STT/README.md
@@ -10,6 +10,7 @@ This document summarizes the Speech-to-Text (STT) implementations in the `STT/` 
 - `faster-whisper` → `STT/faster_whisper_handler.py`
 - `parakeet-tdt` → `STT/parakeet_tdt_handler.py`
 - `paraformer` → `STT/paraformer_handler.py`
+- `qwen3-asr` → `STT/qwen3_asr_handler.py`
 - `openai` → `STT/openai_compatible_handler.py`
 
 ## Language Support by Handler
@@ -76,7 +77,21 @@ This document summarizes the Speech-to-Text (STT) implementations in the `STT/` 
   - Depends on selected FunASR model checkpoint
   - Default setup is Chinese-oriented (`zh`)
 
-### 7) OpenAI-compatible endpoint (`--stt openai`)
+### 7) Qwen3-ASR (`--stt qwen3-asr`)
+
+- Handler: `Qwen3ASRSTTHandler`
+- Model flag: `--qwen3_asr_model_name` (default `Qwen/Qwen3-ASR-0.6B-hf`; `Qwen/Qwen3-ASR-1.7B-hf` is more accurate)
+- Language flag: `--qwen3_asr_language` (ISO code or name, default `auto`)
+- Context flag: `--qwen3_asr_prompt` (optional hotwords or domain context)
+- Supported languages: the 30 in the checkpoint's language table
+  - `ar`, `yue`, `zh`, `cs`, `da`, `nl`, `en`, `fil`, `fi`, `fr`, `de`, `el`, `hi`, `hu`, `id`, `it`, `ja`, `ko`, `mk`, `ms`, `fa`, `pl`, `pt`, `ro`, `ru`, `es`, `sv`, `th`, `tr`, `vi`
+- Behavior:
+  - With `auto`, the model identifies the language of each final turn and reports it with the `-auto` suffix
+  - Progressive (partial) windows are short and fool the language ID, so they reuse the language of the last final turn
+  - A forced language is passed on every request and reported as is
+- Needs `transformers>=5.13.0`, which `pyproject.toml` already requires
+
+### 8) OpenAI-compatible endpoint (`--stt openai`)
 
 - Handler: `OpenAICompatibleSTTHandler`
 - Endpoint: `POST /v1/audio/transcriptions`
@@ -171,4 +186,14 @@ speech-to-speech serve --stt parakeet-tdt \
 
 ```bash
 speech-to-speech serve --stt paraformer --paraformer_stt_model_name paraformer-zh
+```
+
+### Qwen3-ASR
+
+```bash
+speech-to-speech serve --stt qwen3-asr
+speech-to-speech serve --stt qwen3-asr --qwen3_asr_language fr
+speech-to-speech serve --stt qwen3-asr \
+  --qwen3_asr_model_name Qwen/Qwen3-ASR-1.7B-hf \
+  --qwen3_asr_prompt "Vocabulary: Quilter, apostle."
 ```

--- a/src/speech_to_speech/STT/qwen3_asr_handler.py
+++ b/src/speech_to_speech/STT/qwen3_asr_handler.py
@@ -1,7 +1,7 @@
 from __future__ import annotations
 
+import inspect
 import logging
-from sys import platform
 from time import perf_counter
 from typing import Any, Iterator, Optional
 
@@ -39,12 +39,14 @@ def language_to_code(language: Optional[str]) -> Optional[str]:
 
 
 def resolve_device(device: str) -> str:
-    """Turn ``auto`` into a concrete device the same way the other local handlers do."""
+    """Turn ``auto`` into CUDA, then MPS, then CPU; keep an explicit choice as is."""
     if device != "auto":
         return device
-    if platform == "darwin":
+    if torch.cuda.is_available():
+        return "cuda"
+    if torch.backends.mps.is_available():
         return "mps"
-    return "cuda" if torch.cuda.is_available() else "cpu"
+    return "cpu"
 
 
 def resolve_torch_dtype(torch_dtype: str, device: str) -> torch.dtype:
@@ -52,10 +54,15 @@ def resolve_torch_dtype(torch_dtype: str, device: str) -> torch.dtype:
     if torch_dtype != "auto":
         return getattr(torch, torch_dtype)
     if device.startswith("cuda"):
-        return torch.bfloat16
+        return torch.bfloat16 if torch.cuda.is_bf16_supported() else torch.float16
     if device.startswith("mps"):
         return torch.float16
     return torch.float32
+
+
+def _accepts_prompt(processor: Any) -> bool:
+    """Transformers 5.15 added ``prompt`` to ``apply_transcription_request``; 5.14 rejects it."""
+    return "prompt" in inspect.signature(processor.apply_transcription_request).parameters
 
 
 class Qwen3ASRSTTHandler(BaseSTTHandler):
@@ -84,6 +91,9 @@ class Qwen3ASRSTTHandler(BaseSTTHandler):
         self.configure_language(language)
 
         self.processor = transformers.AutoProcessor.from_pretrained(model_name)
+        if self.prompt and not _accepts_prompt(self.processor):
+            logger.warning("Ignoring the Qwen3-ASR prompt: passing context needs transformers>=5.15.1.")
+            self.prompt = None
         model = transformers.AutoModelForMultimodalLM.from_pretrained(model_name, dtype=self.torch_dtype)
         self.model = model.to(self.device).eval()
         self.warmup()
@@ -106,8 +116,12 @@ class Qwen3ASRSTTHandler(BaseSTTHandler):
 
     def _transcribe(self, audio: np.ndarray, language: Optional[str]) -> tuple[str, Optional[str]]:
         """Run one generation. Return the text and the language name the model identified (auto mode only)."""
-        inputs = self.processor.apply_transcription_request(audio=audio, language=language, prompt=self.prompt)
-        inputs = inputs.to(self.device, self.torch_dtype)
+        request: dict[str, Any] = {"audio": audio}
+        if language is not None:
+            request["language"] = language
+        if self.prompt:
+            request["prompt"] = self.prompt
+        inputs = self.processor.apply_transcription_request(**request).to(self.device, self.torch_dtype)
         with torch.inference_mode():
             output_ids = self.model.generate(**inputs, **self.gen_kwargs)
         generated_ids = output_ids[:, inputs["input_ids"].shape[1] :]

--- a/src/speech_to_speech/STT/qwen3_asr_handler.py
+++ b/src/speech_to_speech/STT/qwen3_asr_handler.py
@@ -1,0 +1,165 @@
+from __future__ import annotations
+
+import logging
+from sys import platform
+from time import perf_counter
+from typing import Any, Iterator, Optional
+
+import numpy as np
+import torch
+import transformers
+from rich.console import Console
+from transformers.models.qwen3_asr.processing_qwen3_asr import LANGUAGE_CODE_TO_NAME
+
+from speech_to_speech.pipeline.handler_types import STTIn, STTOut
+from speech_to_speech.pipeline.messages import PartialTranscription, Transcription
+from speech_to_speech.STT.base_stt_handler import BaseSTTHandler
+
+logger = logging.getLogger(__name__)
+console = Console()
+
+DEFAULT_MODEL = "Qwen/Qwen3-ASR-0.6B-hf"
+DEFAULT_LANGUAGE = "en"
+SAMPLE_RATE = 16000
+
+# The processor owns the language table: it validates forced languages against it and the
+# model emits these names before ``<asr_text>`` when it identifies the language itself.
+SUPPORTED_LANGUAGES = list(LANGUAGE_CODE_TO_NAME)
+_LANGUAGE_NAME_TO_CODE = {name.lower(): code for code, name in LANGUAGE_CODE_TO_NAME.items()}
+
+
+def language_to_code(language: Optional[str]) -> Optional[str]:
+    """Map a language name or ISO code to the ISO code Qwen3-ASR supports. Unknown values give ``None``."""
+    if not language:
+        return None
+    normalized = language.strip().lower()
+    if normalized in LANGUAGE_CODE_TO_NAME:
+        return normalized
+    return _LANGUAGE_NAME_TO_CODE.get(normalized)
+
+
+def resolve_device(device: str) -> str:
+    """Turn ``auto`` into a concrete device the same way the other local handlers do."""
+    if device != "auto":
+        return device
+    if platform == "darwin":
+        return "mps"
+    return "cuda" if torch.cuda.is_available() else "cpu"
+
+
+def resolve_torch_dtype(torch_dtype: str, device: str) -> torch.dtype:
+    """Turn ``auto`` into the dtype that runs well on ``device``; keep an explicit choice as is."""
+    if torch_dtype != "auto":
+        return getattr(torch, torch_dtype)
+    if device.startswith("cuda"):
+        return torch.bfloat16
+    if device.startswith("mps"):
+        return torch.float16
+    return torch.float32
+
+
+class Qwen3ASRSTTHandler(BaseSTTHandler):
+    """Speech to text with a Qwen3-ASR checkpoint through Transformers.
+
+    Language policy: with ``language="auto"`` the model identifies the language on
+    every final turn and the code is reported with the ``-auto`` suffix. Progressive
+    windows are short and fool the language ID, so they reuse the language of the
+    last final turn instead. A forced language is passed on every request.
+    """
+
+    def setup(
+        self,
+        model_name: str = DEFAULT_MODEL,
+        device: str = "auto",
+        torch_dtype: str = "auto",
+        language: Optional[str] = "auto",
+        prompt: Optional[str] = None,
+        gen_kwargs: Optional[dict[str, Any]] = None,
+    ) -> None:
+        logger.info("Loading Qwen3-ASR STT model: %s", model_name)
+        self.device = resolve_device(device)
+        self.torch_dtype = resolve_torch_dtype(torch_dtype, self.device)
+        self.prompt = prompt or None
+        self.gen_kwargs = dict(gen_kwargs or {})
+        self.configure_language(language)
+
+        self.processor = transformers.AutoProcessor.from_pretrained(model_name)
+        model = transformers.AutoModelForMultimodalLM.from_pretrained(model_name, dtype=self.torch_dtype)
+        self.model = model.to(self.device).eval()
+        self.warmup()
+
+    def configure_language(self, language: Optional[str]) -> None:
+        """Set the forced language, or ``None`` for per-turn detection."""
+        requested = (language or "").strip()
+        if requested.lower() in ("", "auto"):
+            self.forced_language: Optional[str] = None
+        else:
+            # Pass unknown codes through: the processor validates what the checkpoint supports.
+            self.forced_language = language_to_code(requested) or requested
+        self.last_language: Optional[str] = self.forced_language
+
+    def warmup(self) -> None:
+        logger.info("Warming up %s", self.__class__.__name__)
+        start = perf_counter()
+        self._transcribe(np.zeros(SAMPLE_RATE, dtype=np.float32), self.forced_language)
+        logger.info("%s: warmed up! time: %.3f s", self.__class__.__name__, perf_counter() - start)
+
+    def _transcribe(self, audio: np.ndarray, language: Optional[str]) -> tuple[str, Optional[str]]:
+        """Run one generation. Return the text and the language name the model identified (auto mode only)."""
+        inputs = self.processor.apply_transcription_request(audio=audio, language=language, prompt=self.prompt)
+        inputs = inputs.to(self.device, self.torch_dtype)
+        with torch.inference_mode():
+            output_ids = self.model.generate(**inputs, **self.gen_kwargs)
+        generated_ids = output_ids[:, inputs["input_ids"].shape[1] :]
+
+        text = self.processor.decode(generated_ids, return_format="transcription_only")[0].strip()
+        if language is not None:
+            return text, None
+        parsed = self.processor.decode(generated_ids, return_format="parsed")[0]
+        detected = parsed.get("language") if isinstance(parsed, dict) else None
+        return text, detected
+
+    def _final_language_code(self, detected: Optional[str]) -> str:
+        if self.forced_language is not None:
+            return self.forced_language
+        code = language_to_code(detected)
+        if code is not None:
+            self.last_language = code
+        elif detected:
+            logger.warning("Qwen3-ASR detected unsupported language: %s", detected)
+        return f"{self.last_language or DEFAULT_LANGUAGE}-auto"
+
+    def process(self, vad_audio: STTIn) -> Iterator[STTOut]:
+        progressive = vad_audio.mode == "progressive"
+        request_language = self.forced_language
+        if request_language is None and progressive:
+            request_language = self.last_language
+        audio = np.asarray(vad_audio.audio, dtype=np.float32)
+
+        start = perf_counter()
+        text, detected = self._transcribe(audio, request_language)
+        logger.debug(
+            "Qwen3-ASR %s transcription took %.3f s for %.2f s of audio",
+            vad_audio.mode,
+            perf_counter() - start,
+            len(audio) / SAMPLE_RATE,
+        )
+
+        if progressive:
+            yield PartialTranscription(
+                text=text,
+                turn_id=vad_audio.turn_id,
+                turn_revision=vad_audio.turn_revision,
+            )
+            return
+
+        language_code = self._final_language_code(detected)
+        console.print(f"[yellow]USER: {text}")
+        logger.debug("Language Code Qwen3-ASR: %s", language_code)
+        yield Transcription(
+            text=text,
+            language_code=language_code,
+            turn_id=vad_audio.turn_id,
+            turn_revision=vad_audio.turn_revision,
+            speech_stopped_at_s=vad_audio.created_at_s,
+        )

--- a/src/speech_to_speech/arguments_classes/qwen3_asr_stt_arguments.py
+++ b/src/speech_to_speech/arguments_classes/qwen3_asr_stt_arguments.py
@@ -1,0 +1,52 @@
+from dataclasses import dataclass, field
+from typing import Optional
+
+
+@dataclass
+class Qwen3ASRSTTHandlerArguments:
+    qwen3_asr_model_name: str = field(
+        default="Qwen/Qwen3-ASR-0.6B-hf",
+        metadata={
+            "help": (
+                "The Qwen3-ASR checkpoint to load through Transformers. "
+                "'Qwen/Qwen3-ASR-1.7B-hf' is more accurate and needs about 4 GB of VRAM. "
+                "Default is 'Qwen/Qwen3-ASR-0.6B-hf'."
+            )
+        },
+    )
+    qwen3_asr_device: str = field(
+        default="auto",
+        metadata={"help": "The device to run on. 'auto' picks CUDA, then MPS, then CPU. Default is 'auto'."},
+    )
+    qwen3_asr_torch_dtype: str = field(
+        default="auto",
+        metadata={
+            "help": (
+                "The model dtype. 'auto' picks bfloat16 on CUDA, float16 on MPS and float32 on CPU. "
+                "Also accepts 'float32', 'float16' or 'bfloat16'. Default is 'auto'."
+            )
+        },
+    )
+    qwen3_asr_language: str = field(
+        default="auto",
+        metadata={
+            "help": (
+                "The language of the speech as an ISO code ('en', 'fr', 'zh', ...) or a name ('English'). "
+                "'auto' lets the model identify the language of each final turn and forwards it to the LLM "
+                "and TTS. Default is 'auto'."
+            )
+        },
+    )
+    qwen3_asr_prompt: Optional[str] = field(
+        default=None,
+        metadata={
+            "help": (
+                "Optional context or hotwords that bias the transcription, "
+                "for example 'Vocabulary: Quilter, apostle.'. Default is None."
+            )
+        },
+    )
+    qwen3_asr_gen_max_new_tokens: int = field(
+        default=256,
+        metadata={"help": "The maximum number of tokens to generate per turn. Default is 256."},
+    )

--- a/src/speech_to_speech/backend_registry.py
+++ b/src/speech_to_speech/backend_registry.py
@@ -30,6 +30,7 @@ from speech_to_speech.arguments_classes.parakeet_tdt_arguments import (
     ParakeetTDTSTTHandlerArguments,
 )
 from speech_to_speech.arguments_classes.pocket_tts_arguments import PocketTTSHandlerArguments
+from speech_to_speech.arguments_classes.qwen3_asr_stt_arguments import Qwen3ASRSTTHandlerArguments
 from speech_to_speech.arguments_classes.qwen3_tts_arguments import Qwen3TTSHandlerArguments
 from speech_to_speech.arguments_classes.responses_api_language_model_arguments import (
     ResponsesApiLanguageModelHandlerArguments,
@@ -380,6 +381,17 @@ STT_BACKENDS = build_backend_registry(
             ),
             config_prefix="paraformer_stt",
             required_extra="paraformer",
+        ),
+        BackendSpec(
+            "qwen3-asr",
+            "stt",
+            Qwen3ASRSTTHandlerArguments,
+            _simple_handler_factory(
+                "speech_to_speech.STT.qwen3_asr_handler",
+                "Qwen3ASRSTTHandler",
+                attach_speculative_turns=True,
+            ),
+            config_prefix="qwen3_asr",
         ),
         BackendSpec(
             "openai",

--- a/tests/test_llm_utils.py
+++ b/tests/test_llm_utils.py
@@ -47,6 +47,7 @@ _STT_HANDLER_MODULES = [
     "speech_to_speech.STT.mlx_audio_whisper_handler",
     "speech_to_speech.STT.lightning_whisper_mlx_handler",
     "speech_to_speech.STT.faster_whisper_handler",
+    "speech_to_speech.STT.qwen3_asr_handler",
 ]
 
 # These have no optional top-level dependency, so a skip here means something is wrong
@@ -55,6 +56,7 @@ _ALWAYS_IMPORTABLE = {
     "speech_to_speech.STT.parakeet_tdt_handler",
     "speech_to_speech.STT.whisper_stt_handler",
     "speech_to_speech.STT.mlx_audio_whisper_handler",
+    "speech_to_speech.STT.qwen3_asr_handler",
     # Importable via the stub above, so a skip here would mean the stub stopped working.
     "speech_to_speech.STT.faster_whisper_handler",
 }
@@ -120,7 +122,8 @@ def test_language_names_are_lowercase_and_non_empty():
 
 def test_whisper_language_coverage_is_complete():
     """Whisper reports 100 languages; a missing name silently drops the prompt."""
-    assert len(WHISPER_LANGUAGE_TO_LLM_LANGUAGE) == 100
+    # Other backends add codes Whisper lacks (Qwen3-ASR reports Filipino as "fil"), hence at least.
+    assert len(WHISPER_LANGUAGE_TO_LLM_LANGUAGE) >= 100
     # Spot-check languages that only Whisper-family backends can report.
     for code in ("ar", "tr", "he", "th", "yue", "haw"):
         assert code in WHISPER_LANGUAGE_TO_LLM_LANGUAGE

--- a/tests/test_qwen3_asr_transcription_events.py
+++ b/tests/test_qwen3_asr_transcription_events.py
@@ -1,0 +1,361 @@
+from __future__ import annotations
+
+import logging
+from typing import Any
+
+import numpy as np
+import pytest
+import torch
+
+from speech_to_speech.pipeline.messages import PartialTranscription, Transcription, VADAudio
+from speech_to_speech.STT import qwen3_asr_handler
+from speech_to_speech.STT.qwen3_asr_handler import (
+    Qwen3ASRSTTHandler,
+    language_to_code,
+    resolve_device,
+    resolve_torch_dtype,
+)
+
+_PROMPT_TOKENS = 3
+
+
+class _FakeInputs(dict):
+    """Mimics the BatchFeature returned by ``apply_transcription_request``."""
+
+    def to(self, *args: Any, **kwargs: Any) -> "_FakeInputs":
+        return self
+
+
+class _FakeProcessor:
+    """Mirrors the real Qwen3ASRProcessor: ``parsed`` carries a language only in auto mode."""
+
+    def __init__(self, language: str | None = "English", text: str = "hello world") -> None:
+        self.language = language
+        self.text = text
+        self.requests: list[dict[str, Any]] = []
+
+    def apply_transcription_request(
+        self, audio: Any, language: str | None = None, prompt: str | None = None
+    ) -> _FakeInputs:
+        self.requests.append({"language": language, "prompt": prompt, "samples": len(audio)})
+        return _FakeInputs(input_ids=torch.zeros((1, _PROMPT_TOKENS), dtype=torch.long))
+
+    def decode(self, generated_ids: Any, return_format: str = "raw") -> list[Any]:
+        forced = self.requests[-1]["language"] is not None
+        language = None if forced else self.language
+        if return_format == "transcription_only":
+            return [self.text]
+        if return_format == "parsed":
+            return [{"language": language, "transcription": self.text}]
+        return [f"language {language}<asr_text>{self.text}"]
+
+
+class _FakeModel:
+    def __init__(self) -> None:
+        self.generate_calls: list[dict[str, Any]] = []
+
+    def generate(self, **kwargs: Any) -> torch.Tensor:
+        self.generate_calls.append(kwargs)
+        return torch.zeros((1, _PROMPT_TOKENS + 4), dtype=torch.long)
+
+
+def _handler(
+    *,
+    language: str = "auto",
+    processor: _FakeProcessor | None = None,
+    prompt: str | None = None,
+    gen_kwargs: dict[str, Any] | None = None,
+) -> Qwen3ASRSTTHandler:
+    handler = object.__new__(Qwen3ASRSTTHandler)
+    handler.processor = processor or _FakeProcessor()
+    handler.model = _FakeModel()
+    handler.device = "cpu"
+    handler.torch_dtype = torch.float32
+    handler.prompt = prompt
+    handler.gen_kwargs = dict(gen_kwargs or {})
+    handler.configure_language(language)
+    return handler
+
+
+def _vad_audio(mode: str = "final", seconds: float = 2.0, revision: int = 1) -> VADAudio:
+    return VADAudio(
+        audio=np.zeros(int(16000 * seconds), dtype=np.float32),
+        mode=mode,
+        turn_id="turn_1",
+        turn_revision=revision,
+        created_at_s=123.0,
+    )
+
+
+@pytest.fixture(autouse=True)
+def _quiet_console(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setattr(qwen3_asr_handler.console, "print", lambda *args, **kwargs: None)
+
+
+# ── language and device helpers ──────────────────────────────────────
+
+
+@pytest.mark.parametrize(
+    ("value", "expected"),
+    [
+        ("English", "en"),
+        ("english", "en"),
+        ("Cantonese", "yue"),
+        ("Chinese", "zh"),
+        ("zh", "zh"),
+        (" French ", "fr"),
+        ("Klingon", None),
+        ("None", None),
+        (None, None),
+        ("", None),
+    ],
+)
+def test_language_to_code(value: str | None, expected: str | None) -> None:
+    assert language_to_code(value) == expected
+
+
+def test_resolve_device_auto_prefers_cuda(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setattr(qwen3_asr_handler, "platform", "linux")
+    monkeypatch.setattr(qwen3_asr_handler.torch.cuda, "is_available", lambda: True)
+    assert resolve_device("auto") == "cuda"
+
+
+def test_resolve_device_auto_falls_back_to_cpu(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setattr(qwen3_asr_handler, "platform", "linux")
+    monkeypatch.setattr(qwen3_asr_handler.torch.cuda, "is_available", lambda: False)
+    assert resolve_device("auto") == "cpu"
+
+
+def test_resolve_device_auto_uses_mps_on_macos(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setattr(qwen3_asr_handler, "platform", "darwin")
+    assert resolve_device("auto") == "mps"
+
+
+def test_resolve_device_keeps_explicit_choice(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setattr(qwen3_asr_handler, "platform", "linux")
+    monkeypatch.setattr(qwen3_asr_handler.torch.cuda, "is_available", lambda: True)
+    assert resolve_device("cpu") == "cpu"
+
+
+@pytest.mark.parametrize(
+    ("dtype", "device", "expected"),
+    [
+        ("auto", "cuda", torch.bfloat16),
+        ("auto", "mps", torch.float16),
+        ("auto", "cpu", torch.float32),
+        ("float16", "cpu", torch.float16),
+        ("bfloat16", "cuda", torch.bfloat16),
+    ],
+)
+def test_resolve_torch_dtype(dtype: str, device: str, expected: torch.dtype) -> None:
+    assert resolve_torch_dtype(dtype, device) == expected
+
+
+# ── transcription events ─────────────────────────────────────────────
+
+
+def test_final_transcription_reports_text_and_detected_language() -> None:
+    result = list(_handler().process(_vad_audio("final")))
+
+    assert len(result) == 1
+    assert isinstance(result[0], Transcription)
+    assert result[0].text == "hello world"
+    assert result[0].language_code == "en-auto"
+    assert result[0].turn_id == "turn_1"
+    assert result[0].turn_revision == 1
+    assert result[0].speech_stopped_at_s == 123.0
+
+
+def test_final_transcription_in_auto_mode_lets_the_model_detect_language() -> None:
+    handler = _handler()
+
+    list(handler.process(_vad_audio("final")))
+
+    assert handler.processor.requests[0]["language"] is None
+
+
+def test_progressive_transcription_is_partial() -> None:
+    result = list(_handler().process(_vad_audio("progressive")))
+
+    assert len(result) == 1
+    assert isinstance(result[0], PartialTranscription)
+    assert result[0].text == "hello world"
+    assert result[0].turn_id == "turn_1"
+    assert result[0].turn_revision == 1
+    assert not hasattr(result[0], "language_code")
+
+
+def test_progressive_reuses_last_final_language_in_auto_mode() -> None:
+    """Short progressive windows fool the language ID, so partials stick to the last final language."""
+    processor = _FakeProcessor(language="French", text="bonjour")
+    handler = _handler(processor=processor)
+
+    list(handler.process(_vad_audio("final")))
+    list(handler.process(_vad_audio("progressive", seconds=0.5)))
+    list(handler.process(_vad_audio("final")))
+
+    assert [request["language"] for request in processor.requests] == [None, "fr", None]
+
+
+def test_progressive_before_any_final_uses_auto_detection() -> None:
+    handler = _handler()
+
+    list(handler.process(_vad_audio("progressive")))
+
+    assert handler.processor.requests[0]["language"] is None
+
+
+def test_forced_language_is_passed_on_every_request_and_reported() -> None:
+    processor = _FakeProcessor()
+    handler = _handler(language="de", processor=processor)
+
+    list(handler.process(_vad_audio("progressive")))
+    result = list(handler.process(_vad_audio("final")))
+
+    assert [request["language"] for request in processor.requests] == ["de", "de"]
+    assert isinstance(result[0], Transcription)
+    assert result[0].language_code == "de"
+
+
+def test_forced_language_accepts_full_name() -> None:
+    handler = _handler(language="German")
+
+    result = list(handler.process(_vad_audio("final")))
+
+    assert handler.processor.requests[0]["language"] == "de"
+    assert result[0].language_code == "de"
+
+
+def test_forced_language_outside_the_map_is_passed_through() -> None:
+    """The processor validates the checkpoint's languages, so the handler does not gatekeep."""
+    handler = _handler(language="sw")
+
+    result = list(handler.process(_vad_audio("final")))
+
+    assert handler.processor.requests[0]["language"] == "sw"
+    assert result[0].language_code == "sw"
+
+
+def test_unknown_detected_language_is_not_sticky_and_falls_back() -> None:
+    processor = _FakeProcessor(language="English")
+    handler = _handler(processor=processor)
+    list(handler.process(_vad_audio("final")))
+
+    processor.language = "Klingon"
+    result = list(handler.process(_vad_audio("final")))
+    list(handler.process(_vad_audio("progressive")))
+
+    assert result[0].language_code == "en-auto"
+    assert processor.requests[-1]["language"] == "en"
+
+
+def test_silence_reports_no_language_and_defaults_to_english() -> None:
+    """On silence the model emits ``language None<asr_text>`` with an empty transcription."""
+    handler = _handler(processor=_FakeProcessor(language=None, text=""))
+
+    result = list(handler.process(_vad_audio("final")))
+
+    assert result[0].text == ""
+    assert result[0].language_code == "en-auto"
+
+
+def test_prompt_and_generation_kwargs_are_forwarded() -> None:
+    handler = _handler(prompt="Vocabulary: Quilter.", gen_kwargs={"max_new_tokens": 64})
+
+    list(handler.process(_vad_audio("final")))
+
+    assert handler.processor.requests[0]["prompt"] == "Vocabulary: Quilter."
+    assert handler.model.generate_calls[0]["max_new_tokens"] == 64
+
+
+def test_generation_strips_the_prompt_tokens_before_decoding() -> None:
+    class _RecordingProcessor(_FakeProcessor):
+        decoded_length = 0
+
+        def decode(self, generated_ids: Any, return_format: str = "raw") -> list[Any]:
+            self.decoded_length = generated_ids.shape[1]
+            return super().decode(generated_ids, return_format)
+
+    processor = _RecordingProcessor()
+    handler = _handler(processor=processor)
+
+    list(handler.process(_vad_audio("final")))
+
+    assert processor.decoded_length == 4
+
+
+# ── setup ────────────────────────────────────────────────────────────
+
+
+class _FakeTransformers:
+    """Stands in for the ``transformers`` module inside the handler."""
+
+    def __init__(self) -> None:
+        self.processor = _FakeProcessor()
+        self.model = _FakeModel()
+        self.model.eval = lambda: self.model  # type: ignore[attr-defined]
+        self.model.to = lambda device: self.model  # type: ignore[attr-defined]
+        self.loaded: list[tuple[str, Any]] = []
+
+        outer = self
+
+        class AutoProcessor:
+            @staticmethod
+            def from_pretrained(name: str) -> _FakeProcessor:
+                outer.loaded.append(("processor", name))
+                return outer.processor
+
+        class AutoModelForMultimodalLM:
+            @staticmethod
+            def from_pretrained(name: str, **kwargs: Any) -> _FakeModel:
+                outer.loaded.append(("model", kwargs.get("dtype")))
+                return outer.model
+
+        self.AutoProcessor = AutoProcessor
+        self.AutoModelForMultimodalLM = AutoModelForMultimodalLM
+
+
+def test_setup_loads_model_warms_up_and_logs(monkeypatch: pytest.MonkeyPatch, caplog: pytest.LogCaptureFixture) -> None:
+    fake = _FakeTransformers()
+    monkeypatch.setattr(qwen3_asr_handler, "transformers", fake)
+
+    handler = object.__new__(Qwen3ASRSTTHandler)
+    with caplog.at_level(logging.INFO, logger="speech_to_speech.STT.qwen3_asr_handler"):
+        handler.setup(model_name="Qwen/Qwen3-ASR-0.6B-hf", device="cpu", torch_dtype="float32", language="auto")
+
+    assert ("processor", "Qwen/Qwen3-ASR-0.6B-hf") in fake.loaded
+    assert ("model", torch.float32) in fake.loaded
+    assert len(fake.model.generate_calls) == 1, "setup must run one warmup generation"
+    assert "Loading Qwen3-ASR STT model: Qwen/Qwen3-ASR-0.6B-hf" in caplog.text
+    assert handler.last_language is None
+
+
+def test_setup_does_not_share_generation_kwargs_between_handlers(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setattr(qwen3_asr_handler, "transformers", _FakeTransformers())
+
+    first = object.__new__(Qwen3ASRSTTHandler)
+    first.setup(device="cpu")
+    first.gen_kwargs["max_new_tokens"] = 1
+    second = object.__new__(Qwen3ASRSTTHandler)
+    second.setup(device="cpu")
+
+    assert second.gen_kwargs.get("max_new_tokens") != 1
+
+
+# ── registry wiring ──────────────────────────────────────────────────
+
+
+def test_registry_normalizes_qwen3_asr_arguments() -> None:
+    from speech_to_speech.arguments_classes.qwen3_asr_stt_arguments import Qwen3ASRSTTHandlerArguments
+    from speech_to_speech.backend_registry import STT_BACKENDS, select_backend
+
+    config = Qwen3ASRSTTHandlerArguments(qwen3_asr_language="fr", qwen3_asr_gen_max_new_tokens=64)
+    selection = select_backend(STT_BACKENDS, "qwen3-asr", config)
+
+    assert selection.config["model_name"] == "Qwen/Qwen3-ASR-0.6B-hf"
+    assert selection.config["device"] == "auto"
+    assert selection.config["torch_dtype"] == "auto"
+    assert selection.config["language"] == "fr"
+    assert selection.config["prompt"] is None
+    assert selection.config["gen_kwargs"] == {"max_new_tokens": 64}
+    assert selection.spec.required_extra is None

--- a/tests/test_qwen3_asr_transcription_events.py
+++ b/tests/test_qwen3_asr_transcription_events.py
@@ -1,13 +1,19 @@
 from __future__ import annotations
 
 import logging
+from queue import Queue
+from threading import Event
 from typing import Any
 
 import numpy as np
 import pytest
 import torch
 
+from speech_to_speech.backend_registry import HandlerContext, create_backend_handler
+from speech_to_speech.pipeline.cancel_scope import CancelScope
 from speech_to_speech.pipeline.messages import PartialTranscription, Transcription, VADAudio
+from speech_to_speech.pipeline.speculative_turns import SpeculativeTurnTracker
+from speech_to_speech.s2s_pipeline import parse_arguments
 from speech_to_speech.STT import qwen3_asr_handler
 from speech_to_speech.STT.qwen3_asr_handler import (
     Qwen3ASRSTTHandler,
@@ -53,6 +59,12 @@ class _FakeProcessor:
 class _FakeModel:
     def __init__(self) -> None:
         self.generate_calls: list[dict[str, Any]] = []
+
+    def to(self, device: str) -> "_FakeModel":
+        return self
+
+    def eval(self) -> "_FakeModel":
+        return self
 
     def generate(self, **kwargs: Any) -> torch.Tensor:
         self.generate_calls.append(kwargs)
@@ -114,40 +126,47 @@ def test_language_to_code(value: str | None, expected: str | None) -> None:
     assert language_to_code(value) == expected
 
 
+def _hardware(monkeypatch: pytest.MonkeyPatch, *, cuda: bool, mps: bool = False, bf16: bool = True) -> None:
+    monkeypatch.setattr(qwen3_asr_handler.torch.cuda, "is_available", lambda: cuda)
+    monkeypatch.setattr(qwen3_asr_handler.torch.cuda, "is_bf16_supported", lambda: bf16)
+    monkeypatch.setattr(qwen3_asr_handler.torch.backends.mps, "is_available", lambda: mps)
+
+
 def test_resolve_device_auto_prefers_cuda(monkeypatch: pytest.MonkeyPatch) -> None:
-    monkeypatch.setattr(qwen3_asr_handler, "platform", "linux")
-    monkeypatch.setattr(qwen3_asr_handler.torch.cuda, "is_available", lambda: True)
+    _hardware(monkeypatch, cuda=True, mps=True)
     assert resolve_device("auto") == "cuda"
 
 
-def test_resolve_device_auto_falls_back_to_cpu(monkeypatch: pytest.MonkeyPatch) -> None:
-    monkeypatch.setattr(qwen3_asr_handler, "platform", "linux")
-    monkeypatch.setattr(qwen3_asr_handler.torch.cuda, "is_available", lambda: False)
-    assert resolve_device("auto") == "cpu"
-
-
-def test_resolve_device_auto_uses_mps_on_macos(monkeypatch: pytest.MonkeyPatch) -> None:
-    monkeypatch.setattr(qwen3_asr_handler, "platform", "darwin")
+def test_resolve_device_auto_uses_mps_when_cuda_is_unavailable(monkeypatch: pytest.MonkeyPatch) -> None:
+    _hardware(monkeypatch, cuda=False, mps=True)
     assert resolve_device("auto") == "mps"
 
 
+def test_resolve_device_auto_falls_back_to_cpu(monkeypatch: pytest.MonkeyPatch) -> None:
+    _hardware(monkeypatch, cuda=False, mps=False)
+    assert resolve_device("auto") == "cpu"
+
+
 def test_resolve_device_keeps_explicit_choice(monkeypatch: pytest.MonkeyPatch) -> None:
-    monkeypatch.setattr(qwen3_asr_handler, "platform", "linux")
-    monkeypatch.setattr(qwen3_asr_handler.torch.cuda, "is_available", lambda: True)
+    _hardware(monkeypatch, cuda=True)
     assert resolve_device("cpu") == "cpu"
 
 
 @pytest.mark.parametrize(
-    ("dtype", "device", "expected"),
+    ("dtype", "device", "bf16", "expected"),
     [
-        ("auto", "cuda", torch.bfloat16),
-        ("auto", "mps", torch.float16),
-        ("auto", "cpu", torch.float32),
-        ("float16", "cpu", torch.float16),
-        ("bfloat16", "cuda", torch.bfloat16),
+        ("auto", "cuda", True, torch.bfloat16),
+        ("auto", "cuda", False, torch.float16),
+        ("auto", "mps", True, torch.float16),
+        ("auto", "cpu", True, torch.float32),
+        ("float16", "cpu", True, torch.float16),
+        ("bfloat16", "cuda", False, torch.bfloat16),
     ],
 )
-def test_resolve_torch_dtype(dtype: str, device: str, expected: torch.dtype) -> None:
+def test_resolve_torch_dtype(
+    monkeypatch: pytest.MonkeyPatch, dtype: str, device: str, bf16: bool, expected: torch.dtype
+) -> None:
+    _hardware(monkeypatch, cuda=True, bf16=bf16)
     assert resolve_torch_dtype(dtype, device) == expected
 
 
@@ -268,6 +287,38 @@ def test_prompt_and_generation_kwargs_are_forwarded() -> None:
     assert handler.model.generate_calls[0]["max_new_tokens"] == 64
 
 
+class _LegacyProcessor(_FakeProcessor):
+    """Transformers 5.14.1: ``apply_transcription_request`` takes no ``prompt`` and rejects unknown kwargs."""
+
+    def apply_transcription_request(self, audio: Any, language: str | None = None) -> _FakeInputs:  # type: ignore[override]
+        return super().apply_transcription_request(audio, language=language)
+
+
+def test_requests_omit_unset_language_and_prompt_for_older_transformers() -> None:
+    handler = _handler(processor=_LegacyProcessor())
+
+    result = list(handler.process(_vad_audio("final")))
+
+    assert isinstance(result[0], Transcription)
+    assert handler.processor.requests[0] == {"language": None, "prompt": None, "samples": 32000}
+
+
+def test_setup_drops_the_prompt_with_a_warning_when_the_processor_lacks_it(
+    monkeypatch: pytest.MonkeyPatch, caplog: pytest.LogCaptureFixture
+) -> None:
+    fake = _FakeTransformers()
+    fake.processor = _LegacyProcessor()
+    monkeypatch.setattr(qwen3_asr_handler, "transformers", fake)
+
+    handler = object.__new__(Qwen3ASRSTTHandler)
+    with caplog.at_level(logging.WARNING, logger="speech_to_speech.STT.qwen3_asr_handler"):
+        handler.setup(device="cpu", prompt="Vocabulary: Quilter.")
+
+    assert handler.prompt is None
+    assert "transformers>=5.15.1" in caplog.text
+    assert len(fake.model.generate_calls) == 1
+
+
 def test_generation_strips_the_prompt_tokens_before_decoding() -> None:
     class _RecordingProcessor(_FakeProcessor):
         decoded_length = 0
@@ -293,8 +344,6 @@ class _FakeTransformers:
     def __init__(self) -> None:
         self.processor = _FakeProcessor()
         self.model = _FakeModel()
-        self.model.eval = lambda: self.model  # type: ignore[attr-defined]
-        self.model.to = lambda device: self.model  # type: ignore[attr-defined]
         self.loaded: list[tuple[str, Any]] = []
 
         outer = self
@@ -342,7 +391,38 @@ def test_setup_does_not_share_generation_kwargs_between_handlers(monkeypatch: py
     assert second.gen_kwargs.get("max_new_tokens") != 1
 
 
-# ── registry wiring ──────────────────────────────────────────────────
+# ── registry and CLI wiring ──────────────────────────────────────────
+
+
+def _context() -> HandlerContext:
+    return HandlerContext(
+        stop_event=Event(),
+        queue_in=Queue(),
+        queue_out=Queue(),
+        text_output_queue=Queue(),
+        should_listen=Event(),
+        cancel_scope=CancelScope(),
+        speculative_turns=SpeculativeTurnTracker(),
+        pipeline_index=0,
+        sample_rate=16000,
+        enable_live_transcription=False,
+        live_transcription_update_interval=0.5,
+    )
+
+
+def test_cli_builds_a_qwen3_asr_handler_from_its_flags(monkeypatch: pytest.MonkeyPatch) -> None:
+    fake = _FakeTransformers()
+    monkeypatch.setattr(qwen3_asr_handler, "transformers", fake)
+    args = parse_arguments(["--stt", "qwen3-asr", "--qwen3_asr_language", "fr", "--qwen3_asr_gen_max_new_tokens", "64"])
+    context = _context()
+
+    handler = create_backend_handler(args.stt_backend, context)
+
+    assert isinstance(handler, Qwen3ASRSTTHandler)
+    assert handler.speculative_turns is context.speculative_turns
+    assert handler.forced_language == "fr"
+    assert handler.gen_kwargs == {"max_new_tokens": 64}
+    assert ("processor", "Qwen/Qwen3-ASR-0.6B-hf") in fake.loaded
 
 
 def test_registry_normalizes_qwen3_asr_arguments() -> None:


### PR DESCRIPTION
Closes #337. Supersedes #382 by @poorvajasathasivam: same idea, rebased on the new backend registry. Credit to them for the first version.

## What

+ Backend - `--stt qwen3-asr` runs the `Qwen/Qwen3-ASR-*-hf` checkpoints through Transformers (`AutoModelForMultimodalLM`, `apply_transcription_request`).
+ Partials - progressive mode yields partial transcriptions, like the other local STT backends.
+ Language - `auto` reports the model's own language ID per final turn, with the `-auto` suffix like faster-whisper. Short partial windows reuse the last final language, because the model's ID flips on 1 s clips.
+ Defaults - `auto` device picks CUDA, then MPS, then CPU. `auto` dtype picks bfloat16 where the GPU supports it, else float16, and float32 on CPU.
+ Flags - `--qwen3_asr_model_name`, `--qwen3_asr_device`, `--qwen3_asr_torch_dtype`, `--qwen3_asr_language`, `--qwen3_asr_prompt`, `--qwen3_asr_gen_max_new_tokens`.
+ Deps - none new. `pyproject.toml` already pins a Transformers that knows `qwen3_asr`. On 5.14.1 (the macOS pin) the processor has no `prompt` parameter, so the handler drops it with a warning there.
+ Language table - comes from the Transformers processor, so there is no copy to keep in sync. `fil` (Filipino) added to the LLM language map.

## Tested

+ Tests - 38 new. `uv run pytest`: 1411 passed. `ruff check`, `ruff format --check`, `mypy src`: clean.
+ Linux rig - RTX 3090 24 GB (driver 580), Ryzen 7 7700, Python 3.13, torch 2.11 cu130, Transformers 5.16.1. 0.6B in bfloat16: setup 4.5 s, 1.6 GB VRAM, 4 s turn 227 ms, 15 s turn 522 ms, 1 s partial 52 ms.
+ Mac - Apple M5 Pro 64 GB, macOS 26.4.1, Python 3.11, torch 2.11, Transformers 5.14.1. 0.6B on MPS in float16: same transcripts, setup 4.4 s, 1.6 GB, 4 s turn 303 ms, 15 s turn 784 ms. The prompt is dropped with the warning as documented.

## Not in here

+ torch.compile - 2x faster once warm, but it recompiled on each new audio length (36 s stall). A follow-up could pad audio to fixed buckets.
+ Streaming - Qwen3-ASR supports it. Fits the streaming STT interface in #537 once it lands.

cc @andimarafioti @ebezzam
