### PR TITLE
Document microphone blocking in the quickstart

### DIFF
--- a/README.md
+++ b/README.md
@@ -52,6 +52,8 @@ pip install speech-to-speech
 
 Run the configuration you chose with this environment activated. Activate the same environment in any additional terminal where you run `speech-to-speech`. The first run downloads and warms up the models before connecting the microphone. Allow microphone access if prompted, use headphones to avoid speaker feedback, then speak and pause for a reply. Stop with `Ctrl+C`.
 
+If speaker feedback interrupts replies, add `--local_audio_block_mic_during_playback` to your `speech-to-speech local` command. This pauses microphone capture during playback, so you cannot interrupt the assistant while it speaks.
+
 ### Apple Silicon, fully local
 
 Run all three models locally on an Apple Silicon Mac, using a quantized LLM through MLX. No API key is needed.


### PR DESCRIPTION
Add a short quickstart note for `--local_audio_block_mic_during_playback` when speaker feedback interrupts replies. Explain that it pauses microphone capture during playback, so users cannot interrupt the assistant while it speaks.

Validation: `git diff --check` passed. Documentation only; no runtime changes.
