### PR TITLE
Document three starting configurations in the README

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,14 +28,12 @@ This pipeline runs in production as the conversation backend for thousands of [R
 
 ## Quickstart
 
-Choose where the language model should run. All three configurations use local Parakeet TDT speech recognition and Qwen3-TTS speech output, and include the packaged microphone/speaker client. The Mac and hosted LLM routes use one terminal; the llama.cpp route uses two.
-
-Following the [Reachy Mini local conversation guide](https://huggingface.co/blog/local-reachy-mini-conversation), start with the default speech components and choose an LLM that fits your hardware: Silero detects speech boundaries, Parakeet transcribes your words, and Qwen3-TTS speaks the reply. MLX is the simplest Mac starting point; a separate llama.cpp server lets you tune or replace the local LLM independently of the speech pipeline. Both approaches keep the conversation local.
+Choose where the language model should run. All three configurations use local Parakeet TDT speech recognition and Qwen3-TTS speech output **by default**. You can change the STT, LLM, and TTS models and backends; see [Supported components](#supported-components). Each configuration runs from one terminal with the packaged microphone/speaker client.
 
 | Starting configuration | Hardware to plan for | Conversation data sent to a provider |
 |---|---|---|
 | [Apple Silicon, fully local](#apple-silicon-fully-local) | Apple Silicon Mac; budget 16 GB or more of unified memory | None |
-| [NVIDIA GPU, fully local](#nvidia-gpu-fully-local) | Linux with an NVIDIA GPU; budget 16 GB of VRAM for the quantized Gemma 4 LLM, speech models, and caches below, plus system RAM | None |
+| [NVIDIA GPU, fully local](#nvidia-gpu-fully-local) | Linux with an NVIDIA GPU; budget 24 GB of VRAM for the unquantized LLM, speech models, and caches below, plus system RAM | None |
 | [Local speech with a hosted LLM](#local-speech-with-a-hosted-llm) | Apple Silicon: budget ~8 GB of available unified memory (16 GB total recommended); Linux/NVIDIA: ~8 GB of available VRAM, plus system RAM | Transcribed text, instructions, and conversation history; microphone audio stays local |
 
 The memory figures are planning estimates for one conversation, not measured minimum requirements. Actual use depends on context length, audio length, and backend versions. All configurations need internet access for the first model downloads; the hosted LLM also needs an API key and internet access during conversations.
@@ -56,7 +54,7 @@ Run the configuration you chose with this environment activated. Activate the sa
 
 ### Apple Silicon, fully local
 
-Use this on an Apple Silicon Mac to run speech recognition, the language model, and speech synthesis on your own machine. Start here for a single-command setup with a small, quantized LLM. No API key is needed.
+Run all three models locally on an Apple Silicon Mac, using a quantized LLM through MLX. No API key is needed.
 
 ```bash
 speech-to-speech local \
@@ -66,50 +64,30 @@ speech-to-speech local \
 
 The Mac preset selects Parakeet TDT through MLX, the 4-bit Qwen3-4B language model through MLX LM, and the 6-bit Qwen3-TTS CustomVoice model through MLX Audio. The core model weights total approximately **7.5 GB**: [STT](https://huggingface.co/mlx-community/parakeet-tdt-0.6b-v3/tree/main), [LLM](https://huggingface.co/mlx-community/Qwen3-4B-Instruct-2507-4bit/tree/main), and [TTS](https://huggingface.co/mlx-community/Qwen3-TTS-12Hz-1.7B-CustomVoice-6bit/tree/main). Allow additional disk space for dependencies and auxiliary model assets.
 
-After the exact configuration has run once online, follow [Offline operation](#offline-operation) to run without internet access. To use Gemma 4 through a separate llama.cpp server on your Mac, follow the [local LLM guidance](#fully-local). For a local model that accepts audio directly, see the [Gemma 4 12B example](./examples/gemma4-12b-macos/README.md).
+For a separate local LLM server, see the [llama.cpp option](#fully-local). For a model that accepts audio directly, see the [Gemma 4 12B example](./examples/gemma4-12b-macos/README.md).
 
 ### NVIDIA GPU, fully local
 
-Use this on a Linux workstation with a CUDA-capable NVIDIA GPU. Run a quantized Gemma 4 E4B model in llama.cpp and connect the speech pipeline to its local Responses API. No provider API key is needed. Install a current [llama.cpp CUDA build](https://github.com/ggml-org/llama.cpp/blob/master/docs/build.md#cuda) and make `llama-server` available on your PATH.
-
-In terminal 1, start the LLM server:
-
-```bash
-llama-server \
-    -hf ggml-org/gemma-4-E4B-it-GGUF:Q4_0 \
-    --alias local-gemma \
-    --host 127.0.0.1 --port 8080 \
-    -ngl all -np 1 -c 8192 -fa on \
-    --no-mmproj \
-    --reasoning off
-```
-
-This explicitly selects the [4-bit weights, approximately **4.6 GB**](https://huggingface.co/ggml-org/gemma-4-E4B-it-GGUF/blob/main/gemma-4-E4B-it-Q4_0.gguf), with one request slot and an 8k context. `--no-mmproj` skips the image/audio projector because Parakeet supplies text. Wait for the server to finish loading, then leave it running.
-
-In terminal 2, activate the same Python environment and start the speech pipeline and microphone client:
+Run all three models locally on a Linux workstation with a CUDA-capable NVIDIA GPU. Transformers loads the LLM in the speech process, so no separate LLM server or API key is needed.
 
 ```bash
 speech-to-speech local \
     --device cuda \
     --stt parakeet-tdt \
-    --llm_backend responses-api \
-    --model_name local-gemma \
-    --responses_api_base_url http://127.0.0.1:8080/v1 \
-    --responses_api_api_key "" \
-    --responses_api_reasoning_effort none \
+    --llm_backend transformers \
+    --model_name Qwen/Qwen3-4B-Instruct-2507 \
+    --llm_torch_dtype float16 \
     --tts qwen3 \
     --qwen3_tts_backend ggml
 ```
 
-The two processes share the GPU: leave approximately **8 GB of available VRAM for the speech pipeline**, in addition to the LLM's weights and runtime cache. Parakeet uses nano-parakeet and Qwen3-TTS CustomVoice uses GGML. Speech model downloads, GGUF caches, and dependencies require additional disk space. The local URL and matching `local-gemma` model alias route replies to your own server; using the Responses API does not imply a cloud service.
-
-If memory is tight, reduce the LLM context or use the hosted LLM route below. For tuning and an in-process Transformers alternative, see [Fully Local](#fully-local). After downloading the required assets, this configuration can also run [offline](#offline-operation). Stop both processes with `Ctrl+C` in their respective terminals. For a server running in containers, see [Docker](#docker).
+The [LLM weights alone are approximately **8 GB**](https://huggingface.co/Qwen/Qwen3-4B-Instruct-2507/tree/main); speech models, caches, and dependencies need additional disk space. For a quantized LLM in a separate server, see the [llama.cpp option](#fully-local), available on both Apple Silicon and NVIDIA.
 
 ### Local speech with a hosted LLM
 
-Use this to keep speech recognition and synthesis on your computer while a hosted model generates the reply. It works on Apple Silicon or the Linux/CUDA setup above and avoids loading the local LLM. On Apple Silicon, the speech backends select MLX automatically.
+Run speech recognition and synthesis locally on Apple Silicon or Linux/NVIDIA while a hosted LLM generates replies. The speech backends select MLX automatically on Apple Silicon.
 
-Budget approximately **8 GB of available memory for the local speech pipeline**. On Apple Silicon, this comes from unified memory; **16 GB total is recommended** to leave room for macOS and other apps. On Linux/NVIDIA, budget **8 GB of available GPU VRAM**, with separate system RAM for model loading, the operating system, and other apps. These are planning estimates for one conversation, not verified minimums; the model download sizes below are disk requirements, not runtime memory measurements.
+Budget approximately **8 GB of available memory for the local speech pipeline**: unified memory on Apple Silicon (**16 GB total recommended**) or GPU VRAM on NVIDIA, with separate system RAM. Leave room for the operating system and other apps.
 
 ```bash
 export OPENAI_API_KEY=...
@@ -122,6 +100,8 @@ speech-to-speech local \
 This uses the default OpenAI model described under [Realtime Server](#realtime-server), with provider API charges. Only the speech models download locally: approximately **5.2 GB** of core weights on Apple Silicon, plus dependencies and auxiliary assets; Linux uses different speech-model formats and caches. Transcribed text, instructions, and conversation history are sent to OpenAI. Microphone audio and speech synthesis remain on your computer in this configuration. For another provider, see [LLM backends](#llm-backends).
 
 ### Languages and other clients
+
+For offline use, first cache the selected models and dependencies as described in [Offline operation](#offline-operation).
 
 Start in English. The Parakeet/Qwen3-TTS pairing also covers French, German, Italian, Portuguese, Russian, and Spanish; use `--language auto` for language switching. For languages outside this overlap, choose an STT/TTS pairing from [Multi-language support](#multi-language-support).
 
@@ -544,31 +524,37 @@ speech-to-speech serve \
 
 ### Fully Local
 
-Choose the [MLX quickstart](#apple-silicon-fully-local) for a single-command Mac setup, or the [llama.cpp/Gemma 4 quickstart](#nvidia-gpu-fully-local) to serve and tune the LLM separately, following the approach in the [Reachy Mini guide](https://huggingface.co/blog/local-reachy-mini-conversation).
+Use llama.cpp as a separate local LLM server on **Apple Silicon or Linux/NVIDIA**, independently of your STT/TTS choices. Install it with `brew install llama.cpp` on macOS or use a [CUDA build](https://github.com/ggml-org/llama.cpp/blob/master/docs/build.md#cuda) on NVIDIA.
 
-**llama.cpp on Apple Silicon:** install it with `brew install llama.cpp`, then use the same two-terminal Gemma 4 recipe, omitting `--device cuda` from the speech-to-speech command. The speech backends select MLX automatically. Budget **24 GB of total unified memory** for this larger local combination and system headroom; this is a planning estimate, separate from the 16 GB estimate for the smaller Qwen3-4B MLX recipe.
+For this Gemma 4 configuration with the default speech models, budget **24 GB of total unified memory on Mac** or **16 GB of GPU VRAM on NVIDIA**, plus system RAM. These are planning estimates; reserve approximately 8 GB for the speech pipeline alongside the LLM and its runtime cache.
 
-Tune one setting at a time while checking how long it takes to hear the first reply:
+Terminal 1 — start the LLM and leave it running:
 
-- **Start with a small, quantized LLM.** Fit speech models and runtime caches alongside it before moving to a larger model. The recipes pin their quantization so a different default download does not change the memory budget.
-- **Keep reasoning off for conversation.** The llama.cpp recipe uses `--reasoning off`; the pipeline streams replies and requests reasoning effort `none`. Enable thinking only when the task needs the extra reasoning time.
-- **Start with one slot and an 8k context.** Increase `-c` for longer conversations and `-np` for concurrent requests only when needed; size the context for all slots and leave memory for speech. The blog's `-np 2 -c 65536` is an option for machines with more headroom.
-- **Tune attention after the baseline works.** `-fa on` enables Flash Attention. Try `--swa-full` for Gemma prompt processing when memory permits; it allocates a larger sliding-window cache. See the [llama.cpp server reference](https://github.com/ggml-org/llama.cpp/tree/master/tools/server) for these controls.
+```bash
+llama-server \
+    -hf ggml-org/gemma-4-E4B-it-GGUF:Q4_0 \
+    --alias local-gemma \
+    --host 127.0.0.1 --port 8080 \
+    -ngl all -np 1 -c 8192 -fa on \
+    --no-mmproj \
+    --reasoning off
+```
 
-**Transformers alternative on NVIDIA:** use this if you want to load a Hugging Face model directly in the speech process. It needs no separate LLM server. Budget **24 GB of VRAM** for this unquantized LLM, the speech models, and runtime headroom; the [LLM weights alone are approximately 8 GB](https://huggingface.co/Qwen/Qwen3-4B-Instruct-2507/tree/main).
+Terminal 2 — activate your Python environment and start the speech pipeline:
 
 ```bash
 speech-to-speech local \
-    --device cuda \
     --stt parakeet-tdt \
-    --llm_backend transformers \
-    --model_name Qwen/Qwen3-4B-Instruct-2507 \
-    --llm_torch_dtype float16 \
-    --tts qwen3 \
-    --qwen3_tts_backend ggml
+    --llm_backend responses-api \
+    --model_name local-gemma \
+    --responses_api_base_url http://127.0.0.1:8080/v1 \
+    --responses_api_api_key "" \
+    --tts qwen3
 ```
 
-For a fully local native-audio setup with the browser demo, Realtime turn revisions, and barge-in, see the tested [Gemma 4 12B speech-to-speech example for Apple Silicon](./examples/gemma4-12b-macos/README.md).
+The speech backends automatically select MLX on Apple Silicon or CUDA/GGML on NVIDIA. Change `--stt` and `--tts` to use other speech backends, or `-hf` to use another supported GGUF model; keep the server alias and `--model_name` matched.
+
+The [Q4_0 LLM weights are approximately **4.6 GB**](https://huggingface.co/ggml-org/gemma-4-E4B-it-GGUF/blob/main/gemma-4-E4B-it-Q4_0.gguf). The example uses one 8k context and disables reasoning for faster replies; `--no-mmproj` skips the image/audio projector because STT supplies text. Increase context or concurrency only as needed, leaving memory for speech. Stop both processes with `Ctrl+C` in their respective terminals.
 
 ## Offline Operation
 
@@ -576,8 +562,8 @@ The pipeline can run without internet access after the dependencies and model as
 are installed locally. Before disconnecting, start the exact configuration once while online so it can cache the
 STT, LLM, TTS, Silero VAD, NLTK, and Smart Turn resources it needs.
 
-For the lowest-friction fully local LLM setup, run llama.cpp on the same machine as described in
-[Fully Local](#fully-local). Once llama.cpp and the pipeline assets are available locally, set
+For the [llama.cpp configuration](#fully-local), keep the local LLM server running. Once its model
+and the pipeline assets are cached, set
 `HF_HUB_OFFLINE=1` when starting speech-to-speech to prevent Hugging Face Hub requests:
 
 ```bash

--- a/README.md
+++ b/README.md
@@ -42,24 +42,24 @@ The memory figures are planning estimates for one conversation, not measured min
 
 ### Install for these examples
 
-Install [Git](https://git-scm.com/downloads) and [uv](https://docs.astral.sh/uv/getting-started/installation/), then use a source checkout. These examples use the current `serve`, `talk`, and `local` commands; PyPI 0.2.12 uses the earlier interface documented in its [release README](https://github.com/huggingface/speech-to-speech/blob/v0.2.12/README.md).
+Use Python 3.10+ (Python 3.11 recommended) and install the package in a virtual environment.
 
 On Ubuntu, install the local audio libraries first: `sudo apt-get install libportaudio2 libsndfile1`. The default Linux Qwen3-TTS wheel targets CUDA 12.8 and glibc 2.39 (Ubuntu 24.04); check the [CUDA installation note](#cuda-note-for-qwen3-tts) if your system differs.
 
 ```bash
-git clone https://github.com/huggingface/speech-to-speech.git
-cd speech-to-speech
-uv sync --python 3.11
+python3 -m venv .venv
+source .venv/bin/activate
+pip install speech-to-speech
 ```
 
-Run the configuration you chose from this directory. The first run downloads and warms up the models before connecting the microphone. Allow microphone access if prompted, use headphones to avoid speaker feedback, then speak and pause for a reply. Stop with `Ctrl+C`.
+Run the configuration you chose with this environment activated. Activate the same environment in any additional terminal where you run `speech-to-speech`. The first run downloads and warms up the models before connecting the microphone. Allow microphone access if prompted, use headphones to avoid speaker feedback, then speak and pause for a reply. Stop with `Ctrl+C`.
 
 ### Apple Silicon, fully local
 
 Use this on an Apple Silicon Mac to run speech recognition, the language model, and speech synthesis on your own machine. Start here for a single-command setup with a small, quantized LLM. No API key is needed.
 
 ```bash
-uv run speech-to-speech local \
+speech-to-speech local \
     --mac-optimal-settings \
     --model_name mlx-community/Qwen3-4B-Instruct-2507-4bit
 ```
@@ -86,10 +86,10 @@ llama-server \
 
 This explicitly selects the [4-bit weights, approximately **4.6 GB**](https://huggingface.co/ggml-org/gemma-4-E4B-it-GGUF/blob/main/gemma-4-E4B-it-Q4_0.gguf), with one request slot and an 8k context. `--no-mmproj` skips the image/audio projector because Parakeet supplies text. Wait for the server to finish loading, then leave it running.
 
-In terminal 2, from your speech-to-speech checkout, start the speech pipeline and microphone client:
+In terminal 2, activate the same Python environment and start the speech pipeline and microphone client:
 
 ```bash
-uv run speech-to-speech local \
+speech-to-speech local \
     --device cuda \
     --stt parakeet-tdt \
     --llm_backend responses-api \
@@ -113,7 +113,7 @@ Budget approximately **8 GB of available memory for the local speech pipeline**.
 
 ```bash
 export OPENAI_API_KEY=...
-uv run speech-to-speech local \
+speech-to-speech local \
     --stt parakeet-tdt \
     --llm_backend responses-api \
     --tts qwen3
@@ -125,10 +125,10 @@ This uses the default OpenAI model described under [Realtime Server](#realtime-s
 
 Start in English. The Parakeet/Qwen3-TTS pairing also covers French, German, Italian, Portuguese, Russian, and Spanish; use `--language auto` for language switching. For languages outside this overlap, choose an STT/TTS pairing from [Multi-language support](#multi-language-support).
 
-To connect an app instead of the packaged microphone client, replace `local` with `serve` in your chosen speech-to-speech command, keeping any separate LLM server running. The speech server listens at `ws://127.0.0.1:8765/v1/realtime`. You can then connect from another terminal in the checkout:
+To connect an app instead of the packaged microphone client, replace `local` with `serve` in your chosen speech-to-speech command, keeping any separate LLM server running. The speech server listens at `ws://127.0.0.1:8765/v1/realtime`. You can then connect from another terminal with the same Python environment activated:
 
 ```bash
-uv run speech-to-speech talk --url ws://127.0.0.1:8765/v1/realtime
+speech-to-speech talk --url ws://127.0.0.1:8765/v1/realtime
 ```
 
 For a browser interface, start your chosen configuration with `serve`, then follow the [browser demo setup](./demo/README.md#quick-start-local) using that running backend.
@@ -166,13 +166,11 @@ Every stage has multiple interchangeable backends, selected via CLI flags. The c
 
 ## Installation
 
-Requires Python 3.10+. The [quickstart](#quickstart) uses a source checkout with Python 3.11. To install a published release instead:
+Requires Python 3.10+. Install from PyPI in an activated virtual environment (see the [quickstart setup](#install-for-these-examples)):
 
 ```bash
 pip install speech-to-speech
 ```
-
-Use the README for your installed [release](https://github.com/huggingface/speech-to-speech/releases) when following release-specific commands. The source examples in this README use `uv run`; prefix later CLI examples with `uv run` as well when running from the checkout.
 
 The default install covers the standard realtime path:
 
@@ -226,7 +224,16 @@ Deprecated implementations, including MeloTTS, live in [`archive/`](./archive) a
 
 ### From Source
 
-Follow [Install for these examples](#install-for-these-examples) to clone the repository and run `uv sync --python 3.11`. This installs the package in editable mode and makes the CLI available through `uv run speech-to-speech`.
+To work on the code, install [Git](https://git-scm.com/downloads) and [uv](https://docs.astral.sh/uv/getting-started/installation/), then run:
+
+```bash
+git clone https://github.com/huggingface/speech-to-speech.git
+cd speech-to-speech
+uv sync --python 3.11
+source .venv/bin/activate
+```
+
+This installs the package in editable mode. With the environment activated, use the same `speech-to-speech` commands shown above.
 
 ## Supported Components
 
@@ -551,7 +558,7 @@ Tune one setting at a time while checking how long it takes to hear the first re
 **Transformers alternative on NVIDIA:** use this if you want to load a Hugging Face model directly in the speech process. It needs no separate LLM server. Budget **24 GB of VRAM** for this unquantized LLM, the speech models, and runtime headroom; the [LLM weights alone are approximately 8 GB](https://huggingface.co/Qwen/Qwen3-4B-Instruct-2507/tree/main).
 
 ```bash
-uv run speech-to-speech local \
+speech-to-speech local \
     --device cuda \
     --stt parakeet-tdt \
     --llm_backend transformers \
@@ -574,7 +581,7 @@ For the lowest-friction fully local LLM setup, run llama.cpp on the same machine
 `HF_HUB_OFFLINE=1` when starting speech-to-speech to prevent Hugging Face Hub requests:
 
 ```bash
-HF_HUB_OFFLINE=1 uv run speech-to-speech serve \
+HF_HUB_OFFLINE=1 speech-to-speech serve \
     --model_name local-gemma \
     --responses_api_base_url "http://127.0.0.1:8080/v1" \
     --responses_api_api_key ""

--- a/README.md
+++ b/README.md
@@ -28,46 +28,95 @@ This pipeline runs in production as the conversation backend for thousands of [R
 
 ## Quickstart
 
+Choose where the language model should run. All three configurations use local Parakeet TDT speech recognition and Qwen3-TTS speech output, and start the packaged microphone/speaker client so you can talk from one terminal.
+
+| Starting configuration | Hardware to plan for | Conversation data sent to a provider |
+|---|---|---|
+| [Apple Silicon, fully local](#apple-silicon-fully-local) | Apple Silicon Mac; budget 16 GB or more of unified memory | None |
+| [NVIDIA GPU, fully local](#nvidia-gpu-fully-local) | Linux with an NVIDIA GPU; budget 24 GB of VRAM for all three models with the unquantized LLM below | None |
+| [Local speech with a hosted LLM](#local-speech-with-a-hosted-llm) | Apple Silicon Mac or Linux with an NVIDIA GPU; no local LLM to load | Transcribed text, instructions, and conversation history; microphone audio stays local |
+
+The memory figures are planning estimates for one conversation, not measured minimum requirements. Actual use depends on context length, audio length, and backend versions. All configurations need internet access for the first model downloads; the hosted LLM also needs an API key and internet access during conversations.
+
+### Install for these examples
+
+Install [Git](https://git-scm.com/downloads) and [uv](https://docs.astral.sh/uv/getting-started/installation/), then use a source checkout. These examples use the current `serve`, `talk`, and `local` commands; PyPI 0.2.12 uses the earlier interface documented in its [release README](https://github.com/huggingface/speech-to-speech/blob/v0.2.12/README.md).
+
+On Ubuntu, install the local audio libraries first: `sudo apt-get install libportaudio2 libsndfile1`. The default Linux Qwen3-TTS wheel targets CUDA 12.8 and glibc 2.39 (Ubuntu 24.04); check the [CUDA installation note](#cuda-note-for-qwen3-tts) if your system differs.
+
 ```bash
-pip install speech-to-speech
+git clone https://github.com/huggingface/speech-to-speech.git
+cd speech-to-speech
+uv sync --python 3.11
+```
+
+Run the configuration you chose from this directory. The first run downloads and warms up the models before connecting the microphone. Allow microphone access if prompted, use headphones to avoid speaker feedback, then speak and pause for a reply. Stop with `Ctrl+C`.
+
+### Apple Silicon, fully local
+
+Use this on an Apple Silicon Mac to run speech recognition, the language model, and speech synthesis on your own machine. No API key is needed.
+
+```bash
+uv run speech-to-speech local \
+    --mac-optimal-settings \
+    --model_name mlx-community/Qwen3-4B-Instruct-2507-4bit
+```
+
+The Mac preset selects Parakeet TDT through MLX, the 4-bit Qwen3-4B language model through MLX LM, and the 6-bit Qwen3-TTS CustomVoice model through MLX Audio. The core model weights total approximately **7.5 GB**: [STT](https://huggingface.co/mlx-community/parakeet-tdt-0.6b-v3/tree/main), [LLM](https://huggingface.co/mlx-community/Qwen3-4B-Instruct-2507-4bit/tree/main), and [TTS](https://huggingface.co/mlx-community/Qwen3-TTS-12Hz-1.7B-CustomVoice-6bit/tree/main). Allow additional disk space for dependencies and auxiliary model assets.
+
+After the exact configuration has run once online, follow [Offline operation](#offline-operation) to run without internet access. For a local model that accepts audio directly, see the [Gemma 4 12B example](./examples/gemma4-12b-macos/README.md).
+
+### NVIDIA GPU, fully local
+
+Use this on a Linux workstation with a CUDA-capable NVIDIA GPU. All three models run on the same GPU, with the language model loaded directly through Transformers. No separate LLM server or API key is needed.
+
+```bash
+uv run speech-to-speech local \
+    --device cuda \
+    --stt parakeet-tdt \
+    --llm_backend transformers \
+    --model_name Qwen/Qwen3-4B-Instruct-2507 \
+    --llm_torch_dtype float16 \
+    --tts qwen3 \
+    --qwen3_tts_backend ggml
+```
+
+This uses Parakeet TDT through nano-parakeet and Qwen3-TTS CustomVoice through GGML. The [LLM weights alone are approximately **8 GB**](https://huggingface.co/Qwen/Qwen3-4B-Instruct-2507/tree/main); speech models, GGUF caches, and dependencies require additional disk space. If GPU memory is tight, use the hosted LLM configuration below or serve a quantized LLM with [llama.cpp](#fully-local).
+
+After downloading the required assets, this configuration can also run [offline](#offline-operation). For a server running in containers, see [Docker](#docker).
+
+### Local speech with a hosted LLM
+
+Use this to keep speech recognition and synthesis on your computer while a hosted model generates the reply. It works on Apple Silicon or the Linux/CUDA setup above and avoids loading the local LLM. On Apple Silicon, the speech backends select MLX automatically.
+
+```bash
 export OPENAI_API_KEY=...
-speech-to-speech serve
+uv run speech-to-speech local \
+    --stt parakeet-tdt \
+    --llm_backend responses-api \
+    --tts qwen3
 ```
 
-This starts an OpenAI Realtime-compatible server at `ws://localhost:8765/v1/realtime` using Parakeet TDT for local STT, an OpenAI-compatible LLM, and Qwen3-TTS for local speech output.
+This uses the default OpenAI model described under [Realtime Server](#realtime-server), with provider API charges. Only the speech models download locally: approximately **5.2 GB** of core weights on Apple Silicon, plus dependencies and auxiliary assets; Linux uses different speech-model formats and caches. Transcribed text, instructions, and conversation history are sent to OpenAI. Microphone audio and speech synthesis remain on your computer in this configuration. For another provider, see [LLM backends](#llm-backends).
 
-Talk to it from a second terminal:
+### Languages and other clients
+
+Start in English. The Parakeet/Qwen3-TTS pairing also covers French, German, Italian, Portuguese, Russian, and Spanish; use `--language auto` for language switching. For languages outside this overlap, choose an STT/TTS pairing from [Multi-language support](#multi-language-support).
+
+To connect an app instead of the packaged microphone client, replace `local` with `serve` in your chosen command. The server listens at `ws://127.0.0.1:8765/v1/realtime`. You can then connect from a second terminal in the checkout:
 
 ```bash
-speech-to-speech talk --url ws://127.0.0.1:8765/v1/realtime
+uv run speech-to-speech talk --url ws://127.0.0.1:8765/v1/realtime
 ```
 
-To start the server and packaged microphone/speaker client in one command:
-
-```bash
-speech-to-speech local
-```
-
-Prefer to keep the LLM on your own machine? Serve Gemma 4 with llama.cpp:
-
-```bash
-llama-server -hf ggml-org/gemma-4-E4B-it-GGUF -np 2 -c 65536 -fa on --swa-full
-```
-
-Then point the OpenAI-compatible LLM backend at it:
-
-```bash
-speech-to-speech serve \
-    --model_name "ggml-org/gemma-4-E4B-it-GGUF" \
-    --responses_api_base_url "http://127.0.0.1:8080/v1" \
-    --responses_api_api_key ""
-```
+For a browser interface, start your chosen configuration with `serve`, then follow the [browser demo setup](./demo/README.md#quick-start-local) using that running backend.
 
 Clients using the implemented core Realtime event set can connect. The official OpenAI Agents SDK is tested over both stock transports; see [Realtime API](#realtime-api) for the tested surface and [LLM backends](#llm-backends) for provider and local-server options.
 
 ## Index
 
 * [How it works](#how-it-works)
+* [Starting configurations](#quickstart)
 * [Installation](#installation)
 * [Offline operation](#offline-operation)
 * [Supported components](#supported-components)
@@ -95,11 +144,13 @@ Every stage has multiple interchangeable backends, selected via CLI flags. The c
 
 ## Installation
 
-Requires Python 3.10+.
+Requires Python 3.10+. The [quickstart](#quickstart) uses a source checkout with Python 3.11. To install a published release instead:
 
 ```bash
 pip install speech-to-speech
 ```
+
+Use the README for your installed [release](https://github.com/huggingface/speech-to-speech/releases) when following release-specific commands. The source examples in this README use `uv run`; prefix later CLI examples with `uv run` as well when running from the checkout.
 
 The default install covers the standard realtime path:
 
@@ -153,13 +204,7 @@ Deprecated implementations, including MeloTTS, live in [`archive/`](./archive) a
 
 ### From Source
 
-```bash
-git clone https://github.com/huggingface/speech-to-speech.git
-cd speech-to-speech
-uv sync
-```
-
-This installs the package in editable mode and makes the `speech-to-speech` CLI available.
+Follow [Install for these examples](#install-for-these-examples) to clone the repository and run `uv sync --python 3.11`. This installs the package in editable mode and makes the CLI available through `uv run speech-to-speech`.
 
 ## Supported Components
 
@@ -254,24 +299,7 @@ The default model is `gpt-5.6-terra` through the OpenAI Responses API with reaso
 
 ### Local Mac
 
-```bash
-speech-to-speech local --mac-optimal-settings
-```
-
-Optionally with a specific LLM:
-
-```bash
-speech-to-speech local \
-    --mac-optimal-settings \
-    --model_name mlx-community/Qwen3-4B-Instruct-2507-4bit
-```
-
-This setting:
-
-- Uses MPS defaults for supported model components.
-- Sets Parakeet TDT for STT.
-- Sets MLX LM as the LLM backend.
-- Sets Qwen3-TTS for TTS, using `mlx-audio` with the `6bit` MLX variant by default.
+Start with [Apple Silicon, fully local](#apple-silicon-fully-local). Its `--mac-optimal-settings` preset supplies MPS defaults for supported components, Parakeet TDT for STT, MLX LM for the LLM, and Qwen3-TTS through `mlx-audio` with the `6bit` variant.
 
 The preset supplies these as defaults only: explicit `--device`, component-device flags such as `--qwen3_tts_device`, and `--stt`, `--llm_backend`, `--model_name`, and `--tts` all win. Use it with `serve` instead of `local` when you want to expose the server without starting the microphone/speaker client.
 

--- a/README.md
+++ b/README.md
@@ -34,7 +34,7 @@ Choose where the language model should run. All three configurations use local P
 |---|---|---|
 | [Apple Silicon, fully local](#apple-silicon-fully-local) | Apple Silicon Mac; budget 16 GB or more of unified memory | None |
 | [NVIDIA GPU, fully local](#nvidia-gpu-fully-local) | Linux with an NVIDIA GPU; budget 24 GB of VRAM for all three models with the unquantized LLM below | None |
-| [Local speech with a hosted LLM](#local-speech-with-a-hosted-llm) | Apple Silicon Mac or Linux with an NVIDIA GPU; no local LLM to load | Transcribed text, instructions, and conversation history; microphone audio stays local |
+| [Local speech with a hosted LLM](#local-speech-with-a-hosted-llm) | Apple Silicon: budget ~8 GB of available unified memory (16 GB total recommended); Linux/NVIDIA: ~8 GB of available VRAM, plus system RAM | Transcribed text, instructions, and conversation history; microphone audio stays local |
 
 The memory figures are planning estimates for one conversation, not measured minimum requirements. Actual use depends on context length, audio length, and backend versions. All configurations need internet access for the first model downloads; the hosted LLM also needs an API key and internet access during conversations.
 
@@ -88,6 +88,8 @@ After downloading the required assets, this configuration can also run [offline]
 ### Local speech with a hosted LLM
 
 Use this to keep speech recognition and synthesis on your computer while a hosted model generates the reply. It works on Apple Silicon or the Linux/CUDA setup above and avoids loading the local LLM. On Apple Silicon, the speech backends select MLX automatically.
+
+Budget approximately **8 GB of available memory for the local speech pipeline**. On Apple Silicon, this comes from unified memory; **16 GB total is recommended** to leave room for macOS and other apps. On Linux/NVIDIA, budget **8 GB of available GPU VRAM**, with separate system RAM for model loading, the operating system, and other apps. These are planning estimates for one conversation, not verified minimums; the model download sizes below are disk requirements, not runtime memory measurements.
 
 ```bash
 export OPENAI_API_KEY=...

--- a/README.md
+++ b/README.md
@@ -64,7 +64,7 @@ speech-to-speech local \
 
 The Mac preset selects Parakeet TDT through MLX, the 4-bit Qwen3-4B language model through MLX LM, and the 6-bit Qwen3-TTS CustomVoice model through MLX Audio. The core model weights total approximately **7.5 GB**: [STT](https://huggingface.co/mlx-community/parakeet-tdt-0.6b-v3/tree/main), [LLM](https://huggingface.co/mlx-community/Qwen3-4B-Instruct-2507-4bit/tree/main), and [TTS](https://huggingface.co/mlx-community/Qwen3-TTS-12Hz-1.7B-CustomVoice-6bit/tree/main). Allow additional disk space for dependencies and auxiliary model assets.
 
-For a separate local LLM server, see the [llama.cpp option](#fully-local). For a model that accepts audio directly, see the [Gemma 4 12B example](./examples/gemma4-12b-macos/README.md).
+For a separate local LLM server, see [Combining with llama.cpp](#combining-with-llamacpp). For a model that accepts audio directly, see the [Gemma 4 12B example](./examples/gemma4-12b-macos/README.md).
 
 ### NVIDIA GPU, fully local
 
@@ -81,7 +81,7 @@ speech-to-speech local \
     --qwen3_tts_backend ggml
 ```
 
-The [LLM weights alone are approximately **8 GB**](https://huggingface.co/Qwen/Qwen3-4B-Instruct-2507/tree/main); speech models, caches, and dependencies need additional disk space. For a quantized LLM in a separate server, see the [llama.cpp option](#fully-local), available on both Apple Silicon and NVIDIA.
+The [LLM weights alone are approximately **8 GB**](https://huggingface.co/Qwen/Qwen3-4B-Instruct-2507/tree/main); speech models, caches, and dependencies need additional disk space. For a quantized LLM in a separate server, see [Combining with llama.cpp](#combining-with-llamacpp), available on both Apple Silicon and NVIDIA.
 
 ### Local speech with a hosted LLM
 
@@ -520,9 +520,9 @@ speech-to-speech serve \
     --responses_api_stream
 ```
 
-### Fully Local
+### Combining with llama.cpp
 
-Use llama.cpp as a separate local LLM server on **Apple Silicon or Linux/NVIDIA**, independently of your STT/TTS choices. Install it with `brew install llama.cpp` on macOS or use a [CUDA build](https://github.com/ggml-org/llama.cpp/blob/master/docs/build.md#cuda) on NVIDIA.
+Serve the LLM with llama.cpp and connect speech-to-speech through its local Responses API, keeping your choice of STT/TTS backends. This works on **Apple Silicon or Linux/NVIDIA**. Install llama.cpp with `brew install llama.cpp` on macOS or use a [CUDA build](https://github.com/ggml-org/llama.cpp/blob/master/docs/build.md#cuda) on NVIDIA.
 
 For this Gemma 4 configuration with the default speech models, budget **24 GB of total unified memory on Mac** or **16 GB of GPU VRAM on NVIDIA**, plus system RAM. These are planning estimates; reserve approximately 8 GB for the speech pipeline alongside the LLM and its runtime cache.
 
@@ -538,7 +538,7 @@ llama-server \
     --reasoning off
 ```
 
-Terminal 2 — activate your Python environment and start the speech pipeline:
+Terminal 2 — activate your Python environment and connect the speech pipeline to that LLM:
 
 ```bash
 speech-to-speech local \
@@ -560,7 +560,7 @@ The pipeline can run without internet access after the dependencies and model as
 are installed locally. Before disconnecting, start the exact configuration once while online so it can cache the
 STT, LLM, TTS, Silero VAD, NLTK, and Smart Turn resources it needs.
 
-For the [llama.cpp configuration](#fully-local), keep the local LLM server running. Once its model
+For the [llama.cpp configuration](#combining-with-llamacpp), keep the local LLM server running. Once its model
 and the pipeline assets are cached, set
 `HF_HUB_OFFLINE=1` when starting speech-to-speech to prevent Hugging Face Hub requests:
 

--- a/README.md
+++ b/README.md
@@ -99,11 +99,9 @@ speech-to-speech local \
 
 This uses the default OpenAI model described under [Realtime Server](#realtime-server), with provider API charges. Only the speech models download locally: approximately **5.2 GB** of core weights on Apple Silicon, plus dependencies and auxiliary assets; Linux uses different speech-model formats and caches. Transcribed text, instructions, and conversation history are sent to OpenAI. Microphone audio and speech synthesis remain on your computer in this configuration. For another provider, see [LLM backends](#llm-backends).
 
-### Languages and other clients
+### Other clients and offline use
 
 For offline use, first cache the selected models and dependencies as described in [Offline operation](#offline-operation).
-
-Start in English. The Parakeet/Qwen3-TTS pairing also covers French, German, Italian, Portuguese, Russian, and Spanish; use `--language auto` for language switching. For languages outside this overlap, choose an STT/TTS pairing from [Multi-language support](#multi-language-support).
 
 To connect an app instead of the packaged microphone client, replace `local` with `serve` in your chosen speech-to-speech command, keeping any separate LLM server running. The speech server listens at `ws://127.0.0.1:8765/v1/realtime`. You can then connect from another terminal with the same Python environment activated:
 

--- a/README.md
+++ b/README.md
@@ -28,12 +28,14 @@ This pipeline runs in production as the conversation backend for thousands of [R
 
 ## Quickstart
 
-Choose where the language model should run. All three configurations use local Parakeet TDT speech recognition and Qwen3-TTS speech output, and start the packaged microphone/speaker client so you can talk from one terminal.
+Choose where the language model should run. All three configurations use local Parakeet TDT speech recognition and Qwen3-TTS speech output, and include the packaged microphone/speaker client. The Mac and hosted LLM routes use one terminal; the llama.cpp route uses two.
+
+Following the [Reachy Mini local conversation guide](https://huggingface.co/blog/local-reachy-mini-conversation), start with the default speech components and choose an LLM that fits your hardware: Silero detects speech boundaries, Parakeet transcribes your words, and Qwen3-TTS speaks the reply. MLX is the simplest Mac starting point; a separate llama.cpp server lets you tune or replace the local LLM independently of the speech pipeline. Both approaches keep the conversation local.
 
 | Starting configuration | Hardware to plan for | Conversation data sent to a provider |
 |---|---|---|
 | [Apple Silicon, fully local](#apple-silicon-fully-local) | Apple Silicon Mac; budget 16 GB or more of unified memory | None |
-| [NVIDIA GPU, fully local](#nvidia-gpu-fully-local) | Linux with an NVIDIA GPU; budget 24 GB of VRAM for all three models with the unquantized LLM below | None |
+| [NVIDIA GPU, fully local](#nvidia-gpu-fully-local) | Linux with an NVIDIA GPU; budget 16 GB of VRAM for the quantized Gemma 4 LLM, speech models, and caches below, plus system RAM | None |
 | [Local speech with a hosted LLM](#local-speech-with-a-hosted-llm) | Apple Silicon: budget ~8 GB of available unified memory (16 GB total recommended); Linux/NVIDIA: ~8 GB of available VRAM, plus system RAM | Transcribed text, instructions, and conversation history; microphone audio stays local |
 
 The memory figures are planning estimates for one conversation, not measured minimum requirements. Actual use depends on context length, audio length, and backend versions. All configurations need internet access for the first model downloads; the hosted LLM also needs an API key and internet access during conversations.
@@ -54,7 +56,7 @@ Run the configuration you chose from this directory. The first run downloads and
 
 ### Apple Silicon, fully local
 
-Use this on an Apple Silicon Mac to run speech recognition, the language model, and speech synthesis on your own machine. No API key is needed.
+Use this on an Apple Silicon Mac to run speech recognition, the language model, and speech synthesis on your own machine. Start here for a single-command setup with a small, quantized LLM. No API key is needed.
 
 ```bash
 uv run speech-to-speech local \
@@ -64,26 +66,44 @@ uv run speech-to-speech local \
 
 The Mac preset selects Parakeet TDT through MLX, the 4-bit Qwen3-4B language model through MLX LM, and the 6-bit Qwen3-TTS CustomVoice model through MLX Audio. The core model weights total approximately **7.5 GB**: [STT](https://huggingface.co/mlx-community/parakeet-tdt-0.6b-v3/tree/main), [LLM](https://huggingface.co/mlx-community/Qwen3-4B-Instruct-2507-4bit/tree/main), and [TTS](https://huggingface.co/mlx-community/Qwen3-TTS-12Hz-1.7B-CustomVoice-6bit/tree/main). Allow additional disk space for dependencies and auxiliary model assets.
 
-After the exact configuration has run once online, follow [Offline operation](#offline-operation) to run without internet access. For a local model that accepts audio directly, see the [Gemma 4 12B example](./examples/gemma4-12b-macos/README.md).
+After the exact configuration has run once online, follow [Offline operation](#offline-operation) to run without internet access. To use Gemma 4 through a separate llama.cpp server on your Mac, follow the [local LLM guidance](#fully-local). For a local model that accepts audio directly, see the [Gemma 4 12B example](./examples/gemma4-12b-macos/README.md).
 
 ### NVIDIA GPU, fully local
 
-Use this on a Linux workstation with a CUDA-capable NVIDIA GPU. All three models run on the same GPU, with the language model loaded directly through Transformers. No separate LLM server or API key is needed.
+Use this on a Linux workstation with a CUDA-capable NVIDIA GPU. Run a quantized Gemma 4 E4B model in llama.cpp and connect the speech pipeline to its local Responses API. No provider API key is needed. Install a current [llama.cpp CUDA build](https://github.com/ggml-org/llama.cpp/blob/master/docs/build.md#cuda) and make `llama-server` available on your PATH.
+
+In terminal 1, start the LLM server:
+
+```bash
+llama-server \
+    -hf ggml-org/gemma-4-E4B-it-GGUF:Q4_0 \
+    --alias local-gemma \
+    --host 127.0.0.1 --port 8080 \
+    -ngl all -np 1 -c 8192 -fa on \
+    --no-mmproj \
+    --reasoning off
+```
+
+This explicitly selects the [4-bit weights, approximately **4.6 GB**](https://huggingface.co/ggml-org/gemma-4-E4B-it-GGUF/blob/main/gemma-4-E4B-it-Q4_0.gguf), with one request slot and an 8k context. `--no-mmproj` skips the image/audio projector because Parakeet supplies text. Wait for the server to finish loading, then leave it running.
+
+In terminal 2, from your speech-to-speech checkout, start the speech pipeline and microphone client:
 
 ```bash
 uv run speech-to-speech local \
     --device cuda \
     --stt parakeet-tdt \
-    --llm_backend transformers \
-    --model_name Qwen/Qwen3-4B-Instruct-2507 \
-    --llm_torch_dtype float16 \
+    --llm_backend responses-api \
+    --model_name local-gemma \
+    --responses_api_base_url http://127.0.0.1:8080/v1 \
+    --responses_api_api_key "" \
+    --responses_api_reasoning_effort none \
     --tts qwen3 \
     --qwen3_tts_backend ggml
 ```
 
-This uses Parakeet TDT through nano-parakeet and Qwen3-TTS CustomVoice through GGML. The [LLM weights alone are approximately **8 GB**](https://huggingface.co/Qwen/Qwen3-4B-Instruct-2507/tree/main); speech models, GGUF caches, and dependencies require additional disk space. If GPU memory is tight, use the hosted LLM configuration below or serve a quantized LLM with [llama.cpp](#fully-local).
+The two processes share the GPU: leave approximately **8 GB of available VRAM for the speech pipeline**, in addition to the LLM's weights and runtime cache. Parakeet uses nano-parakeet and Qwen3-TTS CustomVoice uses GGML. Speech model downloads, GGUF caches, and dependencies require additional disk space. The local URL and matching `local-gemma` model alias route replies to your own server; using the Responses API does not imply a cloud service.
 
-After downloading the required assets, this configuration can also run [offline](#offline-operation). For a server running in containers, see [Docker](#docker).
+If memory is tight, reduce the LLM context or use the hosted LLM route below. For tuning and an in-process Transformers alternative, see [Fully Local](#fully-local). After downloading the required assets, this configuration can also run [offline](#offline-operation). Stop both processes with `Ctrl+C` in their respective terminals. For a server running in containers, see [Docker](#docker).
 
 ### Local speech with a hosted LLM
 
@@ -105,7 +125,7 @@ This uses the default OpenAI model described under [Realtime Server](#realtime-s
 
 Start in English. The Parakeet/Qwen3-TTS pairing also covers French, German, Italian, Portuguese, Russian, and Spanish; use `--language auto` for language switching. For languages outside this overlap, choose an STT/TTS pairing from [Multi-language support](#multi-language-support).
 
-To connect an app instead of the packaged microphone client, replace `local` with `serve` in your chosen command. The server listens at `ws://127.0.0.1:8765/v1/realtime`. You can then connect from a second terminal in the checkout:
+To connect an app instead of the packaged microphone client, replace `local` with `serve` in your chosen speech-to-speech command, keeping any separate LLM server running. The speech server listens at `ws://127.0.0.1:8765/v1/realtime`. You can then connect from another terminal in the checkout:
 
 ```bash
 uv run speech-to-speech talk --url ws://127.0.0.1:8765/v1/realtime
@@ -517,29 +537,31 @@ speech-to-speech serve \
 
 ### Fully Local
 
-Run the LLM in a separate llama.cpp process for the lowest-friction fully local setup, as shown in the [Reachy Mini local conversation guide](https://huggingface.co/blog/local-reachy-mini-conversation):
+Choose the [MLX quickstart](#apple-silicon-fully-local) for a single-command Mac setup, or the [llama.cpp/Gemma 4 quickstart](#nvidia-gpu-fully-local) to serve and tune the LLM separately, following the approach in the [Reachy Mini guide](https://huggingface.co/blog/local-reachy-mini-conversation).
+
+**llama.cpp on Apple Silicon:** install it with `brew install llama.cpp`, then use the same two-terminal Gemma 4 recipe, omitting `--device cuda` from the speech-to-speech command. The speech backends select MLX automatically. Budget **24 GB of total unified memory** for this larger local combination and system headroom; this is a planning estimate, separate from the 16 GB estimate for the smaller Qwen3-4B MLX recipe.
+
+Tune one setting at a time while checking how long it takes to hear the first reply:
+
+- **Start with a small, quantized LLM.** Fit speech models and runtime caches alongside it before moving to a larger model. The recipes pin their quantization so a different default download does not change the memory budget.
+- **Keep reasoning off for conversation.** The llama.cpp recipe uses `--reasoning off`; the pipeline streams replies and requests reasoning effort `none`. Enable thinking only when the task needs the extra reasoning time.
+- **Start with one slot and an 8k context.** Increase `-c` for longer conversations and `-np` for concurrent requests only when needed; size the context for all slots and leave memory for speech. The blog's `-np 2 -c 65536` is an option for machines with more headroom.
+- **Tune attention after the baseline works.** `-fa on` enables Flash Attention. Try `--swa-full` for Gemma prompt processing when memory permits; it allocates a larger sliding-window cache. See the [llama.cpp server reference](https://github.com/ggml-org/llama.cpp/tree/master/tools/server) for these controls.
+
+**Transformers alternative on NVIDIA:** use this if you want to load a Hugging Face model directly in the speech process. It needs no separate LLM server. Budget **24 GB of VRAM** for this unquantized LLM, the speech models, and runtime headroom; the [LLM weights alone are approximately 8 GB](https://huggingface.co/Qwen/Qwen3-4B-Instruct-2507/tree/main).
+
+```bash
+uv run speech-to-speech local \
+    --device cuda \
+    --stt parakeet-tdt \
+    --llm_backend transformers \
+    --model_name Qwen/Qwen3-4B-Instruct-2507 \
+    --llm_torch_dtype float16 \
+    --tts qwen3 \
+    --qwen3_tts_backend ggml
+```
 
 For a fully local native-audio setup with the browser demo, Realtime turn revisions, and barge-in, see the tested [Gemma 4 12B speech-to-speech example for Apple Silicon](./examples/gemma4-12b-macos/README.md).
-
-```bash
-# Terminal 1: llama.cpp serving Gemma 4
-llama-server -hf ggml-org/gemma-4-E4B-it-GGUF -np 2 -c 65536 -fa on --swa-full
-```
-
-```bash
-# Terminal 2: speech-to-speech using that local LLM server
-speech-to-speech serve \
-    --stt parakeet-tdt \
-    --llm_backend responses-api \
-    --tts qwen3 \
-    --model_name "ggml-org/gemma-4-E4B-it-GGUF" \
-    --responses_api_base_url "http://127.0.0.1:8080/v1" \
-    --responses_api_api_key "" \
-    --responses_api_stream \
-    --enable_live_transcription
-```
-
-Use `speech-to-speech local` when you want to run the same server and talk through the machine hosting it. In-process local backends are available with `--llm_backend mlx-lm` on Apple Silicon or `--llm_backend transformers` on CUDA / CPU.
 
 ## Offline Operation
 
@@ -552,8 +574,8 @@ For the lowest-friction fully local LLM setup, run llama.cpp on the same machine
 `HF_HUB_OFFLINE=1` when starting speech-to-speech to prevent Hugging Face Hub requests:
 
 ```bash
-HF_HUB_OFFLINE=1 speech-to-speech serve \
-    --model_name "ggml-org/gemma-4-E4B-it-GGUF" \
+HF_HUB_OFFLINE=1 uv run speech-to-speech serve \
+    --model_name local-gemma \
     --responses_api_base_url "http://127.0.0.1:8080/v1" \
     --responses_api_api_key ""
 ```


### PR DESCRIPTION
The README now provides three single-terminal starting configurations: MLX with Qwen3-4B on Apple Silicon, Transformers with Qwen3-4B on NVIDIA, and local speech with a hosted LLM. It marks the model choices as defaults that can be changed, includes memory and download estimates, and uses pip installation for the upcoming release.

A separate llama.cpp/Gemma 4 recipe works on Apple Silicon and NVIDIA with independently selectable STT/TTS backends. Shared guidance covers offline use and other clients. Only README.md changes.

Validation:
- 163 CLI defaults, backend registry, and Responses API handler tests passed during this PR.
- Rechecked 16 platform/mode recipe variants, the talk client, local model alias, URL, empty API key, streaming, and device selection.
- Checked all 29 shell examples and 15 local links/anchors; git diff --check passed.
- Validated llama.cpp flags with installed llama-server build 10210 in help mode, without loading a model.
- Checked download sizes against model metadata. Memory budgets are planning estimates; live inference and minimum hardware requirements were not benchmarked.
