### PR TITLE
Support admitted session model updates and optional remote stages

### DIFF
--- a/docs/session-routing-handoff.md
+++ b/docs/session-routing-handoff.md
@@ -22,6 +22,10 @@ The internal WebSocket handshake supplies `X-Speech-Session-Routing`:
 
 The configuration requires remote OpenAI-compatible STT and TTS handlers and a
 consistent Chat Completions or Responses LLM adapter across the CPU pool.
+In this mode, building CPU pipeline units initializes the remote clients without
+running inference against their bootstrap models. Gateway pools own readiness
+and model warmup; a failed optional model must not prevent the session service
+from starting. Without this opt-in, the adapters retain their startup warmups.
 Malformed, disabled, oversized, or mismatched handoffs fail before claiming a
 pipeline. URLs, credentials, catalogs, capacity policies and workers remain
 deployment-owned. All routes on a CPU worker must accept that worker's configured

--- a/docs/session-routing-handoff.md
+++ b/docs/session-routing-handoff.md
@@ -129,6 +129,8 @@ model/provider plus the original allocator affinity ID.
 The initial compatibility boundary is deliberately limited: the same LLM adapter
 protocol, full-context continuation, an equal or larger declared context window,
 and capabilities for configured tools and retained images/audio/tool history.
+The context-window floor survives LLM removal and resets with the session;
+disabling and re-adding the stage cannot bypass it while retaining Chat.
 Unsupported voice choices fail during a routed update. No tokenizer conversion,
 backend-local continuation migration, in-flight generation migration or arbitrary
 local model loading is implemented.

--- a/docs/session-routing-handoff.md
+++ b/docs/session-routing-handoff.md
@@ -1,7 +1,7 @@
-# Initial routing from a trusted admission proxy
+# Session routing from a trusted admission proxy
 
 `session_routing_enabled` is an opt-in extension for deployments whose allocator
-has already selected compatible STT, LLM and TTS routes. Enable it only on a
+selects compatible remote STT, LLM and TTS routes. Enable it only on a
 private listener behind that proxy. The public proxy must authenticate the
 allocation and construct the header from its signed claims; never forward a
 client's copy. This server does not authenticate the header itself.
@@ -33,18 +33,111 @@ audio format, sample rate and request options. For example, OpenAI speech uses
 `stream_format=audio`, not vLLM's `stream` or `language` extensions; configure
 compatible options when advertising both. The handoff does not translate dialects.
 
-The immutable route travels through the existing per-session RuntimeConfig.
+The route snapshot travels through the existing per-session RuntimeConfig.
 Each inference request uses its selected model plus `X-Speech-Provider` and
 `X-Speech-Session-Id`; background LLM compaction retains the same selection.
 The gateway consumes these headers. Requests still carry full conversation
 context. This supplies an affinity identifier, not a backend cache or migration
 guarantee.
 
-`session.created` reports the admitted LLM model and initial TTS voice. Ordinary
-session updates, tools, cancellation and context behavior remain unchanged.
-A different `session.update.model` is rejected before applying any other fields;
-repeating the admitted model is allowed. Mid-session switching remains separate
-work in [#547](https://github.com/huggingface/speech-to-speech/issues/547).
-Standard clients require no new WebSocket messages. Unconfigured sessions retain
-their existing behavior. This extension currently covers the managed WebSocket
-handoff, not WebRTC admission.
+`session.created` reports the admitted LLM model and initial TTS voice. Without
+the additional `updates_enabled` handshake capability, admitted models remain
+fixed and ordinary session settings retain their existing behavior.
+
+## Optional model selection through session.update
+
+A trusted proxy may supply `"updates_enabled": true` in the handshake. In this
+mode each route may be `null`, including all three for an initially empty session.
+The deployment proxy supports the following public extension:
+
+```json
+{
+  "type": "session.update",
+  "event_id": "select-models",
+  "session": {
+    "type": "realtime",
+    "models": {
+      "stt": {"model": "qwen-asr", "provider": "hf"},
+      "llm": "gemma-route",
+      "tts": null
+    }
+  }
+}
+```
+
+Omitted stages keep their selections. A `null` value disables a stage; it does
+not unload process-wide weights. `session.model` remains an LLM shorthand.
+`session.created` and `session.updated` include the effective `models` map and
+the effective LLM `model`. Disabling TTS produces text-only responses; adding it
+again enables audio unless the update explicitly requests text. With STT disabled,
+text input remains available, and a declared audio-input LLM can receive VAD
+audio directly through the existing Chat Completions audio path. The Responses
+adapter's audio path uses Chat Completions internally, so it is not advertised
+as a native Responses audio route. With the LLM disabled, STT can transcribe but
+`response.create` fails clearly. Disabled stages never use bootstrap defaults.
+
+The allocator resolves/authorizes choices and reserves added pool capacity. The
+proxy strips client-supplied `_session_routing` fields and attaches this private
+envelope to the standard update before forwarding to the private listener:
+
+```json
+{
+  "_session_routing": {
+    "update_id": "unique-update-id",
+    "routing": {
+      "id": "allocator-session-id",
+      "pipeline": "deployment-accounting-key",
+      "updates_enabled": true,
+      "routes": {
+        "stt": null,
+        "tts": null,
+        "llm": {
+          "model": "audio-llm-route",
+          "provider": "hf",
+          "protocol": "chat_completions",
+          "capabilities": {
+            "context_window": 32768,
+            "tools": true,
+            "images": false,
+            "audio_input": true,
+            "continuation": "full_context"
+          }
+        }
+      }
+    }
+  }
+}
+```
+
+The envelope accompanies `type`, `event_id` and `session`; it is not a public
+client API. TTS routes also declare a default `voice` and supported `voices`.
+The corresponding `session.updated` or `error` carries the private
+`_session_routing` update ID. The proxy settles the reservation and strips that
+field before forwarding the event. It holds the old/new pool union until this
+acknowledgement and blocks subsequent client events while settlement is pending.
+On an uncertain/lost handoff, the proxy must close and release the allocation.
+
+Updates require an idle turn boundary. The dispatcher rejects active/pending
+responses and unresolved tools, then passes a barrier through the handler chain
+to check that cancellation cleanup and earlier audio have finished. Progressive
+STT, hidden prefetch and compaction must also finish. A rejected combined update
+changes no session fields. A successful update replaces the configuration as a
+whole while retaining the session ID, conversation ID and Chat. Old provider
+compaction callbacks are detached; each future request receives the selected
+model/provider plus the original allocator affinity ID.
+
+The initial compatibility boundary is deliberately limited: the same LLM adapter
+protocol, full-context continuation, an equal or larger declared context window,
+and capabilities for configured tools and retained images/audio/tool history.
+Unsupported voice choices fail during a routed update. No tokenizer conversion,
+backend-local continuation migration, in-flight generation migration or arbitrary
+local model loading is implemented.
+
+This extends [#547](https://github.com/huggingface/speech-to-speech/issues/547).
+OpenAI's hosted Realtime API does not allow model changes through `session.update`
+([official reference](https://developers.openai.com/api/reference/resources/realtime/client-events#session.update)).
+The optional `models` field may require a client's raw-event/extra-fields support;
+the LLM-only `model` spelling uses the existing event shape. Clients that do not
+enable/request the extension keep existing supported WebSocket/WebRTC flows.
+Managed routing currently covers WebSocket only; ordinary WebRTC behavior is
+unchanged.

--- a/docs/session-routing-handoff.md
+++ b/docs/session-routing-handoff.md
@@ -1,0 +1,46 @@
+# Initial routing from a trusted admission proxy
+
+`session_routing_enabled` is an opt-in extension for deployments whose allocator
+has already selected compatible STT, LLM and TTS routes. Enable it only on a
+private listener behind that proxy. The public proxy must authenticate the
+allocation and construct the header from its signed claims; never forward a
+client's copy. This server does not authenticate the header itself.
+
+The internal WebSocket handshake supplies `X-Speech-Session-Routing`:
+
+```json
+{
+  "id": "allocator-session-id",
+  "pipeline": "qwen-gemma-qwen",
+  "routes": {
+    "stt": {"model": "qwen-asr", "provider": "hf", "protocol": "transcriptions"},
+    "llm": {"model": "gemma", "provider": "hf", "protocol": "chat_completions"},
+    "tts": {"model": "qwen-tts", "provider": "hf", "protocol": "speech", "voice": "aiden"}
+  }
+}
+```
+
+The configuration requires remote OpenAI-compatible STT and TTS handlers and a
+consistent Chat Completions or Responses LLM adapter across the CPU pool.
+Malformed, disabled, oversized, or mismatched handoffs fail before claiming a
+pipeline. URLs, credentials, catalogs, capacity policies and workers remain
+deployment-owned. All routes on a CPU worker must accept that worker's configured
+audio format, sample rate and request options. For example, OpenAI speech uses
+`stream_format=audio`, not vLLM's `stream` or `language` extensions; configure
+compatible options when advertising both. The handoff does not translate dialects.
+
+The immutable route travels through the existing per-session RuntimeConfig.
+Each inference request uses its selected model plus `X-Speech-Provider` and
+`X-Speech-Session-Id`; background LLM compaction retains the same selection.
+The gateway consumes these headers. Requests still carry full conversation
+context. This supplies an affinity identifier, not a backend cache or migration
+guarantee.
+
+`session.created` reports the admitted LLM model and initial TTS voice. Ordinary
+session updates, tools, cancellation and context behavior remain unchanged.
+A different `session.update.model` is rejected before applying any other fields;
+repeating the admitted model is allowed. Mid-session switching remains separate
+work in [#547](https://github.com/huggingface/speech-to-speech/issues/547).
+Standard clients require no new WebSocket messages. Unconfigured sessions retain
+their existing behavior. This extension currently covers the managed WebSocket
+handoff, not WebRTC admission.

--- a/src/speech_to_speech/LLM/base_openai_compatible_language_model.py
+++ b/src/speech_to_speech/LLM/base_openai_compatible_language_model.py
@@ -177,6 +177,7 @@ class BaseOpenAICompatibleHandler(BaseHandler[LLMIn, LLMOut], ABC):
         audio_temperature: float = 0.0,
         audio_content_type: Literal["input_audio", "audio_url"] = "input_audio",
         audio_history_turns: int = 1,
+        warmup_enabled: bool = True,
         **_kwargs: Any,
     ) -> None:
         self.cancel_scope = cancel_scope
@@ -213,7 +214,8 @@ class BaseOpenAICompatibleHandler(BaseHandler[LLMIn, LLMOut], ABC):
         self._prefetch_workers_lock = Lock()
         self._prefetch_workers: set[Thread] = set()
         self.compactor = build_compactor(self._build_compaction_generate_fn()) if compact_history else None
-        self.warmup()
+        if warmup_enabled:
+            self.warmup()
 
     @staticmethod
     def _is_official_openai(base_url: Optional[str]) -> bool:

--- a/src/speech_to_speech/LLM/base_openai_compatible_language_model.py
+++ b/src/speech_to_speech/LLM/base_openai_compatible_language_model.py
@@ -786,6 +786,8 @@ class BaseOpenAICompatibleHandler(BaseHandler[LLMIn, LLMOut], ABC):
                     provider_request_started = True
 
                     routing = turn.runtime_config.routing
+                    if routing is not None and routing.routes.llm is None:
+                        raise ValueError("No LLM model selected")
                     route_kwargs = (
                         {"model": routing.routes.llm.model, "extra_headers": routing.headers("llm")}
                         if routing is not None
@@ -992,7 +994,7 @@ class BaseOpenAICompatibleHandler(BaseHandler[LLMIn, LLMOut], ABC):
         req_tool_choice = (
             response.tool_choice if response and response.tool_choice else runtime_config.session.tool_choice
         )
-        wants_audio = response_wants_audio(response)
+        wants_audio = response_wants_audio(response, runtime_config)
         self._apply_config(active_chat, instructions, wants_audio, language_name=lang_name)
 
         audio_b64 = self._audio_to_wav_base64(request.audio, request.audio_sample_rate)
@@ -1117,7 +1119,7 @@ class BaseOpenAICompatibleHandler(BaseHandler[LLMIn, LLMOut], ABC):
         req_tool_choice = (
             response.tool_choice if response and response.tool_choice else runtime_config.session.tool_choice
         )
-        wants_audio = response_wants_audio(response)
+        wants_audio = response_wants_audio(response, runtime_config)
         self._apply_config(active_chat, instructions, wants_audio, language_name=lang_name)
 
         optional_kwargs = self._build_optional_kwargs(req_tools, req_tool_choice)

--- a/src/speech_to_speech/LLM/base_openai_compatible_language_model.py
+++ b/src/speech_to_speech/LLM/base_openai_compatible_language_model.py
@@ -272,7 +272,7 @@ class BaseOpenAICompatibleHandler(BaseHandler[LLMIn, LLMOut], ABC):
         ...
 
     @abstractmethod
-    def _build_compaction_generate_fn(self) -> CompactGenerateFn:
+    def _build_compaction_generate_fn(self, request_overrides: dict[str, Any] | None = None) -> CompactGenerateFn:
         """Return a ``(system, user) -> text`` fn used to compact long histories."""
         ...
 
@@ -783,8 +783,16 @@ class BaseOpenAICompatibleHandler(BaseHandler[LLMIn, LLMOut], ABC):
                 else:
                     provider_request_started = True
 
+                    routing = turn.runtime_config.routing
+                    route_kwargs = (
+                        {"model": routing.routes.llm.model, "extra_headers": routing.headers("llm")}
+                        if routing is not None
+                        else {}
+                    )
+                    request_kwargs = {**optional_kwargs, **route_kwargs}
+
                     def make_request() -> Any:
-                        return (request_fn or self._request)(api_input, optional_kwargs)
+                        return (request_fn or self._request)(api_input, request_kwargs)
 
                     if turn.prefetch_transaction is not None:
                         events = self._iter_prefetch_events_interruptibly(
@@ -871,7 +879,10 @@ class BaseOpenAICompatibleHandler(BaseHandler[LLMIn, LLMOut], ABC):
                                     original_chat.strip_images(consumed_image_ids)
                                     if history_commit_fn is not None:
                                         history_commit_fn()
-                                    original_chat.trim_if_needed(self.compactor)
+                                    compactor = self.compactor
+                                    if compactor is not None and route_kwargs:
+                                        compactor = build_compactor(self._build_compaction_generate_fn(route_kwargs))
+                                    original_chat.trim_if_needed(compactor)
                                 except Exception:
                                     original_chat.restore_history_cleanup(snapshot)
                                     raise

--- a/src/speech_to_speech/LLM/chat.py
+++ b/src/speech_to_speech/LLM/chat.py
@@ -366,6 +366,14 @@ class Chat:
         with self._lock:
             return bool(self._pending_tool_calls)
 
+    def prepare_route_change(self) -> bool:
+        """At a drained turn boundary, detach the old provider's deferred compactor."""
+        with self._lock:
+            if self._pending_tool_calls or self._provisional_generations or self._compact_in_flight:
+                return False
+            self._deferred_compactor = None
+            return True
+
     def trim_if_needed(self, compactor: CompactFn | None = None) -> None:
         """Enforce the size limit after a generation completes. Fires when
         ``user_turn_count > size``.

--- a/src/speech_to_speech/LLM/chat_completions_language_model.py
+++ b/src/speech_to_speech/LLM/chat_completions_language_model.py
@@ -168,14 +168,12 @@ def _request_chat_completions(
     optional_kwargs: dict[str, Any],
 ) -> Any:
     """Issue a Chat Completions request with consistent streaming usage accounting."""
-    create_kwargs = dict(optional_kwargs)
+    create_kwargs = {"model": model_name, "extra_body": extra_body, **optional_kwargs}
     if stream:
         create_kwargs["stream_options"] = {"include_usage": True}
     return client.chat.completions.create(
-        model=model_name,
         messages=messages,
         stream=stream,
-        extra_body=extra_body,
         timeout=timeout,
         **create_kwargs,
     )
@@ -300,22 +298,22 @@ class ChatCompletionsApiModelHandler(BaseOpenAICompatibleHandler):
         end = time.time()
         logger.info(f"{self.__class__.__name__}:  warmed up! time: {(end - start):.3f} s")
 
-    def _build_compaction_generate_fn(self) -> CompactGenerateFn:
+    def _build_compaction_generate_fn(self, request_overrides: dict[str, Any] | None = None) -> CompactGenerateFn:
         """Return a generate fn that calls Chat Completions for compaction."""
         client = self.client
         model_name = self.model_name
         timeout = self.request_timeout
         extra_body = self._extra_body
+        request_kwargs = {"model": model_name, "extra_body": extra_body, **(request_overrides or {})}
 
         def generate(system: str, user: str) -> str:
             response = client.chat.completions.create(
-                model=model_name,
                 messages=[
                     {"role": "system", "content": system},
                     {"role": "user", "content": user},
                 ],
-                extra_body=extra_body,
                 timeout=timeout,
+                **request_kwargs,
             )
             return response.choices[0].message.content or ""
 

--- a/src/speech_to_speech/LLM/lm_output_processor.py
+++ b/src/speech_to_speech/LLM/lm_output_processor.py
@@ -205,7 +205,7 @@ class LMOutputProcessor(BaseHandler[LLMOut, TTSIn | PipelineEvent]):
             if (
                 not isinstance(part, AssistantTextPart)
                 or not part.text.strip()
-                or not response_wants_audio(lm_output.response)
+                or not response_wants_audio(lm_output.response, lm_output.runtime_config)
             ):
                 continue
             logger.debug("Forwarding to TTS: %s", transcript_for_log(part.text))

--- a/src/speech_to_speech/LLM/responses_api_language_model.py
+++ b/src/speech_to_speech/LLM/responses_api_language_model.py
@@ -81,16 +81,16 @@ class ResponsesApiModelHandler(BaseOpenAICompatibleHandler):
         end = time.time()
         logger.info(f"{self.__class__.__name__}:  warmed up! time: {(end - start):.3f} s")
 
-    def _build_compaction_generate_fn(self) -> CompactGenerateFn:
+    def _build_compaction_generate_fn(self, request_overrides: dict[str, Any] | None = None) -> CompactGenerateFn:
         """Return a generate fn that calls the Responses API for compaction."""
         client = self.client
         model_name = self.model_name
         timeout = self.request_timeout
         reasoning_kwargs = self._reasoning_kwargs()
+        request_kwargs = {"model": model_name, **reasoning_kwargs, **(request_overrides or {})}
 
         def generate(system: str, user: str) -> str:
             response = client.responses.create(
-                model=model_name,
                 input=[
                     {
                         "type": "message",
@@ -104,7 +104,7 @@ class ResponsesApiModelHandler(BaseOpenAICompatibleHandler):
                     },
                 ],
                 timeout=timeout,
-                **reasoning_kwargs,
+                **request_kwargs,
             )
             return response.output_text
 
@@ -161,12 +161,10 @@ class ResponsesApiModelHandler(BaseOpenAICompatibleHandler):
 
     def _request(self, api_input: Any, optional_kwargs: dict[str, Any]) -> Any:
         return self.client.responses.create(
-            model=self.model_name,
             input=api_input,
             stream=self.stream,
-            extra_body=self._extra_body,
             timeout=self.request_timeout,
-            **optional_kwargs,
+            **{"model": self.model_name, "extra_body": self._extra_body, **optional_kwargs},
         )
 
     @staticmethod

--- a/src/speech_to_speech/STT/openai_compatible_handler.py
+++ b/src/speech_to_speech/STT/openai_compatible_handler.py
@@ -128,6 +128,7 @@ class OpenAICompatibleSTTHandler(BaseSTTHandler):
         speculative_turns: SpeculativeTurnTracker | None = None,
         final_revision_settle_s: float = 0.0,
         gen_kwargs: dict[str, Any] | None = None,
+        warmup_enabled: bool = True,
     ) -> None:
         if response_format not in {"json", "text"}:
             raise ValueError("OpenAI-compatible STT response_format must be 'json' or 'text'")
@@ -153,7 +154,8 @@ class OpenAICompatibleSTTHandler(BaseSTTHandler):
         self._progressive_lock = Lock()
         self._progressive_key: tuple[str | None, int | None] | None = None
         self._progressive_thread: Thread | None = None
-        self.warmup()
+        if warmup_enabled:
+            self.warmup()
 
     def warmup(self) -> None:
         """Validate the configured transcription endpoint before accepting sessions."""

--- a/src/speech_to_speech/STT/openai_compatible_handler.py
+++ b/src/speech_to_speech/STT/openai_compatible_handler.py
@@ -13,6 +13,7 @@ from typing import Any, Iterator
 import httpx
 import numpy as np
 
+from speech_to_speech.api.openai_realtime.runtime_config import RuntimeConfig
 from speech_to_speech.pipeline.handler_types import STTIn, STTOut
 from speech_to_speech.pipeline.log_context import pipeline_log_ctx
 from speech_to_speech.pipeline.messages import (
@@ -52,9 +53,10 @@ class HttpTranscriptionOperation:
     response_format: str
     timeout_s: float
     extra_fields: dict[str, Any] | None = None
+    extra_headers: dict[str, str] | None = None
 
     def run(self) -> HttpTranscriptionResult:
-        headers = {}
+        headers = dict(self.extra_headers or {})
         if self.api_key:
             headers["Authorization"] = f"Bearer {self.api_key}"
         data: dict[str, Any] = {
@@ -180,7 +182,7 @@ class OpenAICompatibleSTTHandler(BaseSTTHandler):
     def _run_request(self, vad_audio: VADAudio) -> STTOut | None:
         started_at_s = perf_counter()
         try:
-            result = self._make_operation(vad_audio.audio).run()
+            result = self._make_operation(vad_audio.audio, runtime_config=vad_audio.runtime_config).run()
         except Exception as exc:
             if not self._is_request_relevant(vad_audio):
                 return None
@@ -301,16 +303,20 @@ class OpenAICompatibleSTTHandler(BaseSTTHandler):
         with self._progressive_lock:
             self._progressive_key = None
 
-    def _make_operation(self, audio: np.ndarray) -> HttpTranscriptionOperation:
+    def _make_operation(
+        self, audio: np.ndarray, *, runtime_config: RuntimeConfig | None = None
+    ) -> HttpTranscriptionOperation:
+        routing = runtime_config.routing if runtime_config is not None else None
         return HttpTranscriptionOperation(
             endpoint_url=self.endpoint_url,
             api_key=self.api_key,
-            model=self.model,
+            model=routing.routes.stt.model if routing else self.model,
             wav_bytes=self._encode_wav(audio),
             language=self.language,
             response_format=self.response_format,
             timeout_s=self.timeout,
             extra_fields=self.gen_kwargs,
+            extra_headers=routing.headers("stt") if routing else None,
         )
 
     @staticmethod

--- a/src/speech_to_speech/STT/openai_compatible_handler.py
+++ b/src/speech_to_speech/STT/openai_compatible_handler.py
@@ -172,6 +172,12 @@ class OpenAICompatibleSTTHandler(BaseSTTHandler):
         if not self._is_request_relevant(vad_audio):
             return
 
+        cfg = vad_audio.runtime_config
+        if cfg is not None and cfg.routing is not None and cfg.routing.routes.stt is None:
+            if cfg.accepts_audio_input and vad_audio.mode != "progressive":
+                yield vad_audio
+            return
+
         if vad_audio.mode == "progressive":
             self._start_progressive_request(vad_audio)
             return
@@ -309,10 +315,13 @@ class OpenAICompatibleSTTHandler(BaseSTTHandler):
         self, audio: np.ndarray, *, runtime_config: RuntimeConfig | None = None
     ) -> HttpTranscriptionOperation:
         routing = runtime_config.routing if runtime_config is not None else None
+        route = routing.routes.stt if routing is not None else None
+        if routing is not None and route is None:
+            raise ValueError("No STT model selected")
         return HttpTranscriptionOperation(
             endpoint_url=self.endpoint_url,
             api_key=self.api_key,
-            model=routing.routes.stt.model if routing else self.model,
+            model=route.model if route is not None else self.model,
             wav_bytes=self._encode_wav(audio),
             language=self.language,
             response_format=self.response_format,

--- a/src/speech_to_speech/STT/transcription_notifier.py
+++ b/src/speech_to_speech/STT/transcription_notifier.py
@@ -37,9 +37,11 @@ class TranscriptionNotifier(BaseHandler[STTOut, LLMIn]):
         self,
         text_output_queue: Queue[TextEventItem] | None = None,
         should_listen: Event | None = None,
+        sample_rate: int = 16000,
     ) -> None:
         self.text_output_queue = text_output_queue
         self.should_listen = should_listen
+        self.sample_rate = sample_rate
 
     def process(self, transcription: STTOut) -> Iterator[LLMIn]:
         if isinstance(transcription, VADAudio):
@@ -47,8 +49,8 @@ class TranscriptionNotifier(BaseHandler[STTOut, LLMIn]):
                 self.text_output_queue.put(
                     AudioInputCompletedEvent(
                         audio=transcription.audio,
-                        audio_sample_rate=16000,
-                        audio_duration_s=len(transcription.audio) / 16000,
+                        audio_sample_rate=self.sample_rate,
+                        audio_duration_s=len(transcription.audio) / self.sample_rate,
                         turn_id=transcription.turn_id,
                         turn_revision=transcription.turn_revision,
                         speech_stopped_at_s=transcription.created_at_s,

--- a/src/speech_to_speech/STT/transcription_notifier.py
+++ b/src/speech_to_speech/STT/transcription_notifier.py
@@ -7,6 +7,7 @@ from typing import Iterator
 
 from speech_to_speech.baseHandler import BaseHandler
 from speech_to_speech.pipeline.events import (
+    AudioInputCompletedEvent,
     PartialTranscriptionEvent,
     TranscriptionCompletedEvent,
     TranscriptionFailedEvent,
@@ -16,6 +17,7 @@ from speech_to_speech.pipeline.messages import (
     PartialTranscription,
     Transcription,
     TranscriptionFailure,
+    VADAudio,
 )
 from speech_to_speech.pipeline.queue_types import TextEventItem
 from speech_to_speech.pipeline.transcript_logging import transcript_for_log
@@ -40,6 +42,19 @@ class TranscriptionNotifier(BaseHandler[STTOut, LLMIn]):
         self.should_listen = should_listen
 
     def process(self, transcription: STTOut) -> Iterator[LLMIn]:
+        if isinstance(transcription, VADAudio):
+            if self.text_output_queue is not None:
+                self.text_output_queue.put(
+                    AudioInputCompletedEvent(
+                        audio=transcription.audio,
+                        audio_sample_rate=16000,
+                        audio_duration_s=len(transcription.audio) / 16000,
+                        turn_id=transcription.turn_id,
+                        turn_revision=transcription.turn_revision,
+                        speech_stopped_at_s=transcription.created_at_s,
+                    )
+                )
+            return
         if isinstance(transcription, PartialTranscription):
             if self.text_output_queue and transcription.text:
                 self.text_output_queue.put(

--- a/src/speech_to_speech/TTS/openai_compatible_handler.py
+++ b/src/speech_to_speech/TTS/openai_compatible_handler.py
@@ -60,10 +60,12 @@ class HttpSpeechOperation:
         payload: dict[str, Any],
         timeout_s: float,
         response_format: str | None = None,
+        extra_headers: dict[str, str] | None = None,
     ) -> None:
         self.endpoint_url = endpoint_url
         self.api_key = api_key
         self.payload = payload
+        self.extra_headers = dict(extra_headers or {})
         self.timeout_s = timeout_s
         self.response_format = response_format if response_format is not None else payload.get("response_format")
         self._cancelled = Event()
@@ -76,7 +78,7 @@ class HttpSpeechOperation:
         deadline_at_s = perf_counter() + self.timeout_s
         self._raise_if_stopped(cancel_check)
         results: Queue[tuple[bool, object]] = Queue(maxsize=_SPEECH_STREAM_QUEUE_MAXSIZE)
-        headers = {}
+        headers = dict(self.extra_headers)
         if self.api_key:
             headers["Authorization"] = f"Bearer {self.api_key}"
 
@@ -501,7 +503,7 @@ class OpenAICompatibleTTSHandler(BaseHandler[TTSIn, TTSOut]):
         operation: HttpSpeechOperation | None = None
         try:
             voice = self._resolve_voice(tts_input.runtime_config, tts_input.response)
-            operation = self._make_operation(text=text, voice=voice)
+            operation = self._make_operation(text=text, voice=voice, runtime_config=tts_input.runtime_config)
             with self._operation_lock:
                 self._active_operation = operation
             source_chunks = operation.iter_bytes(cancel_check)
@@ -572,13 +574,19 @@ class OpenAICompatibleTTSHandler(BaseHandler[TTSIn, TTSOut]):
         *,
         text: str,
         voice: str | dict[str, str],
+        runtime_config: RuntimeConfig | None = None,
     ) -> HttpSpeechOperation:
+        routing = runtime_config.routing if runtime_config is not None else None
+        payload = self._request_payload(text=text, voice=voice)
+        if routing is not None:
+            payload["model"] = routing.routes.tts.model
         return HttpSpeechOperation(
             endpoint_url=self.endpoint_url,
             api_key=self.api_key,
-            payload=self._request_payload(text=text, voice=voice),
+            payload=payload,
             timeout_s=self.timeout,
             response_format=self.response_format,
+            extra_headers=routing.headers("tts") if routing else None,
         )
 
     def _request_payload(

--- a/src/speech_to_speech/TTS/openai_compatible_handler.py
+++ b/src/speech_to_speech/TTS/openai_compatible_handler.py
@@ -382,6 +382,7 @@ class OpenAICompatibleTTSHandler(BaseHandler[TTSIn, TTSOut]):
         cancel_scope: CancelScope | None = None,
         speculative_turns: SpeculativeTurnTracker | None = None,
         gen_kwargs: dict[str, Any] | None = None,
+        warmup_enabled: bool = True,
     ) -> None:
         if response_format not in {"pcm", "wav"}:
             raise ValueError("OpenAI-compatible TTS currently supports response_format 'pcm' or 'wav'")
@@ -415,7 +416,8 @@ class OpenAICompatibleTTSHandler(BaseHandler[TTSIn, TTSOut]):
         self._operation_lock = Lock()
         self._active_operation: HttpSpeechOperation | None = None
         self._failed_responses: set[tuple[int | None, str | None, str | None, int | None]] = set()
-        self.warmup()
+        if warmup_enabled:
+            self.warmup()
 
     def warmup(self) -> None:
         """Validate the configured speech endpoint before accepting sessions."""

--- a/src/speech_to_speech/TTS/openai_compatible_handler.py
+++ b/src/speech_to_speech/TTS/openai_compatible_handler.py
@@ -581,6 +581,8 @@ class OpenAICompatibleTTSHandler(BaseHandler[TTSIn, TTSOut]):
         routing = runtime_config.routing if runtime_config is not None else None
         payload = self._request_payload(text=text, voice=voice)
         if routing is not None:
+            if routing.routes.tts is None:
+                raise ValueError("No TTS model selected")
             payload["model"] = routing.routes.tts.model
         return HttpSpeechOperation(
             endpoint_url=self.endpoint_url,

--- a/src/speech_to_speech/api/openai_realtime/handlers/response.py
+++ b/src/speech_to_speech/api/openai_realtime/handlers/response.py
@@ -458,7 +458,9 @@ class ResponseHandler(RealtimeBaseHandler):
         # helper the event path uses, so the field and the events come from one
         # decision. The two values are exclusive: "audio" already means audio
         # plus its transcript.
-        output_modalities: list[Literal["text", "audio"]] = ["audio"] if response_wants_audio(rp) else ["text"]
+        output_modalities: list[Literal["text", "audio"]] = (
+            ["audio"] if response_wants_audio(rp, st.runtime_config) else ["text"]
+        )
 
         return RealtimeResponse(
             id=st.current_response_id,
@@ -513,7 +515,7 @@ class ResponseHandler(RealtimeBaseHandler):
             item_status = cast(Literal["completed", "incomplete"], pending.get("status", assistant_status))
             output_by_index[output_index] = self._build_message_item(
                 pending,
-                response_wants_audio(st.current_response_params),
+                response_wants_audio(st.current_response_params, st.runtime_config),
                 item_status,
             )
 
@@ -690,7 +692,7 @@ class ResponseHandler(RealtimeBaseHandler):
         )
         if pending is None:
             return []
-        wants_audio = response_wants_audio(st.current_response_params)
+        wants_audio = response_wants_audio(st.current_response_params, st.runtime_config)
         events = self.finish_audio_output(conn_id, response_key) if wants_audio else []
         events.extend(
             self._finish_message_output(
@@ -712,7 +714,16 @@ class ResponseHandler(RealtimeBaseHandler):
         on failure, or ``None`` if there is no text_prompt_queue.
         """
         st = self._state(conn_id)
+        routing = st.runtime_config.routing
+        if routing is not None and routing.routes.llm is None:
+            return self.make_error("No LLM model selected for this session.", "invalid_request_error")
         if event.response:
+            if (
+                routing is not None
+                and routing.routes.tts is None
+                and "audio" in (event.response.output_modalities or [])
+            ):
+                return self.make_error("No TTS model selected for audio output.", "invalid_request_error")
             if event.response.tool_choice and not isinstance(event.response.tool_choice, str):
                 return self.make_error(
                     message="Only string tool_choice values are supported for now (auto, required, none).",
@@ -875,7 +886,7 @@ class ResponseHandler(RealtimeBaseHandler):
             if status == "completed" and st.response_failed:
                 status = "failed"
             resp_id, _ = self._ensure_response(conn_id)
-            wants_audio = response_wants_audio(st.current_response_params)
+            wants_audio = response_wants_audio(st.current_response_params, st.runtime_config)
             if wants_audio and st.pending_text_outputs:
                 events.extend(self.finish_audio_output(conn_id, response_key))
             item_status: Literal["completed", "incomplete"] = "completed" if status == "completed" else "incomplete"
@@ -977,7 +988,7 @@ class ResponseHandler(RealtimeBaseHandler):
                     st.next_assistant_output_sequence,
                     output_sequence,
                 )
-        wants_audio = response_wants_audio(st.current_response_params)
+        wants_audio = response_wants_audio(st.current_response_params, st.runtime_config)
         meaningful_parts = [
             part
             for part in event.parts

--- a/src/speech_to_speech/api/openai_realtime/handlers/session.py
+++ b/src/speech_to_speech/api/openai_realtime/handlers/session.py
@@ -44,7 +44,7 @@ class SessionHandler(RealtimeBaseHandler):
             logger.info(f"Session model set to: {model}")
 
         cfg = self._state(conn_id).runtime_config
-        if cfg.routing is not None and "model" in s.model_fields_set and model != cfg.routing.routes.llm.model:
+        if cfg.routing is not None and "model" in s.model_fields_set and model != cfg.session.model:
             return self.make_error(
                 message="The admitted model cannot be changed within this session.",
                 _type="invalid_request_error",

--- a/src/speech_to_speech/api/openai_realtime/handlers/session.py
+++ b/src/speech_to_speech/api/openai_realtime/handlers/session.py
@@ -44,6 +44,11 @@ class SessionHandler(RealtimeBaseHandler):
             logger.info(f"Session model set to: {model}")
 
         cfg = self._state(conn_id).runtime_config
+        if cfg.routing is not None and "model" in s.model_fields_set and model != cfg.routing.routes.llm.model:
+            return self.make_error(
+                message="The admitted model cannot be changed within this session.",
+                _type="invalid_request_error",
+            )
         current = cfg.session
         if current is None:
             cfg.session = s

--- a/src/speech_to_speech/api/openai_realtime/handlers/session.py
+++ b/src/speech_to_speech/api/openai_realtime/handlers/session.py
@@ -134,9 +134,8 @@ class SessionHandler(RealtimeBaseHandler):
         caps = new.capabilities
         if caps.context_window is None or caps.continuation != "full_context":
             raise ValueError("The selected LLM must declare its context window and support full retained context.")
-        if old is not None and (
-            new.protocol != old.protocol
-            or caps.context_window < (old.capabilities.context_window or caps.context_window)
+        if (old is not None and new.protocol != old.protocol) or caps.context_window < max(
+            previous.llm_context_window_floor, (old.capabilities.context_window or 0) if old is not None else 0
         ):
             raise ValueError("The destination must use the same protocol and an equal or larger context window.")
         if candidate.session.tools and not caps.tools:

--- a/src/speech_to_speech/api/openai_realtime/handlers/session.py
+++ b/src/speech_to_speech/api/openai_realtime/handlers/session.py
@@ -5,6 +5,7 @@ from typing import Optional
 
 from openai.types.realtime import (
     RealtimeErrorEvent,
+    RealtimeSessionCreateRequest,
     SessionCreatedEvent,
     SessionUpdatedEvent,
     SessionUpdateEvent,
@@ -14,6 +15,8 @@ from openai.types.realtime.realtime_transcription_session_create_request import 
 )
 
 from speech_to_speech.api.openai_realtime.handlers.base import RealtimeBaseHandler
+from speech_to_speech.api.openai_realtime.runtime_config import RuntimeConfig
+from speech_to_speech.api.openai_realtime.session_routing import SessionRouting
 
 logger = logging.getLogger(__name__)
 
@@ -21,7 +24,9 @@ logger = logging.getLogger(__name__)
 class SessionHandler(RealtimeBaseHandler):
     """Owns session lifecycle: config updates and lifecycle events."""
 
-    def handle_session_update(self, conn_id: str, event: SessionUpdateEvent) -> Optional[RealtimeErrorEvent]:
+    def handle_session_update(
+        self, conn_id: str, event: SessionUpdateEvent, *, routing: SessionRouting | None = None
+    ) -> Optional[RealtimeErrorEvent]:
         """Apply session config changes.
 
         Only ``RealtimeSessionCreateRequest`` sessions are accepted;
@@ -44,6 +49,10 @@ class SessionHandler(RealtimeBaseHandler):
             logger.info(f"Session model set to: {model}")
 
         cfg = self._state(conn_id).runtime_config
+        if routing is not None:
+            return self._apply_routed_update(conn_id, event, routing)
+        if "models" in s.model_fields_set:
+            return self.make_error("Model selection requires the trusted session proxy.", "invalid_request_error")
         if cfg.routing is not None and "model" in s.model_fields_set and model != cfg.session.model:
             return self.make_error(
                 message="The admitted model cannot be changed within this session.",
@@ -56,6 +65,101 @@ class SessionHandler(RealtimeBaseHandler):
             cfg.apply_session_update(s)
         logger.info("Session configuration updated")
         return None
+
+    def _apply_routed_update(
+        self, conn_id: str, event: SessionUpdateEvent, routing: SessionRouting
+    ) -> Optional[RealtimeErrorEvent]:
+        assert isinstance(event.session, RealtimeSessionCreateRequest)
+        state = self._state(conn_id)
+        cfg = state.runtime_config
+        try:
+            if (
+                cfg.routing is None
+                or not cfg.routing.updates_enabled
+                or not routing.updates_enabled
+                or routing.id != cfg.routing.id
+            ):
+                raise ValueError("Invalid session routing update.")
+            if (
+                state.in_response
+                or state.response_pending
+                or state.input_items
+                or state.tool_followup_prefetch_request is not None
+            ):
+                raise ValueError("Finish or cancel the pending turn and wait for cleanup before changing models.")
+            candidate = cfg.model_copy(update={"session": cfg.session.model_copy(deep=True), "routing": routing})
+            candidate.apply_session_update(event.session)
+            candidate.session = candidate.session  # Reestablish the optional audio structure after a clear.
+            self._validate_routed_settings(cfg, candidate)
+            old_tts, new_tts = cfg.routing.routes.tts, routing.routes.tts
+            assert candidate.session.audio is not None and candidate.session.audio.output is not None
+            voice = candidate.session.audio.output.voice
+            audio = event.session.audio
+            explicit_voice = audio is not None and audio.output is not None and "voice" in audio.output.model_fields_set
+            if new_tts is not None:
+                if old_tts != new_tts and not explicit_voice:
+                    voice = new_tts.voice
+                if voice not in [new_tts.voice, *new_tts.voices]:
+                    raise ValueError("The selected TTS model does not support this voice.")
+            if (
+                new_tts is None
+                and "output_modalities" in event.session.model_fields_set
+                and "audio" in (event.session.output_modalities or [])
+            ):
+                raise ValueError("Audio output requires a selected TTS model.")
+            candidate.apply_routing_defaults()
+            assert candidate.session.audio is not None and candidate.session.audio.output is not None
+            if new_tts is not None:
+                candidate.session.audio.output.voice = voice
+                if old_tts is None and "output_modalities" not in event.session.model_fields_set:
+                    candidate.session.output_modalities = ["audio"]
+            if not cfg.chat.prepare_route_change():
+                raise ValueError(
+                    "Resolve pending tools or wait for generation/compaction cleanup before changing models."
+                )
+            # The WebSocket dispatcher has drained serial work. No await occurs
+            # between validation and replacement; queued new requests see this
+            # complete configuration and the same retained Chat.
+            state.runtime_config = candidate
+        except ValueError as exc:
+            return self.make_error(str(exc), "invalid_request_error")
+        return None
+
+    @staticmethod
+    def _validate_routed_settings(previous: RuntimeConfig, candidate: RuntimeConfig) -> None:
+        assert previous.routing is not None and candidate.routing is not None
+        old, new = previous.routing.routes.llm, candidate.routing.routes.llm
+        if new is None:
+            return
+        caps = new.capabilities
+        if caps.context_window is None or caps.continuation != "full_context":
+            raise ValueError("The selected LLM must declare its context window and support full retained context.")
+        if old is not None and (
+            new.protocol != old.protocol
+            or caps.context_window < (old.capabilities.context_window or caps.context_window)
+        ):
+            raise ValueError("The destination must use the same protocol and an equal or larger context window.")
+        if candidate.session.tools and not caps.tools:
+            raise ValueError("The selected LLM does not support the session's tools.")
+        snapshot = candidate.chat.copy(deep=True)
+
+        def validate(value):
+            if isinstance(value, dict):
+                kind = value.get("type")
+                if kind in {"input_image", "image_url"} and not caps.images:
+                    raise ValueError("The selected LLM does not support retained images.")
+                if kind == "input_audio" and (not caps.audio_input or new.protocol != "chat_completions"):
+                    raise ValueError("The selected LLM cannot preserve the retained audio input.")
+                if kind in {"function_call", "function_call_output"} and not caps.tools:
+                    raise ValueError("The selected LLM does not support retained tool history.")
+                for item in value.values():
+                    validate(item)
+            elif isinstance(value, list):
+                for item in value:
+                    validate(item)
+
+        for item in snapshot.buffer:
+            validate(item.model_dump(mode="json"))
 
     def build_session_created(self, conn_id: str) -> SessionCreatedEvent:
         """Build a SessionCreatedEvent populated with the current config."""

--- a/src/speech_to_speech/api/openai_realtime/runtime_config.py
+++ b/src/speech_to_speech/api/openai_realtime/runtime_config.py
@@ -77,6 +77,25 @@ class RuntimeConfig(BaseModel):
             return True
         return val if val is not None else True
 
+    @property
+    def accepts_audio_input(self) -> bool:
+        if self.routing is None or self.routing.routes.stt is not None:
+            return True
+        llm = self.routing.routes.llm
+        return llm is not None and llm.protocol == "chat_completions" and llm.capabilities.audio_input
+
+    def apply_routing_defaults(self) -> None:
+        if self.routing is None:
+            return
+        routes = self.routing.routes
+        self.session.model = routes.llm.model if routes.llm is not None else None
+        assert self.session.audio is not None and self.session.audio.output is not None
+        self.session.audio.output.voice = routes.tts.voice if routes.tts is not None else None
+        if self.routing.updates_enabled:
+            self.session = self.session.model_copy(update={"models": self.routing.models()})
+            if routes.tts is None:
+                self.session.output_modalities = ["text"]
+
     def apply_session_update(self, update: RealtimeSessionCreateRequest) -> None:
         """Merge non-None, explicitly-set fields from 'update' into the
         current 'session', preserving any fields not present in the update."""

--- a/src/speech_to_speech/api/openai_realtime/runtime_config.py
+++ b/src/speech_to_speech/api/openai_realtime/runtime_config.py
@@ -4,6 +4,7 @@ from openai.types.realtime.realtime_audio_config_input import RealtimeAudioConfi
 from openai.types.realtime.realtime_audio_config_output import RealtimeAudioConfigOutput
 from pydantic import BaseModel, ConfigDict, Field, field_validator
 
+from speech_to_speech.api.openai_realtime.session_routing import SessionRouting
 from speech_to_speech.LLM.chat import Chat
 
 
@@ -38,6 +39,7 @@ class RuntimeConfig(BaseModel):
     model_config = ConfigDict(validate_assignment=True, arbitrary_types_allowed=True)
 
     chat: Chat = Field(default_factory=lambda: Chat(10))
+    routing: SessionRouting | None = Field(default=None, frozen=True)
     session: RealtimeSessionCreateRequest = Field(
         default_factory=lambda: RealtimeSessionCreateRequest(type="realtime"),
         validate_default=True,

--- a/src/speech_to_speech/api/openai_realtime/runtime_config.py
+++ b/src/speech_to_speech/api/openai_realtime/runtime_config.py
@@ -40,6 +40,8 @@ class RuntimeConfig(BaseModel):
 
     chat: Chat = Field(default_factory=lambda: Chat(10))
     routing: SessionRouting | None = Field(default=None, frozen=True)
+    # Retained history survives disabling LLM, so its window constraint must too.
+    llm_context_window_floor: int = Field(default=0, ge=0)
     session: RealtimeSessionCreateRequest = Field(
         default_factory=lambda: RealtimeSessionCreateRequest(type="realtime"),
         validate_default=True,
@@ -92,6 +94,10 @@ class RuntimeConfig(BaseModel):
         assert self.session.audio is not None and self.session.audio.output is not None
         self.session.audio.output.voice = routes.tts.voice if routes.tts is not None else None
         if self.routing.updates_enabled:
+            if routes.llm is not None:
+                self.llm_context_window_floor = max(
+                    self.llm_context_window_floor, routes.llm.capabilities.context_window or 0
+                )
             self.session = self.session.model_copy(update={"models": self.routing.models()})
             if routes.tts is None:
                 self.session.output_modalities = ["text"]

--- a/src/speech_to_speech/api/openai_realtime/server.py
+++ b/src/speech_to_speech/api/openai_realtime/server.py
@@ -27,6 +27,7 @@ class RealtimeServer:
         host: str = "0.0.0.0",
         port: int = 8765,
         llm_proxy_config: LLMProxyConfig | None = None,
+        session_routing_enabled: bool = False,
     ) -> None:
         if not pool:
             raise ValueError("RealtimeServer requires at least one PipelineUnit in the pool")
@@ -35,10 +36,16 @@ class RealtimeServer:
         self.host = host
         self.port = port
         self.llm_proxy_config = llm_proxy_config
+        self.session_routing_enabled = session_routing_enabled
 
     def run(self) -> None:
         """Start the FastAPI/uvicorn server (called from a ThreadManager thread)."""
-        app = create_app(pool=self.pool, stop_event=self.stop_event, llm_proxy_config=self.llm_proxy_config)
+        app = create_app(
+            pool=self.pool,
+            stop_event=self.stop_event,
+            llm_proxy_config=self.llm_proxy_config,
+            session_routing_enabled=self.session_routing_enabled,
+        )
 
         logger.info(
             f"OpenAI Realtime API starting on ws://{self.host}:{self.port}/v1/realtime (pool size {len(self.pool)})"

--- a/src/speech_to_speech/api/openai_realtime/service.py
+++ b/src/speech_to_speech/api/openai_realtime/service.py
@@ -407,8 +407,10 @@ class RealtimeService:
     def build_session_updated(self, conn_id: str) -> SessionUpdatedEvent:
         return self.session.build_session_updated(conn_id)
 
-    def handle_session_update(self, conn_id: str, event: SessionUpdateEvent) -> Optional[RealtimeErrorEvent]:
-        error = self.session.handle_session_update(conn_id, event)
+    def handle_session_update(
+        self, conn_id: str, event: SessionUpdateEvent, *, routing: SessionRouting | None = None
+    ) -> Optional[RealtimeErrorEvent]:
+        error = self.session.handle_session_update(conn_id, event, routing=routing)
         if error is None:
             # A prefetch captured the previous session configuration.
             self.response.discard_tool_followup_prefetch(conn_id)

--- a/src/speech_to_speech/api/openai_realtime/service.py
+++ b/src/speech_to_speech/api/openai_realtime/service.py
@@ -346,11 +346,7 @@ class RealtimeService:
                 ),
             )
         )
-        if routing is not None:
-            state.runtime_config.session.model = routing.routes.llm.model
-            assert state.runtime_config.session.audio is not None
-            assert state.runtime_config.session.audio.output is not None
-            state.runtime_config.session.audio.output.voice = routing.routes.tts.voice
+        state.runtime_config.apply_routing_defaults()
         self._conns[state.session_id] = state
         self.total_usage.connections += 1
         return state.session_id
@@ -679,7 +675,7 @@ class RealtimeService:
             st.speculative_user_speech_stopped_at_s = event.speech_stopped_at_s
 
         queue = self.text_prompt_queue
-        if queue and transcript:
+        if queue and transcript and (cfg.routing is None or cfg.routing.routes.llm is not None):
             request = GenerateResponseRequest(
                 runtime_config=cfg,
                 language_code=event.language_code,

--- a/src/speech_to_speech/api/openai_realtime/service.py
+++ b/src/speech_to_speech/api/openai_realtime/service.py
@@ -54,6 +54,7 @@ from speech_to_speech.api.openai_realtime.handlers import (
 )
 from speech_to_speech.api.openai_realtime.input_state import InputItemState
 from speech_to_speech.api.openai_realtime.runtime_config import RuntimeConfig
+from speech_to_speech.api.openai_realtime.session_routing import SessionRouting
 from speech_to_speech.LLM.chat import Chat, make_user_message
 from speech_to_speech.pipeline.events import (
     AssistantOutputEvent,
@@ -331,12 +332,13 @@ class RealtimeService:
 
     # ── Connection lifecycle ─────────────────────
 
-    def register(self) -> str:
+    def register(self, *, routing: SessionRouting | None = None) -> str:
         """Register a new connection and return its session_id."""
         if self.speculative_turns:
             self.speculative_turns.reset()
         state = ConnState(
             runtime_config=RuntimeConfig(
+                routing=routing,
                 chat=Chat(self._chat_size),
                 session=RealtimeSessionCreateRequest(
                     type="realtime",
@@ -344,6 +346,11 @@ class RealtimeService:
                 ),
             )
         )
+        if routing is not None:
+            state.runtime_config.session.model = routing.routes.llm.model
+            assert state.runtime_config.session.audio is not None
+            assert state.runtime_config.session.audio.output is not None
+            state.runtime_config.session.audio.output.voice = routing.routes.tts.voice
         self._conns[state.session_id] = state
         self.total_usage.connections += 1
         return state.session_id

--- a/src/speech_to_speech/api/openai_realtime/session_routing.py
+++ b/src/speech_to_speech/api/openai_realtime/session_routing.py
@@ -1,0 +1,46 @@
+"""Immutable initial routes supplied by a trusted admission proxy, never clients."""
+
+from typing import Annotated, Literal
+
+from pydantic import BaseModel, ConfigDict, Field
+
+Identity = Annotated[str, Field(min_length=1, max_length=160, pattern=r"^[A-Za-z0-9][A-Za-z0-9._/@:-]*$")]
+
+
+class Route(BaseModel):
+    model_config = ConfigDict(extra="forbid", frozen=True, strict=True, hide_input_in_errors=True)
+
+    model: Identity
+    provider: Identity
+
+
+class TranscriptionRoute(Route):
+    protocol: Literal["transcriptions"]
+
+
+class LanguageRoute(Route):
+    protocol: Literal["chat_completions", "responses"]
+
+
+class SpeechRoute(Route):
+    protocol: Literal["speech"]
+    voice: Identity
+
+
+class SessionRoutes(BaseModel):
+    model_config = Route.model_config
+
+    stt: TranscriptionRoute
+    llm: LanguageRoute
+    tts: SpeechRoute
+
+
+class SessionRouting(BaseModel):
+    model_config = Route.model_config
+
+    id: Annotated[str, Field(min_length=1, max_length=160, pattern=r"^[A-Za-z0-9_-]+$")]
+    pipeline: Identity
+    routes: SessionRoutes
+
+    def headers(self, stage: Literal["stt", "llm", "tts"]) -> dict[str, str]:
+        return {"X-Speech-Provider": getattr(self.routes, stage).provider, "X-Speech-Session-Id": self.id}

--- a/src/speech_to_speech/api/openai_realtime/session_routing.py
+++ b/src/speech_to_speech/api/openai_realtime/session_routing.py
@@ -36,6 +36,7 @@ class LanguageCapabilities(BaseModel):
 class SpeechRoute(Route):
     protocol: Literal["speech"]
     voice: Identity
+    voices: list[Identity] = Field(default_factory=list)
 
 
 class SessionRoutes(BaseModel):

--- a/src/speech_to_speech/api/openai_realtime/session_routing.py
+++ b/src/speech_to_speech/api/openai_realtime/session_routing.py
@@ -2,7 +2,7 @@
 
 from typing import Annotated, Literal
 
-from pydantic import BaseModel, ConfigDict, Field
+from pydantic import BaseModel, ConfigDict, Field, model_validator
 
 Identity = Annotated[str, Field(min_length=1, max_length=160, pattern=r"^[A-Za-z0-9][A-Za-z0-9._/@:-]*$")]
 
@@ -20,6 +20,17 @@ class TranscriptionRoute(Route):
 
 class LanguageRoute(Route):
     protocol: Literal["chat_completions", "responses"]
+    capabilities: "LanguageCapabilities" = Field(default_factory=lambda: LanguageCapabilities())
+
+
+class LanguageCapabilities(BaseModel):
+    model_config = Route.model_config
+
+    tools: bool = False
+    images: bool = False
+    audio_input: bool = False
+    context_window: int | None = Field(default=None, gt=0)
+    continuation: Literal["full_context", "provider_state"] = "full_context"
 
 
 class SpeechRoute(Route):
@@ -30,17 +41,34 @@ class SpeechRoute(Route):
 class SessionRoutes(BaseModel):
     model_config = Route.model_config
 
-    stt: TranscriptionRoute
-    llm: LanguageRoute
-    tts: SpeechRoute
+    stt: TranscriptionRoute | None
+    llm: LanguageRoute | None
+    tts: SpeechRoute | None
 
 
 class SessionRouting(BaseModel):
     model_config = Route.model_config
 
     id: Annotated[str, Field(min_length=1, max_length=160, pattern=r"^[A-Za-z0-9_-]+$")]
-    pipeline: Identity
+    pipeline: Annotated[str, Field(min_length=1, max_length=800, pattern=r"^[A-Za-z0-9@][A-Za-z0-9._/@:+-]*$")]
     routes: SessionRoutes
+    updates_enabled: bool = False
+
+    @model_validator(mode="after")
+    def require_legacy_stages(self) -> "SessionRouting":
+        if not self.updates_enabled and any(getattr(self.routes, stage) is None for stage in ("stt", "llm", "tts")):
+            raise ValueError("partial routes require session updates to be enabled")
+        return self
+
+    def models(self) -> dict[str, dict[str, str] | None]:
+        return {
+            stage: {"model": route.model, "provider": route.provider} if route is not None else None
+            for stage in ("stt", "llm", "tts")
+            for route in (getattr(self.routes, stage),)
+        }
 
     def headers(self, stage: Literal["stt", "llm", "tts"]) -> dict[str, str]:
-        return {"X-Speech-Provider": getattr(self.routes, stage).provider, "X-Speech-Session-Id": self.id}
+        route = getattr(self.routes, stage)
+        if route is None:
+            raise ValueError(f"No {stage.upper()} model selected")
+        return {"X-Speech-Provider": route.provider, "X-Speech-Session-Id": self.id}

--- a/src/speech_to_speech/api/openai_realtime/websocket_router.py
+++ b/src/speech_to_speech/api/openai_realtime/websocket_router.py
@@ -415,6 +415,11 @@ async def _dispatch_client_event(
         return
 
     if isinstance(event, InputAudioBufferAppendEvent):
+        if not service._state(session_id).runtime_config.accepts_audio_input:
+            await send_correlated(
+                [service.make_error("No compatible audio input model selected.", "invalid_request_error")]
+            )
+            return
         if transport_kind == "webrtc":
             await send_correlated(
                 [
@@ -576,7 +581,7 @@ def create_app(
                 if not session_routing_enabled or len(raw_routing) > 4096:
                     raise ValueError("Session routing is disabled or the handoff is too large")
                 routing = SessionRouting.model_validate_json(raw_routing)
-                if routing.routes.llm.protocol != routing_protocol:
+                if routing.routes.llm is not None and routing.routes.llm.protocol != routing_protocol:
                     raise ValueError("Admitted LLM protocol does not match the CPU adapter")
             except ValueError:
                 await send_ws_event(

--- a/src/speech_to_speech/api/openai_realtime/websocket_router.py
+++ b/src/speech_to_speech/api/openai_realtime/websocket_router.py
@@ -31,7 +31,7 @@ from speech_to_speech.api.openai_realtime.transports import (
     WebSocketTransport,
     send_ws_event,
 )
-from speech_to_speech.pipeline.control import SESSION_END, PipelineControlMessage, is_control_message
+from speech_to_speech.pipeline.control import SESSION_END, ControlKind, PipelineControlMessage, is_control_message
 from speech_to_speech.pipeline.events import (
     AssistantOutputEvent,
     AssistantResponseDoneEvent,
@@ -399,12 +399,16 @@ async def _dispatch_client_event(
     """
     service = unit.service
     client_event_id = raw.get("event_id")
+    routing_update = raw.get("_session_routing")
+    routing_update_id = routing_update.get("update_id") if isinstance(routing_update, dict) else None
 
     async def send_correlated(events: list[Any]) -> None:
         if isinstance(client_event_id, str):
             for outgoing in events:
                 if getattr(outgoing, "type", None) == "error":
                     outgoing.error.event_id = client_event_id
+        if isinstance(routing_update_id, str):
+            events = [event.model_copy(update={"_session_routing": routing_update_id}) for event in events]
         await transport.send_events(events)
 
     event = service.parse_client_event(raw)
@@ -455,7 +459,24 @@ async def _dispatch_client_event(
         transport.discard_pending_audio()
 
     elif isinstance(event, SessionUpdateEvent):
-        err = service.handle_session_update(session_id, event)
+        proposed = None
+        if routing_update is not None:
+            from speech_to_speech.api.openai_realtime.session_routing import SessionRouting
+
+            cfg = service._state(session_id).runtime_config
+            try:
+                if cfg.routing is None or not cfg.routing.updates_enabled or transport_kind != "websocket":
+                    raise ValueError("Session model updates are not enabled on this connection.")
+                if not isinstance(routing_update_id, str) or not 1 <= len(routing_update_id) <= 64:
+                    raise ValueError("Invalid session routing update.")
+                proposed = SessionRouting.model_validate(routing_update["routing"])
+                if proposed.routes.llm is not None and proposed.routes.llm.protocol != _unit_llm_protocol(unit):
+                    raise ValueError("The selected LLM protocol does not match this CPU adapter.")
+                await _drain_for_routing_update(unit, session_id)
+            except (ValueError, KeyError, TypeError) as exc:
+                await send_correlated([service.make_error(str(exc), "invalid_request_error")])
+                return
+        err = service.handle_session_update(session_id, event, routing=proposed)
         if err:
             await send_correlated([err])
         else:
@@ -498,6 +519,56 @@ async def _dispatch_client_event(
         if events:
             await send_correlated(events)
         unit.response_playing.clear()
+
+
+def _unit_llm_protocol(unit: PipelineUnit) -> str:
+    from speech_to_speech.LLM.chat_completions_language_model import ChatCompletionsApiModelHandler
+    from speech_to_speech.LLM.responses_api_language_model import ResponsesApiModelHandler
+
+    for handler in unit.handlers:
+        if isinstance(handler, ChatCompletionsApiModelHandler):
+            return "chat_completions"
+        if isinstance(handler, ResponsesApiModelHandler):
+            return "responses"
+    raise ValueError("Session routing requires a remote LLM adapter.")
+
+
+async def _drain_for_routing_update(unit: PipelineUnit, session_id: str) -> None:
+    def require_idle():
+        state = unit.service._state(session_id)
+        if (
+            state.in_response
+            or state.response_pending
+            or state.input_items
+            or state.runtime_config.chat.has_pending_tool_calls()
+        ):
+            raise ValueError("Finish or cancel the pending turn and wait for cleanup before changing models.")
+
+    require_idle()
+    reached = ThreadingEvent()
+    unit.input_queue.put(PipelineControlMessage(ControlKind.ROUTING_BARRIER, session_id=session_id, reached=reached))
+    if not await asyncio.to_thread(reached.wait, 0.25):
+        raise ValueError("Pipeline work is still draining; retry the model update after cleanup.")
+    require_idle()
+    if not unit.text_output_queue.empty() or not unit.text_prompt_queue.empty():
+        raise ValueError("Pipeline events are still pending; retry the model update after cleanup.")
+    for handler in unit.handlers:
+        # A queue barrier covers serial work. Progressive STT and hidden LLM
+        # prefetch also own background workers that must finish before a switch.
+        progressive = getattr(handler, "_progressive_thread", None)
+        if progressive is not None and progressive.is_alive():
+            raise ValueError("Transcription cleanup is still pending.")
+        workers_lock = getattr(handler, "_prefetch_workers_lock", None)
+        if workers_lock is not None:
+            with workers_lock:
+                if handler._prefetch_workers:
+                    raise ValueError("Generation cleanup is still pending.")
+        if (
+            getattr(handler, "_speech_started_emitted", False)
+            or getattr(handler, "_pending_short_segment", None) is not None
+            or getattr(handler, "_pending_reopen_candidate", None) is not None
+        ):
+            raise ValueError("Input speech is still pending; finish the turn before changing models.")
 
 
 def create_app(
@@ -1070,6 +1141,9 @@ def create_app(
                         continue
 
                     if is_control_message(audio_chunk):
+                        if audio_chunk.kind == ControlKind.ROUTING_BARRIER and audio_chunk.reached is not None:
+                            if session is not None and audio_chunk.session_id == session.session_id:
+                                audio_chunk.reached.set()
                         continue
 
                     if _should_discard_audio(unit, audio_chunk):

--- a/src/speech_to_speech/api/openai_realtime/websocket_router.py
+++ b/src/speech_to_speech/api/openai_realtime/websocket_router.py
@@ -553,11 +553,12 @@ async def _drain_for_routing_update(unit: PipelineUnit, session_id: str) -> None
     if not unit.text_output_queue.empty() or not unit.text_prompt_queue.empty():
         raise ValueError("Pipeline events are still pending; retry the model update after cleanup.")
     for handler in unit.handlers:
-        # A queue barrier covers serial work. Progressive STT and hidden LLM
+        # A queue barrier covers serial work. Remote STT and hidden LLM
         # prefetch also own background workers that must finish before a switch.
-        progressive = getattr(handler, "_progressive_thread", None)
-        if progressive is not None and progressive.is_alive():
-            raise ValueError("Transcription cleanup is still pending.")
+        for name in ("_progressive_thread", "_final_thread"):
+            worker = getattr(handler, name, None)
+            if worker is not None and worker.is_alive():
+                raise ValueError("Transcription cleanup is still pending.")
         workers_lock = getattr(handler, "_prefetch_workers_lock", None)
         if workers_lock is not None:
             with workers_lock:

--- a/src/speech_to_speech/api/openai_realtime/websocket_router.py
+++ b/src/speech_to_speech/api/openai_realtime/websocket_router.py
@@ -499,7 +499,31 @@ def create_app(
     pool: list[PipelineUnit],
     stop_event: ThreadingEvent,
     llm_proxy_config: LLMProxyConfig | None = None,
+    session_routing_enabled: bool = False,
 ) -> FastAPI:
+    from speech_to_speech.api.openai_realtime.session_routing import SessionRouting
+
+    routing_protocol = None
+    if session_routing_enabled:
+        from speech_to_speech.LLM.chat_completions_language_model import ChatCompletionsApiModelHandler
+        from speech_to_speech.LLM.responses_api_language_model import ResponsesApiModelHandler
+        from speech_to_speech.STT.openai_compatible_handler import OpenAICompatibleSTTHandler
+        from speech_to_speech.TTS.openai_compatible_handler import OpenAICompatibleTTSHandler
+
+        for unit in pool:
+            if not any(isinstance(h, OpenAICompatibleSTTHandler) for h in unit.handlers) or not any(
+                isinstance(h, OpenAICompatibleTTSHandler) for h in unit.handlers
+            ):
+                raise ValueError("Session routing requires remote OpenAI-compatible STT and TTS handlers")
+            protocols = [
+                "chat_completions" if isinstance(h, ChatCompletionsApiModelHandler) else "responses"
+                for h in unit.handlers
+                if isinstance(h, (ChatCompletionsApiModelHandler, ResponsesApiModelHandler))
+            ]
+            if len(protocols) != 1 or routing_protocol not in (None, protocols[0]):
+                raise ValueError("Session routing requires one consistent remote LLM protocol across the pool")
+            routing_protocol = protocols[0]
+
     @asynccontextmanager
     async def lifespan(app: FastAPI) -> AsyncIterator[None]:
         # One send loop per pipeline unit; each polls its own queues and forwards
@@ -545,6 +569,25 @@ def create_app(
         }
         await ws.accept(subprotocol="realtime" if "realtime" in offered_subprotocols else None)
 
+        routing = None
+        raw_routing = ws.headers.get("X-Speech-Session-Routing")
+        if raw_routing is not None:
+            try:
+                if not session_routing_enabled or len(raw_routing) > 4096:
+                    raise ValueError("Session routing is disabled or the handoff is too large")
+                routing = SessionRouting.model_validate_json(raw_routing)
+                if routing.routes.llm.protocol != routing_protocol:
+                    raise ValueError("Admitted LLM protocol does not match the CPU adapter")
+            except ValueError:
+                await send_ws_event(
+                    ws,
+                    build_error_event(
+                        "Invalid or unsupported session routing handoff.", error_type="invalid_request_error"
+                    ),
+                )
+                await ws.close(code=1008, reason="Invalid session routing")
+                return
+
         transport = WebSocketTransport(ws)
         unit = _claim_unit(transport)
         if unit is None:
@@ -567,7 +610,7 @@ def create_app(
         # releases the unit, even if session setup fails.
         session_id = ""
         try:
-            session_id = unit.service.register()
+            session_id = unit.service.register(routing=routing) if routing is not None else unit.service.register()
             unit.session.session_id = session_id
             logger.info(f"Client connected to pipeline {unit.index} (session {session_id})")
 

--- a/src/speech_to_speech/arguments_classes/realtime_server_arguments.py
+++ b/src/speech_to_speech/arguments_classes/realtime_server_arguments.py
@@ -3,6 +3,12 @@ from dataclasses import dataclass, field
 
 @dataclass
 class RealtimeServerArguments:
+    session_routing_enabled: bool = field(
+        default=False,
+        metadata={
+            "help": "Accept initial model/provider routes from X-Speech-Session-Routing. Enable only behind a trusted admission proxy on a private listener."
+        },
+    )
     host: str = field(
         default="127.0.0.1",
         metadata={

--- a/src/speech_to_speech/baseHandler.py
+++ b/src/speech_to_speech/baseHandler.py
@@ -10,7 +10,7 @@ from typing import Any, Generic, Iterator, TypeVar, cast
 
 import numpy as np
 
-from speech_to_speech.pipeline.control import PipelineControlMessage, is_control_message, SESSION_END
+from speech_to_speech.pipeline.control import ControlKind, PipelineControlMessage, is_control_message, SESSION_END
 from speech_to_speech.pipeline.events import PipelineEvent, TokenUsageEvent
 from speech_to_speech.pipeline.log_context import pipeline_log_ctx
 from speech_to_speech.pipeline.messages import PIPELINE_END, AudioOutput, EndOfResponse, TTSInput
@@ -128,6 +128,9 @@ class BaseHandler(Generic[InT, OutT]):
                 break
 
             if isinstance(item, PipelineControlMessage):
+                if item.kind == ControlKind.ROUTING_BARRIER:
+                    self.queue_out.put(item)
+                    continue
                 logger.warning("%s: unexpected control message kind: %s", self.__class__.__name__, item.kind)
                 continue
 

--- a/src/speech_to_speech/pipeline/control.py
+++ b/src/speech_to_speech/pipeline/control.py
@@ -2,12 +2,14 @@ from __future__ import annotations
 
 from dataclasses import dataclass
 from enum import Enum
+from threading import Event
 
 
 class ControlKind(str, Enum):
     """Strongly-typed kinds for :class:`PipelineControlMessage`."""
 
     SESSION_END = "session_end"
+    ROUTING_BARRIER = "routing_barrier"
 
 
 @dataclass(frozen=True)
@@ -17,6 +19,7 @@ class PipelineControlMessage:
     # send loop ignore a SESSION_END from a force-released session so it can't
     # satisfy the drain wait of the session that claimed the unit afterwards.
     session_id: str | None = None
+    reached: Event | None = None
 
 
 SESSION_END = PipelineControlMessage(ControlKind.SESSION_END)

--- a/src/speech_to_speech/pipeline/handler_types.py
+++ b/src/speech_to_speech/pipeline/handler_types.py
@@ -34,7 +34,7 @@ VADOut: TypeAlias = VADAudio
 
 # ── STT stage ─────────────────────────────────────────────────────────
 STTIn: TypeAlias = VADAudio
-STTOut: TypeAlias = PartialTranscription | Transcription | TranscriptionFailure
+STTOut: TypeAlias = PartialTranscription | Transcription | TranscriptionFailure | VADAudio
 
 # ── LLM stage ─────────────────────────────────────────────────────────
 LLMIn: TypeAlias = GenerateResponseRequest

--- a/src/speech_to_speech/s2s_pipeline.py
+++ b/src/speech_to_speech/s2s_pipeline.py
@@ -414,6 +414,7 @@ def _build_handlers(
             setup_kwargs={
                 "text_output_queue": text_output_queue,
                 "should_listen": should_listen,
+                "sample_rate": vad_handler_kwargs.sample_rate,
             },
         )
         speech_input_handlers.append(transcription_notifier)

--- a/src/speech_to_speech/s2s_pipeline.py
+++ b/src/speech_to_speech/s2s_pipeline.py
@@ -467,6 +467,7 @@ def _build_pipeline_unit(
     stt_backend: BackendSelection,
     llm_backend: BackendSelection,
     tts_backend: BackendSelection,
+    session_routing_enabled: bool = False,
 ) -> "PipelineUnit":
     """Build one isolated pipeline with its own state and queues.
 
@@ -481,6 +482,17 @@ def _build_pipeline_unit(
     stt_selection = stt_backend.copy_for_pipeline()
     llm_selection = llm_backend.copy_for_pipeline()
     tts_selection = tts_backend.copy_for_pipeline()
+    if session_routing_enabled:
+        if (
+            stt_selection.name != "openai"
+            or llm_selection.name not in {"chat-completions", "responses-api"}
+            or tts_selection.name != "openai"
+        ):
+            raise ValueError("session routing requires remote OpenAI-compatible STT, LLM and TTS adapters")
+        # Gateway pools own model readiness. Per-session CPU slots initialize
+        # clients and local resources without probing a bootstrap model.
+        for selection in (stt_selection, llm_selection, tts_selection):
+            selection.config["warmup_enabled"] = False
 
     should_listen = Event()
     response_playing = Event()
@@ -566,6 +578,7 @@ def build_pipeline(
             stt_backend=args.stt_backend,
             llm_backend=args.llm_backend,
             tts_backend=args.tts_backend,
+            session_routing_enabled=args.realtime_server_kwargs.session_routing_enabled,
         )
         for index in range(module_kwargs.num_pipelines)
     ]

--- a/src/speech_to_speech/s2s_pipeline.py
+++ b/src/speech_to_speech/s2s_pipeline.py
@@ -575,6 +575,7 @@ def build_pipeline(
         pool=pool,
         host=host or args.realtime_server_kwargs.host,
         port=args.realtime_server_kwargs.port,
+        session_routing_enabled=args.realtime_server_kwargs.session_routing_enabled,
         llm_proxy_config=(
             build_llm_proxy_config(module_kwargs, args.llm_backend) if module_kwargs.enable_llm_proxy else None
         ),

--- a/src/speech_to_speech/utils/utils.py
+++ b/src/speech_to_speech/utils/utils.py
@@ -8,8 +8,12 @@ import numpy as np
 if TYPE_CHECKING:
     from openai.types.realtime.realtime_response_create_params import RealtimeResponseCreateParams
 
+    from speech_to_speech.api.openai_realtime.runtime_config import RuntimeConfig
 
-def response_wants_audio(response: RealtimeResponseCreateParams | None) -> bool:
+
+def response_wants_audio(
+    response: RealtimeResponseCreateParams | None, runtime_config: RuntimeConfig | None = None
+) -> bool:
     """Whether a response should produce audio (and audio events) vs. text only.
 
     Mirrors the OpenAI realtime semantics for ``output_modalities``: an absent
@@ -17,6 +21,11 @@ def response_wants_audio(response: RealtimeResponseCreateParams | None) -> bool:
     audio; a non-empty list without ``"audio"`` (e.g. ``["text"]``) means text
     only.
     """
+    if runtime_config is not None and runtime_config.routing is not None and runtime_config.routing.updates_enabled:
+        if runtime_config.routing.routes.tts is None:
+            return False
+        if response is None or response.output_modalities is None:
+            return "audio" in (runtime_config.session.output_modalities or ["audio"])
     if response is None:
         return True
     mods = response.output_modalities

--- a/tests/openai_realtime/test_optional_session_stages.py
+++ b/tests/openai_realtime/test_optional_session_stages.py
@@ -1,0 +1,88 @@
+from queue import Queue
+from threading import Event
+from unittest.mock import Mock
+
+import numpy as np
+import pytest
+from openai.types.realtime import ResponseCreateEvent
+
+from speech_to_speech.api.openai_realtime.runtime_config import RuntimeConfig
+from speech_to_speech.api.openai_realtime.service import RealtimeService
+from speech_to_speech.api.openai_realtime.session_routing import SessionRouting
+from speech_to_speech.pipeline.events import AudioInputCompletedEvent, TranscriptionCompletedEvent
+from speech_to_speech.pipeline.messages import VADAudio
+from speech_to_speech.STT.openai_compatible_handler import OpenAICompatibleSTTHandler
+from speech_to_speech.STT.transcription_notifier import TranscriptionNotifier
+
+
+def selection(*, stt=None, llm=None, tts=None):
+    return SessionRouting.model_validate(
+        {
+            "id": "allocated-session",
+            "pipeline": "empty",
+            "updates_enabled": True,
+            "routes": {"stt": stt, "llm": llm, "tts": tts},
+        }
+    )
+
+
+def test_empty_session_exposes_disabled_stages_and_rejects_generation():
+    queue = Queue()
+    service = RealtimeService(text_prompt_queue=queue, should_listen=Event())
+    sid = service.register(routing=selection())
+    created = service.build_session_created(sid).model_dump()
+    assert created["session"]["model"] is None
+    assert created["session"]["models"] == {"stt": None, "llm": None, "tts": None}
+    assert created["session"]["output_modalities"] == ["text"]
+    error = service.handle_response_create(sid, ResponseCreateEvent(type="response.create"))
+    assert error.type == "error"
+    assert "LLM" in error.error.message
+    assert queue.empty()
+
+
+def test_transcription_only_session_records_text_without_generating():
+    queue = Queue()
+    service = RealtimeService(text_prompt_queue=queue, should_listen=Event())
+    sid = service.register(
+        routing=selection(stt={"model": "asr", "provider": "hf", "protocol": "transcriptions"})
+    )
+    events = service.dispatch_pipeline_event(sid, TranscriptionCompletedEvent(transcript="Keep this transcript."))
+    assert any(e.type == "conversation.item.input_audio_transcription.completed" for e in events)
+    assert "Keep this transcript." in str(service._state(sid).runtime_config.chat.to_transformers_chat())
+    assert queue.empty()
+
+
+def test_disabling_stt_for_audio_llm_bypasses_transcription_and_preserves_audio():
+    cfg = RuntimeConfig(
+        routing=selection(
+            llm={
+                "model": "audio-llm",
+                "provider": "hf",
+                "protocol": "chat_completions",
+                "capabilities": {"audio_input": True, "context_window": 32768},
+            }
+        )
+    )
+    handler = OpenAICompatibleSTTHandler(
+        Event(), Queue(), Queue(), setup_kwargs={"warmup_enabled": False}
+    )
+    handler._make_operation = Mock(side_effect=AssertionError("disabled STT must not call a model"))
+    audio = VADAudio(audio=np.arange(160, dtype=np.float32), runtime_config=cfg, mode="final")
+    assert list(handler.process(audio)) == [audio]
+    progressive = audio.model_copy(update={"mode": "progressive"})
+    assert list(handler.process(progressive)) == []
+    events = Queue()
+    notifier = TranscriptionNotifier(Event(), Queue(), Queue(), setup_kwargs={"text_output_queue": events})
+    assert list(notifier.process(audio)) == []
+    event = events.get_nowait()
+    assert isinstance(event, AudioInputCompletedEvent)
+    np.testing.assert_array_equal(event.audio, audio.audio)
+    assert event.audio_sample_rate == 16000
+
+
+@pytest.mark.parametrize("protocol", ["responses", "chat_completions"])
+def test_audio_bypass_requires_an_explicit_compatible_audio_route(protocol):
+    cfg = RuntimeConfig(
+        routing=selection(llm={"model": "text-llm", "provider": "hf", "protocol": protocol})
+    )
+    assert not cfg.accepts_audio_input

--- a/tests/openai_realtime/test_optional_session_stages.py
+++ b/tests/openai_realtime/test_optional_session_stages.py
@@ -1,5 +1,6 @@
 from queue import Queue
 from threading import Event
+from types import SimpleNamespace
 from unittest.mock import Mock
 
 import numpy as np
@@ -43,9 +44,7 @@ def test_empty_session_exposes_disabled_stages_and_rejects_generation():
 def test_transcription_only_session_records_text_without_generating():
     queue = Queue()
     service = RealtimeService(text_prompt_queue=queue, should_listen=Event())
-    sid = service.register(
-        routing=selection(stt={"model": "asr", "provider": "hf", "protocol": "transcriptions"})
-    )
+    sid = service.register(routing=selection(stt={"model": "asr", "provider": "hf", "protocol": "transcriptions"}))
     events = service.dispatch_pipeline_event(sid, TranscriptionCompletedEvent(transcript="Keep this transcript."))
     assert any(e.type == "conversation.item.input_audio_transcription.completed" for e in events)
     assert "Keep this transcript." in str(service._state(sid).runtime_config.chat.to_transformers_chat())
@@ -63,9 +62,7 @@ def test_disabling_stt_for_audio_llm_bypasses_transcription_and_preserves_audio(
             }
         )
     )
-    handler = OpenAICompatibleSTTHandler(
-        Event(), Queue(), Queue(), setup_kwargs={"warmup_enabled": False}
-    )
+    handler = OpenAICompatibleSTTHandler(Event(), Queue(), Queue(), setup_kwargs={"warmup_enabled": False})
     handler._make_operation = Mock(side_effect=AssertionError("disabled STT must not call a model"))
     audio = VADAudio(audio=np.arange(160, dtype=np.float32), runtime_config=cfg, mode="final")
     assert list(handler.process(audio)) == [audio]
@@ -82,7 +79,46 @@ def test_disabling_stt_for_audio_llm_bypasses_transcription_and_preserves_audio(
 
 @pytest.mark.parametrize("protocol", ["responses", "chat_completions"])
 def test_audio_bypass_requires_an_explicit_compatible_audio_route(protocol):
-    cfg = RuntimeConfig(
-        routing=selection(llm={"model": "text-llm", "provider": "hf", "protocol": protocol})
-    )
+    cfg = RuntimeConfig(routing=selection(llm={"model": "text-llm", "provider": "hf", "protocol": protocol}))
     assert not cfg.accepts_audio_input
+
+
+@pytest.mark.parametrize("audio_input", [False, True])
+def test_llm_without_tts_returns_text_and_audio_input_uses_the_selected_model(audio_input):
+    from speech_to_speech.LLM.chat import make_user_message
+    from speech_to_speech.LLM.chat_completions_language_model import ChatCompletionsApiModelHandler
+    from speech_to_speech.LLM.lm_output_processor import LMOutputProcessor
+    from speech_to_speech.pipeline.messages import GenerateResponseRequest, TTSInput
+
+    cfg = RuntimeConfig(
+        routing=selection(
+            llm={
+                "model": "audio-llm",
+                "provider": "hf",
+                "protocol": "chat_completions",
+                "capabilities": {"audio_input": True, "context_window": 32768},
+            }
+        )
+    )
+    cfg.chat.add_item(make_user_message("Remember the blue bicycle."))
+    handler = ChatCompletionsApiModelHandler(
+        Event(),
+        Queue(),
+        Queue(),
+        setup_kwargs={"api_key": "test", "stream": False, "warmup_enabled": False},
+    )
+    create = Mock(
+        return_value=SimpleNamespace(
+            choices=[SimpleNamespace(message=SimpleNamespace(content="It is blue.", tool_calls=[]))], usage=None
+        )
+    )
+    handler.client = SimpleNamespace(chat=SimpleNamespace(completions=SimpleNamespace(create=create)))
+    request = GenerateResponseRequest(runtime_config=cfg, audio=np.zeros(160) if audio_input else None)
+    outputs = list(handler.process(request))
+    assert create.call_args.kwargs["model"] == "audio-llm"
+    messages = str(create.call_args.kwargs["messages"])
+    assert "blue bicycle" in messages
+    assert ("input_audio" in messages) is audio_input
+    processor = LMOutputProcessor(Event(), Queue(), Queue())
+    processed = [item for output in outputs for item in processor.process(output)]
+    assert not any(isinstance(item, TTSInput) for item in processed)

--- a/tests/openai_realtime/test_pipeline_builder.py
+++ b/tests/openai_realtime/test_pipeline_builder.py
@@ -1,10 +1,64 @@
+import json
 import sys
 from threading import Event
 from types import SimpleNamespace
+from unittest.mock import Mock
+
+import pytest
+from starlette.testclient import TestClient
 
 from speech_to_speech.api.openai_realtime.audio_client import RealtimeAudioClient
 from speech_to_speech.api.openai_realtime.server import RealtimeServer
 from speech_to_speech.s2s_pipeline import build_local_pipeline, build_pipeline, parse_arguments
+
+
+@pytest.mark.parametrize("llm", ["chat-completions", "responses-api"])
+def test_routed_pool_construction_does_not_probe_bootstrap_models(monkeypatch, llm):
+    from speech_to_speech.api.openai_realtime.websocket_router import create_app
+    from speech_to_speech.LLM.base_openai_compatible_language_model import BaseOpenAICompatibleHandler
+    from speech_to_speech.STT.openai_compatible_handler import OpenAICompatibleSTTHandler
+    from speech_to_speech.TTS.openai_compatible_handler import OpenAICompatibleTTSHandler
+
+    args = parse_arguments(["--stt", "openai", "--llm-backend", llm, "--tts", "openai"], command="serve")
+    args.module_kwargs.num_pipelines = 2
+    args.realtime_server_kwargs.session_routing_enabled = True
+    args.llm_backend.config.update(base_url="http://gateway/v1", api_key="test-key")
+    monkeypatch.setattr("speech_to_speech.s2s_pipeline.VADHandler", lambda *a, **kw: SimpleNamespace())
+    probes = []
+    for handler in (OpenAICompatibleSTTHandler, BaseOpenAICompatibleHandler, OpenAICompatibleTTSHandler):
+        probe = Mock(side_effect=RuntimeError("bootstrap model is unavailable"))
+        monkeypatch.setattr(handler, "warmup", probe)
+        probes.append(probe)
+    manager = build_pipeline(args, Event())
+    server = manager.handlers[-1]
+    assert len(server.pool) == 2
+    routes = {
+        "id": "allocated-session",
+        "pipeline": "healthy-alternative",
+        "routes": {
+            "stt": {"model": "healthy-stt", "provider": "test", "protocol": "transcriptions"},
+            "llm": {
+                "model": "healthy-llm",
+                "provider": "test",
+                "protocol": "chat_completions" if llm == "chat-completions" else "responses",
+            },
+            "tts": {"model": "healthy-tts", "provider": "test", "protocol": "speech", "voice": "alloy"},
+        },
+    }
+    with TestClient(create_app(server.pool, server.stop_event, session_routing_enabled=True)) as client:
+        with client.websocket_connect("/v1/realtime", headers={"X-Speech-Session-Routing": json.dumps(routes)}) as ws:
+            event = ws.receive_json()
+            assert event["type"] == "session.created"
+            assert event["session"]["model"] == "healthy-llm"
+    for probe in probes:
+        probe.assert_not_called()
+    # Per-unit routing setup must not mutate the configuration used by legacy builds.
+    assert "warmup_enabled" not in args.stt_backend.config
+    assert "warmup_enabled" not in args.llm_backend.config
+    assert "warmup_enabled" not in args.tts_backend.config
+    args.realtime_server_kwargs.session_routing_enabled = False
+    with pytest.raises(RuntimeError, match="bootstrap model is unavailable"):
+        build_pipeline(args, Event())
 
 
 def _default_args():

--- a/tests/openai_realtime/test_session_model_updates.py
+++ b/tests/openai_realtime/test_session_model_updates.py
@@ -85,6 +85,33 @@ def test_smaller_context_and_unresolved_tools_are_rejected_without_changes():
     assert state.runtime_config is before
 
 
+@pytest.mark.parametrize("context, accepted", [(8192, False), (32768, True), (65536, True)])
+def test_llm_removal_preserves_context_floor_until_session_ends(context, accepted):
+    service = RealtimeService(text_prompt_queue=Queue(), should_listen=Event())
+    sid = service.register(routing=route())
+    state = service._state(sid)
+    chat = state.runtime_config.chat
+    chat.add_item(make_user_message("Keep this conversation while the LLM is disabled."))
+    disabled = route().model_copy(update={"routes": route().routes.model_copy(update={"llm": None})})
+    assert service.handle_session_update(sid, event(models={"llm": None}), routing=disabled) is None
+    before = state.runtime_config
+    error = service.handle_session_update(
+        sid, event(model="second", instructions="new instructions"), routing=route("second", context=context)
+    )
+    assert (error is None) == accepted
+    assert state.runtime_config.chat is chat
+    assert "Keep this conversation" in str(chat.to_transformers_chat())
+    if not accepted:
+        assert state.runtime_config is before
+        assert state.runtime_config.routing.routes.llm is None
+        assert state.runtime_config.session.instructions != "new instructions"
+
+    # The constraint belongs to this conversation, never to a reused CPU slot.
+    service.unregister(sid)
+    new_sid = service.register(routing=disabled)
+    assert service.handle_session_update(new_sid, event(model="small"), routing=route("small", context=8192)) is None
+
+
 def test_public_models_cannot_change_or_fake_the_trusted_selection():
     service = RealtimeService(text_prompt_queue=Queue(), should_listen=Event())
     sid = service.register(routing=route())

--- a/tests/openai_realtime/test_session_model_updates.py
+++ b/tests/openai_realtime/test_session_model_updates.py
@@ -349,3 +349,49 @@ def test_cancelled_generation_must_drain_before_switching(running_unit):
                 release.set()
     finally:
         release.set()
+
+
+def test_background_final_stt_must_drain_before_switching(running_unit, monkeypatch):
+    import numpy as np
+    from starlette.testclient import TestClient
+
+    from speech_to_speech.api.openai_realtime.session_routing import TranscriptionRoute
+    from speech_to_speech.api.openai_realtime.websocket_router import create_app
+    from speech_to_speech.pipeline.messages import VADAudio
+    from speech_to_speech.STT.openai_compatible_handler import HttpTranscriptionResult
+
+    unit, stop, _ = running_unit
+    entered, release = Event(), Event()
+
+    class BlockingTranscription:
+        def run(self, cancel_check):
+            entered.set()
+            assert release.wait(5)
+            return HttpTranscriptionResult(text="Hello")
+
+        def cancel(self, reason):
+            release.set()
+
+    monkeypatch.setattr(unit.handlers[0], "_make_operation", lambda *args, **kwargs: BlockingTranscription())
+    initial = route().model_copy(
+        update={
+            "routes": route().routes.model_copy(
+                update={"stt": TranscriptionRoute(model="asr", provider="hf", protocol="transcriptions")}
+            )
+        }
+    )
+    try:
+        with TestClient(create_app([unit], stop, session_routing_enabled=True)) as client:
+            with client.websocket_connect(
+                "/v1/realtime", headers={"X-Speech-Session-Routing": initial.model_dump_json()}
+            ) as ws:
+                ws.receive_json()
+                before = unit.service._state(unit.session.session_id).runtime_config
+                unit.input_queue.put(VADAudio(audio=np.zeros(160, dtype=np.float32), runtime_config=before))
+                assert entered.wait(1)
+                rejected = send_switch(ws, route("second"), model="second", instructions="must not apply")
+                assert rejected["type"] == "error"
+                assert rejected["error"]["event_id"] == "client-update"
+                assert unit.service._state(unit.session.session_id).runtime_config is before
+    finally:
+        release.set()

--- a/tests/openai_realtime/test_session_model_updates.py
+++ b/tests/openai_realtime/test_session_model_updates.py
@@ -10,13 +10,23 @@ from speech_to_speech.LLM.chat import make_user_message
 
 
 def route(model="first", *, context=32768, tools=True, images=True, audio=True):
-    return SessionRouting.model_validate({
-        "id": "allocated-session", "pipeline": model, "updates_enabled": True,
-        "routes": {"stt": None, "tts": None, "llm": {
-            "model": model, "provider": "hf", "protocol": "chat_completions",
-            "capabilities": {"context_window": context, "tools": tools, "images": images, "audio_input": audio},
-        }},
-    })
+    return SessionRouting.model_validate(
+        {
+            "id": "allocated-session",
+            "pipeline": model,
+            "updates_enabled": True,
+            "routes": {
+                "stt": None,
+                "tts": None,
+                "llm": {
+                    "model": model,
+                    "provider": "hf",
+                    "protocol": "chat_completions",
+                    "capabilities": {"context_window": context, "tools": tools, "images": images, "audio_input": audio},
+                },
+            },
+        }
+    )
 
 
 def event(**fields):
@@ -30,7 +40,12 @@ def test_switch_preserves_identity_and_context_and_reports_effective_selection()
     old = state.runtime_config
     old.chat.add_item(make_user_message("Remember the blue bicycle."))
     conversation_id = state.conversation_id
-    assert service.handle_session_update(sid, event(model="second", instructions="new instructions"), routing=route("second")) is None
+    assert (
+        service.handle_session_update(
+            sid, event(model="second", instructions="new instructions"), routing=route("second")
+        )
+        is None
+    )
     assert state.runtime_config.routing.id == old.routing.id
     assert state.runtime_config.chat is old.chat
     assert state.conversation_id == conversation_id
@@ -63,7 +78,9 @@ def test_smaller_context_and_unresolved_tools_are_rejected_without_changes():
     before = state.runtime_config
     assert service.handle_session_update(sid, event(model="second"), routing=route("second", context=8192)) is not None
     assert state.runtime_config is before
-    before.chat.add_item(RealtimeConversationItemFunctionCall(type="function_call", name="look", call_id="pending", arguments="{}"))
+    before.chat.add_item(
+        RealtimeConversationItemFunctionCall(type="function_call", name="look", call_id="call_pending", arguments="{}")
+    )
     assert service.handle_session_update(sid, event(model="second"), routing=route("second")) is not None
     assert state.runtime_config is before
 
@@ -74,3 +91,234 @@ def test_public_models_cannot_change_or_fake_the_trusted_selection():
     before = service._state(sid).runtime_config
     assert service.handle_session_update(sid, event(models={"llm": "second"}, instructions="changed")) is not None
     assert service._state(sid).runtime_config is before
+
+
+def test_removed_stages_can_be_added_again_and_bad_voice_updates_are_atomic():
+    from speech_to_speech.api.openai_realtime.session_routing import SpeechRoute
+
+    service = RealtimeService(text_prompt_queue=Queue(), should_listen=Event())
+    sid = service.register(routing=route())
+    with_tts = route().model_copy(
+        update={
+            "routes": route().routes.model_copy(
+                update={
+                    "tts": SpeechRoute(
+                        model="tts", provider="hf", protocol="speech", voice="aiden", voices=["aiden", "alloy"]
+                    )
+                }
+            )
+        }
+    )
+    assert service.handle_session_update(sid, event(models={"tts": "tts"}), routing=with_tts) is None
+    assert service.build_session_updated(sid).session.output_modalities == ["audio"]
+    before = service._state(sid).runtime_config
+    error = service.handle_session_update(
+        sid, event(instructions="must not apply", audio={"output": {"voice": "missing"}}), routing=with_tts
+    )
+    assert error is not None
+    assert service._state(sid).runtime_config is before
+    assert service.handle_session_update(sid, event(models={"tts": None}), routing=route()) is None
+    assert service.build_session_updated(sid).session.output_modalities == ["text"]
+
+
+def test_media_and_completed_tool_history_require_destination_capabilities():
+    from openai.types.realtime import RealtimeConversationItemFunctionCall, RealtimeConversationItemFunctionCallOutput
+
+    from speech_to_speech.LLM.chat import UserContent, make_user_audio_message
+
+    image_message = make_user_message("")
+    image_message.content = [UserContent(type="input_image", image_url="https://example.com/image.png")]
+
+    for item, selected in [
+        (image_message, route("second", images=False)),
+        (make_user_audio_message("AA=="), route("second", audio=False)),
+    ]:
+        service = RealtimeService(text_prompt_queue=Queue(), should_listen=Event())
+        sid = service.register(routing=route())
+        cfg = service._state(sid).runtime_config
+        cfg.chat.add_item(item)
+        assert service.handle_session_update(sid, event(model="second"), routing=selected) is not None
+        assert service._state(sid).runtime_config is cfg
+    service = RealtimeService(text_prompt_queue=Queue(), should_listen=Event())
+    sid = service.register(routing=route())
+    cfg = service._state(sid).runtime_config
+    cfg.chat.add_item(
+        RealtimeConversationItemFunctionCall(type="function_call", name="look", call_id="call_done", arguments="{}")
+    )
+    cfg.chat.add_item(
+        RealtimeConversationItemFunctionCallOutput(type="function_call_output", call_id="call_done", output="result")
+    )
+    assert not cfg.chat.has_pending_tool_calls()
+    assert service.handle_session_update(sid, event(model="second"), routing=route("second", tools=False)) is not None
+    assert service._state(sid).runtime_config is cfg
+
+
+@pytest.fixture
+def running_unit():
+    from threading import Thread
+    from types import SimpleNamespace
+    from unittest.mock import Mock
+
+    from speech_to_speech.api.openai_realtime.pipeline_unit import PipelineUnit
+    from speech_to_speech.LLM.chat_completions_language_model import ChatCompletionsApiModelHandler
+    from speech_to_speech.LLM.lm_output_processor import LMOutputProcessor
+    from speech_to_speech.pipeline.cancel_scope import CancelScope
+    from speech_to_speech.STT.openai_compatible_handler import OpenAICompatibleSTTHandler
+    from speech_to_speech.STT.transcription_notifier import TranscriptionNotifier
+    from speech_to_speech.TTS.openai_compatible_handler import OpenAICompatibleTTSHandler
+
+    stop, listen, cancel = Event(), Event(), CancelScope()
+    queues = [Queue() for _ in range(7)]
+    incoming, transcription, prompts, lm_output, speech, outgoing, events = queues
+    stt = OpenAICompatibleSTTHandler(stop, incoming, transcription, setup_kwargs={"warmup_enabled": False})
+    notifier = TranscriptionNotifier(stop, transcription, prompts, setup_kwargs={"text_output_queue": events})
+    llm = ChatCompletionsApiModelHandler(
+        stop,
+        prompts,
+        lm_output,
+        setup_kwargs={"api_key": "test", "stream": False, "warmup_enabled": False, "cancel_scope": cancel},
+    )
+    create = Mock(
+        return_value=SimpleNamespace(
+            choices=[SimpleNamespace(message=SimpleNamespace(content="It is blue.", tool_calls=[]))], usage=None
+        )
+    )
+    llm.client = SimpleNamespace(chat=SimpleNamespace(completions=SimpleNamespace(create=create)))
+    processor = LMOutputProcessor(stop, lm_output, speech, setup_kwargs={"text_output_queue": events})
+    tts = OpenAICompatibleTTSHandler(
+        stop, speech, outgoing, setup_kwargs={"warmup_enabled": False, "should_listen": listen, "cancel_scope": cancel}
+    )
+    unit = PipelineUnit(
+        index=0,
+        service=RealtimeService(text_prompt_queue=prompts, should_listen=listen),
+        cancel_scope=cancel,
+        should_listen=listen,
+        response_playing=Event(),
+        input_queue=incoming,
+        output_queue=outgoing,
+        text_output_queue=events,
+        text_prompt_queue=prompts,
+        handlers=[stt, notifier, llm, processor, tts],
+    )
+    workers = [Thread(target=handler.run, daemon=True) for handler in unit.handlers]
+    for worker in workers:
+        worker.start()
+    yield unit, stop, create
+    stop.set()
+    for worker in workers:
+        worker.join(timeout=2)
+        assert not worker.is_alive()
+
+
+def send_switch(ws, selected, *, update_id="update", **session):
+    import json
+
+    from openai.resources.realtime.realtime import RealtimeConnection
+
+    class AdmissionProxy:
+        def send(self, message):
+            raw = json.loads(message)
+            assert "_session_routing" not in raw
+            raw["_session_routing"] = {"update_id": update_id, "routing": selected.model_dump()}
+            ws.send_json(raw)
+
+    # Use the installed official SDK serializer for the public event. Only the
+    # admission proxy attaches the already-reserved private route proposal.
+    RealtimeConnection(connection=AdmissionProxy()).session.update(
+        session={"type": "realtime", **session}, event_id="client-update"
+    )
+    return ws.receive_json()
+
+
+def test_websocket_switch_drains_handlers_and_next_request_uses_retained_context(running_unit):
+    import json
+
+    from starlette.testclient import TestClient
+
+    from speech_to_speech.api.openai_realtime.websocket_router import create_app
+
+    unit, stop, create = running_unit
+    empty = route().model_copy(update={"routes": route().routes.model_copy(update={"llm": None})})
+    with TestClient(create_app([unit], stop, session_routing_enabled=True)) as client:
+        with client.websocket_connect(
+            "/v1/realtime", headers={"X-Speech-Session-Routing": empty.model_dump_json()}
+        ) as ws:
+            created = ws.receive_json()
+            sid = created["session"]["id"]
+            for index, model in enumerate(("first", "second")):
+                updated = send_switch(ws, route(model), model=model)
+                assert updated["type"] == "session.updated", updated
+                assert updated["_session_routing"] == "update"
+                assert updated["session"]["id"] == sid
+                ws.send_json(
+                    {
+                        "type": "conversation.item.create",
+                        "item": {
+                            "type": "message",
+                            "role": "user",
+                            "content": [
+                                {
+                                    "type": "input_text",
+                                    "text": "Remember the blue bicycle." if index == 0 else "Which color?",
+                                }
+                            ],
+                        },
+                    }
+                )
+                assert ws.receive_json()["type"] == "conversation.item.created"
+                ws.send_json({"type": "response.create"})
+                received = []
+                while not received or received[-1]["type"] != "response.done":
+                    received.append(ws.receive_json())
+                assert received[-1]["response"]["status"] == "completed"
+                assert any(event["type"] == "response.output_text.delta" for event in received)
+                assert not any(event["type"] == "response.output_audio.delta" for event in received)
+                assert create.call_args.kwargs["model"] == model
+                assert "blue bicycle" in json.dumps(create.call_args.kwargs["messages"])
+                assert create.call_args.kwargs["extra_headers"]["X-Speech-Session-Id"] == "allocated-session"
+
+
+def test_cancelled_generation_must_drain_before_switching(running_unit):
+    from starlette.testclient import TestClient
+
+    from speech_to_speech.api.openai_realtime.websocket_router import create_app
+
+    unit, stop, create = running_unit
+    entered, release = Event(), Event()
+    response = create.return_value
+
+    def blocked(**kwargs):
+        entered.set()
+        assert release.wait(5)
+        return response
+
+    create.side_effect = blocked
+    try:
+        with TestClient(create_app([unit], stop, session_routing_enabled=True)) as client:
+            with client.websocket_connect(
+                "/v1/realtime", headers={"X-Speech-Session-Routing": route().model_dump_json()}
+            ) as ws:
+                ws.receive_json()
+                ws.send_json(
+                    {
+                        "type": "conversation.item.create",
+                        "item": {
+                            "type": "message",
+                            "role": "user",
+                            "content": [{"type": "input_text", "text": "Hello"}],
+                        },
+                    }
+                )
+                ws.receive_json()
+                ws.send_json({"type": "response.create"})
+                assert ws.receive_json()["type"] == "response.created"
+                assert entered.wait(1)
+                ws.send_json({"type": "response.cancel"})
+                assert ws.receive_json()["type"] == "response.done"
+                rejected = send_switch(ws, route("second"), model="second", instructions="must not apply")
+                assert rejected["type"] == "error"
+                assert rejected["error"]["event_id"] == "client-update"
+                assert unit.service._state(unit.session.session_id).runtime_config.session.model == "first"
+                release.set()
+    finally:
+        release.set()

--- a/tests/openai_realtime/test_session_model_updates.py
+++ b/tests/openai_realtime/test_session_model_updates.py
@@ -1,0 +1,76 @@
+from queue import Queue
+from threading import Event
+
+import pytest
+from openai.types.realtime import RealtimeSessionCreateRequest, SessionUpdateEvent
+
+from speech_to_speech.api.openai_realtime.service import RealtimeService
+from speech_to_speech.api.openai_realtime.session_routing import SessionRouting
+from speech_to_speech.LLM.chat import make_user_message
+
+
+def route(model="first", *, context=32768, tools=True, images=True, audio=True):
+    return SessionRouting.model_validate({
+        "id": "allocated-session", "pipeline": model, "updates_enabled": True,
+        "routes": {"stt": None, "tts": None, "llm": {
+            "model": model, "provider": "hf", "protocol": "chat_completions",
+            "capabilities": {"context_window": context, "tools": tools, "images": images, "audio_input": audio},
+        }},
+    })
+
+
+def event(**fields):
+    return SessionUpdateEvent(type="session.update", session=RealtimeSessionCreateRequest(type="realtime", **fields))
+
+
+def test_switch_preserves_identity_and_context_and_reports_effective_selection():
+    service = RealtimeService(text_prompt_queue=Queue(), should_listen=Event())
+    sid = service.register(routing=route())
+    state = service._state(sid)
+    old = state.runtime_config
+    old.chat.add_item(make_user_message("Remember the blue bicycle."))
+    conversation_id = state.conversation_id
+    assert service.handle_session_update(sid, event(model="second", instructions="new instructions"), routing=route("second")) is None
+    assert state.runtime_config.routing.id == old.routing.id
+    assert state.runtime_config.chat is old.chat
+    assert state.conversation_id == conversation_id
+    assert "blue bicycle" in str(state.runtime_config.chat.to_transformers_chat())
+    updated = service.build_session_updated(sid).model_dump()["session"]
+    assert updated["id"] == sid
+    assert updated["model"] == "second"
+    assert updated["models"]["llm"] == {"model": "second", "provider": "hf"}
+    assert updated["instructions"] == "new instructions"
+
+
+@pytest.mark.parametrize("busy", ["in_response", "response_pending"])
+def test_busy_combined_update_is_atomic(busy):
+    service = RealtimeService(text_prompt_queue=Queue(), should_listen=Event())
+    sid = service.register(routing=route())
+    state = service._state(sid)
+    setattr(state, busy, True)
+    before = state.runtime_config
+    error = service.handle_session_update(sid, event(model="second", instructions="changed"), routing=route("second"))
+    assert error.type == "error"
+    assert state.runtime_config is before
+
+
+def test_smaller_context_and_unresolved_tools_are_rejected_without_changes():
+    from openai.types.realtime import RealtimeConversationItemFunctionCall
+
+    service = RealtimeService(text_prompt_queue=Queue(), should_listen=Event())
+    sid = service.register(routing=route())
+    state = service._state(sid)
+    before = state.runtime_config
+    assert service.handle_session_update(sid, event(model="second"), routing=route("second", context=8192)) is not None
+    assert state.runtime_config is before
+    before.chat.add_item(RealtimeConversationItemFunctionCall(type="function_call", name="look", call_id="pending", arguments="{}"))
+    assert service.handle_session_update(sid, event(model="second"), routing=route("second")) is not None
+    assert state.runtime_config is before
+
+
+def test_public_models_cannot_change_or_fake_the_trusted_selection():
+    service = RealtimeService(text_prompt_queue=Queue(), should_listen=Event())
+    sid = service.register(routing=route())
+    before = service._state(sid).runtime_config
+    assert service.handle_session_update(sid, event(models={"llm": "second"}, instructions="changed")) is not None
+    assert service._state(sid).runtime_config is before

--- a/tests/openai_realtime/test_session_routing.py
+++ b/tests/openai_realtime/test_session_routing.py
@@ -1,32 +1,56 @@
 from queue import Queue
 from threading import Event
+from types import SimpleNamespace
+from unittest.mock import Mock
 
 import numpy as np
 import pytest
 from openai.types.realtime import RealtimeSessionCreateRequest, SessionUpdateEvent
+from starlette.testclient import TestClient
 
+from speech_to_speech.api.openai_realtime.pipeline_unit import PipelineUnit
 from speech_to_speech.api.openai_realtime.runtime_config import RuntimeConfig
 from speech_to_speech.api.openai_realtime.service import RealtimeService
 from speech_to_speech.api.openai_realtime.session_routing import SessionRouting
+from speech_to_speech.api.openai_realtime.websocket_router import create_app
+from speech_to_speech.LLM.chat import make_user_message
+from speech_to_speech.LLM.chat_completions_language_model import ChatCompletionsApiModelHandler
+from speech_to_speech.LLM.responses_api_language_model import ResponsesApiModelHandler
+from speech_to_speech.pipeline.cancel_scope import CancelScope
+from speech_to_speech.pipeline.messages import GenerateResponseRequest
 from speech_to_speech.STT.openai_compatible_handler import OpenAICompatibleSTTHandler
+from speech_to_speech.TTS.openai_compatible_handler import OpenAICompatibleTTSHandler
 
 
 def routing():
-    return SessionRouting.model_validate({
-        "id": "allocated-session", "pipeline": "qwen-gemma-openai",
-        "routes": {
-            "stt": {"model": "qwen-asr", "provider": "vllm", "protocol": "transcriptions"},
-            "llm": {"model": "gemma", "provider": "vllm", "protocol": "chat_completions"},
-            "tts": {"model": "mini-tts", "provider": "openai", "protocol": "speech", "voice": "alloy"},
-        },
-    })
+    return SessionRouting.model_validate(
+        {
+            "id": "allocated-session",
+            "pipeline": "qwen-gemma-openai",
+            "routes": {
+                "stt": {"model": "qwen-asr", "provider": "vllm", "protocol": "transcriptions"},
+                "llm": {"model": "gemma", "provider": "vllm", "protocol": "chat_completions"},
+                "tts": {"model": "mini-tts", "provider": "openai", "protocol": "speech", "voice": "alloy"},
+            },
+        }
+    )
+
+
+def test_allocator_ids_accept_urlsafe_leading_punctuation():
+    for session_id in ("-allocated", "_allocated"):
+        payload = routing().model_dump()
+        payload["id"] = session_id
+        assert SessionRouting.model_validate(payload).id == session_id
 
 
 def test_admitted_model_update_is_atomic_and_unconfigured_sessions_keep_existing_behavior():
     service = RealtimeService(text_prompt_queue=Queue(), should_listen=Event())
     sid = service.register(routing=routing())
     cfg = service._state(sid).runtime_config
-    event = SessionUpdateEvent(type="session.update", session=RealtimeSessionCreateRequest(type="realtime", model="other", instructions="changed"))
+    event = SessionUpdateEvent(
+        type="session.update",
+        session=RealtimeSessionCreateRequest(type="realtime", model="other", instructions="changed"),
+    )
     before = cfg.session.model_dump()
     assert service.session.handle_session_update(sid, event) is not None
     assert cfg.session.model_dump() == before
@@ -39,7 +63,12 @@ def test_admitted_model_update_is_atomic_and_unconfigured_sessions_keep_existing
 
 def test_stt_operation_captures_the_admitted_route_without_mutating_handler_defaults(monkeypatch):
     monkeypatch.setattr(OpenAICompatibleSTTHandler, "warmup", lambda self: None)
-    handler = OpenAICompatibleSTTHandler(Event(), queue_in=Queue(), queue_out=Queue(), setup_kwargs={"base_url": "http://gateway/v1", "model": "default", "api_key": "gateway-key"})
+    handler = OpenAICompatibleSTTHandler(
+        Event(),
+        queue_in=Queue(),
+        queue_out=Queue(),
+        setup_kwargs={"base_url": "http://gateway/v1", "model": "default", "api_key": "gateway-key"},
+    )
     cfg = RuntimeConfig(routing=routing())
     first = handler._make_operation(np.zeros(160), runtime_config=cfg)
     second = handler._make_operation(np.zeros(160))
@@ -51,3 +80,119 @@ def test_stt_operation_captures_the_admitted_route_without_mutating_handler_defa
     assert second.extra_headers is None
     with pytest.raises(ValueError):
         cfg.routing.routes.stt.model = "changed"
+
+
+@pytest.mark.parametrize("handler_type", [ChatCompletionsApiModelHandler, ResponsesApiModelHandler])
+def test_llm_requests_and_compaction_capture_routes_and_preserve_context(monkeypatch, handler_type):
+    monkeypatch.setattr(handler_type, "warmup", lambda self: None)
+    handler = handler_type(
+        Event(),
+        Queue(),
+        Queue(),
+        setup_kwargs={"model_name": "default", "api_key": "gateway-key", "stream": False, "disable_thinking": False},
+    )
+    response = SimpleNamespace(
+        choices=[SimpleNamespace(message=SimpleNamespace(content="Hello.", tool_calls=[]))],
+        output=[],
+        output_text="summary",
+        usage=None,
+    )
+    create = Mock(return_value=response)
+    handler.client = SimpleNamespace(
+        chat=SimpleNamespace(completions=SimpleNamespace(create=create)), responses=SimpleNamespace(create=create)
+    )
+    admitted = routing()
+    if handler_type is ResponsesApiModelHandler:
+        data = admitted.model_dump()
+        data["routes"]["llm"]["protocol"] = "responses"
+        admitted = SessionRouting.model_validate(data)
+    cfg = RuntimeConfig(routing=admitted)
+    cfg.chat.add_item(make_user_message("Remember the blue bicycle."))
+    cfg.chat.add_item(make_user_message("What color was it?"))
+    list(handler.process(GenerateResponseRequest(runtime_config=cfg)))
+    assert create.call_args.kwargs["model"] == "gemma"
+    assert create.call_args.kwargs["extra_headers"] == admitted.headers("llm")
+    assert "blue bicycle" in str(create.call_args.kwargs.get("messages", create.call_args.kwargs.get("input")))
+    assert handler.model_name == "default"
+    generate = handler._build_compaction_generate_fn({"model": "gemma", "extra_headers": admitted.headers("llm")})
+    generate("summarize", "history")
+    assert create.call_args.kwargs["model"] == "gemma"
+    assert create.call_args.kwargs["extra_headers"] == admitted.headers("llm")
+
+
+def test_tts_routing_keeps_transport_and_voice_updates(monkeypatch):
+    monkeypatch.setattr(OpenAICompatibleTTSHandler, "warmup", lambda self: None)
+    handler = OpenAICompatibleTTSHandler(
+        Event(),
+        Queue(),
+        Queue(),
+        setup_kwargs={
+            "base_url": "http://gateway/v1",
+            "api_key": "gateway-key",
+            "model": "default",
+            "stream": False,
+            "should_listen": Event(),
+        },
+    )
+    cfg = RuntimeConfig(routing=routing())
+    operation = handler._make_operation(text="Hello.", voice="coral", runtime_config=cfg)
+    assert operation.payload["model"] == "mini-tts"
+    assert operation.payload["voice"] == "coral"
+    assert operation.extra_headers == routing().headers("tts")
+    assert operation.api_key == "gateway-key"
+    assert operation.endpoint_url == "http://gateway/v1/audio/speech"
+    assert handler._make_operation(text="Hello.", voice="alloy").payload["model"] == "default"
+
+
+def unit():
+    return PipelineUnit(
+        index=0,
+        service=RealtimeService(text_prompt_queue=Queue(), should_listen=Event()),
+        cancel_scope=CancelScope(),
+        should_listen=Event(),
+        response_playing=Event(),
+        input_queue=Queue(),
+        output_queue=Queue(),
+        text_output_queue=Queue(),
+        text_prompt_queue=Queue(),
+        handlers=[
+            object.__new__(OpenAICompatibleSTTHandler),
+            object.__new__(OpenAICompatibleTTSHandler),
+            object.__new__(ChatCompletionsApiModelHandler),
+        ],
+    )
+
+
+@pytest.mark.parametrize("enabled,invalid", [(False, False), (True, True)])
+def test_untrusted_or_wrong_protocol_handoff_is_rejected_before_claim(enabled, invalid):
+    pipeline = unit()
+    payload = routing().model_dump()
+    if invalid:
+        payload["routes"]["llm"]["protocol"] = "responses"
+    import json
+
+    with TestClient(create_app([pipeline], Event(), session_routing_enabled=enabled)) as client:
+        with client.websocket_connect("/v1/realtime", headers={"X-Speech-Session-Routing": json.dumps(payload)}) as ws:
+            assert ws.receive_json()["type"] == "error"
+            assert pipeline.session is None
+            assert pipeline.service.total_usage.connections == 0
+
+
+def test_valid_handoff_sets_effective_session_before_created_event():
+    pipeline = unit()
+    with TestClient(create_app([pipeline], Event(), session_routing_enabled=True)) as client:
+        with client.websocket_connect(
+            "/v1/realtime", headers={"X-Speech-Session-Routing": routing().model_dump_json()}
+        ) as ws:
+            event = ws.receive_json()
+            assert event["session"]["model"] == "gemma"
+            assert event["session"]["audio"]["output"]["voice"] == "alloy"
+            cfg = pipeline.service._state(event["session"]["id"]).runtime_config
+            assert cfg.routing == routing()
+
+
+def test_routing_rejects_local_handlers_at_startup():
+    pipeline = unit()
+    pipeline.handlers = []
+    with pytest.raises(ValueError, match="remote"):
+        create_app([pipeline], Event(), session_routing_enabled=True)

--- a/tests/openai_realtime/test_session_routing.py
+++ b/tests/openai_realtime/test_session_routing.py
@@ -1,0 +1,53 @@
+from queue import Queue
+from threading import Event
+
+import numpy as np
+import pytest
+from openai.types.realtime import RealtimeSessionCreateRequest, SessionUpdateEvent
+
+from speech_to_speech.api.openai_realtime.runtime_config import RuntimeConfig
+from speech_to_speech.api.openai_realtime.service import RealtimeService
+from speech_to_speech.api.openai_realtime.session_routing import SessionRouting
+from speech_to_speech.STT.openai_compatible_handler import OpenAICompatibleSTTHandler
+
+
+def routing():
+    return SessionRouting.model_validate({
+        "id": "allocated-session", "pipeline": "qwen-gemma-openai",
+        "routes": {
+            "stt": {"model": "qwen-asr", "provider": "vllm", "protocol": "transcriptions"},
+            "llm": {"model": "gemma", "provider": "vllm", "protocol": "chat_completions"},
+            "tts": {"model": "mini-tts", "provider": "openai", "protocol": "speech", "voice": "alloy"},
+        },
+    })
+
+
+def test_admitted_model_update_is_atomic_and_unconfigured_sessions_keep_existing_behavior():
+    service = RealtimeService(text_prompt_queue=Queue(), should_listen=Event())
+    sid = service.register(routing=routing())
+    cfg = service._state(sid).runtime_config
+    event = SessionUpdateEvent(type="session.update", session=RealtimeSessionCreateRequest(type="realtime", model="other", instructions="changed"))
+    before = cfg.session.model_dump()
+    assert service.session.handle_session_update(sid, event) is not None
+    assert cfg.session.model_dump() == before
+    assert service.build_session_created(sid).session.model == "gemma"
+    plain = service.register()
+    assert service.session.handle_session_update(plain, event) is None
+    assert service._state(plain).runtime_config.session.model == "other"
+    assert cfg.routing.id == "allocated-session"
+
+
+def test_stt_operation_captures_the_admitted_route_without_mutating_handler_defaults(monkeypatch):
+    monkeypatch.setattr(OpenAICompatibleSTTHandler, "warmup", lambda self: None)
+    handler = OpenAICompatibleSTTHandler(Event(), queue_in=Queue(), queue_out=Queue(), setup_kwargs={"base_url": "http://gateway/v1", "model": "default", "api_key": "gateway-key"})
+    cfg = RuntimeConfig(routing=routing())
+    first = handler._make_operation(np.zeros(160), runtime_config=cfg)
+    second = handler._make_operation(np.zeros(160))
+    assert first.model == "qwen-asr"
+    assert first.extra_headers == {"X-Speech-Provider": "vllm", "X-Speech-Session-Id": "allocated-session"}
+    assert first.api_key == "gateway-key"
+    assert first.endpoint_url == "http://gateway/v1/audio/transcriptions"
+    assert second.model == "default"
+    assert second.extra_headers is None
+    with pytest.raises(ValueError):
+        cfg.routing.routes.stt.model = "changed"

--- a/tests/test_openai_stt_handler.py
+++ b/tests/test_openai_stt_handler.py
@@ -380,7 +380,7 @@ def test_final_request_does_not_wait_for_in_flight_progressive(monkeypatch):
             return HttpTranscriptionResult(text="final", language="en")
 
     operations = iter([_BlockingProgressiveOperation(), _FinalOperation()])
-    monkeypatch.setattr(handler, "_make_operation", lambda _audio: next(operations))
+    monkeypatch.setattr(handler, "_make_operation", lambda _audio, **_kwargs: next(operations))
     handler_thread = Thread(target=handler.run, daemon=True)
     handler_thread.start()
 
@@ -424,7 +424,7 @@ def test_additional_progressive_requests_are_dropped_while_one_is_in_flight(monk
             assert release_progressive.wait(timeout=2)
             return HttpTranscriptionResult(text="partial")
 
-    def make_operation(_audio):
+    def make_operation(_audio, **_kwargs):
         nonlocal operation_count
         operation_count += 1
         return _BlockingProgressiveOperation()
@@ -459,7 +459,7 @@ def test_session_end_suppresses_in_flight_progressive_result(monkeypatch):
             assert release_progressive.wait(timeout=2)
             return HttpTranscriptionResult(text="old session")
 
-    monkeypatch.setattr(handler, "_make_operation", lambda _audio: _BlockingProgressiveOperation())
+    monkeypatch.setattr(handler, "_make_operation", lambda _audio, **_kwargs: _BlockingProgressiveOperation())
 
     assert list(handler.process(_audio("progressive"))) == []
     assert progressive_started.wait(timeout=1)


### PR DESCRIPTION
Managed Realtime sessions can now select, change or remove configured remote STT/LLM/TTS routes without reconnecting. A session may start empty, receive a trusted admitted selection with `session.update`, and retain its conversation when changing models at a drained turn boundary. Remote-client initialization no longer requires bootstrap-model inference in this opt-in mode.

The private WebSocket handoff carries validated model/provider routes and a stable allocator identity through existing STT, LLM, TTS and compaction requests. The admission proxy reserves new capacity before supplying an update proposal; upstream validates the complete candidate and returns a correlated private acknowledgement. Active work, unresolved tools, incompatible context/capabilities/protocol or voice reject the update atomically. Retained Chat and session/conversation identities remain unchanged.

Null removes a stage: TTS-off means text output; LLM-off allows transcription without response generation; STT-off accepts text and can pass audio to a declared compatible Chat Completions LLM. No disabled stage falls back to its bootstrap model. Re-adding stages uses the same configured remote adapters. Legacy startup, unconfigured WebSocket and WebRTC behavior remain covered.

This addresses the requested extension in #547 and is the upstream companion to andimarafioti/s2s-endpoint#114 / #116. Catalogs, capacity admission, fleet policy, credentials and backend inventory remain at the endpoint/gateway layer. Cross-protocol history conversion, weight hot-loading, automatic fallback and cache migration are excluded. Model switching is an optional extension to Realtime event framing, not a claim that the OpenAI-hosted Realtime API permits switching its model within a session.

Validation: **1528 Python tests passed, 8 skipped**; Mypy (104 source files), Ruff lint/format, wheel/sdist and strict Twine checks passed. All six pinned OpenAI Agents SDK checks and every current-head CI job passed. Threaded WebSocket tests use the official OpenAI SDK serializer and cover effective next-inference routing, retained context, disabled TTS and cancellation cleanup. The companion endpoint has 602 passing tests and all three actual Dockerfile builds passed.

The earlier six independent review passes and the first pass on the expanded session-update scope are complete. The identified code blockers have been corrected, including the retained context-window constraint across LLM removal. The second fresh review completed with **no concrete in-scope code blockers**. Its P1 live-evidence finding is accepted and remains unresolved: required current-head model/provider, dynamic-update, modest workload and latency validation must still be completed before declaring acceptance complete. Independent focused checks passed 21 endpoint tests and 30 upstream tests. Latest upstream main (2735263, PR #512) was integrated with a normal merge; a regression proves model updates wait for asynchronous final STT cleanup. Required current live model/provider and modest workload validation remains pending approval for a temporary test-image upload. No production deployment or merge; keep this PR draft and open.
